### PR TITLE
fix(app): project source-aware visibility and local KeyPackage tombstones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1991,6 +1991,7 @@ version = "0.9.15"
 dependencies = [
  "libc",
  "tempfile",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -2056,8 +2056,8 @@ impl<S: StorageProvider> Engine<S> {
         }
 
         if let Some(mut request) = self.storage.leave_request(group_id)? {
-            if request.last_proposed_epoch.is_none()
-                && self.sent_self_remove_leaving_gate_should_restore(
+            if (request.last_proposed_epoch.is_none() || request.last_proposed_message_id.is_none())
+                && let Some(message_id) = self.sent_self_remove_message_to_restore(
                     group_id,
                     mls_group,
                     group,
@@ -2065,13 +2065,18 @@ impl<S: StorageProvider> Engine<S> {
                     stored_message_records,
                 )?
             {
-                request.last_proposed_epoch = Some(group.epoch);
+                if request.last_proposed_epoch.is_none() {
+                    request.last_proposed_epoch = Some(group.epoch);
+                }
+                if request.last_proposed_message_id.is_none() {
+                    request.last_proposed_message_id = Some(message_id);
+                }
                 self.storage.put_leave_request(&request)?;
             }
             return Ok(Some(request));
         }
 
-        if self.sent_self_remove_leaving_gate_should_restore(
+        if let Some(message_id) = self.sent_self_remove_message_to_restore(
             group_id,
             mls_group,
             group,
@@ -2082,6 +2087,7 @@ impl<S: StorageProvider> Engine<S> {
                 group_id: group_id.clone(),
                 requested_at_ms: self.convergence_now_ms(),
                 last_proposed_epoch: Some(group.epoch),
+                last_proposed_message_id: Some(message_id),
             };
             self.storage.put_leave_request(&request)?;
             return Ok(Some(request));
@@ -2215,20 +2221,20 @@ impl<S: StorageProvider> Engine<S> {
         Ok(())
     }
 
-    fn sent_self_remove_leaving_gate_should_restore(
+    fn sent_self_remove_message_to_restore(
         &self,
         group_id: &GroupId,
         mls_group: &mut openmls::group::MlsGroup,
         group: &Group,
         provider: &crate::provider::EngineOpenMlsProvider<'_, S>,
         stored_message_records: &[cgka_traits::message::MessageRecord],
-    ) -> Result<bool, cgka_traits::storage::StorageError> {
+    ) -> Result<Option<MessageId>, cgka_traits::storage::StorageError> {
         if !group
             .members
             .iter()
             .any(|member| &member.id == self.identity.self_id())
         {
-            return Ok(false);
+            return Ok(None);
         }
 
         for record in stored_message_records {
@@ -2277,11 +2283,11 @@ impl<S: StorageProvider> Engine<S> {
                 && matches!(queued.proposal(), Proposal::SelfRemove)
                 && crate::app_components::authorize_standalone_proposal(mls_group, &queued).is_ok()
             {
-                return Ok(true);
+                return Ok(Some(record.id.clone()));
             }
         }
 
-        Ok(false)
+        Ok(None)
     }
 
     fn quarantine_stored_group_on_hydrate(

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -1197,9 +1197,16 @@ impl<S: StorageProvider> Engine<S> {
                     let mut lifecycle = maintenance
                         .key_package_lifecycle()?
                         .unwrap_or_else(|| KeyPackageLifecycleState::slot_only(String::new()));
-                    lifecycle.last_consumed_key_package_ref =
-                        Some(consumed_key_package_ref.clone());
-                    lifecycle.last_consumed_at = Some(joined_at);
+                    lifecycle
+                        .record_consumed_key_package_ref(
+                            consumed_key_package_ref.clone(),
+                            joined_at,
+                        )
+                        .map_err(|_| {
+                            EngineError::Backend(
+                                "consumed KeyPackage cleanup journal is full".into(),
+                            )
+                        })?;
                     maintenance.put_key_package_lifecycle(&lifecycle)?;
                 }
 

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -705,8 +705,10 @@ impl<S: StorageProvider> Engine<S> {
             group_id: group_id.clone(),
             requested_at_ms,
             last_proposed_epoch: None,
+            last_proposed_message_id: None,
         });
         request.last_proposed_epoch = Some(proposed_epoch);
+        request.last_proposed_message_id = Some(msg.id.clone());
         self.record_sent_openmls_message_with_leave_request(
             &msg,
             proposal_bytes.as_slice(),
@@ -833,6 +835,7 @@ impl<S: StorageProvider> Engine<S> {
         let (msg, proposal_bytes, proposed_epoch) =
             self.prepare_self_remove_proposal(group_id).await?;
         request.last_proposed_epoch = Some(proposed_epoch);
+        request.last_proposed_message_id = Some(msg.id.clone());
         self.record_sent_openmls_message_with_leave_request(
             &msg,
             proposal_bytes.as_slice(),

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -3029,11 +3029,18 @@ async fn leave_hydration_preserves_existing_last_proposed_message_id() {
     bob_storage.put_leave_request(&request).unwrap();
     drop(bob);
 
-    let _reopened = build_client_on_storage(b"bob", bob_storage.clone());
+    let mut reopened = build_client_on_storage(b"bob", bob_storage.clone());
+    reopened
+        .hydrate_all_stored_groups()
+        .expect("eager hydrate restores the leave request");
     let restored = bob_storage
         .leave_request(&group_id)
         .unwrap()
         .expect("hydration restores the LeaveRequest");
+    assert!(
+        restored.last_proposed_epoch.is_some(),
+        "epoch-only hydration repair must fill last_proposed_epoch"
+    );
     assert_eq!(
         restored.last_proposed_message_id.as_ref(),
         Some(&second_id),

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -1336,6 +1336,7 @@ async fn realization_with_pending_leave_request_attributes_member_left() {
             group_id: group_id.clone(),
             requested_at_ms: 1,
             last_proposed_epoch: None,
+            last_proposed_message_id: None,
         })
         .unwrap();
 
@@ -2945,6 +2946,103 @@ async fn repeat_leave_in_the_same_epoch_is_classified_by_the_engine() {
         bob_storage.leave_request(&group_id).unwrap(),
         Some(recorded),
         "refused duplicates must leave the durable request byte-identical"
+    );
+}
+
+#[tokio::test]
+async fn leave_hydration_preserves_existing_last_proposed_message_id() {
+    let mut alice = build_client(b"alice");
+    let (mut bob, bob_storage) = build_with_storage(b"bob");
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "hydrate-leave-id".into(),
+            description: "".into(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let welcome_for_bob = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            alice.confirm_published(pending).await.unwrap();
+            welcomes.remove(0)
+        }
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    bob.join_welcome(welcome_for_bob).await.unwrap();
+
+    let first = bob
+        .send(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    let first_id = match first {
+        SendResult::Proposal { msg } => msg.id,
+        other => panic!("expected SelfRemove proposal, got {other:?}"),
+    };
+
+    let rename = alice
+        .send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some("still includes bob".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let (commit, pending) = match rename {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    let routed = TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..commit
+    };
+    let outcome = bob.ingest(routed).await.unwrap();
+    assert!(matches!(outcome, IngestOutcome::Buffered { .. }));
+    converge_buffered_commit(&mut bob, &group_id);
+    let _ = bob.advance_convergence(&group_id).await.unwrap();
+    let reproposals = bob.drain_auto_proposals();
+    assert_eq!(reproposals.len(), 1);
+    let second_id = reproposals[0].id.clone();
+    assert_ne!(
+        first_id, second_id,
+        "the epoch-changed SelfRemove must be a new message"
+    );
+
+    let mut request = bob_storage
+        .leave_request(&group_id)
+        .unwrap()
+        .expect("reproposal keeps the durable request");
+    assert_eq!(request.last_proposed_message_id.as_ref(), Some(&second_id));
+    request.last_proposed_epoch = None;
+    bob_storage.put_leave_request(&request).unwrap();
+    drop(bob);
+
+    let _reopened = build_client_on_storage(b"bob", bob_storage.clone());
+    let restored = bob_storage
+        .leave_request(&group_id)
+        .unwrap()
+        .expect("hydration restores the LeaveRequest");
+    assert_eq!(
+        restored.last_proposed_message_id.as_ref(),
+        Some(&second_id),
+        "epoch-only hydration repair must not overwrite the exact Leave id"
+    );
+    assert_ne!(
+        restored.last_proposed_message_id.as_ref(),
+        Some(&first_id),
+        "hydration must not replace the current Leave id with an earlier SelfRemove"
     );
 }
 

--- a/crates/cgka-engine/tests/publish_lifecycle.rs
+++ b/crates/cgka-engine/tests/publish_lifecycle.rs
@@ -1606,6 +1606,7 @@ fn key_package_bundle_and_lifecycle_intent_roll_back_together() {
     let mut state = KeyPackageLifecycleState {
         stable_slot_id: "stable-slot".into(),
         phase: MaintenancePhase::Complete,
+        cutover_publication_blocked: false,
         current_key_package: None,
         current_key_package_ref: None,
         current_not_before: None,
@@ -1613,11 +1614,15 @@ fn key_package_bundle_and_lifecycle_intent_roll_back_together() {
         authored_event_id: None,
         authored_event_created_at: None,
         authored_signed_event: None,
+        deleted_live_revision_event_ids: Vec::new(),
+        deletion_overflow_owner_event_id: None,
+        retired_publications_pending_deletion: Vec::new(),
         publication_targets: Vec::new(),
         refresh_at: None,
         upgrade_rotation_recorded: false,
         last_consumed_key_package_ref: None,
         last_consumed_at: None,
+        consumed_key_package_refs: Vec::new(),
         retained_private_material: Vec::new(),
         pending_replacement: None,
     };

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -432,6 +432,18 @@ impl AccountDeviceSession {
         &self.open_timings
     }
 
+    /// A clone of the session's closeable storage handle.
+    ///
+    /// Hosts that must release local file locks at a known instant retain this
+    /// alongside the live session and call [`SqliteAccountStorage::close`]
+    /// during terminal shutdown. Every engine/OpenMLS clone shares the same
+    /// underlying close state, so closing this handle makes the whole session
+    /// storage graph inert without requiring the session to be dropped first.
+    #[must_use]
+    pub fn storage_handle(&self) -> SqliteAccountStorage {
+        self.storage.clone()
+    }
+
     /// Promote one bounded batch of legacy message rows after session
     /// readiness.
     ///

--- a/crates/fs-private/Cargo.toml
+++ b/crates/fs-private/Cargo.toml
@@ -8,5 +8,8 @@ publish.workspace = true
 [dependencies]
 libc.workspace = true
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
+
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/fs-private/src/lib.rs
+++ b/crates/fs-private/src/lib.rs
@@ -9,9 +9,13 @@
 //! Mode application is Unix-only; on other platforms the helpers still create
 //! the artifacts and the mode calls are no-ops.
 
-use std::fs::OpenOptions;
+use std::ffi::OsString;
+use std::fs::{File, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static ATOMIC_PRIVATE_WRITE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Owner-only mode for files holding private data.
 pub const PRIVATE_FILE_MODE: u32 = 0o600;
@@ -779,6 +783,110 @@ pub fn write_private(path: &Path, bytes: &[u8]) -> io::Result<()> {
     file.sync_all()
 }
 
+/// Atomically replace `path` with owner-only `bytes`.
+///
+/// The complete new value is written and synced through a private sibling
+/// inode before rename, then the parent directory is synced where supported.
+/// A process or power failure on Unix therefore leaves either the previous
+/// value or the complete new value, never a truncate-before-write fragment.
+/// The parent directory must already exist; this helper never creates or
+/// changes its permissions.
+pub fn write_private_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    use std::io::Write;
+
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let file_name = path.file_name().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "atomic private write target must name a file",
+        )
+    })?;
+
+    let mut allocated = None;
+    for _ in 0..32 {
+        let attempt = ATOMIC_PRIVATE_WRITE_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let mut temp_name = OsString::from(".");
+        temp_name.push(file_name);
+        temp_name.push(format!(".tmp.{}.{}", std::process::id(), attempt));
+        let temp_path = parent.join(temp_name);
+        match create_new_private(&temp_path) {
+            Ok(file) => {
+                allocated = Some((file, temp_path));
+                break;
+            }
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        }
+    }
+    let (mut file, temp_path) = allocated.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "could not allocate unique atomic private write temp file",
+        )
+    })?;
+
+    let result = (|| -> io::Result<()> {
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        drop(file);
+        replace_private_file(&temp_path, path)?;
+        sync_private_parent(parent)
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp_path);
+    }
+    result
+}
+
+#[cfg(windows)]
+fn replace_private_file(temp_path: &Path, path: &Path) -> io::Result<()> {
+    use std::iter;
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW,
+    };
+
+    let temp_path = temp_path
+        .as_os_str()
+        .encode_wide()
+        .chain(iter::once(0))
+        .collect::<Vec<_>>();
+    let path = path
+        .as_os_str()
+        .encode_wide()
+        .chain(iter::once(0))
+        .collect::<Vec<_>>();
+    let result = unsafe {
+        MoveFileExW(
+            temp_path.as_ptr(),
+            path.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if result == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn replace_private_file(temp_path: &Path, path: &Path) -> io::Result<()> {
+    std::fs::rename(temp_path, path)
+}
+
+#[cfg(unix)]
+fn sync_private_parent(path: &Path) -> io::Result<()> {
+    File::open(path)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_private_parent(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
 /// Open `path` for appending, creating it 0600; tightens a pre-existing file
 /// to 0600.
 pub fn open_private_append(path: &Path) -> io::Result<std::fs::File> {
@@ -1071,6 +1179,46 @@ mod tests {
             assert!(parse_octal_mode(input).is_err(), "input {input:?}");
         }
     }
+
+    #[test]
+    fn write_private_atomic_replaces_complete_value_without_temp_artifacts() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("frontier.json");
+        write_private_atomic(&path, b"old").unwrap();
+        write_private_atomic(&path, b"complete replacement").unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"complete replacement");
+        let entries = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<Vec<_>>();
+        assert_eq!(entries, vec![path.file_name().unwrap()]);
+    }
+
+    #[test]
+    fn write_private_atomic_removes_temp_after_failed_replace() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("occupied");
+        std::fs::create_dir(&path).unwrap();
+
+        assert!(write_private_atomic(&path, b"replacement").is_err());
+        let entries = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<Vec<_>>();
+        assert_eq!(entries, vec![path.file_name().unwrap()]);
+    }
+
+    #[test]
+    fn write_private_atomic_requires_an_existing_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing_parent = dir.path().join("missing");
+        let error = write_private_atomic(&missing_parent.join("frontier.json"), b"value")
+            .expect_err("atomic writes must not create their parent");
+
+        assert_eq!(error.kind(), io::ErrorKind::NotFound);
+        assert!(!missing_parent.exists());
+    }
 }
 
 #[cfg(all(test, unix))]
@@ -1089,6 +1237,61 @@ mod unix_tests {
         write_private(&path, b"secret").unwrap();
         assert_eq!(mode_of(&path), 0o600);
         assert_eq!(std::fs::read(&path).unwrap(), b"secret");
+    }
+
+    #[test]
+    fn write_private_atomic_replacement_remains_owner_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("frontier.json");
+        write_private_atomic(&path, b"old").unwrap();
+        write_private_atomic(&path, b"new").unwrap();
+        assert_eq!(mode_of(&path), 0o600);
+    }
+
+    #[test]
+    fn write_private_atomic_preserves_existing_parent_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("externally-managed");
+        std::fs::create_dir(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let path = parent.join("frontier.json");
+        write_private_atomic(&path, b"value").unwrap();
+
+        assert_eq!(mode_of(&parent), 0o755);
+        assert_eq!(mode_of(&path), 0o600);
+    }
+
+    #[test]
+    fn write_private_atomic_bare_relative_filename_child_process() {
+        let Some(directory) = std::env::var_os("FS_PRIVATE_ATOMIC_RELATIVE_CHILD_DIR") else {
+            return;
+        };
+        std::env::set_current_dir(&directory).unwrap();
+
+        write_private_atomic(Path::new("frontier.json"), b"value").unwrap();
+
+        assert_eq!(mode_of(Path::new(".")), 0o755);
+        assert_eq!(mode_of(Path::new("frontier.json")), 0o600);
+    }
+
+    #[test]
+    fn write_private_atomic_bare_relative_filename_preserves_current_directory_mode() {
+        use std::process::Command;
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+        let status = Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg("unix_tests::write_private_atomic_bare_relative_filename_child_process")
+            .arg("--nocapture")
+            .env("FS_PRIVATE_ATOMIC_RELATIVE_CHILD_DIR", dir.path())
+            .status()
+            .expect("run bare-relative atomic-write child test");
+
+        assert!(status.success(), "atomic-write child process failed");
+        assert_eq!(mode_of(dir.path()), 0o755);
+        assert_eq!(mode_of(&dir.path().join("frontier.json")), 0o600);
     }
 
     #[test]

--- a/crates/marmot-account/Cargo.toml
+++ b/crates/marmot-account/Cargo.toml
@@ -18,6 +18,7 @@ marmot-forensics.workspace = true
 nostr.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+storage-sqlite.workspace = true
 rand.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
@@ -27,7 +28,6 @@ zeroize.workspace = true
 [dev-dependencies]
 cgka-engine.workspace = true
 rusqlite.workspace = true
-storage-sqlite.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 

--- a/crates/marmot-account/src/home.rs
+++ b/crates/marmot-account/src/home.rs
@@ -10,7 +10,8 @@ use zeroize::Zeroizing;
 
 use crate::error::{AccountHomeError, AccountHomeResult};
 use crate::io::{
-    read_json, validate_account_label, write_json, write_secret_bytes, write_secret_json,
+    read_json, sync_directory, validate_account_label, write_json, write_secret_bytes,
+    write_secret_json,
 };
 use crate::secret_store::{
     AccountSecretStore, KeychainSecretStore, LocalFileSecretStore,
@@ -586,6 +587,7 @@ impl AccountHome {
 
     pub fn complete_account_setup(&self, account_ref: &str) -> AccountHomeResult<()> {
         let account = self.account(account_ref)?;
+        let account_dir = self.account_dir(&account.label);
         for path in [
             self.account_setup_state_path(&account.label),
             self.account_setup_context_path(&account.label),
@@ -596,6 +598,10 @@ impl AccountHome {
                 Err(err) => return Err(err.into()),
             }
         }
+        // Setup completion is the durable commit record for restart. Persist
+        // both unlinks before reporting success so a crash cannot resurrect
+        // only one side of the state/context pair.
+        sync_directory(&account_dir)?;
         Ok(())
     }
 

--- a/crates/marmot-account/src/io.rs
+++ b/crates/marmot-account/src/io.rs
@@ -206,12 +206,12 @@ fn replace_file(temp_path: &Path, path: &Path) -> io::Result<()> {
 }
 
 #[cfg(unix)]
-fn sync_directory(path: &Path) -> io::Result<()> {
+pub(crate) fn sync_directory(path: &Path) -> io::Result<()> {
     File::open(path)?.sync_all()
 }
 
 #[cfg(not(unix))]
-fn sync_directory(_path: &Path) -> io::Result<()> {
+pub(crate) fn sync_directory(_path: &Path) -> io::Result<()> {
     Ok(())
 }
 

--- a/crates/marmot-account/src/key_package.rs
+++ b/crates/marmot-account/src/key_package.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use cgka_traits::engine::KeyPackage;
 use cgka_traits::maintenance::SignedPublicationArtifact;
-use cgka_traits::{MemberId, Timestamp, TransportEndpoint};
+use cgka_traits::{MemberId, MessageId, Timestamp, TransportEndpoint};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct KeyPackagePublication {
@@ -22,13 +22,63 @@ pub struct KeyPackagePublishReceipt {
     pub failed: Vec<TransportEndpoint>,
 }
 
+/// Endpoint-level publication evidence for lifecycle-aware callers.
+///
+/// This additive receipt preserves distinctions that the legacy
+/// [`KeyPackagePublishReceipt`] cannot represent. Implementers that only
+/// provide the legacy publisher method remain source-compatible: the trait's
+/// default detailed method adapts their accepted/failed result.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct DetailedKeyPackagePublishReceipt {
+    pub accepted: Vec<TransportEndpoint>,
+    /// Endpoint returned an explicit negative acknowledgement for this exact
+    /// publication attempt. This remains retryable and does not prove absence:
+    /// a legacy client may have exposed the same signed event before crashing
+    /// without persisting its pre-I/O marker.
+    pub rejected: Vec<TransportEndpoint>,
+    /// Endpoint explicitly proved the exact event absent (for example a
+    /// kind-5 target-not-found response). This is terminal for deletion and
+    /// proves a rejected publication revision needs no later deletion there.
+    pub confirmed_absent: Vec<TransportEndpoint>,
+    pub failed: Vec<TransportEndpoint>,
+}
+
+impl From<KeyPackagePublishReceipt> for DetailedKeyPackagePublishReceipt {
+    fn from(receipt: KeyPackagePublishReceipt) -> Self {
+        Self {
+            accepted: receipt.accepted,
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: receipt.failed,
+        }
+    }
+}
+
+impl From<DetailedKeyPackagePublishReceipt> for KeyPackagePublishReceipt {
+    fn from(mut receipt: DetailedKeyPackagePublishReceipt) -> Self {
+        receipt.failed.append(&mut receipt.rejected);
+        receipt.failed.append(&mut receipt.confirmed_absent);
+        receipt.failed.sort();
+        receipt.failed.dedup();
+        receipt
+            .failed
+            .retain(|endpoint| !receipt.accepted.contains(endpoint));
+        Self {
+            accepted: receipt.accepted,
+            failed: receipt.failed,
+        }
+    }
+}
+
 /// Failure returned by a [`KeyPackagePublisher`].
 ///
 /// `externally_exposed` records whether the exact signed event crossed the
 /// transport boundary before the error occurred. The pending replacement and
 /// its private bundle remain durable in either case until acknowledgement or
 /// MLS lifetime expiry; this bit only distinguishes safe regeneration before
-/// exposure from an ambiguous publication that must retry identical bytes.
+/// exposure from an ambiguous publication that must retry identical bytes
+/// within the authored revision. A bounded-age transport may later supersede
+/// that revision at the same replaceable coordinate.
 #[derive(Debug, thiserror::Error)]
 #[error("key package publication failed: {message}")]
 pub struct KeyPackagePublishError {
@@ -69,19 +119,66 @@ pub trait KeyPackagePublisher: Send + Sync {
         Ok(None)
     }
 
+    /// Inclusive age at which a prepared signed artifact is reauthored before
+    /// the next publish attempt.
+    ///
+    /// `None` disables age-based reauthoring and preserves legacy exact-retry
+    /// behavior. Transports whose relays enforce a bounded timestamp window
+    /// may return an age below that window. At `artifact_age >= threshold`,
+    /// the account runtime requests a strictly newer `created_at` for the same
+    /// semantic KeyPackage and stable replaceable-event slot, then persists
+    /// that replacement revision before any network attempt.
+    fn signed_artifact_reauthor_at_age_secs(&self) -> Option<u64> {
+        None
+    }
+
     /// Produce the exact signed transport artifact without network exposure.
     async fn prepare_key_package(
         &self,
         publication: KeyPackagePublication,
     ) -> Result<SignedPublicationArtifact, KeyPackagePublishError>;
 
-    /// Publish an already signed artifact. Retries must pass the identical
-    /// bytes returned by `prepare_key_package`.
+    /// Publish an already signed artifact. Retries within one authored
+    /// revision must pass the identical bytes returned by
+    /// `prepare_key_package`. The runtime may prepare and durably replace a
+    /// stale revision first when [`Self::signed_artifact_reauthor_at_age_secs`]
+    /// opts this transport into bounded-age reauthoring.
     async fn publish_prepared_key_package(
         &self,
         publication: &KeyPackagePublication,
         artifact: &SignedPublicationArtifact,
     ) -> Result<KeyPackagePublishReceipt, KeyPackagePublishError>;
+
+    /// Publish an already signed artifact with detailed endpoint evidence.
+    ///
+    /// Existing implementations need not override this additive method; their
+    /// legacy accepted/failed receipt is promoted conservatively by default.
+    async fn publish_prepared_key_package_detailed(
+        &self,
+        publication: &KeyPackagePublication,
+        artifact: &SignedPublicationArtifact,
+    ) -> Result<DetailedKeyPackagePublishReceipt, KeyPackagePublishError> {
+        self.publish_prepared_key_package(publication, artifact)
+            .await
+            .map(Into::into)
+    }
+
+    /// Delete one superseded signed revision from the listed transport
+    /// endpoints.
+    ///
+    /// Implementations must report endpoint identities exactly. The account
+    /// runtime removes only acknowledged endpoints from its durable deletion
+    /// obligation; a failed, cancelled, or ambiguous call remains retryable.
+    async fn delete_key_package_revision(
+        &self,
+        _event_id: &MessageId,
+        endpoints: &[TransportEndpoint],
+    ) -> Result<DetailedKeyPackagePublishReceipt, KeyPackagePublishError> {
+        Err(KeyPackagePublishError::unexposed(format!(
+            "key package revision deletion is unsupported for {} endpoint(s)",
+            endpoints.len()
+        )))
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -112,6 +209,19 @@ impl KeyPackagePublisher for NoopKeyPackagePublisher {
     ) -> Result<KeyPackagePublishReceipt, KeyPackagePublishError> {
         Ok(KeyPackagePublishReceipt {
             accepted: publication.endpoints.clone(),
+            failed: Vec::new(),
+        })
+    }
+
+    async fn delete_key_package_revision(
+        &self,
+        _event_id: &MessageId,
+        endpoints: &[TransportEndpoint],
+    ) -> Result<DetailedKeyPackagePublishReceipt, KeyPackagePublishError> {
+        Ok(DetailedKeyPackagePublishReceipt {
+            accepted: endpoints.to_vec(),
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
             failed: Vec::new(),
         })
     }

--- a/crates/marmot-account/src/lib.rs
+++ b/crates/marmot-account/src/lib.rs
@@ -21,15 +21,19 @@ pub use home::{
     DEFAULT_KEYCHAIN_SERVICE_NAME, EXTERNAL_SQLCIPHER_SECRET_FILE, NostrAccountImport,
 };
 pub use key_package::{
-    KeyPackagePublication, KeyPackagePublishError, KeyPackagePublishReceipt, KeyPackagePublisher,
-    NoopKeyPackagePublisher,
+    DetailedKeyPackagePublishReceipt, KeyPackagePublication, KeyPackagePublishError,
+    KeyPackagePublishReceipt, KeyPackagePublisher, NoopKeyPackagePublisher,
 };
 pub use routing::{StaticTransportRouting, TransportRoutingError, TransportRoutingPolicy};
 pub use runtime::{
-    AccountDeviceEffects, AccountDeviceRuntime, AccountIngestEffects, CompletedWelcomePublishTask,
+    AccountDeviceEffects, AccountDeviceRuntime, AccountIngestEffects,
+    AccountVisibilityActionOutcome, AccountVisibilityBatch, AccountVisibilityLease,
+    AccountVisibilityOutboundAction, AccountVisibilityRecordKind, AccountVisibilitySource,
+    CompletedWelcomePublishTask, LeasedAccountDeviceEffects, LeasedAccountIngestEffects,
     PendingResolution, PreparedSessionCommit, PreparedSessionSend, PreparedWelcomePublishTask,
-    PublishFailure, PublishedApplicationMessage, UnresolvedApplicationMessage, UnresolvedPublish,
-    UnresolvedPublishReason, WelcomeDeliveryFailure,
+    PublishFailure, PublishedApplicationMessage, RetiredKeyPackageDeletionPassReport,
+    UnresolvedApplicationMessage, UnresolvedPublish, UnresolvedPublishReason,
+    WelcomeDeliveryFailure,
 };
 pub use secret_store::{AccountSecretStore, KeychainSecretStore, LocalFileSecretStore};
 pub use time::{

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -1,7 +1,7 @@
 //! Account-device runtime: drives session effects through transport publish,
 //! confirmation, and rollback, and the effect aggregates it produces.
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -18,13 +18,16 @@ use cgka_traits::group::{Group, Member};
 use cgka_traits::ingest::IngestOutcome;
 use cgka_traits::maintenance::{
     DurableTransportFanout, GroupEvolutionPhase, GroupEvolutionSemantic, GroupMaintenanceStatus,
-    KeyPackageLifecycleState, MaintenanceObligation, MaintenancePhase, MaintenanceTrigger,
-    PeriodicMaintenancePolicy, RetainedKeyPackagePrivateMaterial, SendMaintenanceDisposition,
-    TransportFanoutAttemptState, TransportFanoutTarget,
+    KeyPackageLifecycleState, MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES,
+    MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES_WITH_LIVE_DELETION_OVERFLOW,
+    MaintenanceObligation, MaintenancePhase, MaintenanceTrigger, PeriodicMaintenancePolicy,
+    RetainedKeyPackagePrivateMaterial, RetiredKeyPackagePublication, SendMaintenanceDisposition,
+    SignedPublicationArtifact, TransportFanoutAttemptState, TransportFanoutTarget,
 };
+use cgka_traits::storage::{LeaveRequestStorage, MessageStorage, StorageProvider};
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::{
-    EpochId, FanoutMlsState, FanoutPendingKind, GroupId, MemberId, OutboundFanout,
+    EpochId, FanoutMlsState, FanoutPendingKind, GroupId, MemberId, MessageId, OutboundFanout,
     OutboundFanoutOutcome, StorageError, Timestamp, TransportAccountActivation, TransportAdapter,
     TransportAdapterError, TransportDelivery, TransportEndpoint, TransportEndpointFailure,
     TransportEndpointFailureKind, TransportEndpointReceipt, TransportGroupSync,
@@ -35,9 +38,18 @@ use futures::stream::FuturesUnordered;
 use marmot_forensics::{
     AuditEventContext, AuditEventKind, AuditTransportWire, MessageArtifactKind, PublishRelayFailure,
 };
+use rand::RngCore;
+use rand::rngs::OsRng;
+use serde::{Deserialize, Serialize};
+use storage_sqlite::{
+    AccountVisibilityJournalRow, AccountVisibilityJournalUpsert, SqliteAccountStorage,
+};
 
 use crate::error::{AccountError, AccountResult};
-use crate::key_package::{KeyPackagePublication, KeyPackagePublisher, NoopKeyPackagePublisher};
+use crate::key_package::{
+    DetailedKeyPackagePublishReceipt, KeyPackagePublication, KeyPackagePublisher,
+    NoopKeyPackagePublisher,
+};
 use crate::routing::{
     StaticTransportRouting, TransportRoutingPolicy, publish_target_group_id, publish_target_kind,
     publish_target_relay_urls,
@@ -50,6 +62,10 @@ use crate::time::{
 const TRACE_TARGET: &str = "marmot_account::runtime";
 const WELCOME_PUBLISH_CONCURRENCY: usize = 8;
 const KEY_PACKAGE_MAX_FUTURE_SKEW_SECS: u64 = 5 * 60;
+// One relay attempt bounds a maintenance call by one transport publish
+// deadline even when the durable privacy journal is full. Later ticks drain
+// additional endpoints without monopolizing the serialized account worker.
+const KEY_PACKAGE_RETIRED_DELETION_ATTEMPTS_PER_CALL: usize = 1;
 const KEY_PACKAGE_REFRESH_MIN_LEAD_SECS: u64 = 14 * 24 * 60 * 60;
 const KEY_PACKAGE_REFRESH_MAX_LEAD_SECS: u64 = 21 * 24 * 60 * 60;
 const MAINTENANCE_EOSE_TIMEOUT_SECS: u64 = 5 * 60;
@@ -60,6 +76,9 @@ const PERIODIC_MAX_SECS: u64 = 36 * 24 * 60 * 60;
 const TRANSPORT_FANOUT_RETENTION_SECS: u64 = 24 * 60 * 60;
 const FROZEN_FANOUT_RETRY_BASE_MS: u64 = 30 * 1_000;
 const FROZEN_FANOUT_RETRY_MAX_MS: u64 = 60 * 60 * 1_000;
+const ACCOUNT_VISIBILITY_RECORD_VERSION: u8 = 1;
+const ACCOUNT_VISIBILITY_CONTROL_ORDINAL: u64 = i64::MAX as u64 - 1;
+const ACCOUNT_VISIBILITY_NON_SESSION_ORDINAL: u64 = i64::MAX as u64;
 
 /// Run independent async work with fixed fan-out while returning results in
 /// input order. Completion order therefore cannot reorder reports or select a
@@ -98,6 +117,21 @@ struct PendingFanoutContinuation {
     pending: PendingStateRef,
     kind: FanoutPendingKind,
     post_confirmation_welcomes: Vec<TransportMessage>,
+}
+
+/// Cutover-facing outcome from one bounded retired-KeyPackage deletion pass.
+///
+/// `terminal_endpoints` contains only endpoints whose accepted deletion or
+/// confirmed-absence receipt has already been committed durably. A remaining
+/// uncovered deletion is currently eligible even though no strictly newer
+/// live revision has an accepted receipt at that endpoint; cutover discovery
+/// must therefore stay armed because a later retry may reveal older relay
+/// history.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[must_use]
+pub struct RetiredKeyPackageDeletionPassReport {
+    pub terminal_endpoints: Vec<TransportEndpoint>,
+    pub has_uncovered_eligible_deletion: bool,
 }
 
 enum PreparedLegacyPublish {
@@ -147,6 +181,91 @@ struct CompletedWelcomePublish {
     group_id: Option<GroupId>,
     metadata: Vec<WelcomePublishMetadata>,
     completions: Vec<Option<LegacyPublishCompletion>>,
+}
+
+/// One caller-visible account-effects batch that has not yet crossed the
+/// account-runtime boundary.
+///
+/// The engine persists application deliveries for process-restart replay, but
+/// its live `events_buf` and the account runtime's publication summaries are
+/// one-shot. Keeping the complete account-shaped batch prevents a failed or
+/// cancelled later publish from losing an earlier report, application-message
+/// acceptance, pending resolution, or session event.
+struct RetainedSessionVisibilityBatch {
+    operation_id: Option<[u8; 16]>,
+    effects: AccountDeviceEffects,
+}
+
+#[derive(Clone, Copy)]
+struct SessionVisibilityHandoff {
+    retained_batch_count: usize,
+    operation_id: [u8; 16],
+    fragment_id: u64,
+}
+
+struct DurableVisibilityOperation {
+    source: AccountVisibilitySource,
+    next_event_ordinal: u64,
+    session_control: StoredSessionControlV1,
+    non_session_fragments: BTreeMap<u64, AccountDeviceEffects>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct StoredAccountVisibilityRecordV1 {
+    version: u8,
+    source: AccountVisibilitySource,
+    payload: StoredAccountVisibilityPayloadV1,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum StoredAccountVisibilityPayloadV1 {
+    Header {
+        maintenance_disposition: SendMaintenanceDisposition,
+    },
+    Event {
+        event: GroupEvent,
+        engine_outbox_provenance: bool,
+    },
+    SessionControl(StoredSessionControlV1),
+    NonSession(StoredNonSessionEffectsV1),
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct StoredSessionControlV1 {
+    queued: Vec<StoredQueuedIntentRefV1>,
+    pending_convergence: Vec<GroupId>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct StoredQueuedIntentRefV1 {
+    group_id: GroupId,
+    intent_id: MessageId,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct StoredNonSessionEffectsV1 {
+    reports: Vec<TransportPublishReport>,
+    fanout: Vec<OutboundFanoutOutcome>,
+    failures: Vec<PublishFailure>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    action_outcomes: Vec<AccountVisibilityActionOutcome>,
+    published_app_messages: Vec<PublishedApplicationMessage>,
+    welcome_failures: Vec<WelcomeDeliveryFailure>,
+    pending: Vec<PendingResolution>,
+}
+
+/// Opaque generation for one account-effects visibility handoff.
+///
+/// Acknowledging a stale generation is a no-op: every later leased return
+/// supersedes the prior lease and contains its still-unacknowledged effects.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[must_use = "the matching visibility lease must be acknowledged after projection staging"]
+pub struct AccountVisibilityLease(u64);
+
+struct RetainedReturnedVisibilityLease {
+    lease: AccountVisibilityLease,
+    batch_ids: Vec<Vec<u8>>,
 }
 
 /// Relay-only half of a prepared Welcome retry.
@@ -275,6 +394,25 @@ pub struct AccountDeviceRuntime<A, R = StaticTransportRouting, K = NoopKeyPackag
     /// legacy publish for this message id fails with a transient storage
     /// error. Never set by production code.
     finish_stage_failure: Option<cgka_traits::MessageId>,
+    /// Session visibility drained before an awaited publication completed.
+    /// Batches stay here across `Err` and future cancellation. A later
+    /// successful leased return hands them off in original order.
+    retained_session_visibility: VecDeque<RetainedSessionVisibilityBatch>,
+    visibility_storage: SqliteAccountStorage,
+    durable_visibility_operations: HashMap<[u8; 16], DurableVisibilityOperation>,
+    active_visibility_operation: Option<[u8; 16]>,
+    next_visibility_fragment_id: u64,
+    visibility_load_error: Option<String>,
+    /// Engine application-outbox events are hydrated into the session's live
+    /// buffer before this runtime opens. When the same exact event already has
+    /// a durable visibility row, suppress that one live copy so replay + later
+    /// drain cannot publish it twice.
+    hydrated_visibility_suppressions: Vec<GroupEvent>,
+    /// Exact effects already returned through a leased API but not yet
+    /// acknowledged by the app projection/V1 boundary. A later leased return
+    /// prepends this batch without re-running any publication work.
+    returned_visibility_lease: Option<RetainedReturnedVisibilityLease>,
+    next_visibility_lease_id: u64,
 }
 
 impl<A, R, K> AccountDeviceRuntime<A, R, K>
@@ -284,6 +422,34 @@ where
     K: KeyPackagePublisher,
 {
     pub fn new(session: AccountDeviceSession, adapter: A, routing: R, key_packages: K) -> Self {
+        let visibility_storage = session.storage_handle();
+        let (visibility_load_error, hydrated_visibility_suppressions) =
+            match visibility_storage.load_account_visibility_journal() {
+                Ok(rows) => {
+                    let mut suppressions = Vec::new();
+                    let mut decode_error = None;
+                    for row in rows {
+                        match decode_account_visibility_row(row) {
+                            Ok(batch) => {
+                                if matches!(
+                                    batch.kind,
+                                    AccountVisibilityRecordKind::Event {
+                                        engine_outbox_provenance: true
+                                    }
+                                ) {
+                                    suppressions.extend(batch.effects.events);
+                                }
+                            }
+                            Err(error) => {
+                                decode_error = Some(error.to_string());
+                                break;
+                            }
+                        }
+                    }
+                    (decode_error, suppressions)
+                }
+                Err(error) => (Some(error.to_string()), Vec::new()),
+            };
         Self {
             session,
             adapter,
@@ -296,6 +462,15 @@ where
             maintenance_quiet_monotonic: HashMap::new(),
             detached_welcome_publishes: HashSet::new(),
             finish_stage_failure: None,
+            retained_session_visibility: VecDeque::new(),
+            visibility_storage,
+            durable_visibility_operations: HashMap::new(),
+            active_visibility_operation: None,
+            next_visibility_fragment_id: 1,
+            visibility_load_error,
+            hydrated_visibility_suppressions,
+            returned_visibility_lease: None,
+            next_visibility_lease_id: 1,
         }
     }
 
@@ -472,8 +647,10 @@ where
         Ok(())
     }
 
-    /// Re-send the exact current durable authored KeyPackage event to the
-    /// current authoritative publication targets without staging a replacement.
+    /// Re-send the current durable authored KeyPackage event to the current
+    /// authoritative publication targets without staging a replacement MLS
+    /// KeyPackage. A bounded-age transport may first author a newer signed
+    /// revision at the same replaceable-event coordinate.
     ///
     /// When no usable current package or signed artifact exists, this falls back to
     /// [`Self::publish_fresh_key_package`].
@@ -487,6 +664,7 @@ where
             );
             return self.publish_fresh_key_package().await;
         };
+        ensure_key_package_cutover_publication_allowed(&lifecycle)?;
         if lifecycle.pending_replacement.is_some() {
             return Err(AccountError::KeyPackageRotationInProgress);
         }
@@ -515,6 +693,19 @@ where
         );
 
         let current_endpoints = self.routing.key_package_endpoints();
+        let additional_policy_targets = current_endpoints
+            .iter()
+            .filter(|endpoint| {
+                !lifecycle
+                    .publication_targets
+                    .iter()
+                    .any(|target| target.endpoint == **endpoint)
+            })
+            .count();
+        self.ensure_key_package_publication_liability_capacity(
+            &mut lifecycle,
+            additional_policy_targets,
+        )?;
         merge_republish_publication_targets(&mut lifecycle.publication_targets, &current_endpoints);
         let endpoints = current_endpoints.to_vec();
         if endpoints.is_empty() {
@@ -525,15 +716,6 @@ where
             .into());
         }
 
-        let Some(artifact) = lifecycle.authored_signed_event.clone() else {
-            tracing::debug!(
-                target: TRACE_TARGET,
-                method = "republish_key_package",
-                fallback_reason = "missing_authored_signed_event",
-                "no republishable current key package artifact; falling back to fresh publication"
-            );
-            return self.publish_fresh_key_package().await;
-        };
         let Some(key_package) = lifecycle.current_key_package.clone() else {
             tracing::debug!(
                 target: TRACE_TARGET,
@@ -543,9 +725,18 @@ where
             );
             return self.publish_fresh_key_package().await;
         };
+        self.reauthor_current_key_package_if_stale(&mut lifecycle, &key_package, &endpoints)
+            .await?;
+        let Some(artifact) = lifecycle.authored_signed_event.clone() else {
+            tracing::debug!(
+                target: TRACE_TARGET,
+                method = "republish_key_package",
+                fallback_reason = "missing_authored_signed_event",
+                "no republishable current key package artifact; falling back to fresh publication"
+            );
+            return self.publish_fresh_key_package().await;
+        };
 
-        lifecycle.phase = cgka_traits::MaintenancePhase::Fanout;
-        self.session.put_key_package_lifecycle(&lifecycle)?;
         let publication = KeyPackagePublication {
             account_id: self.session.self_id().clone(),
             key_package: key_package.clone(),
@@ -553,18 +744,26 @@ where
             created_at: artifact.created_at,
             endpoints: endpoints.clone(),
         };
+        lifecycle.phase = cgka_traits::MaintenancePhase::Fanout;
+        begin_key_package_attempt(
+            &mut lifecycle.publication_targets,
+            &publication.endpoints,
+            self.wall_clock.now(),
+        );
+        self.session.put_key_package_lifecycle(&lifecycle)?;
         match self
             .key_packages
-            .publish_prepared_key_package(&publication, &artifact)
+            .publish_prepared_key_package_detailed(&publication, &artifact)
             .await
         {
             Ok(receipt) => {
-                note_key_package_attempt(
+                let receipt = scope_key_package_publish_receipt(receipt, &publication.endpoints);
+                finish_key_package_attempt(
                     &mut lifecycle.publication_targets,
-                    &publication.endpoints,
                     &receipt.accepted,
+                    &receipt.rejected,
+                    &receipt.confirmed_absent,
                     &receipt.failed,
-                    self.wall_clock.now(),
                 );
                 if receipt.accepted.is_empty() {
                     lifecycle.phase = cgka_traits::MaintenancePhase::Retry;
@@ -574,13 +773,11 @@ where
                     )
                     .into());
                 }
-                lifecycle.phase = if lifecycle.publication_targets.iter().all(|target| {
-                    matches!(
-                        target.state,
-                        TransportFanoutAttemptState::Accepted
-                            | TransportFanoutAttemptState::PolicyProhibited
-                    )
-                }) {
+                lifecycle.phase = if lifecycle
+                    .publication_targets
+                    .iter()
+                    .all(key_package_target_is_terminal)
+                {
                     cgka_traits::MaintenancePhase::Complete
                 } else {
                     cgka_traits::MaintenancePhase::Fanout
@@ -589,13 +786,6 @@ where
                 Ok(key_package)
             }
             Err(error) => {
-                note_key_package_attempt(
-                    &mut lifecycle.publication_targets,
-                    &publication.endpoints,
-                    &[],
-                    &[],
-                    self.wall_clock.now(),
-                );
                 lifecycle.phase = if error.externally_exposed {
                     cgka_traits::MaintenancePhase::Fanout
                 } else {
@@ -607,13 +797,213 @@ where
         }
     }
 
-    /// Stage the exact next KeyPackage and authored publication bytes without
-    /// performing any network I/O.
+    /// Replace a stale pending transport revision without replacing the MLS
+    /// KeyPackage or its durable private material. The signed revision and all
+    /// correlated lifecycle fields are committed before any network call.
+    async fn reauthor_pending_key_package_if_stale(
+        &mut self,
+        lifecycle: &mut KeyPackageLifecycleState,
+    ) -> AccountResult<()> {
+        let Some(pending) = lifecycle.pending_replacement.as_ref() else {
+            return Ok(());
+        };
+        let Some(previous_artifact) = pending.signed_event.clone() else {
+            return Ok(());
+        };
+        let pending_key_package = pending.key_package.clone();
+        let pending_key_package_ref = pending.key_package_ref.clone();
+        let pending_not_after = pending.not_after;
+        let pending_targets = pending.targets.clone();
+        let now = self.wall_clock.now();
+        let force_reauthor = lifecycle
+            .deleted_live_revision_event_ids
+            .contains(&previous_artifact.id);
+        let reauthor_after = force_reauthor
+            .then_some(0)
+            .or(self.key_packages.signed_artifact_reauthor_at_age_secs());
+        let created_at = match key_package_reauthor_created_at(
+            &previous_artifact,
+            now,
+            reauthor_after,
+            lifecycle.authored_event_created_at,
+            true,
+        ) {
+            Ok(Some(created_at)) => created_at,
+            Ok(None) => return Ok(()),
+            Err(()) => {
+                lifecycle.phase = MaintenancePhase::ClockSkewBlocked;
+                self.session.put_key_package_lifecycle(lifecycle)?;
+                return Err(AccountError::ClockSkewBlocked);
+            }
+        };
+        let endpoints = pending_targets
+            .iter()
+            .filter(|target| target.state != TransportFanoutAttemptState::PolicyProhibited)
+            .map(|target| target.endpoint.clone())
+            .collect::<Vec<_>>();
+        let publication = KeyPackagePublication {
+            account_id: self.session.self_id().clone(),
+            key_package: pending_key_package,
+            slot_id: lifecycle.stable_slot_id.clone(),
+            created_at,
+            endpoints: endpoints.clone(),
+        };
+        let retired_publication = retired_key_package_publication(
+            &previous_artifact,
+            Some(&pending_key_package_ref),
+            Some(pending_not_after),
+            false,
+            &pending_targets,
+        );
+        let projected_liabilities = projected_pending_key_package_reauthor_liability_count(
+            lifecycle,
+            retired_publication.as_ref(),
+            &endpoints,
+        );
+        self.ensure_key_package_publication_liability_count(lifecycle, projected_liabilities)?;
+        let artifact = self.key_packages.prepare_key_package(publication).await?;
+        validate_reauthored_key_package_artifact(&previous_artifact, created_at, &artifact)?;
+
+        if let Some(retired_publication) = retired_publication {
+            retain_retired_key_package_publication(lifecycle, retired_publication);
+        }
+        let pending = lifecycle
+            .pending_replacement
+            .as_mut()
+            .expect("pending replacement remains serialized while reauthoring");
+        pending.authored_created_at = artifact.created_at;
+        pending.signed_event = Some(artifact);
+        pending.attempt_count = 0;
+        pending.last_failure_code = None;
+        replace_key_package_publication_targets(&mut pending.targets, &endpoints);
+        lifecycle
+            .deleted_live_revision_event_ids
+            .retain(|event_id| *event_id != previous_artifact.id);
+        lifecycle.phase = MaintenancePhase::PendingPublication;
+        self.session.put_key_package_lifecycle(lifecycle)?;
+        Ok(())
+    }
+
+    /// Reconcile a durable pending revision with the account's current
+    /// authoritative publication policy before either reauthoring or sending
+    /// it. Endpoint changes do not alter the signed Nostr event bytes, but they
+    /// do alter the exact privacy-liability set and therefore must pass the
+    /// global bound and commit before network I/O.
+    fn reconcile_pending_key_package_publication_targets(
+        &mut self,
+        lifecycle: &mut KeyPackageLifecycleState,
+        authoritative_endpoints: &[TransportEndpoint],
+    ) -> AccountResult<()> {
+        let Some(_) = lifecycle.pending_replacement.as_ref() else {
+            return Ok(());
+        };
+        let mut reconciled = lifecycle.clone();
+        merge_republish_publication_targets(
+            &mut reconciled
+                .pending_replacement
+                .as_mut()
+                .expect("pending replacement remains present in cloned lifecycle")
+                .targets,
+            authoritative_endpoints,
+        );
+        if key_package_signed_publication_liability_count(&reconciled)
+            > MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES
+        {
+            lifecycle.phase = MaintenancePhase::Retry;
+            self.session.put_key_package_lifecycle(lifecycle)?;
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "key package signed-publication endpoint-liability journal is full",
+            )
+            .into());
+        }
+        if reconciled != *lifecycle {
+            *lifecycle = reconciled;
+            self.session.put_key_package_lifecycle(lifecycle)?;
+        }
+        Ok(())
+    }
+
+    /// Replace a stale current transport revision while retaining the same MLS
+    /// KeyPackage coordinate. Every live target must receive the newer
+    /// parameterized-replaceable event, including relays that acknowledged the
+    /// superseded revision.
+    async fn reauthor_current_key_package_if_stale(
+        &mut self,
+        lifecycle: &mut KeyPackageLifecycleState,
+        key_package: &KeyPackage,
+        live_endpoints: &[TransportEndpoint],
+    ) -> AccountResult<()> {
+        let Some(previous_artifact) = lifecycle.authored_signed_event.clone() else {
+            return Ok(());
+        };
+        let now = self.wall_clock.now();
+        let force_reauthor = lifecycle
+            .deleted_live_revision_event_ids
+            .contains(&previous_artifact.id);
+        let reauthor_after = force_reauthor
+            .then_some(0)
+            .or(self.key_packages.signed_artifact_reauthor_at_age_secs());
+        let created_at = match key_package_reauthor_created_at(
+            &previous_artifact,
+            now,
+            reauthor_after,
+            lifecycle.authored_event_created_at,
+            false,
+        ) {
+            Ok(Some(created_at)) => created_at,
+            Ok(None) => return Ok(()),
+            Err(()) => {
+                lifecycle.phase = MaintenancePhase::ClockSkewBlocked;
+                self.session.put_key_package_lifecycle(lifecycle)?;
+                return Err(AccountError::ClockSkewBlocked);
+            }
+        };
+        let publication = KeyPackagePublication {
+            account_id: self.session.self_id().clone(),
+            key_package: key_package.clone(),
+            slot_id: lifecycle.stable_slot_id.clone(),
+            created_at,
+            endpoints: live_endpoints.to_vec(),
+        };
+        let retired_publication = retired_key_package_publication(
+            &previous_artifact,
+            lifecycle.current_key_package_ref.as_deref(),
+            lifecycle.current_not_after,
+            false,
+            &lifecycle.publication_targets,
+        );
+        let projected_liabilities = projected_current_key_package_reauthor_liability_count(
+            lifecycle,
+            retired_publication.as_ref(),
+            live_endpoints,
+        );
+        self.ensure_key_package_publication_liability_count(lifecycle, projected_liabilities)?;
+        let artifact = self.key_packages.prepare_key_package(publication).await?;
+        validate_reauthored_key_package_artifact(&previous_artifact, created_at, &artifact)?;
+
+        if let Some(retired_publication) = retired_publication {
+            retain_retired_key_package_publication(lifecycle, retired_publication);
+        }
+        lifecycle.authored_event_id = Some(artifact.id.clone());
+        lifecycle.authored_event_created_at = Some(artifact.created_at);
+        lifecycle.authored_signed_event = Some(artifact);
+        lifecycle
+            .deleted_live_revision_event_ids
+            .retain(|event_id| *event_id != previous_artifact.id);
+        replace_key_package_publication_targets(&mut lifecycle.publication_targets, live_endpoints);
+        lifecycle.phase = MaintenancePhase::Fanout;
+        self.session.put_key_package_lifecycle(lifecycle)?;
+        Ok(())
+    }
+
+    /// Stage the next MLS KeyPackage, durable private material, and initial
+    /// signed publication revision without performing any network I/O.
     ///
     /// This is the durable local-readiness boundary for generated accounts:
     /// callers may return the identity only after this succeeds, then resume
-    /// [`Self::publish_fresh_key_package`] later with the same persisted
-    /// private material and signed artifact.
+    /// the same durable lifecycle later. Publication uses the current signed
+    /// revision exactly unless bounded-age policy first persists a newer
+    /// revision at the same replaceable-event coordinate.
     pub async fn prepare_fresh_key_package(
         &mut self,
         endpoints: Vec<TransportEndpoint>,
@@ -624,6 +1014,7 @@ where
             endpoint_count = endpoints.len(),
             "preparing fresh key package for later publication"
         );
+        self.sweep_expired_key_package_private_material()?;
         let now = self.wall_clock.now();
         let mut lifecycle = match self.session.key_package_lifecycle()? {
             Some(state) => state,
@@ -639,6 +1030,7 @@ where
                 KeyPackageLifecycleState {
                     stable_slot_id,
                     phase: cgka_traits::MaintenancePhase::Complete,
+                    cutover_publication_blocked: false,
                     current_key_package: None,
                     current_key_package_ref: None,
                     current_not_before: None,
@@ -646,11 +1038,15 @@ where
                     authored_event_id: None,
                     authored_event_created_at: None,
                     authored_signed_event: None,
+                    deleted_live_revision_event_ids: Vec::new(),
+                    deletion_overflow_owner_event_id: None,
+                    retired_publications_pending_deletion: Vec::new(),
                     publication_targets: Vec::new(),
                     refresh_at: None,
                     upgrade_rotation_recorded: false,
                     last_consumed_key_package_ref: None,
                     last_consumed_at: None,
+                    consumed_key_package_refs: Vec::new(),
                     retained_private_material: Vec::new(),
                     pending_replacement: None,
                 }
@@ -685,7 +1081,8 @@ where
                 created_at,
                 lead,
                 endpoints
-                    .into_iter()
+                    .iter()
+                    .cloned()
                     .map(|endpoint| TransportFanoutTarget {
                         endpoint,
                         state: TransportFanoutAttemptState::Unattempted,
@@ -696,6 +1093,12 @@ where
                     .collect(),
             )?;
         }
+
+        // A pending replacement can outlive the route policy that originally
+        // staged it. Reconcile before signing so a zero-target draft is not
+        // frozen into an artifact that a real transport correctly refuses to
+        // publish once a route later appears.
+        self.reconcile_pending_key_package_publication_targets(&mut lifecycle, &endpoints)?;
 
         if lifecycle
             .pending_replacement
@@ -714,9 +1117,14 @@ where
                 endpoints: pending
                     .targets
                     .iter()
+                    .filter(|target| target.state != TransportFanoutAttemptState::PolicyProhibited)
                     .map(|target| target.endpoint.clone())
                     .collect(),
             };
+            self.ensure_key_package_publication_liability_capacity(
+                &mut lifecycle,
+                publication.endpoints.len(),
+            )?;
             let artifact = self.key_packages.prepare_key_package(publication).await?;
             lifecycle
                 .pending_replacement
@@ -726,6 +1134,14 @@ where
             // Exact signed bytes are durable before the first network call.
             self.session.put_key_package_lifecycle(&lifecycle)?;
         }
+
+        // Relay discovery may have advanced the stable-slot high-water after
+        // this exact pending artifact was signed. Reauthor locally while the
+        // cutover gate is still armed; the superseded exact revision and the
+        // strict-newer signed bytes commit before this method returns, and no
+        // network I/O occurs here.
+        self.reauthor_pending_key_package_if_stale(&mut lifecycle)
+            .await?;
 
         Ok(lifecycle
             .pending_replacement
@@ -742,12 +1158,20 @@ where
             endpoint_count = self.routing.key_package_endpoints().len(),
             "publishing fresh key package"
         );
+        if let Some(lifecycle) = self.session.key_package_lifecycle()? {
+            ensure_key_package_cutover_publication_allowed(&lifecycle)?;
+        }
         let endpoints = self.routing.key_package_endpoints().to_vec();
-        self.prepare_fresh_key_package(endpoints).await?;
+        self.prepare_fresh_key_package(endpoints.clone()).await?;
         let mut lifecycle = self
             .session
             .key_package_lifecycle()?
             .expect("prepared lifecycle is durable");
+
+        self.reconcile_pending_key_package_publication_targets(&mut lifecycle, &endpoints)?;
+
+        self.reauthor_pending_key_package_if_stale(&mut lifecycle)
+            .await?;
 
         let pending = lifecycle
             .pending_replacement
@@ -766,15 +1190,27 @@ where
             endpoints: pending
                 .targets
                 .iter()
+                .filter(|target| target.state != TransportFanoutAttemptState::PolicyProhibited)
                 .map(|target| target.endpoint.clone())
                 .collect(),
         };
+        begin_key_package_attempt(
+            &mut lifecycle
+                .pending_replacement
+                .as_mut()
+                .expect("pending replacement remains durable before publication")
+                .targets,
+            &publication.endpoints,
+            self.wall_clock.now(),
+        );
+        lifecycle.phase = MaintenancePhase::PendingPublication;
+        self.session.put_key_package_lifecycle(&lifecycle)?;
         let receipt = match self
             .key_packages
-            .publish_prepared_key_package(&publication, &artifact)
+            .publish_prepared_key_package_detailed(&publication, &artifact)
             .await
         {
-            Ok(receipt) => receipt,
+            Ok(receipt) => scope_key_package_publish_receipt(receipt, &publication.endpoints),
             Err(error) => {
                 if let Some(pending) = lifecycle.pending_replacement.as_mut() {
                     pending.attempt_count = pending.attempt_count.saturating_add(1);
@@ -786,13 +1222,6 @@ where
                         }
                         .into(),
                     );
-                    note_key_package_attempt(
-                        &mut pending.targets,
-                        &publication.endpoints,
-                        &[],
-                        &[],
-                        self.wall_clock.now(),
-                    );
                 }
                 lifecycle.phase = cgka_traits::MaintenancePhase::Retry;
                 self.session.put_key_package_lifecycle(&lifecycle)?;
@@ -803,12 +1232,12 @@ where
             if let Some(pending) = lifecycle.pending_replacement.as_mut() {
                 pending.attempt_count = pending.attempt_count.saturating_add(1);
                 pending.last_failure_code = Some("ambiguous_exposure".into());
-                note_key_package_attempt(
+                finish_key_package_attempt(
                     &mut pending.targets,
-                    &publication.endpoints,
                     &receipt.accepted,
+                    &receipt.rejected,
+                    &receipt.confirmed_absent,
                     &receipt.failed,
-                    self.wall_clock.now(),
                 );
             }
             lifecycle.phase = cgka_traits::MaintenancePhase::Retry;
@@ -823,16 +1252,27 @@ where
             .pending_replacement
             .take()
             .expect("published replacement exists");
-        note_key_package_attempt(
+        finish_key_package_attempt(
             &mut replacement.targets,
-            &publication.endpoints,
             &receipt.accepted,
+            &receipt.rejected,
+            &receipt.confirmed_absent,
             &receipt.failed,
-            self.wall_clock.now(),
         );
         let previous = lifecycle.current_key_package.clone();
-        let previous_was_consumed = lifecycle.current_key_package_ref.is_some()
-            && lifecycle.current_key_package_ref == lifecycle.last_consumed_key_package_ref;
+        let previous_key_package_ref = lifecycle.current_key_package_ref.clone();
+        let previous_was_consumed = previous_key_package_ref
+            .as_deref()
+            .is_some_and(|key_package_ref| lifecycle.key_package_ref_is_consumed(key_package_ref));
+        let superseded_publication =
+            retired_current_key_package_publication(&lifecycle, previous_was_consumed);
+        if let Some(superseded_publication) = superseded_publication {
+            retain_retired_key_package_publication(&mut lifecycle, superseded_publication);
+        }
+        if previous_was_consumed && let Some(key_package_ref) = previous_key_package_ref.as_deref()
+        {
+            mark_retired_key_package_revisions_unusable(&mut lifecycle, key_package_ref);
+        }
         if !previous_was_consumed
             && let (Some(key_package), Some(key_package_ref), Some(not_after)) = (
                 previous.clone(),
@@ -856,22 +1296,27 @@ where
         lifecycle.authored_event_id = Some(artifact.id.clone());
         lifecycle.authored_event_created_at = Some(artifact.created_at);
         lifecycle.authored_signed_event = Some(artifact);
+        // A relay-acknowledged semantic replacement supersedes every deleted
+        // live revision that could otherwise have been retried.
+        lifecycle.deleted_live_revision_event_ids.clear();
         lifecycle.publication_targets = replacement.targets;
         lifecycle.refresh_at = Some(replacement.refresh_at);
-        lifecycle.phase = if lifecycle.publication_targets.iter().all(|target| {
-            matches!(
-                target.state,
-                TransportFanoutAttemptState::Accepted
-                    | TransportFanoutAttemptState::PolicyProhibited
-            )
-        }) {
+        lifecycle.phase = if lifecycle
+            .publication_targets
+            .iter()
+            .all(key_package_target_is_terminal)
+        {
             cgka_traits::MaintenancePhase::Complete
         } else {
             cgka_traits::MaintenancePhase::Fanout
         };
         lifecycle.upgrade_rotation_recorded = true;
-        lifecycle.last_consumed_key_package_ref = None;
-        lifecycle.last_consumed_at = None;
+        if previous_was_consumed
+            && let Some(key_package_ref) = previous_key_package_ref.as_deref()
+            && !key_package_ref_has_live_private_material(&lifecycle, key_package_ref)
+        {
+            lifecycle.clear_consumed_key_package_ref(key_package_ref);
+        }
         let retired = if previous_was_consumed {
             previous.into_iter().collect::<Vec<_>>()
         } else {
@@ -888,6 +1333,659 @@ where
         Ok(self.session.key_package_lifecycle()?)
     }
 
+    /// Transfer cutover-era Welcome-consumption evidence onto every exact
+    /// relay revision admitted by a completed authoritative scan, then reclaim
+    /// bounded ref-journal entries that no longer protect live private
+    /// material.
+    ///
+    /// The app calls this after all authoritative relay pages were processed
+    /// and before it persists the scan-complete marker or clears the
+    /// publication gate. A crash beforehand retains the refs; afterward each
+    /// matching exact liability independently carries
+    /// `delete_without_successor`.
+    pub fn finalize_key_package_cutover_consumption_evidence(&mut self) -> AccountResult<()> {
+        let Some(mut lifecycle) = self.session.key_package_lifecycle()? else {
+            return Ok(());
+        };
+        let mut live_refs = lifecycle
+            .current_key_package_ref
+            .clone()
+            .into_iter()
+            .chain(
+                lifecycle
+                    .pending_replacement
+                    .as_ref()
+                    .map(|pending| pending.key_package_ref.clone()),
+            )
+            .chain(
+                lifecycle
+                    .retained_private_material
+                    .iter()
+                    .map(|retained| retained.key_package_ref.clone()),
+            )
+            .collect::<Vec<_>>();
+        for key_package in self.session.durably_owned_key_packages()? {
+            let metadata = self.session.key_package_metadata(&key_package)?;
+            live_refs.push(hex::decode(&metadata.key_package_ref_hex).map_err(|error| {
+                cgka_traits::EngineError::Serialize(format!(
+                    "durable key package reference: {error}"
+                ))
+            })?);
+        }
+        live_refs.sort();
+        live_refs.dedup();
+
+        let refs = lifecycle.consumed_key_package_refs.clone();
+        for key_package_ref in refs {
+            mark_retired_key_package_revisions_unusable(&mut lifecycle, &key_package_ref);
+            if live_refs.contains(&key_package_ref) {
+                continue;
+            }
+            lifecycle.clear_consumed_key_package_ref(&key_package_ref);
+        }
+        self.session.put_key_package_lifecycle(&lifecycle)?;
+        Ok(())
+    }
+
+    /// Persist the upgrade-cutover publication interlock under the account
+    /// runtime's single-writer authority.
+    ///
+    /// Exact retired-revision deletion remains available while blocked. Every
+    /// kind-30443 publication path checks this bit immediately before it can
+    /// prepare a network attempt, so worker ticks and manual commands cannot
+    /// race an incomplete relay scan.
+    pub fn set_key_package_cutover_publication_blocked(
+        &mut self,
+        blocked: bool,
+    ) -> AccountResult<()> {
+        let Some(mut lifecycle) = self.session.key_package_lifecycle()? else {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "cannot update the key package cutover gate without lifecycle state",
+            )
+            .into());
+        };
+        if lifecycle.stable_slot_id.is_empty() {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "cannot update the key package cutover gate without a stable slot",
+            )
+            .into());
+        }
+        if lifecycle.cutover_publication_blocked != blocked {
+            lifecycle.cutover_publication_blocked = blocked;
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+        }
+        Ok(())
+    }
+
+    /// Retain the signed relay timestamp of an exact live same-slot revision.
+    ///
+    /// Upgrade-era cache rows can carry a defaulted or stale `published_at`
+    /// even though the relay still has the exact signed event.  A strict
+    /// cutover scan verifies the event signature and stable slot before
+    /// calling this method. Persisting both the raw timestamp and every exact
+    /// source endpoint before the scan is marked complete prevents a later
+    /// replacement from losing NIP-33 ordering or hiding an old relay copy
+    /// after a local clock rollback or route change. Endpoints beyond the
+    /// ordinary liability bound are returned deferred; strict cutover must
+    /// retain its publication gate until those endpoints are durable.
+    pub fn observe_live_key_package_publication(
+        &mut self,
+        stable_slot_id: String,
+        event_id: &MessageId,
+        authored_created_at: Timestamp,
+        mut endpoints: Vec<TransportEndpoint>,
+    ) -> AccountResult<(Vec<TransportEndpoint>, Vec<TransportEndpoint>)> {
+        if endpoints.is_empty() {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "observed live key package revision requires at least one source endpoint",
+            )
+            .into());
+        }
+        let Some(mut lifecycle) = self.session.key_package_lifecycle()? else {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "cannot observe a live key package revision without lifecycle state",
+            )
+            .into());
+        };
+        if lifecycle.stable_slot_id.is_empty() || lifecycle.stable_slot_id != stable_slot_id {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "observed live key package revision does not match the local stable slot",
+            )
+            .into());
+        }
+        let matches_current = lifecycle
+            .authored_signed_event
+            .as_ref()
+            .is_some_and(|artifact| artifact.id == *event_id)
+            || lifecycle.authored_event_id.as_ref() == Some(event_id);
+        let matches_pending = lifecycle
+            .pending_replacement
+            .as_ref()
+            .and_then(|pending| pending.signed_event.as_ref())
+            .is_some_and(|artifact| artifact.id == *event_id);
+        if !matches_current && !matches_pending {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "observed key package revision is not the exact live current or pending event",
+            )
+            .into());
+        }
+
+        endpoints.sort();
+        endpoints.dedup();
+        let mut liability_count = key_package_signed_publication_liability_count(&lifecycle);
+        let mut admitted = Vec::new();
+        let mut deferred = Vec::new();
+        for endpoint in endpoints {
+            let already_durable =
+                key_package_event_endpoint_is_liability(&lifecycle, event_id, &endpoint);
+            if !already_durable && liability_count >= MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES
+            {
+                deferred.push(endpoint);
+                continue;
+            }
+            if !already_durable {
+                liability_count = liability_count.saturating_add(1);
+            }
+            admitted.push(endpoint);
+        }
+
+        let targets = if matches_current {
+            &mut lifecycle.publication_targets
+        } else {
+            &mut lifecycle
+                .pending_replacement
+                .as_mut()
+                .expect("a matching pending artifact remains in lifecycle state")
+                .targets
+        };
+        let mut targets_changed = false;
+        for endpoint in &admitted {
+            if let Some(target) = targets
+                .iter_mut()
+                .find(|target| target.endpoint == *endpoint)
+            {
+                let observed_attempt_at = target
+                    .last_attempt_at
+                    .map(|previous| previous.max(authored_created_at))
+                    .unwrap_or(authored_created_at);
+                if target.state != TransportFanoutAttemptState::Accepted
+                    || target.attempt_count == 0
+                    || target.last_attempt_at != Some(observed_attempt_at)
+                    || target.failure_code.is_some()
+                {
+                    target.state = TransportFanoutAttemptState::Accepted;
+                    target.attempt_count = target.attempt_count.max(1);
+                    target.last_attempt_at = Some(observed_attempt_at);
+                    target.failure_code = None;
+                    targets_changed = true;
+                }
+            } else {
+                targets.push(TransportFanoutTarget {
+                    endpoint: endpoint.clone(),
+                    state: TransportFanoutAttemptState::Accepted,
+                    attempt_count: 1,
+                    last_attempt_at: Some(authored_created_at),
+                    failure_code: None,
+                });
+                targets_changed = true;
+            }
+        }
+        targets.sort_by(|left, right| left.endpoint.cmp(&right.endpoint));
+
+        let observed_high_water = lifecycle
+            .authored_event_created_at
+            .map(|previous| previous.max(authored_created_at))
+            .unwrap_or(authored_created_at);
+        if lifecycle.authored_event_created_at != Some(observed_high_water) || targets_changed {
+            lifecycle.authored_event_created_at = Some(observed_high_water);
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+        }
+        Ok((admitted, deferred))
+    }
+
+    /// Durably import an exact non-live KeyPackage revision discovered during
+    /// an upgrade relay scan, without performing transport I/O.
+    ///
+    /// The caller must pass the parsed event's stable slot and
+    /// safety-canonicalized source endpoints. The slot must match this local
+    /// account-device lifecycle; same-account directory scans can also return
+    /// sibling-device slots, which must never be deleted. Existing
+    /// event/endpoint liabilities are returned as admitted, while newly seen
+    /// endpoints are admitted individually up to the global journal bound and
+    /// the remainder are returned as deferred. A live current or pending event
+    /// id is rejected so discovery cannot reclassify the selected revision as
+    /// retired behind the account worker's back.
+    pub fn journal_discovered_retired_key_package_publication(
+        &mut self,
+        stable_slot_id: String,
+        event_id: MessageId,
+        authored_created_at: Timestamp,
+        key_package_ref: Vec<u8>,
+        package_not_after: Timestamp,
+        endpoints: Vec<TransportEndpoint>,
+    ) -> AccountResult<(Vec<TransportEndpoint>, Vec<TransportEndpoint>)> {
+        self.journal_discovered_retired_key_package_publication_with_policy(
+            stable_slot_id,
+            event_id,
+            authored_created_at,
+            key_package_ref,
+            package_not_after,
+            endpoints,
+            false,
+        )
+    }
+
+    /// The teardown variant commits destructive eligibility in the same SQL
+    /// lifecycle update that first journals a relay-revealed predecessor.
+    #[allow(clippy::too_many_arguments)]
+    pub fn journal_discovered_retired_key_package_publication_with_policy(
+        &mut self,
+        stable_slot_id: String,
+        event_id: MessageId,
+        authored_created_at: Timestamp,
+        key_package_ref: Vec<u8>,
+        package_not_after: Timestamp,
+        mut endpoints: Vec<TransportEndpoint>,
+        delete_without_successor: bool,
+    ) -> AccountResult<(Vec<TransportEndpoint>, Vec<TransportEndpoint>)> {
+        if endpoints.is_empty() {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "discovered key package revision requires at least one source endpoint",
+            )
+            .into());
+        }
+        let Some(mut lifecycle) = self.session.key_package_lifecycle()? else {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "cannot journal a discovered key package revision without lifecycle state",
+            )
+            .into());
+        };
+        if lifecycle.stable_slot_id.is_empty() {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "cannot journal a discovered key package revision without a stable slot",
+            )
+            .into());
+        }
+        if stable_slot_id != lifecycle.stable_slot_id {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "discovered key package revision does not match the local stable slot",
+            )
+            .into());
+        }
+        let matches_current = lifecycle
+            .authored_signed_event
+            .as_ref()
+            .is_some_and(|artifact| artifact.id == event_id)
+            || lifecycle.authored_event_id.as_ref() == Some(&event_id);
+        let matches_pending = lifecycle
+            .pending_replacement
+            .as_ref()
+            .and_then(|pending| pending.signed_event.as_ref())
+            .is_some_and(|artifact| artifact.id == event_id);
+        let matches_durably_deleted_live_revision = lifecycle
+            .deleted_live_revision_event_ids
+            .contains(&event_id);
+        if (matches_current || matches_pending) && !matches_durably_deleted_live_revision {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "cannot classify a live key package revision as relay-discovered retirement",
+            )
+            .into());
+        }
+
+        // A relay can expose a same-slot revision authored by an older client
+        // after the local lifecycle snapshot was persisted. Preserve that
+        // transport ordering evidence even when journal capacity defers every
+        // endpoint: the next fresh artifact must sort strictly after every
+        // discovered revision or it cannot supersede the relay copy.
+        let previous_authored_high_water = lifecycle.authored_event_created_at;
+        lifecycle.authored_event_created_at = Some(
+            previous_authored_high_water
+                .map(|previous| previous.max(authored_created_at))
+                .unwrap_or(authored_created_at),
+        );
+        let authored_high_water_advanced =
+            lifecycle.authored_event_created_at != previous_authored_high_water;
+
+        endpoints.sort();
+        endpoints.dedup();
+        let mut liability_count = key_package_signed_publication_liability_count(&lifecycle);
+        let mut admitted = Vec::new();
+        let mut deferred = Vec::new();
+        for endpoint in endpoints {
+            let already_durable =
+                key_package_event_endpoint_is_liability(&lifecycle, &event_id, &endpoint);
+            if !already_durable && liability_count >= MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES
+            {
+                deferred.push(endpoint);
+                continue;
+            }
+            if !already_durable {
+                liability_count = liability_count.saturating_add(1);
+            }
+            admitted.push(endpoint);
+        }
+        let delete_without_successor = delete_without_successor
+            || matches_durably_deleted_live_revision
+            || lifecycle.key_package_ref_is_consumed(&key_package_ref);
+        if !admitted.is_empty() {
+            retain_retired_key_package_publication(
+                &mut lifecycle,
+                RetiredKeyPackagePublication {
+                    event_id,
+                    authored_created_at,
+                    key_package_ref: Some(key_package_ref),
+                    package_not_after: Some(package_not_after),
+                    delete_without_successor,
+                    deletion_targets: admitted
+                        .iter()
+                        .cloned()
+                        .map(|endpoint| TransportFanoutTarget {
+                            endpoint,
+                            state: TransportFanoutAttemptState::Unattempted,
+                            attempt_count: 0,
+                            last_attempt_at: None,
+                            failure_code: None,
+                        })
+                        .collect(),
+                },
+            );
+        }
+        if !admitted.is_empty() || authored_high_water_advanced {
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+        }
+        Ok((admitted, deferred))
+    }
+
+    /// Serialize exact endpoint-scoped recovery intent before an explicit
+    /// transport deletion can escape.
+    ///
+    /// Unknown relay-discovered event ids are journaled too: a later local
+    /// NIP-33 replacement cannot supersede an event in another stable slot.
+    /// The returned deferred endpoints were not journaled and must not be sent.
+    pub fn prepare_key_package_deletion_recovery(
+        &mut self,
+        event_id: &cgka_traits::MessageId,
+        endpoints: Vec<TransportEndpoint>,
+    ) -> AccountResult<(Vec<TransportEndpoint>, Vec<TransportEndpoint>)> {
+        if endpoints.is_empty() {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "key package deletion requires at least one relay endpoint",
+            )
+            .into());
+        }
+        let mut lifecycle = match self.session.key_package_lifecycle()? {
+            Some(lifecycle) => lifecycle,
+            None => {
+                let stable_slot_id = self
+                    .key_packages
+                    .legacy_slot_id(&self.session.self_id())?
+                    .ok_or_else(|| {
+                        crate::key_package::KeyPackagePublishError::unexposed(
+                            "cannot durably journal KeyPackage deletion without a stable slot",
+                        )
+                    })?;
+                KeyPackageLifecycleState::slot_only(stable_slot_id)
+            }
+        };
+        if lifecycle.stable_slot_id.is_empty() {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "cannot durably journal KeyPackage deletion without a stable slot",
+            )
+            .into());
+        }
+
+        let deletes_live_revision = lifecycle
+            .authored_signed_event
+            .as_ref()
+            .is_some_and(|artifact| artifact.id == *event_id)
+            || lifecycle
+                .authored_event_id
+                .as_ref()
+                .is_some_and(|authored| authored == event_id)
+            || lifecycle
+                .pending_replacement
+                .as_ref()
+                .and_then(|pending| pending.signed_event.as_ref())
+                .is_some_and(|artifact| artifact.id == *event_id);
+        let mut endpoints = endpoints;
+        endpoints.sort();
+        endpoints.dedup();
+        let overflow_owner_before = lifecycle.deletion_overflow_owner_event_id.clone();
+        let (admitted, deferred) = admit_atomic_exact_key_package_deletion_liabilities(
+            &mut lifecycle,
+            event_id,
+            endpoints,
+        );
+        if !admitted.is_empty()
+            && deletes_live_revision
+            && !lifecycle.deleted_live_revision_event_ids.contains(event_id)
+        {
+            lifecycle
+                .deleted_live_revision_event_ids
+                .push(event_id.clone());
+        }
+        if !admitted.is_empty()
+            || lifecycle.deletion_overflow_owner_event_id != overflow_owner_before
+        {
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+        }
+        Ok((admitted, deferred))
+    }
+
+    /// Atomically retain an unparsable/legacy same-slot revision's exact
+    /// endpoint liabilities and its signed NIP-33 ordering high-water.
+    ///
+    /// This differs from arbitrary manual deletion admission: the caller has
+    /// verified the event signature and stable `d` coordinate, so its raw
+    /// `created_at` must constrain every later replacement even when journal
+    /// capacity defers the endpoint set. The whole exact source set is admitted
+    /// atomically through the bounded deletion reserve or returned deferred;
+    /// live current/pending ids are rejected rather than reclassified as
+    /// cutover debris.
+    pub fn journal_discovered_unparsed_key_package_publication(
+        &mut self,
+        stable_slot_id: String,
+        event_id: cgka_traits::MessageId,
+        authored_created_at: Timestamp,
+        endpoints: Vec<TransportEndpoint>,
+    ) -> AccountResult<(Vec<TransportEndpoint>, Vec<TransportEndpoint>)> {
+        if endpoints.is_empty() {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "discovered key package revision requires at least one source endpoint",
+            )
+            .into());
+        }
+        let Some(mut lifecycle) = self.session.key_package_lifecycle()? else {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "cannot journal a discovered key package revision without lifecycle state",
+            )
+            .into());
+        };
+        if lifecycle.stable_slot_id.is_empty() || lifecycle.stable_slot_id != stable_slot_id {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "discovered key package revision does not match the local stable slot",
+            )
+            .into());
+        }
+        let matches_current = lifecycle
+            .authored_signed_event
+            .as_ref()
+            .is_some_and(|artifact| artifact.id == event_id)
+            || lifecycle.authored_event_id.as_ref() == Some(&event_id);
+        let matches_pending = lifecycle
+            .pending_replacement
+            .as_ref()
+            .and_then(|pending| pending.signed_event.as_ref())
+            .is_some_and(|artifact| artifact.id == event_id);
+        if matches_current || matches_pending {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "cannot classify a live key package revision as relay-discovered retirement",
+            )
+            .into());
+        }
+
+        let previous_authored_high_water = lifecycle.authored_event_created_at;
+        lifecycle.authored_event_created_at = Some(
+            previous_authored_high_water
+                .map(|previous| previous.max(authored_created_at))
+                .unwrap_or(authored_created_at),
+        );
+        let authored_high_water_advanced =
+            lifecycle.authored_event_created_at != previous_authored_high_water;
+        let mut endpoints = endpoints;
+        endpoints.sort();
+        endpoints.dedup();
+        let overflow_owner_before = lifecycle.deletion_overflow_owner_event_id.clone();
+        let (admitted, deferred) = admit_atomic_exact_key_package_deletion_liabilities(
+            &mut lifecycle,
+            &event_id,
+            endpoints,
+        );
+        if let Some(retired) = lifecycle
+            .retired_publications_pending_deletion
+            .iter_mut()
+            .find(|retired| retired.event_id == event_id)
+        {
+            retired.authored_created_at = retired.authored_created_at.max(authored_created_at);
+        }
+        if !admitted.is_empty()
+            || authored_high_water_advanced
+            || lifecycle.deletion_overflow_owner_event_id != overflow_owner_before
+        {
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+        }
+        Ok((admitted, deferred))
+    }
+
+    /// Delete an exact signed KeyPackage revision with the account worker as
+    /// the sole lifecycle-row owner. Admission and a possible-exposure marker
+    /// are durable before network I/O; only endpoint-specific Accepted or
+    /// confirmed-absence receipts prune the retry journal.
+    pub async fn delete_key_package_revision_durably(
+        &mut self,
+        event_id: &cgka_traits::MessageId,
+        endpoints: Vec<TransportEndpoint>,
+    ) -> AccountResult<(DetailedKeyPackagePublishReceipt, Vec<TransportEndpoint>)> {
+        let (mut admitted, mut deferred) =
+            self.prepare_key_package_deletion_recovery(event_id, endpoints)?;
+        let mut combined = DetailedKeyPackagePublishReceipt::default();
+        let mut attempted_cleanup_for_capacity = false;
+
+        loop {
+            if admitted.is_empty() {
+                if deferred.is_empty() || attempted_cleanup_for_capacity {
+                    break;
+                }
+                // A full journal must not permanently wedge explicit cleanup.
+                // One bounded active-deletion attempt may free a slot; failure
+                // leaves every existing liability durable and the new pair
+                // unsent/deferred.
+                attempted_cleanup_for_capacity = true;
+                let _ = self.retry_retired_key_package_deletions().await;
+                (admitted, deferred) =
+                    self.prepare_key_package_deletion_recovery(event_id, deferred)?;
+                continue;
+            }
+
+            let mut lifecycle = self
+                .session
+                .key_package_lifecycle()?
+                .expect("manual KeyPackage deletion admission persists lifecycle state");
+            let retired = lifecycle
+                .retired_publications_pending_deletion
+                .iter_mut()
+                .find(|retired| retired.event_id == *event_id)
+                .expect("manual KeyPackage deletion admission persists the exact event");
+            begin_key_package_attempt(
+                &mut retired.deletion_targets,
+                &admitted,
+                self.wall_clock.now(),
+            );
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+
+            let receipt = self
+                .key_packages
+                .delete_key_package_revision(event_id, &admitted)
+                .await?;
+            let accepted = receipt
+                .accepted
+                .into_iter()
+                .filter(|endpoint| admitted.contains(endpoint))
+                .collect::<Vec<_>>();
+            let rejected = receipt
+                .rejected
+                .into_iter()
+                .filter(|endpoint| admitted.contains(endpoint))
+                .collect::<Vec<_>>();
+            let confirmed_absent = receipt
+                .confirmed_absent
+                .into_iter()
+                .filter(|endpoint| admitted.contains(endpoint))
+                .collect::<Vec<_>>();
+            let failed = receipt
+                .failed
+                .into_iter()
+                .filter(|endpoint| admitted.contains(endpoint))
+                .collect::<Vec<_>>();
+
+            let retired = lifecycle
+                .retired_publications_pending_deletion
+                .iter_mut()
+                .find(|retired| retired.event_id == *event_id)
+                .expect("manual KeyPackage deletion remains serialized through receipt commit");
+            finish_key_package_attempt(
+                &mut retired.deletion_targets,
+                &accepted,
+                &rejected,
+                &confirmed_absent,
+                &failed,
+            );
+            retired.deletion_targets.retain(|target| {
+                !accepted.contains(&target.endpoint) && !confirmed_absent.contains(&target.endpoint)
+            });
+            lifecycle
+                .retired_publications_pending_deletion
+                .retain(|retired| {
+                    retired.event_id != *event_id || !retired.deletion_targets.is_empty()
+                });
+            release_settled_key_package_deletion_overflow_owner(&mut lifecycle);
+            let terminal_endpoints = accepted
+                .iter()
+                .chain(confirmed_absent.iter())
+                .cloned()
+                .collect::<Vec<_>>();
+            mark_live_key_package_revision_endpoints_absent(
+                &mut lifecycle,
+                event_id,
+                &terminal_endpoints,
+            );
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+
+            combined.accepted.extend(accepted);
+            combined.rejected.extend(rejected);
+            combined.confirmed_absent.extend(confirmed_absent);
+            combined.failed.extend(failed);
+            if deferred.is_empty() {
+                break;
+            }
+            // Terminal receipts above may have freed journal capacity. Admit
+            // only the previously deferred endpoints, never resending an
+            // endpoint already attempted by this command.
+            (admitted, deferred) =
+                self.prepare_key_package_deletion_recovery(event_id, deferred)?;
+        }
+
+        combined.accepted.sort();
+        combined.accepted.dedup();
+        combined.rejected.sort();
+        combined.rejected.dedup();
+        combined.confirmed_absent.sort();
+        combined.confirmed_absent.dedup();
+        combined.failed.sort();
+        combined.failed.dedup();
+        Ok((combined, deferred))
+    }
+
     pub fn durably_owned_key_packages(&self) -> AccountResult<Vec<KeyPackage>> {
         Ok(self.session.durably_owned_key_packages()?)
     }
@@ -896,18 +1994,32 @@ where
         let now = self.wall_clock.now();
         Ok(match self.session.key_package_lifecycle()? {
             None => true,
+            Some(lifecycle) if lifecycle.cutover_publication_blocked => false,
             Some(lifecycle) => match lifecycle.pending_replacement.as_ref() {
                 Some(pending) => {
-                    pending.signed_event.is_none()
+                    pending.signed_event.as_ref().is_some_and(|artifact| {
+                        lifecycle
+                            .deleted_live_revision_event_ids
+                            .contains(&artifact.id)
+                            || lifecycle
+                                .authored_event_created_at
+                                .is_some_and(|high_water| artifact.created_at < high_water)
+                    }) || lifecycle.key_package_ref_is_consumed(&pending.key_package_ref)
+                        || pending.signed_event.is_none()
                         || pending
                             .targets
                             .iter()
                             .any(|target| key_package_target_retry_due(target, now))
                 }
                 None => {
-                    lifecycle.current_key_package.is_none()
-                        || lifecycle.last_consumed_key_package_ref
-                            == lifecycle.current_key_package_ref
+                    current_key_package_revision_is_deleted(&lifecycle)
+                        || current_key_package_artifact_precedes_authoring_high_water(&lifecycle)
+                        || lifecycle.current_key_package.is_none()
+                        || lifecycle.current_key_package_ref.as_deref().is_some_and(
+                            |key_package_ref| {
+                                lifecycle.key_package_ref_is_consumed(key_package_ref)
+                            },
+                        )
                         || lifecycle.refresh_at.is_some_and(|deadline| deadline <= now)
                         || !lifecycle.upgrade_rotation_recorded
                 }
@@ -916,28 +2028,315 @@ where
     }
 
     pub fn key_package_has_pending_fanout(&self) -> AccountResult<bool> {
+        let authoritative_endpoints = self.routing.key_package_endpoints();
         Ok(self
             .session
             .key_package_lifecycle()?
             .is_some_and(|lifecycle| {
-                lifecycle.authored_signed_event.is_some()
-                    && lifecycle.publication_targets.iter().any(|target| {
-                        matches!(
-                            target.state,
-                            TransportFanoutAttemptState::Unattempted
-                                | TransportFanoutAttemptState::AttemptedFailed
-                        )
-                    })
+                !lifecycle.cutover_publication_blocked
+                    && lifecycle
+                        .current_key_package_ref
+                        .as_deref()
+                        .is_some_and(|key_package_ref| {
+                            !lifecycle.key_package_ref_is_consumed(key_package_ref)
+                        })
+                    && lifecycle.authored_signed_event.is_some()
+                    && (lifecycle
+                        .publication_targets
+                        .iter()
+                        .any(key_package_target_is_retryable)
+                        || key_package_publication_targets_need_policy_reconciliation(
+                            &lifecycle.publication_targets,
+                            &authoritative_endpoints,
+                        ))
             }))
+    }
+
+    /// Run one bounded pass over eligible superseded-revision deletions.
+    ///
+    /// This is the narrow post-discovery seam for hosts that first journal
+    /// exact relay-observed revisions with
+    /// [`Self::journal_discovered_retired_key_package_publication`]. The
+    /// durable journal is the crash boundary; this call performs at most the
+    /// configured per-pass deletion budget and leaves every failed or deferred
+    /// endpoint for ordinary maintenance/restart recovery.
+    pub async fn retry_retired_key_package_deletions_once(&mut self) -> AccountResult<()> {
+        self.retry_retired_key_package_deletions().await.map(|_| ())
+    }
+
+    /// Make every durably journaled retired revision immediately deletable.
+    ///
+    /// This is reserved for quiesced account teardown after the user requested
+    /// removal of their KeyPackages. Ordinary maintenance must continue to
+    /// require a strictly newer accepted successor so it does not reduce
+    /// invitation availability while the account remains active.
+    pub fn authorize_teardown_key_package_deletions_without_successor(
+        &mut self,
+    ) -> AccountResult<()> {
+        let Some(mut lifecycle) = self.session.key_package_lifecycle()? else {
+            return Ok(());
+        };
+        let mut changed = false;
+        for retired in &mut lifecycle.retired_publications_pending_deletion {
+            if !retired.delete_without_successor {
+                retired.delete_without_successor = true;
+                changed = true;
+            }
+        }
+        if changed {
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+        }
+        Ok(())
+    }
+
+    /// Run one bounded deletion pass and return the durable terminal endpoints
+    /// that a cutover relay-history scan must immediately re-fetch.
+    ///
+    /// Unlike ordinary maintenance, cutover also needs to know whether a later
+    /// retry can delete a revision without an accepted strictly newer successor
+    /// covering that endpoint. The report ignores retry backoff for that
+    /// classification so a deferred liability cannot let the cutover gate open.
+    pub async fn retry_retired_key_package_deletions_once_reported(
+        &mut self,
+    ) -> AccountResult<RetiredKeyPackageDeletionPassReport> {
+        self.retry_retired_key_package_deletions().await
+    }
+
+    /// Retry durable deletion obligations for superseded signed revisions.
+    ///
+    /// A live endpoint is eligible only after it acknowledges a strictly
+    /// newer current revision. Removed-policy endpoints and expired packages
+    /// are eligible immediately. Accepted endpoints are pruned synchronously
+    /// before this future reaches another cancellation point; a process crash
+    /// before that commit merely causes a safe duplicate deletion retry.
+    async fn retry_retired_key_package_deletions(
+        &mut self,
+    ) -> AccountResult<RetiredKeyPackageDeletionPassReport> {
+        let Some(mut lifecycle) = self.session.key_package_lifecycle()? else {
+            return Ok(RetiredKeyPackageDeletionPassReport::default());
+        };
+        let now = self.wall_clock.now();
+        let event_ids = lifecycle
+            .retired_publications_pending_deletion
+            .iter()
+            .map(|retired| retired.event_id.clone())
+            .collect::<Vec<_>>();
+        let mut first_error = None;
+        let mut attempts_remaining = KEY_PACKAGE_RETIRED_DELETION_ATTEMPTS_PER_CALL;
+        let mut reported_terminal_endpoints = Vec::new();
+
+        for event_id in event_ids {
+            if attempts_remaining == 0 {
+                break;
+            }
+            let Some(retired) = lifecycle
+                .retired_publications_pending_deletion
+                .iter()
+                .find(|retired| retired.event_id == event_id)
+                .cloned()
+            else {
+                continue;
+            };
+            let endpoints = retired
+                .deletion_targets
+                .iter()
+                .filter(|target| {
+                    retired_key_package_deletion_target_is_eligible(
+                        &lifecycle, &retired, target, now,
+                    ) && key_package_target_retry_due(target, now)
+                })
+                .map(|target| target.endpoint.clone())
+                .take(attempts_remaining)
+                .collect::<Vec<_>>();
+            if endpoints.is_empty() {
+                continue;
+            }
+            attempts_remaining = attempts_remaining.saturating_sub(endpoints.len());
+            begin_key_package_attempt(
+                &mut lifecycle
+                    .retired_publications_pending_deletion
+                    .iter_mut()
+                    .find(|retired| retired.event_id == event_id)
+                    .expect("retired KeyPackage revision remains serialized before deletion")
+                    .deletion_targets,
+                &endpoints,
+                self.wall_clock.now(),
+            );
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+
+            let (accepted, rejected, confirmed_absent, failed, error) = match self
+                .key_packages
+                .delete_key_package_revision(&event_id, &endpoints)
+                .await
+            {
+                Ok(receipt) => {
+                    let accepted = receipt
+                        .accepted
+                        .into_iter()
+                        .filter(|endpoint| endpoints.contains(endpoint))
+                        .collect::<Vec<_>>();
+                    let rejected = receipt
+                        .rejected
+                        .into_iter()
+                        .filter(|endpoint| endpoints.contains(endpoint))
+                        .collect::<Vec<_>>();
+                    let confirmed_absent = receipt
+                        .confirmed_absent
+                        .into_iter()
+                        .filter(|endpoint| endpoints.contains(endpoint))
+                        .collect::<Vec<_>>();
+                    let failed = receipt
+                        .failed
+                        .into_iter()
+                        .filter(|endpoint| endpoints.contains(endpoint))
+                        .collect::<Vec<_>>();
+                    (accepted, rejected, confirmed_absent, failed, None)
+                }
+                Err(error) => (Vec::new(), Vec::new(), Vec::new(), Vec::new(), Some(error)),
+            };
+
+            let retired = lifecycle
+                .retired_publications_pending_deletion
+                .iter_mut()
+                .find(|retired| retired.event_id == event_id)
+                .expect("retired KeyPackage revision remains serialized during deletion");
+            finish_key_package_attempt(
+                &mut retired.deletion_targets,
+                &accepted,
+                &rejected,
+                &confirmed_absent,
+                &failed,
+            );
+            retired.deletion_targets.retain(|target| {
+                !accepted.contains(&target.endpoint) && !confirmed_absent.contains(&target.endpoint)
+            });
+            lifecycle
+                .retired_publications_pending_deletion
+                .retain(|retired| {
+                    retired.event_id != event_id || !retired.deletion_targets.is_empty()
+                });
+            release_settled_key_package_deletion_overflow_owner(&mut lifecycle);
+            let newly_terminal_endpoints = accepted
+                .iter()
+                .chain(confirmed_absent.iter())
+                .cloned()
+                .collect::<Vec<_>>();
+            mark_live_key_package_revision_endpoints_absent(
+                &mut lifecycle,
+                &event_id,
+                &newly_terminal_endpoints,
+            );
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+            reported_terminal_endpoints.extend(newly_terminal_endpoints);
+
+            if let Some(error) = error
+                && first_error.is_none()
+            {
+                first_error = Some(AccountError::from(error));
+            }
+        }
+
+        match first_error {
+            Some(error) => Err(error),
+            None => Ok(retired_key_package_deletion_pass_report(
+                &lifecycle,
+                self.wall_clock.now(),
+                reported_terminal_endpoints,
+            )),
+        }
+    }
+
+    fn ensure_key_package_publication_liability_capacity(
+        &mut self,
+        lifecycle: &mut KeyPackageLifecycleState,
+        additional_revisions: usize,
+    ) -> AccountResult<()> {
+        let projected = key_package_signed_publication_liability_count(lifecycle)
+            .saturating_add(additional_revisions);
+        self.ensure_key_package_publication_liability_count(lifecycle, projected)
+    }
+
+    fn ensure_key_package_publication_liability_count(
+        &mut self,
+        lifecycle: &mut KeyPackageLifecycleState,
+        projected: usize,
+    ) -> AccountResult<()> {
+        if projected <= MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES {
+            return Ok(());
+        }
+        lifecycle.phase = MaintenancePhase::Retry;
+        self.session.put_key_package_lifecycle(lifecycle)?;
+        Err(crate::key_package::KeyPackagePublishError::unexposed(
+            "key package signed-publication endpoint-liability journal is full",
+        )
+        .into())
     }
 
     async fn retry_key_package_fanout(&mut self) -> AccountResult<()> {
         let Some(mut lifecycle) = self.session.key_package_lifecycle()? else {
             return Ok(());
         };
+        ensure_key_package_cutover_publication_allowed(&lifecycle)?;
         if lifecycle.pending_replacement.is_some() {
             return Ok(());
         }
+        if lifecycle
+            .current_key_package_ref
+            .as_deref()
+            .is_some_and(|key_package_ref| lifecycle.key_package_ref_is_consumed(key_package_ref))
+        {
+            // An MLS KeyPackage is single-use. Once a Welcome consumes the
+            // current revision, only a newly generated replacement may be
+            // published; retrying the exact deleted event would advertise
+            // private material that no longer exists locally.
+            return Ok(());
+        }
+        let Some(key_package) = lifecycle.current_key_package.clone() else {
+            return Ok(());
+        };
+        let live_endpoints = self.routing.key_package_endpoints().to_vec();
+        // Apply removals and re-authorizations of already-journaled endpoints
+        // before admitting any new liability. If the journal is full, a newly
+        // added endpoint may remain deferred, but an endpoint removed from the
+        // authoritative policy must never remain eligible for automatic I/O.
+        let represented_live_endpoints = live_endpoints
+            .iter()
+            .filter(|endpoint| {
+                lifecycle
+                    .publication_targets
+                    .iter()
+                    .any(|target| target.endpoint == **endpoint)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        let targets_before_policy_update = lifecycle.publication_targets.clone();
+        merge_republish_publication_targets(
+            &mut lifecycle.publication_targets,
+            &represented_live_endpoints,
+        );
+        if lifecycle.publication_targets != targets_before_policy_update {
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+        }
+        let additional_policy_targets = live_endpoints
+            .iter()
+            .filter(|endpoint| {
+                !lifecycle
+                    .publication_targets
+                    .iter()
+                    .any(|target| target.endpoint == **endpoint)
+            })
+            .count();
+        self.ensure_key_package_publication_liability_capacity(
+            &mut lifecycle,
+            additional_policy_targets,
+        )?;
+        let targets_before_reconciliation = lifecycle.publication_targets.clone();
+        merge_republish_publication_targets(&mut lifecycle.publication_targets, &live_endpoints);
+        if lifecycle.publication_targets != targets_before_reconciliation {
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+        }
+        self.reauthor_current_key_package_if_stale(&mut lifecycle, &key_package, &live_endpoints)
+            .await?;
         let Some(artifact) = lifecycle.authored_signed_event.clone() else {
             return Ok(());
         };
@@ -950,11 +2349,6 @@ where
         if endpoints.is_empty() {
             return Ok(());
         }
-        let Some(key_package) = lifecycle.current_key_package.clone() else {
-            return Ok(());
-        };
-        lifecycle.phase = cgka_traits::MaintenancePhase::Fanout;
-        self.session.put_key_package_lifecycle(&lifecycle)?;
         let publication = KeyPackagePublication {
             account_id: self.session.self_id().clone(),
             key_package,
@@ -962,26 +2356,32 @@ where
             created_at: artifact.created_at,
             endpoints,
         };
+        lifecycle.phase = cgka_traits::MaintenancePhase::Fanout;
+        begin_key_package_attempt(
+            &mut lifecycle.publication_targets,
+            &publication.endpoints,
+            self.wall_clock.now(),
+        );
+        self.session.put_key_package_lifecycle(&lifecycle)?;
         match self
             .key_packages
-            .publish_prepared_key_package(&publication, &artifact)
+            .publish_prepared_key_package_detailed(&publication, &artifact)
             .await
         {
             Ok(receipt) => {
-                note_key_package_attempt(
+                let receipt = scope_key_package_publish_receipt(receipt, &publication.endpoints);
+                finish_key_package_attempt(
                     &mut lifecycle.publication_targets,
-                    &publication.endpoints,
                     &receipt.accepted,
+                    &receipt.rejected,
+                    &receipt.confirmed_absent,
                     &receipt.failed,
-                    self.wall_clock.now(),
                 );
-                lifecycle.phase = if lifecycle.publication_targets.iter().all(|target| {
-                    matches!(
-                        target.state,
-                        TransportFanoutAttemptState::Accepted
-                            | TransportFanoutAttemptState::PolicyProhibited
-                    )
-                }) {
+                lifecycle.phase = if lifecycle
+                    .publication_targets
+                    .iter()
+                    .all(key_package_target_is_terminal)
+                {
                     cgka_traits::MaintenancePhase::Complete
                 } else {
                     cgka_traits::MaintenancePhase::Fanout
@@ -990,13 +2390,6 @@ where
                 Ok(())
             }
             Err(error) => {
-                note_key_package_attempt(
-                    &mut lifecycle.publication_targets,
-                    &publication.endpoints,
-                    &[],
-                    &[],
-                    self.wall_clock.now(),
-                );
                 lifecycle.phase = cgka_traits::MaintenancePhase::Fanout;
                 self.session.put_key_package_lifecycle(&lifecycle)?;
                 Err(error.into())
@@ -1008,13 +2401,19 @@ where
         let now = self.wall_clock.now();
         Ok(match self.session.key_package_lifecycle()? {
             None => true,
-            Some(lifecycle) => {
-                lifecycle.pending_replacement.is_none()
-                    && lifecycle.last_consumed_key_package_ref != lifecycle.current_key_package_ref
-                    && (lifecycle.current_key_package.is_none()
+            Some(lifecycle) => match lifecycle.pending_replacement.as_ref() {
+                Some(pending) => lifecycle.key_package_ref_is_consumed(&pending.key_package_ref),
+                None => {
+                    lifecycle.current_key_package.is_none()
+                        || lifecycle.current_key_package_ref.as_deref().is_some_and(
+                            |key_package_ref| {
+                                lifecycle.key_package_ref_is_consumed(key_package_ref)
+                            },
+                        )
                         || lifecycle.refresh_at.is_some_and(|deadline| deadline <= now)
-                        || !lifecycle.upgrade_rotation_recorded)
-            }
+                        || !lifecycle.upgrade_rotation_recorded
+                }
+            },
         })
     }
 
@@ -1025,20 +2424,173 @@ where
         let Some(mut lifecycle) = self.session.key_package_lifecycle()? else {
             return Ok(0);
         };
+        let legacy_only_consumption_evidence = lifecycle.consumed_key_package_refs.is_empty()
+            && lifecycle.last_consumed_key_package_ref.is_some();
+        let consumed_refs_before = lifecycle.consumed_key_package_refs.clone();
+        // Import the legacy single marker and deduplicate before making any
+        // consumption decision. Only handled refs are cleared below.
+        lifecycle.reconcile_consumed_key_package_refs();
+        if legacy_only_consumption_evidence {
+            // Legacy writers overwrote this single marker on each Welcome, so
+            // the surviving ref cannot prove that any other durable bundle is
+            // unconsumed, including pre-lifecycle bundles with no current,
+            // pending, or retained projection. Pay a one-time availability
+            // cost at upgrade: retire every durably owned package and every
+            // known signed revision, then force a fresh replacement. Keep the
+            // bounded ref tombstones so a later strict relay scan can classify
+            // an exact revision for deletion without first publishing a
+            // successor. The lifecycle transition and private-material
+            // deletion commit atomically, so a crash observes either the
+            // legacy sentinel again or the complete fail-closed state, never a
+            // republishable half-transition.
+            let legacy_last_consumed_ref = lifecycle.last_consumed_key_package_ref.clone();
+            let legacy_last_consumed_at = lifecycle.last_consumed_at;
+            let durably_owned = self.session.durably_owned_key_packages()?;
+            let mut legacy_consumed_refs = lifecycle.consumed_key_package_refs.clone();
+            let mut durable_packages = Vec::with_capacity(durably_owned.len());
+            for key_package in durably_owned {
+                let metadata = self.session.key_package_metadata(&key_package)?;
+                let key_package_ref =
+                    hex::decode(&metadata.key_package_ref_hex).map_err(|error| {
+                        cgka_traits::EngineError::Serialize(format!(
+                            "durable key package reference: {error}"
+                        ))
+                    })?;
+                legacy_consumed_refs.push(key_package_ref.clone());
+                durable_packages.push((key_package, key_package_ref));
+            }
+            legacy_consumed_refs.sort();
+            legacy_consumed_refs.dedup();
+            if legacy_consumed_refs.len()
+                > cgka_traits::maintenance::MAX_CONSUMED_KEY_PACKAGE_REFS_PENDING_CLEANUP
+            {
+                return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                    "legacy consumed KeyPackage cleanup journal is full",
+                )
+                .into());
+            }
+            let mut retired = retire_legacy_only_consumption_projections(&mut lifecycle, now);
+            for (key_package, key_package_ref) in durable_packages {
+                mark_retired_key_package_revisions_unusable(&mut lifecycle, &key_package_ref);
+                retain_key_package_for_private_material_retirement(&mut retired, key_package);
+            }
+            lifecycle.consumed_key_package_refs = legacy_consumed_refs;
+            lifecycle.last_consumed_key_package_ref = legacy_last_consumed_ref;
+            lifecycle.last_consumed_at = legacy_last_consumed_at;
+            let deleted = retired.len();
+            if deleted > 0 {
+                self.session
+                    .promote_key_package_lifecycle(&retired, &lifecycle)?;
+            } else {
+                self.session.put_key_package_lifecycle(&lifecycle)?;
+            }
+            return Ok(deleted);
+        }
         let mut retired = Vec::new();
+        let mut handled_consumed_refs = Vec::new();
+        let mut lifecycle_changed = lifecycle.consumed_key_package_refs != consumed_refs_before;
+
+        for key_package in self.session.durably_owned_key_packages()? {
+            let metadata = self.session.key_package_metadata(&key_package)?;
+            let key_package_ref = hex::decode(&metadata.key_package_ref_hex).map_err(|error| {
+                cgka_traits::EngineError::Serialize(format!(
+                    "durable key package reference: {error}"
+                ))
+            })?;
+            if lifecycle.key_package_ref_is_consumed(&key_package_ref)
+                && !key_package_ref_has_live_private_material(&lifecycle, &key_package_ref)
+            {
+                mark_retired_key_package_revisions_unusable(&mut lifecycle, &key_package_ref);
+                handled_consumed_refs.push(key_package_ref);
+                retired.push(key_package);
+                lifecycle_changed = true;
+            }
+        }
+        let current_was_consumed = lifecycle
+            .current_key_package_ref
+            .as_deref()
+            .is_some_and(|key_package_ref| lifecycle.key_package_ref_is_consumed(key_package_ref));
+        if current_was_consumed
+            && let Some(key_package_ref) = lifecycle.current_key_package_ref.clone()
+        {
+            let retired_before = lifecycle.retired_publications_pending_deletion.clone();
+            if let Some(retired_publication) =
+                retired_current_key_package_publication(&lifecycle, true)
+            {
+                retain_retired_key_package_publication(&mut lifecycle, retired_publication);
+            }
+            mark_retired_key_package_revisions_unusable(&mut lifecycle, &key_package_ref);
+            lifecycle_changed |= lifecycle.retired_publications_pending_deletion != retired_before;
+        }
         if lifecycle
             .current_not_after
             .is_some_and(|deadline| deadline <= now)
-            && let Some(expired) = lifecycle.current_key_package.take()
+            && lifecycle.current_key_package.is_some()
         {
+            let expired_key_package_ref = lifecycle.current_key_package_ref.clone();
+            if let Some(retired_publication) =
+                retired_current_key_package_publication(&lifecycle, true)
+            {
+                retain_retired_key_package_publication(&mut lifecycle, retired_publication);
+            }
+            let expired = lifecycle
+                .current_key_package
+                .take()
+                .expect("expired current KeyPackage remains present");
             lifecycle.current_key_package_ref = None;
             lifecycle.current_not_before = None;
             lifecycle.current_not_after = None;
+            lifecycle.authored_event_id = None;
+            // Keep the stable-slot authoring high-water even after the
+            // semantic package expires so its replacement cannot sort behind
+            // a relay copy of this exact revision after clock rollback.
             lifecycle.authored_signed_event = None;
             lifecycle.publication_targets.clear();
             lifecycle.refresh_at = None;
             lifecycle.phase = cgka_traits::MaintenancePhase::Retry;
+            if current_was_consumed && let Some(key_package_ref) = expired_key_package_ref {
+                handled_consumed_refs.push(key_package_ref);
+            }
             retired.push(expired);
+            lifecycle_changed = true;
+        }
+        let pending_was_consumed = lifecycle
+            .pending_replacement
+            .as_ref()
+            .is_some_and(|pending| lifecycle.key_package_ref_is_consumed(&pending.key_package_ref));
+        if pending_was_consumed && let Some(consumed) = lifecycle.pending_replacement.take() {
+            let consumed_created_at = consumed
+                .signed_event
+                .as_ref()
+                .map(|artifact| artifact.created_at)
+                .unwrap_or(consumed.authored_created_at);
+            if let Some(retired_publication) = consumed.signed_event.as_ref().and_then(|artifact| {
+                retired_key_package_publication(
+                    artifact,
+                    Some(&consumed.key_package_ref),
+                    Some(consumed.not_after),
+                    true,
+                    &consumed.targets,
+                )
+            }) {
+                retain_retired_key_package_publication(&mut lifecycle, retired_publication);
+            }
+            mark_retired_key_package_revisions_unusable(&mut lifecycle, &consumed.key_package_ref);
+            // The relay may already have selected this newer pending revision
+            // despite the missing acknowledgement. Preserve its authoring
+            // high-water and force an immediate semantic replacement so the
+            // consumed single-use package cannot remain the NIP-33 winner.
+            lifecycle.authored_event_created_at = Some(
+                lifecycle
+                    .authored_event_created_at
+                    .map(|current| current.max(consumed_created_at))
+                    .unwrap_or(consumed_created_at),
+            );
+            lifecycle.refresh_at = Some(now);
+            lifecycle.phase = cgka_traits::MaintenancePhase::Retry;
+            handled_consumed_refs.push(consumed.key_package_ref.clone());
+            retired.push(consumed.key_package);
+            lifecycle_changed = true;
         }
         if lifecycle
             .pending_replacement
@@ -1046,31 +2598,79 @@ where
             .is_some_and(|pending| pending.not_after <= now)
             && let Some(expired) = lifecycle.pending_replacement.take()
         {
-            lifecycle.phase = cgka_traits::MaintenancePhase::Failed;
+            let expired_created_at = expired
+                .signed_event
+                .as_ref()
+                .map(|artifact| artifact.created_at)
+                .unwrap_or(expired.authored_created_at);
+            if let Some(retired_publication) = expired.signed_event.as_ref().and_then(|artifact| {
+                retired_key_package_publication(
+                    artifact,
+                    Some(&expired.key_package_ref),
+                    Some(expired.not_after),
+                    true,
+                    &expired.targets,
+                )
+            }) {
+                retain_retired_key_package_publication(&mut lifecycle, retired_publication);
+            }
+            lifecycle.authored_event_created_at = Some(
+                lifecycle
+                    .authored_event_created_at
+                    .map(|current| current.max(expired_created_at))
+                    .unwrap_or(expired_created_at),
+            );
+            lifecycle.refresh_at = Some(now);
+            lifecycle.phase = cgka_traits::MaintenancePhase::Retry;
             retired.push(expired.key_package);
+            lifecycle_changed = true;
         }
-        let consumed_ref = lifecycle.last_consumed_key_package_ref.as_deref();
-        let mut consumed_retained_deleted = false;
+        let consumed_refs = lifecycle.consumed_key_package_refs.clone();
+        let mut consumed_retained_refs = Vec::new();
         let mut retained = Vec::with_capacity(lifecycle.retained_private_material.len());
         for material in lifecycle.retained_private_material.drain(..) {
-            let was_consumed = consumed_ref
-                .is_some_and(|consumed| consumed == material.key_package_ref.as_slice());
+            let was_consumed = consumed_refs
+                .iter()
+                .any(|consumed| consumed == &material.key_package_ref);
             if material.not_after <= now || was_consumed {
-                consumed_retained_deleted |= was_consumed;
+                if was_consumed {
+                    consumed_retained_refs.push(material.key_package_ref.clone());
+                }
                 retired.push(material.key_package);
             } else {
                 retained.push(material);
             }
         }
         lifecycle.retained_private_material = retained;
-        if consumed_retained_deleted {
-            lifecycle.last_consumed_key_package_ref = None;
-            lifecycle.last_consumed_at = None;
+        for key_package_ref in consumed_retained_refs {
+            mark_retired_key_package_revisions_unusable(&mut lifecycle, &key_package_ref);
+            handled_consumed_refs.push(key_package_ref);
         }
+        handled_consumed_refs.sort();
+        handled_consumed_refs.dedup();
+        for key_package_ref in handled_consumed_refs {
+            if !key_package_ref_has_live_private_material(&lifecycle, &key_package_ref)
+                && !lifecycle.cutover_publication_blocked
+            {
+                lifecycle.clear_consumed_key_package_ref(&key_package_ref);
+            }
+        }
+        let consumed_refs_before_reconcile = lifecycle.consumed_key_package_refs.clone();
+        let last_consumed_before_reconcile = lifecycle.last_consumed_key_package_ref.clone();
+        lifecycle.reconcile_consumed_key_package_refs();
+        lifecycle_changed |= lifecycle.consumed_key_package_refs != consumed_refs_before_reconcile
+            || lifecycle.last_consumed_key_package_ref != last_consumed_before_reconcile;
+        let deleted_live_revision_event_ids_before =
+            lifecycle.deleted_live_revision_event_ids.clone();
+        retain_only_live_deleted_key_package_revision_ids(&mut lifecycle);
+        lifecycle_changed |=
+            lifecycle.deleted_live_revision_event_ids != deleted_live_revision_event_ids_before;
         let deleted = retired.len();
         if deleted > 0 {
             self.session
                 .promote_key_package_lifecycle(&retired, &lifecycle)?;
+        } else if lifecycle_changed {
+            self.session.put_key_package_lifecycle(&lifecycle)?;
         }
         Ok(deleted)
     }
@@ -1245,9 +2845,28 @@ where
     /// Advance durable maintenance state and publish work whose safety windows
     /// have elapsed. Callers may invoke this from any timer cadence; all
     /// deadlines and sampled jitter are persisted.
+    pub async fn run_due_maintenance_leased(
+        &mut self,
+    ) -> AccountResult<LeasedAccountDeviceEffects> {
+        let effects = self.run_due_maintenance_recording_visibility().await?;
+        self.lease_current_returned_visibility(effects)
+    }
+
     pub async fn run_due_maintenance(&mut self) -> AccountResult<AccountDeviceEffects> {
+        let effects = self.run_due_maintenance_recording_visibility().await?;
+        self.discard_active_visibility_operation()?;
+        Ok(effects)
+    }
+
+    async fn run_due_maintenance_recording_visibility(
+        &mut self,
+    ) -> AccountResult<AccountDeviceEffects> {
         use sha2::{Digest, Sha256};
 
+        self.start_account_visibility_operation(AccountVisibilitySource::Maintenance {
+            observed_at: self.wall_clock.now(),
+        })?;
+        let visibility_handoff = self.begin_session_visibility_handoff()?;
         self.sweep_expired_key_package_private_material()?;
         let mut output = AccountDeviceEffects::default();
         // Hydration recreates the publication edge for a surviving staged
@@ -1259,12 +2878,16 @@ where
         // this safe to call before a failed target is retryable.
         let recovered = self.session.drain();
         if !recovered.is_empty() {
-            let recovered = self.publish_session_effects(recovered).await?;
+            let recovered = self
+                .publish_session_effects_in_current_operation(recovered, None)
+                .await?;
+            self.retain_account_visibility_memory_only(&recovered);
             output.absorb_account_effects(recovered);
         }
         let now = self.wall_clock.now();
-        // Fanout of an already-acknowledged exact event is publication
-        // recovery, not a new preparation, so it continues while paused.
+        // Fanout of an already-acknowledged KeyPackage is publication recovery,
+        // not a new MLS preparation, so it continues while paused. A transport
+        // may first supersede a stale signed revision at the same coordinate.
         if self.key_package_has_pending_fanout()?
             && let Err(_error) = self.retry_key_package_fanout().await
         {
@@ -1272,30 +2895,68 @@ where
                 target: TRACE_TARGET,
                 method = "run_due_maintenance",
                 error_kind = "key_package_fanout_retry",
-                "key package exact-event fanout remains retryable"
+                "key package event fanout remains retryable"
             );
         }
         let key_package_due = self.key_package_network_maintenance_due()?;
-        let key_package_prepared = self
-            .session
-            .key_package_lifecycle()?
+        let key_package_lifecycle = self.session.key_package_lifecycle()?;
+        let key_package_prepared = key_package_lifecycle
+            .as_ref()
             .is_some_and(|lifecycle| lifecycle.pending_replacement.is_some());
+        let force_current_reauthor = key_package_lifecycle.as_ref().is_some_and(|lifecycle| {
+            lifecycle.pending_replacement.is_none()
+                && lifecycle.current_key_package.is_some()
+                && lifecycle
+                    .current_key_package_ref
+                    .as_deref()
+                    .is_some_and(|key_package_ref| {
+                        !lifecycle.key_package_ref_is_consumed(key_package_ref)
+                    })
+                && lifecycle.authored_signed_event.is_some()
+                && (current_key_package_revision_is_deleted(lifecycle)
+                    || current_key_package_artifact_precedes_authoring_high_water(lifecycle))
+        });
         if key_package_due
-            && (!self.maintenance_paused || key_package_prepared)
-            && let Err(error) = self.publish_fresh_key_package().await
+            && (!self.maintenance_paused || key_package_prepared || force_current_reauthor)
         {
+            let result = if force_current_reauthor {
+                self.republish_key_package().await.map(|_| ())
+            } else {
+                self.publish_fresh_key_package().await.map(|_| ())
+            };
+            if let Err(error) = result {
+                tracing::warn!(
+                    target: TRACE_TARGET,
+                    method = "run_due_maintenance",
+                    error_kind = if matches!(error, AccountError::ClockSkewBlocked) {
+                        "clock_skew_blocked"
+                    } else {
+                        "key_package_retry"
+                    },
+                    "key package maintenance remains retryable"
+                );
+            }
+        }
+        if self.retry_retired_key_package_deletions().await.is_err() {
             tracing::warn!(
                 target: TRACE_TARGET,
                 method = "run_due_maintenance",
-                error_kind = if matches!(error, AccountError::ClockSkewBlocked) {
-                    "clock_skew_blocked"
-                } else {
-                    "key_package_retry"
-                },
-                "key package maintenance remains retryable"
+                error_kind = "key_package_revision_deletion_retry",
+                "superseded key package revision deletion remains retryable"
             );
         }
-        self.retry_confirmed_transport_fanouts(&mut output).await?;
+        let retry_visibility_handoff = self.begin_session_visibility_handoff()?;
+        self.start_current_publish_visibility(retry_visibility_handoff);
+        let mut retried_fanouts = AccountDeviceEffects::default();
+        self.retry_confirmed_transport_fanouts(
+            &mut retried_fanouts,
+            Some(retry_visibility_handoff),
+        )
+        .await?;
+        self.checkpoint_current_publish_visibility(retry_visibility_handoff, &retried_fanouts)?;
+        self.finish_current_visibility_handoff(retry_visibility_handoff);
+        self.retain_account_visibility_memory_only(&retried_fanouts);
+        output.absorb_account_effects(retried_fanouts);
 
         // Old groups have no enrollment row and are intentionally excluded.
         let active_obligations = self.session.maintenance_obligations()?;
@@ -1510,7 +3171,9 @@ where
                                 queued: Vec::new(),
                                 pending_convergence: Vec::new(),
                             };
-                            let retried = self.publish_session_effects(retry).await?;
+                            let retried = self
+                                .publish_session_effects_in_current_operation(retry, None)
+                                .await?;
                             let confirmed = retried.pending.iter().any(|resolution| {
                                 matches!(
                                     resolution,
@@ -1518,6 +3181,7 @@ where
                                         if *resolved == pending
                                 )
                             });
+                            self.retain_account_visibility_memory_only(&retried);
                             output.absorb_account_effects(retried);
                             if confirmed {
                                 self.complete_maintenance_obligation(&mut obligation, now)?;
@@ -1561,16 +3225,21 @@ where
             }
 
             let group_id = obligation.group_id.clone();
+            let send_visibility_handoff = self.begin_session_visibility_handoff()?;
             match self
-                .send(SendIntent::SelfUpdate {
-                    group_id: group_id.clone(),
-                })
+                .send_in_current_operation(
+                    SendIntent::SelfUpdate {
+                        group_id: group_id.clone(),
+                    },
+                    None,
+                )
                 .await
             {
                 Ok(effects) => {
                     let confirmed = effects.pending.iter().any(|resolution| {
                         matches!(resolution, PendingResolution::Confirmed { .. })
                     });
+                    self.retain_account_visibility_memory_only(&effects);
                     output.absorb_account_effects(effects);
                     if confirmed {
                         self.complete_maintenance_obligation(&mut obligation, now)?;
@@ -1584,6 +3253,13 @@ where
                     }
                 }
                 Err(error) => {
+                    // Maintenance treats one failed self-update as retryable
+                    // and continues the outer pass. Preserve any session
+                    // events the failed child produced before its later
+                    // publication/storage error by copying those journaled
+                    // batches into this call's output before the outer
+                    // handoff clears its own range.
+                    self.append_retained_visibility_since(send_visibility_handoff, &mut output);
                     obligation.phase = MaintenancePhase::Retry;
                     obligation.attempt_count = obligation.attempt_count.saturating_add(1);
                     obligation.last_failure_code = Some(
@@ -1597,6 +3273,7 @@ where
                 }
             }
         }
+        self.finish_current_visibility_handoff(visibility_handoff);
         Ok(output)
     }
 
@@ -1687,8 +3364,33 @@ where
         &mut self,
         request: CreateGroupRequest,
     ) -> AccountResult<(GroupId, AccountDeviceEffects)> {
+        let (group_id, effects) = self.create_group_recording_visibility(request).await?;
+        self.discard_active_visibility_operation()?;
+        Ok((group_id, effects))
+    }
+
+    pub async fn create_group_leased(
+        &mut self,
+        request: CreateGroupRequest,
+    ) -> AccountResult<(GroupId, LeasedAccountDeviceEffects)> {
+        let (group_id, effects) = self.create_group_recording_visibility(request).await?;
+        Ok((group_id, self.lease_current_returned_visibility(effects)?))
+    }
+
+    async fn create_group_recording_visibility(
+        &mut self,
+        request: CreateGroupRequest,
+    ) -> AccountResult<(GroupId, AccountDeviceEffects)> {
+        self.start_account_visibility_operation(AccountVisibilitySource::Outbound {
+            group_id: None,
+            observed_at: self.wall_clock.now(),
+            action: None,
+            action_message_id: None,
+        })?;
         let CreateGroupEffects { group_id, effects } = self.session.create_group(request).await?;
-        let effects = self.publish_session_effects(effects).await?;
+        let effects = self
+            .publish_session_effects_in_current_operation(effects, None)
+            .await?;
         Ok((group_id, effects))
     }
 
@@ -1759,20 +3461,43 @@ where
             .await
     }
 
+    pub async fn publish_prepared_session_effects_with_audit_context_leased(
+        &mut self,
+        effects: SessionEffects,
+        context: AuditEventContext,
+    ) -> AccountResult<LeasedAccountDeviceEffects> {
+        let effects = self
+            .publish_session_effects_recording_visibility(effects, Some(context))
+            .await?;
+        self.lease_current_returned_visibility(effects)
+    }
+
     pub async fn send(&mut self, intent: SendIntent) -> AccountResult<AccountDeviceEffects> {
-        let disposition_group = match &intent {
-            SendIntent::AppMessage { group_id, .. } => Some(group_id.clone()),
-            _ => None,
-        };
-        let effects = self.session.send(intent).await?;
-        let mut output = self.publish_session_effects(effects).await?;
-        if let Some(group_id) = disposition_group
-            && self.post_join_rotation_pending(&group_id)?
-        {
-            output.maintenance_disposition =
-                SendMaintenanceDisposition::PostJoinRotationPendingRetryable;
-        }
-        Ok(output)
+        let effects = self.send_recording_visibility(intent, None).await?;
+        self.discard_active_visibility_operation()?;
+        Ok(effects)
+    }
+
+    pub async fn send_leased(
+        &mut self,
+        intent: SendIntent,
+    ) -> AccountResult<LeasedAccountDeviceEffects> {
+        let effects = self.send_recording_visibility(intent, None).await?;
+        self.lease_current_returned_visibility(effects)
+    }
+
+    async fn send_recording_visibility(
+        &mut self,
+        intent: SendIntent,
+        context: Option<AuditEventContext>,
+    ) -> AccountResult<AccountDeviceEffects> {
+        self.start_account_visibility_operation(AccountVisibilitySource::Outbound {
+            group_id: send_intent_group_id(&intent),
+            observed_at: self.wall_clock.now(),
+            action: account_visibility_outbound_action(&intent),
+            action_message_id: None,
+        })?;
+        self.send_in_current_operation(intent, context).await
     }
 
     pub async fn send_with_audit_context(
@@ -1780,23 +3505,63 @@ where
         intent: SendIntent,
         context: AuditEventContext,
     ) -> AccountResult<AccountDeviceEffects> {
+        let effects = self
+            .send_recording_visibility(intent, Some(context))
+            .await?;
+        self.discard_active_visibility_operation()?;
+        Ok(effects)
+    }
+
+    pub async fn send_with_audit_context_leased(
+        &mut self,
+        intent: SendIntent,
+        context: AuditEventContext,
+    ) -> AccountResult<LeasedAccountDeviceEffects> {
+        let effects = self
+            .send_recording_visibility(intent, Some(context))
+            .await?;
+        self.lease_current_returned_visibility(effects)
+    }
+
+    async fn send_in_current_operation(
+        &mut self,
+        intent: SendIntent,
+        context: Option<AuditEventContext>,
+    ) -> AccountResult<AccountDeviceEffects> {
+        let visibility_handoff = self.begin_session_visibility_handoff()?;
+        let outbound_action = account_visibility_outbound_action(&intent);
         let disposition_group = match &intent {
             SendIntent::AppMessage { group_id, .. } => Some(group_id.clone()),
             _ => None,
         };
-        let effects = self
-            .session
-            .send_with_audit_context(intent, context.clone())
-            .await?;
+        let effects = match context.as_ref() {
+            Some(context) => {
+                self.session
+                    .send_with_audit_context(intent, context.clone())
+                    .await?
+            }
+            None => self.session.send(intent).await?,
+        };
+        if let Some(action) = outbound_action {
+            let message_id = outbound_action_message_id(action, &effects).ok_or_else(|| {
+                account_visibility_error(
+                    "accepted outbound action did not produce its exact publish message",
+                )
+            })?;
+            self.bind_active_outbound_action_message(action, message_id)?;
+        }
         let mut output = self
-            .publish_session_effects_with_audit_context(effects, Some(context))
+            .publish_session_effects_in_current_operation(effects, context)
             .await?;
+        self.retain_account_visibility_memory_only(&output);
         if let Some(group_id) = disposition_group
             && self.post_join_rotation_pending(&group_id)?
         {
             output.maintenance_disposition =
                 SendMaintenanceDisposition::PostJoinRotationPendingRetryable;
+            self.update_active_visibility_header(output.maintenance_disposition)?;
         }
+        self.finish_current_visibility_handoff(visibility_handoff);
         Ok(output)
     }
 
@@ -1833,21 +3598,63 @@ where
         &mut self,
         prepared: PreparedSessionCommit,
     ) -> AccountResult<AccountDeviceEffects> {
+        let effects = self
+            .rollback_prepared_session_commit_recording_visibility(prepared)
+            .await?;
+        self.discard_active_visibility_operation()?;
+        Ok(effects)
+    }
+
+    pub async fn rollback_prepared_session_commit_leased(
+        &mut self,
+        prepared: PreparedSessionCommit,
+    ) -> AccountResult<LeasedAccountDeviceEffects> {
+        let effects = self
+            .rollback_prepared_session_commit_recording_visibility(prepared)
+            .await?;
+        self.lease_current_returned_visibility(effects)
+    }
+
+    async fn rollback_prepared_session_commit_recording_visibility(
+        &mut self,
+        prepared: PreparedSessionCommit,
+    ) -> AccountResult<AccountDeviceEffects> {
+        self.start_account_visibility_operation(AccountVisibilitySource::Outbound {
+            group_id: None,
+            observed_at: self.wall_clock.now(),
+            action: None,
+            action_message_id: None,
+        })?;
+        let visibility_handoff = self.begin_session_visibility_handoff()?;
+        self.start_current_publish_visibility(visibility_handoff);
         let (mut prepared_effects, _welcomes, pending) = prepared.into_parts();
         prepared_effects.publish.clear();
 
         let mut output = AccountDeviceEffects::default();
         let mut queue = VecDeque::new();
-        output.absorb_session_effects(prepared_effects, &mut queue);
+        self.absorb_session_effects_retaining_visibility(
+            &mut output,
+            prepared_effects,
+            &mut queue,
+            visibility_handoff,
+        )?;
 
         let rollback_effects = self.session.publish_failed(pending).await?;
         output
             .pending
             .push(PendingResolution::RolledBack { pending });
-        output.absorb_session_effects(rollback_effects, &mut queue);
-        self.publish_queue(&mut output, &mut queue, None).await?;
+        self.absorb_session_effects_retaining_visibility(
+            &mut output,
+            rollback_effects,
+            &mut queue,
+            visibility_handoff,
+        )?;
+        self.checkpoint_current_publish_visibility(visibility_handoff, &output)?;
+        self.publish_queue(&mut output, &mut queue, None, visibility_handoff)
+            .await?;
         self.reconcile_confirmed_own_leaf_rotations(&output.events)?;
         self.reconcile_superseded_maintenance(&output.events)?;
+        self.finish_current_visibility_handoff(visibility_handoff);
         Ok(output)
     }
 
@@ -1862,6 +3669,36 @@ where
         intent: SendIntent,
         context: AuditEventContext,
     ) -> AccountResult<(AccountDeviceEffects, Vec<TransportMessage>)> {
+        let (effects, welcomes) = self
+            .send_confirming_commit_with_audit_context_recording_visibility(intent, context)
+            .await?;
+        self.discard_active_visibility_operation()?;
+        Ok((effects, welcomes))
+    }
+
+    pub async fn send_confirming_commit_with_audit_context_leased(
+        &mut self,
+        intent: SendIntent,
+        context: AuditEventContext,
+    ) -> AccountResult<(LeasedAccountDeviceEffects, Vec<TransportMessage>)> {
+        let (effects, welcomes) = self
+            .send_confirming_commit_with_audit_context_recording_visibility(intent, context)
+            .await?;
+        Ok((self.lease_current_returned_visibility(effects)?, welcomes))
+    }
+
+    async fn send_confirming_commit_with_audit_context_recording_visibility(
+        &mut self,
+        intent: SendIntent,
+        context: AuditEventContext,
+    ) -> AccountResult<(AccountDeviceEffects, Vec<TransportMessage>)> {
+        self.start_account_visibility_operation(AccountVisibilitySource::Outbound {
+            group_id: send_intent_group_id(&intent),
+            observed_at: self.wall_clock.now(),
+            action: account_visibility_outbound_action(&intent),
+            action_message_id: None,
+        })?;
+        let visibility_handoff = self.begin_session_visibility_handoff()?;
         let disposition_group = match &intent {
             SendIntent::AppMessage { group_id, .. } => Some(group_id.clone()),
             _ => None,
@@ -1877,14 +3714,17 @@ where
             PreparedSessionSend::Queued(effects) => (effects, Vec::new()),
         };
         let mut output = self
-            .publish_session_effects_with_audit_context(session_effects, Some(context))
+            .publish_session_effects_in_current_operation(session_effects, Some(context))
             .await?;
+        self.retain_account_visibility_memory_only(&output);
         if let Some(group_id) = disposition_group
             && self.post_join_rotation_pending(&group_id)?
         {
             output.maintenance_disposition =
                 SendMaintenanceDisposition::PostJoinRotationPendingRetryable;
+            self.update_active_visibility_header(output.maintenance_disposition)?;
         }
+        self.finish_current_visibility_handoff(visibility_handoff);
         Ok((output, welcomes))
     }
 
@@ -1896,7 +3736,7 @@ where
         context: AuditEventContext,
     ) -> AccountResult<AccountDeviceEffects> {
         let mut output = AccountDeviceEffects::default();
-        self.publish_welcome_fanout(welcomes, group_id, &mut output, Some(context), false)
+        self.publish_welcome_fanout(welcomes, group_id, &mut output, Some(context), false, None)
             .await?;
         Ok(output)
     }
@@ -1909,7 +3749,7 @@ where
         context: AuditEventContext,
     ) -> AccountResult<AccountDeviceEffects> {
         let mut output = AccountDeviceEffects::default();
-        self.publish_welcome_fanout(welcomes, None, &mut output, Some(context), true)
+        self.publish_welcome_fanout(welcomes, None, &mut output, Some(context), true, None)
             .await?;
         Ok(output)
     }
@@ -1954,7 +3794,9 @@ where
             message_ids,
         } = task;
         let mut output = AccountDeviceEffects::default();
-        let result = self.finish_welcome_publish(completed, &mut output).await;
+        let result = self
+            .finish_welcome_publish(completed, &mut output, None)
+            .await;
         self.abandon_welcome_publish_task(&message_ids);
         result.map(|()| output)
     }
@@ -1975,16 +3817,51 @@ where
         context: AuditEventContext,
     ) -> AccountResult<AccountDeviceEffects> {
         let effects = self
+            .queue_app_message_with_audit_context_recording_visibility(group_id, payload, context)
+            .await?;
+        self.discard_active_visibility_operation()?;
+        Ok(effects)
+    }
+
+    pub async fn queue_app_message_with_audit_context_leased(
+        &mut self,
+        group_id: GroupId,
+        payload: Vec<u8>,
+        context: AuditEventContext,
+    ) -> AccountResult<LeasedAccountDeviceEffects> {
+        let effects = self
+            .queue_app_message_with_audit_context_recording_visibility(group_id, payload, context)
+            .await?;
+        self.lease_current_returned_visibility(effects)
+    }
+
+    async fn queue_app_message_with_audit_context_recording_visibility(
+        &mut self,
+        group_id: GroupId,
+        payload: Vec<u8>,
+        context: AuditEventContext,
+    ) -> AccountResult<AccountDeviceEffects> {
+        self.start_account_visibility_operation(AccountVisibilitySource::Outbound {
+            group_id: Some(group_id.clone()),
+            observed_at: self.wall_clock.now(),
+            action: None,
+            action_message_id: None,
+        })?;
+        let visibility_handoff = self.begin_session_visibility_handoff()?;
+        let effects = self
             .session
             .queue_app_message_with_audit_context(group_id.clone(), payload, context.clone())
             .await?;
         let mut output = self
-            .publish_session_effects_with_audit_context(effects, Some(context))
+            .publish_session_effects_in_current_operation(effects, Some(context))
             .await?;
+        self.retain_account_visibility_memory_only(&output);
         if self.post_join_rotation_pending(&group_id)? {
             output.maintenance_disposition =
                 SendMaintenanceDisposition::PostJoinRotationPendingRetryable;
+            self.update_active_visibility_header(output.maintenance_disposition)?;
         }
+        self.finish_current_visibility_handoff(visibility_handoff);
         Ok(output)
     }
 
@@ -2006,8 +3883,34 @@ where
         &mut self,
         group_id: &GroupId,
     ) -> AccountResult<AccountDeviceEffects> {
+        let effects = self
+            .advance_convergence_recording_visibility(group_id)
+            .await?;
+        self.discard_active_visibility_operation()?;
+        Ok(effects)
+    }
+
+    async fn advance_convergence_recording_visibility(
+        &mut self,
+        group_id: &GroupId,
+    ) -> AccountResult<AccountDeviceEffects> {
+        self.start_account_visibility_operation(AccountVisibilitySource::Convergence {
+            group_id: group_id.clone(),
+            observed_at: self.wall_clock.now(),
+        })?;
         let effects = self.session.advance_convergence(group_id).await?;
-        self.publish_session_effects(effects).await
+        self.publish_session_effects_in_current_operation(effects, None)
+            .await
+    }
+
+    pub async fn advance_convergence_leased(
+        &mut self,
+        group_id: &GroupId,
+    ) -> AccountResult<LeasedAccountDeviceEffects> {
+        let effects = self
+            .advance_convergence_recording_visibility(group_id)
+            .await?;
+        self.lease_current_returned_visibility(effects)
     }
 
     pub fn has_pending_convergence_inputs(&self, group_id: &GroupId) -> AccountResult<bool> {
@@ -2048,27 +3951,64 @@ where
     /// to trigger a drain (mdk#426). Publishes any incidental transport
     /// work the same way `ingest_delivery` does.
     pub async fn drain(&mut self) -> AccountResult<AccountDeviceEffects> {
+        let (effects, recovered_operation_ids) = self.drain_recording_visibility().await?;
+        self.discard_visibility_operations(&recovered_operation_ids)?;
+        Ok(effects)
+    }
+
+    async fn drain_recording_visibility(
+        &mut self,
+    ) -> AccountResult<(AccountDeviceEffects, Vec<[u8; 16]>)> {
+        self.start_account_visibility_operation(AccountVisibilitySource::Drain {
+            observed_at: self.wall_clock.now(),
+        })?;
         let effects = self.session.drain();
-        let mut output = self.publish_session_effects(effects).await?;
-        let resumed = self.resume_outbound_fanouts().await?;
+        let (mut output, current_visibility_batch) = self
+            .publish_session_effects_retaining_visibility(effects, None)
+            .await?;
+        let resumed = self.resume_outbound_fanouts_in_current_operation().await?;
         output.extend(resumed);
-        Ok(output)
+        let recovered_operation_ids =
+            self.finish_drain_visibility_handoff(current_visibility_batch, &mut output);
+        Ok((output, recovered_operation_ids))
+    }
+
+    pub async fn drain_leased(&mut self) -> AccountResult<LeasedAccountDeviceEffects> {
+        let (effects, _) = self.drain_recording_visibility().await?;
+        self.lease_current_returned_visibility(effects)
     }
 
     pub async fn ingest_delivery(
         &mut self,
         delivery: TransportDelivery,
     ) -> AccountResult<AccountIngestEffects> {
+        let effects = self.ingest_delivery_recording_visibility(delivery).await?;
+        self.discard_active_visibility_operation()?;
+        Ok(effects)
+    }
+
+    async fn ingest_delivery_recording_visibility(
+        &mut self,
+        delivery: TransportDelivery,
+    ) -> AccountResult<AccountIngestEffects> {
         if delivery.account_id != self.session.self_id() {
             return Err(AccountError::WrongAccountDelivery);
         }
+        let source_delivery = delivery.clone();
         let IngestEffects {
             outcome,
             left_object_unpersisted,
             effects,
             valid_proposal_groups,
         } = self.session.ingest_delivery(delivery).await?;
-        let effects = self.publish_session_effects(effects).await?;
+        self.start_account_visibility_operation(AccountVisibilitySource::Inbound {
+            delivery: source_delivery,
+            outcome: outcome.clone(),
+            observed_at: self.wall_clock.now(),
+        })?;
+        let (effects, current_visibility_batch) = self
+            .publish_session_effects_retaining_visibility(effects, None)
+            .await?;
         let mut state_bearing_groups = effects
             .events
             .iter()
@@ -2085,10 +4025,31 @@ where
                 unique_state_bearing_groups.push(group_id);
             }
         }
+        self.finish_current_visibility_handoff(current_visibility_batch);
         Ok(AccountIngestEffects {
             outcome,
             left_object_unpersisted,
             effects,
+        })
+    }
+
+    pub async fn ingest_delivery_leased(
+        &mut self,
+        delivery: TransportDelivery,
+    ) -> AccountResult<LeasedAccountIngestEffects> {
+        let AccountIngestEffects {
+            outcome,
+            left_object_unpersisted,
+            effects,
+        } = self.ingest_delivery_recording_visibility(delivery).await?;
+        let leased = self.lease_current_returned_visibility(effects)?;
+        Ok(LeasedAccountIngestEffects {
+            outcome,
+            left_object_unpersisted,
+            effects: leased.effects,
+            batches: leased.batches,
+            lease: leased.lease,
+            current_operation_id: leased.current_operation_id,
         })
     }
 
@@ -2105,13 +4066,1038 @@ where
         effects: SessionEffects,
         context: Option<AuditEventContext>,
     ) -> AccountResult<AccountDeviceEffects> {
+        let output = self
+            .publish_session_effects_recording_visibility(effects, context)
+            .await?;
+        self.discard_active_visibility_operation()?;
+        Ok(output)
+    }
+
+    async fn publish_session_effects_recording_visibility(
+        &mut self,
+        effects: SessionEffects,
+        context: Option<AuditEventContext>,
+    ) -> AccountResult<AccountDeviceEffects> {
+        self.start_account_visibility_operation(AccountVisibilitySource::Outbound {
+            group_id: None,
+            observed_at: self.wall_clock.now(),
+            action: None,
+            action_message_id: None,
+        })?;
+        self.publish_session_effects_in_current_operation(effects, context)
+            .await
+    }
+
+    async fn publish_session_effects_in_current_operation(
+        &mut self,
+        effects: SessionEffects,
+        context: Option<AuditEventContext>,
+    ) -> AccountResult<AccountDeviceEffects> {
+        let (output, current_visibility_batch) = self
+            .publish_session_effects_retaining_visibility(effects, context)
+            .await?;
+        self.finish_current_visibility_handoff(current_visibility_batch);
+        Ok(output)
+    }
+
+    /// Publish one session batch while leaving its caller-visible vectors in
+    /// runtime-owned memory until the outermost account operation is ready to
+    /// return. This is the cancellation boundary shared by `drain`, ingest,
+    /// and direct session-effect publication.
+    async fn publish_session_effects_retaining_visibility(
+        &mut self,
+        effects: SessionEffects,
+        context: Option<AuditEventContext>,
+    ) -> AccountResult<(AccountDeviceEffects, SessionVisibilityHandoff)> {
+        let visibility_handoff = self.begin_session_visibility_handoff()?;
+        self.start_current_publish_visibility(visibility_handoff);
         let mut output = AccountDeviceEffects::default();
         let mut queue = VecDeque::new();
-        output.absorb_session_effects(effects, &mut queue);
-        self.publish_queue(&mut output, &mut queue, context).await?;
+        self.absorb_session_effects_retaining_visibility(
+            &mut output,
+            effects,
+            &mut queue,
+            visibility_handoff,
+        )?;
+        self.publish_queue(&mut output, &mut queue, context, visibility_handoff)
+            .await?;
         self.reconcile_confirmed_own_leaf_rotations(&output.events)?;
         self.reconcile_superseded_maintenance(&output.events)?;
-        Ok(output)
+        Ok((output, visibility_handoff))
+    }
+
+    fn start_account_visibility_operation(
+        &mut self,
+        source: AccountVisibilitySource,
+    ) -> AccountResult<()> {
+        self.ensure_visibility_journal_loaded()?;
+        let mut operation_id = [0_u8; 16];
+        loop {
+            OsRng.fill_bytes(&mut operation_id);
+            if !self
+                .durable_visibility_operations
+                .contains_key(&operation_id)
+            {
+                break;
+            }
+        }
+        let header = StoredAccountVisibilityRecordV1 {
+            version: ACCOUNT_VISIBILITY_RECORD_VERSION,
+            source: source.clone(),
+            payload: StoredAccountVisibilityPayloadV1::Header {
+                maintenance_disposition: SendMaintenanceDisposition::Ready,
+            },
+        };
+        self.upsert_visibility_record(&operation_id, 0, &header)?;
+        self.durable_visibility_operations.insert(
+            operation_id,
+            DurableVisibilityOperation {
+                source,
+                next_event_ordinal: 1,
+                session_control: StoredSessionControlV1::default(),
+                non_session_fragments: BTreeMap::new(),
+            },
+        );
+        self.active_visibility_operation = Some(operation_id);
+        Ok(())
+    }
+
+    fn begin_session_visibility_handoff(&mut self) -> AccountResult<SessionVisibilityHandoff> {
+        let operation_id = self
+            .active_visibility_operation
+            .ok_or_else(|| account_visibility_error("visibility operation was not started"))?;
+        let fragment_id = self.next_visibility_fragment_id;
+        self.next_visibility_fragment_id = self.next_visibility_fragment_id.wrapping_add(1).max(1);
+        self.durable_visibility_operations
+            .get_mut(&operation_id)
+            .expect("active visibility operation must have durable state")
+            .non_session_fragments
+            .insert(fragment_id, AccountDeviceEffects::default());
+        Ok(SessionVisibilityHandoff {
+            retained_batch_count: self.retained_session_visibility.len(),
+            operation_id,
+            fragment_id,
+        })
+    }
+
+    /// Reserve the first batch in a publish handoff for a replaceable snapshot
+    /// of every non-session field accumulated by completed publish work. The
+    /// following session-event batches remain append-only and preserve their
+    /// own engine order.
+    fn start_current_publish_visibility(&mut self, handoff: SessionVisibilityHandoff) {
+        debug_assert_eq!(
+            self.retained_session_visibility.len(),
+            handoff.retained_batch_count
+        );
+        self.retained_session_visibility
+            .push_back(RetainedSessionVisibilityBatch {
+                operation_id: Some(handoff.operation_id),
+                effects: AccountDeviceEffects::default(),
+            });
+    }
+
+    /// Replace the current publish handoff's non-session snapshot before the
+    /// queue crosses its next await. Replacing one slot instead of appending
+    /// cumulative snapshots prevents replay duplicates.
+    fn checkpoint_current_publish_visibility(
+        &mut self,
+        handoff: SessionVisibilityHandoff,
+        output: &AccountDeviceEffects,
+    ) -> AccountResult<()> {
+        let Some(batch) = self
+            .retained_session_visibility
+            .get_mut(handoff.retained_batch_count)
+        else {
+            debug_assert!(false, "publish visibility slot must remain live");
+            return Err(account_visibility_error(
+                "publish visibility slot did not remain live",
+            ));
+        };
+        batch.effects = output.non_session_visibility_clone();
+        let operation = self
+            .durable_visibility_operations
+            .get_mut(&handoff.operation_id)
+            .ok_or_else(|| account_visibility_error("visibility operation state is missing"))?;
+        operation
+            .non_session_fragments
+            .insert(handoff.fragment_id, output.non_session_visibility_clone());
+        let source = operation.source.clone();
+        let mut cumulative = AccountDeviceEffects::default();
+        for fragment in operation.non_session_fragments.values() {
+            cumulative.extend(fragment.non_session_visibility_clone());
+        }
+        let record = StoredAccountVisibilityRecordV1 {
+            version: ACCOUNT_VISIBILITY_RECORD_VERSION,
+            source,
+            payload: StoredAccountVisibilityPayloadV1::NonSession(
+                StoredNonSessionEffectsV1::from_effects(&cumulative),
+            ),
+        };
+        self.upsert_visibility_record(
+            &handoff.operation_id,
+            ACCOUNT_VISIBILITY_NON_SESSION_ORDINAL,
+            &record,
+        )?;
+        Ok(())
+    }
+
+    fn checkpoint_optional_publish_visibility(
+        &mut self,
+        handoff: Option<SessionVisibilityHandoff>,
+        output: &AccountDeviceEffects,
+    ) -> AccountResult<()> {
+        if let Some(handoff) = handoff {
+            self.checkpoint_current_publish_visibility(handoff, output)?;
+        }
+        Ok(())
+    }
+
+    fn retain_session_visibility(
+        &mut self,
+        handoff: SessionVisibilityHandoff,
+        effects: &SessionEffects,
+    ) -> AccountResult<()> {
+        if effects.events.is_empty()
+            && effects.queued.is_empty()
+            && effects.pending_convergence.is_empty()
+        {
+            return Ok(());
+        }
+
+        let (source, first_event_ordinal, mut control) = {
+            let operation = self
+                .durable_visibility_operations
+                .get(&handoff.operation_id)
+                .ok_or_else(|| account_visibility_error("visibility operation state is missing"))?;
+            (
+                operation.source.clone(),
+                operation.next_event_ordinal,
+                operation.session_control.clone(),
+            )
+        };
+        let mut records = Vec::with_capacity(effects.events.len().saturating_add(1));
+        for (index, event) in effects.events.iter().enumerate() {
+            let ordinal = first_event_ordinal.saturating_add(index as u64);
+            let record = StoredAccountVisibilityRecordV1 {
+                version: ACCOUNT_VISIBILITY_RECORD_VERSION,
+                source: source.clone(),
+                payload: StoredAccountVisibilityPayloadV1::Event {
+                    event: event.clone(),
+                    engine_outbox_provenance: matches!(
+                        event,
+                        GroupEvent::MessageReceived { .. } | GroupEvent::GroupJoined { .. }
+                    ),
+                },
+            };
+            records.push(self.encode_visibility_upsert(&handoff.operation_id, ordinal, &record)?);
+        }
+
+        if !effects.queued.is_empty() || !effects.pending_convergence.is_empty() {
+            control
+                .queued
+                .extend(effects.queued.iter().map(|queued| StoredQueuedIntentRefV1 {
+                    group_id: queued.group_id.clone(),
+                    intent_id: queued.intent_id.clone(),
+                }));
+            control
+                .pending_convergence
+                .extend(effects.pending_convergence.iter().cloned());
+            let record = StoredAccountVisibilityRecordV1 {
+                version: ACCOUNT_VISIBILITY_RECORD_VERSION,
+                source: source.clone(),
+                payload: StoredAccountVisibilityPayloadV1::SessionControl(control.clone()),
+            };
+            records.push(self.encode_visibility_upsert(
+                &handoff.operation_id,
+                ACCOUNT_VISIBILITY_CONTROL_ORDINAL,
+                &record,
+            )?);
+        }
+
+        self.visibility_storage
+            .upsert_account_visibility_journal_records(&records)
+            .map_err(|error| AccountError::Session(SessionError::Storage(error)))?;
+        let operation = self
+            .durable_visibility_operations
+            .get_mut(&handoff.operation_id)
+            .expect("visibility operation remains live after atomic persistence");
+        operation.next_event_ordinal = first_event_ordinal
+            .saturating_add(u64::try_from(effects.events.len()).unwrap_or(u64::MAX));
+        operation.session_control = control;
+
+        self.retained_session_visibility
+            .push_back(RetainedSessionVisibilityBatch {
+                operation_id: Some(handoff.operation_id),
+                effects: AccountDeviceEffects {
+                    events: effects.events.clone(),
+                    queued: effects.queued.clone(),
+                    pending_convergence: effects.pending_convergence.clone(),
+                    ..AccountDeviceEffects::default()
+                },
+            });
+        Ok(())
+    }
+
+    fn retain_account_visibility_memory_only(&mut self, effects: &AccountDeviceEffects) {
+        if effects == &AccountDeviceEffects::default() {
+            return;
+        }
+
+        self.retained_session_visibility
+            .push_back(RetainedSessionVisibilityBatch {
+                operation_id: self.active_visibility_operation,
+                effects: effects.clone(),
+            });
+    }
+
+    fn absorb_session_effects_retaining_visibility(
+        &mut self,
+        output: &mut AccountDeviceEffects,
+        mut effects: SessionEffects,
+        queue: &mut VecDeque<PublishWork>,
+        handoff: SessionVisibilityHandoff,
+    ) -> AccountResult<()> {
+        self.suppress_hydrated_visibility_duplicates(&mut effects);
+        self.retain_session_visibility(handoff, &effects)?;
+        output.absorb_session_effects(effects, queue);
+        Ok(())
+    }
+
+    fn absorb_session_effects_retaining_optional_visibility(
+        &mut self,
+        output: &mut AccountDeviceEffects,
+        mut effects: SessionEffects,
+        queue: &mut VecDeque<PublishWork>,
+        handoff: Option<SessionVisibilityHandoff>,
+    ) -> AccountResult<()> {
+        self.suppress_hydrated_visibility_duplicates(&mut effects);
+        if let Some(handoff) = handoff {
+            self.retain_session_visibility(handoff, &effects)?;
+        }
+        output.absorb_session_effects(effects, queue);
+        Ok(())
+    }
+
+    fn suppress_hydrated_visibility_duplicates(&mut self, effects: &mut SessionEffects) {
+        effects.events.retain(|event| {
+            let Some(index) = self
+                .hydrated_visibility_suppressions
+                .iter()
+                .position(|retained| retained == event)
+            else {
+                return true;
+            };
+            self.hydrated_visibility_suppressions.remove(index);
+            false
+        });
+    }
+
+    /// Every batch created by this operation is already present in its
+    /// `output`; only remove those journal copies after the operation's final
+    /// fallible step has finished.
+    fn finish_current_visibility_handoff(&mut self, handoff: SessionVisibilityHandoff) {
+        self.retained_session_visibility
+            .truncate(handoff.retained_batch_count);
+    }
+
+    fn append_retained_visibility_since(
+        &self,
+        handoff: SessionVisibilityHandoff,
+        output: &mut AccountDeviceEffects,
+    ) {
+        for batch in self
+            .retained_session_visibility
+            .iter()
+            .skip(handoff.retained_batch_count)
+        {
+            output.extend(batch.effects.clone());
+        }
+    }
+
+    fn take_retained_visibility(&mut self) -> AccountDeviceEffects {
+        let mut recovered = AccountDeviceEffects::default();
+        for batch in self.retained_session_visibility.drain(..) {
+            recovered.extend(batch.effects);
+        }
+        recovered
+    }
+
+    /// A no-inbound drain is the replay surface for batches stranded by an
+    /// earlier failed or cancelled operation. Exclude the current batch (it is
+    /// already at the front of `output`) and prepend every older batch in its
+    /// original order. No await may follow this handoff.
+    ///
+    /// Returns the cancelled operations whose effects were actually prepended
+    /// so a legacy `drain` can ACK them in the same transaction as the current
+    /// operation.
+    fn finish_drain_visibility_handoff(
+        &mut self,
+        handoff: SessionVisibilityHandoff,
+        output: &mut AccountDeviceEffects,
+    ) -> Vec<[u8; 16]> {
+        self.finish_current_visibility_handoff(handoff);
+        let mut recovered_operation_ids = Vec::new();
+        let mut seen = HashSet::new();
+        for batch in &self.retained_session_visibility {
+            if let Some(operation_id) = batch.operation_id
+                && seen.insert(operation_id)
+            {
+                recovered_operation_ids.push(operation_id);
+            }
+        }
+        if self.retained_session_visibility.is_empty() {
+            return recovered_operation_ids;
+        }
+
+        let mut recovered = self.take_retained_visibility();
+        recovered.extend(std::mem::take(output));
+        *output = recovered;
+        recovered_operation_ids
+    }
+
+    fn lease_current_returned_visibility(
+        &mut self,
+        effects: AccountDeviceEffects,
+    ) -> AccountResult<LeasedAccountDeviceEffects> {
+        let operation_id = self.active_visibility_operation.ok_or_else(|| {
+            account_visibility_error("leased visibility operation was not started")
+        })?;
+        self.update_active_visibility_header(effects.maintenance_disposition)?;
+        self.lease_returned_visibility(effects, Some(operation_id))
+    }
+
+    fn lease_returned_visibility(
+        &mut self,
+        effects: AccountDeviceEffects,
+        current_operation_id: Option<[u8; 16]>,
+    ) -> AccountResult<LeasedAccountDeviceEffects> {
+        let batches = self.load_visibility_batches()?;
+
+        let lease = AccountVisibilityLease(self.next_visibility_lease_id);
+        self.next_visibility_lease_id = self.next_visibility_lease_id.wrapping_add(1).max(1);
+        self.returned_visibility_lease = Some(RetainedReturnedVisibilityLease {
+            lease,
+            batch_ids: batches.iter().map(|batch| batch.batch_id.clone()).collect(),
+        });
+        Ok(LeasedAccountDeviceEffects {
+            effects,
+            batches,
+            lease,
+            current_operation_id: current_operation_id.map(|operation_id| operation_id.to_vec()),
+        })
+    }
+
+    /// Return durable visibility left by an earlier cancelled/dropped runtime
+    /// before starting any new transport work.
+    pub fn replay_visibility_leased(
+        &mut self,
+    ) -> AccountResult<Option<LeasedAccountDeviceEffects>> {
+        if self
+            .visibility_storage
+            .load_account_visibility_journal()
+            .map_err(|error| AccountError::Session(SessionError::Storage(error)))?
+            .is_empty()
+        {
+            return Ok(None);
+        }
+        self.lease_returned_visibility(AccountDeviceEffects::default(), None)
+            .map(Some)
+    }
+
+    /// Stable row ids for deletion in the app's projection transaction.
+    pub fn visibility_lease_batch_ids(
+        &self,
+        lease: AccountVisibilityLease,
+    ) -> Option<Vec<Vec<u8>>> {
+        self.returned_visibility_lease
+            .as_ref()
+            .filter(|retained| retained.lease == lease)
+            .map(|retained| retained.batch_ids.clone())
+    }
+
+    /// Acknowledge that the app has durably staged every effect carried by
+    /// `lease`. Returns `false` for an already-acknowledged or superseded
+    /// generation and never clears a newer handoff.
+    pub fn acknowledge_visibility_lease(&mut self, lease: AccountVisibilityLease) -> bool {
+        let Some(batch_ids) = self.visibility_lease_batch_ids(lease) else {
+            return false;
+        };
+        self.delete_visibility_batches_acking_engine_outbox(&batch_ids)
+            .is_ok()
+            && self
+                .forget_durably_acknowledged_visibility_lease(lease)
+                .unwrap_or(false)
+    }
+
+    /// Delete visibility rows and ACK any engine application-event ids they
+    /// carry in one storage transaction. Legacy `drain` / `ingest_delivery`
+    /// transfer ownership synchronously; without this ACK a returned
+    /// `MessageReceived` / `GroupJoined` is hydrated back into the engine
+    /// outbox on every reopen.
+    fn delete_visibility_batches_acking_engine_outbox(
+        &self,
+        batch_ids: &[Vec<u8>],
+    ) -> AccountResult<()> {
+        if batch_ids.is_empty() {
+            return Ok(());
+        }
+        let batches = self.load_visibility_batches()?;
+        let engine_outbox_ids = batches
+            .iter()
+            .filter(|batch| batch_ids.contains(&batch.batch_id))
+            .filter(|batch| {
+                matches!(
+                    batch.kind,
+                    AccountVisibilityRecordKind::Event {
+                        engine_outbox_provenance: true
+                    }
+                )
+            })
+            .flat_map(|batch| batch.effects.events.iter())
+            .filter_map(engine_outbox_event_id)
+            .collect::<Vec<_>>();
+        self.visibility_storage
+            .with_transaction(|storage| {
+                storage.delete_pending_application_events(&engine_outbox_ids)?;
+                storage.delete_account_visibility_journal_batches(batch_ids)?;
+                Ok::<_, StorageError>(())
+            })
+            .map_err(|error| AccountError::Session(SessionError::Storage(error)))?;
+        Ok(())
+    }
+
+    /// Forget a lease only after its rows were durably deleted, normally inside
+    /// the app's projection transaction through `SqliteAccountStorage`.
+    pub fn forget_durably_acknowledged_visibility_lease(
+        &mut self,
+        lease: AccountVisibilityLease,
+    ) -> AccountResult<bool> {
+        let Some(batch_ids) = self.visibility_lease_batch_ids(lease) else {
+            return Ok(false);
+        };
+        self.forget_durably_acknowledged_visibility_batches(lease, &batch_ids)
+    }
+
+    /// Advance one lease after the app atomically deleted a projected subset
+    /// of its stable row ids. Returns `true` only when the lease is now fully
+    /// acknowledged; a projected prefix leaves the remaining ids leased.
+    ///
+    /// This boundary is deliberately storage-free. The caller invokes it only
+    /// after its projection transaction has committed the row deletions, and a
+    /// terminal close is allowed to close SQLite immediately after that
+    /// commit. Re-reading the journal here would turn harmless in-memory lease
+    /// cleanup into a post-commit failure window where both durable copies are
+    /// gone but the app cannot promote its one-shot visibility summary.
+    pub fn forget_durably_acknowledged_visibility_batches(
+        &mut self,
+        lease: AccountVisibilityLease,
+        acknowledged_batch_ids: &[Vec<u8>],
+    ) -> AccountResult<bool> {
+        let Some(retained) = self.returned_visibility_lease.as_ref() else {
+            return Ok(false);
+        };
+        if retained.lease != lease
+            || acknowledged_batch_ids
+                .iter()
+                .any(|batch_id| !retained.batch_ids.contains(batch_id))
+        {
+            return Ok(false);
+        }
+        let retained = self
+            .returned_visibility_lease
+            .as_mut()
+            .expect("matching lease remains live");
+        retained
+            .batch_ids
+            .retain(|batch_id| !acknowledged_batch_ids.contains(batch_id));
+        if !retained.batch_ids.is_empty() {
+            return Ok(false);
+        }
+        self.returned_visibility_lease = None;
+        self.retained_session_visibility.clear();
+        // A matching lease is always the newest generation and snapshots every
+        // journal row then present. `&mut self` prevents a new account
+        // operation from adding rows between its return and this advancement;
+        // any later operation would instead have installed a newer lease and
+        // made the generation mismatch above return `false`.
+        self.durable_visibility_operations.clear();
+        Ok(true)
+    }
+
+    fn ensure_visibility_journal_loaded(&self) -> AccountResult<()> {
+        match &self.visibility_load_error {
+            Some(error) => Err(account_visibility_error(format!(
+                "load account visibility journal: {error}"
+            ))),
+            None => Ok(()),
+        }
+    }
+
+    /// Compatibility boundary for legacy methods that return effects without
+    /// an explicit projection lease. A successful legacy call has transferred
+    /// ownership synchronously to its caller, so only that operation's rows
+    /// are removed; older failed/cancelled operations remain replayable.
+    fn discard_active_visibility_operation(&mut self) -> AccountResult<()> {
+        self.discard_visibility_operations(&[])
+    }
+
+    /// ACK the current operation plus every recovered operation whose effects
+    /// were actually handed off, in one storage transaction. Used by legacy
+    /// `drain`, which prepends cancelled batches and must not leave their
+    /// journal rows and engine outbox ids live across reopen.
+    fn discard_visibility_operations(
+        &mut self,
+        recovered_operation_ids: &[[u8; 16]],
+    ) -> AccountResult<()> {
+        let mut operation_ids = recovered_operation_ids.to_vec();
+        if let Some(operation_id) = self.active_visibility_operation.take() {
+            operation_ids.push(operation_id);
+        }
+        if operation_ids.is_empty() {
+            return Ok(());
+        }
+        let batch_ids = self
+            .visibility_storage
+            .load_account_visibility_journal()
+            .map_err(|error| AccountError::Session(SessionError::Storage(error)))?
+            .into_iter()
+            .filter(|row| {
+                operation_ids
+                    .iter()
+                    .any(|operation_id| row.operation_id.as_slice() == operation_id)
+            })
+            .map(|row| row.batch_id)
+            .collect::<Vec<_>>();
+        self.delete_visibility_batches_acking_engine_outbox(&batch_ids)?;
+        for operation_id in operation_ids {
+            self.durable_visibility_operations.remove(&operation_id);
+        }
+        Ok(())
+    }
+
+    fn upsert_visibility_record(
+        &self,
+        operation_id: &[u8; 16],
+        ordinal: u64,
+        record: &StoredAccountVisibilityRecordV1,
+    ) -> AccountResult<u64> {
+        let upsert = self.encode_visibility_upsert(operation_id, ordinal, record)?;
+        self.visibility_storage
+            .upsert_account_visibility_journal(
+                &upsert.operation_id,
+                upsert.ordinal,
+                &upsert.batch_id,
+                &upsert.record,
+            )
+            .map_err(|error| AccountError::Session(SessionError::Storage(error)))
+    }
+
+    fn encode_visibility_upsert(
+        &self,
+        operation_id: &[u8; 16],
+        ordinal: u64,
+        record: &StoredAccountVisibilityRecordV1,
+    ) -> AccountResult<AccountVisibilityJournalUpsert> {
+        let encoded = serde_json::to_vec(record).map_err(|error| {
+            account_visibility_error(format!("serialize account visibility record: {error}"))
+        })?;
+        Ok(AccountVisibilityJournalUpsert {
+            operation_id: operation_id.to_vec(),
+            ordinal,
+            batch_id: account_visibility_batch_id(operation_id, ordinal),
+            record: encoded,
+        })
+    }
+
+    fn update_active_visibility_header(
+        &self,
+        maintenance_disposition: SendMaintenanceDisposition,
+    ) -> AccountResult<()> {
+        let Some(operation_id) = self.active_visibility_operation else {
+            return Ok(());
+        };
+        let source = self
+            .durable_visibility_operations
+            .get(&operation_id)
+            .ok_or_else(|| account_visibility_error("visibility operation state is missing"))?
+            .source
+            .clone();
+        let record = StoredAccountVisibilityRecordV1 {
+            version: ACCOUNT_VISIBILITY_RECORD_VERSION,
+            source,
+            payload: StoredAccountVisibilityPayloadV1::Header {
+                maintenance_disposition,
+            },
+        };
+        self.upsert_visibility_record(&operation_id, 0, &record)?;
+        Ok(())
+    }
+
+    fn bind_active_outbound_action_message(
+        &mut self,
+        action: AccountVisibilityOutboundAction,
+        message_id: MessageId,
+    ) -> AccountResult<()> {
+        let operation_id = self.active_visibility_operation.ok_or_else(|| {
+            account_visibility_error("bound outbound action has no visibility operation")
+        })?;
+        let operation = self
+            .durable_visibility_operations
+            .get_mut(&operation_id)
+            .ok_or_else(|| account_visibility_error("visibility operation state is missing"))?;
+        match &mut operation.source {
+            AccountVisibilitySource::Outbound {
+                action: initiating_action,
+                action_message_id,
+                ..
+            } if *initiating_action == Some(action) => {
+                *action_message_id = Some(message_id);
+            }
+            _ => {
+                return Err(account_visibility_error(
+                    "bound outbound action does not match its visibility source",
+                ));
+            }
+        }
+        // Session acceptance has already atomically installed the exact sent
+        // SelfRemove and LeaveRequest. Rewrite the pre-acceptance Header before
+        // any relay await; a crash in the narrow interval between those writes
+        // is repaired from the request's paired message id below.
+        self.update_active_visibility_header(SendMaintenanceDisposition::Ready)
+    }
+
+    fn load_visibility_batches(&self) -> AccountResult<Vec<AccountVisibilityBatch>> {
+        self.ensure_visibility_journal_loaded()?;
+        let mut batches = self
+            .visibility_storage
+            .load_account_visibility_journal()
+            .map_err(|error| AccountError::Session(SessionError::Storage(error)))?
+            .into_iter()
+            .map(decode_account_visibility_row)
+            .collect::<AccountResult<Vec<_>>>()?;
+        struct LeaveHeaderRef {
+            index: usize,
+            sequence: u64,
+            operation_id: Vec<u8>,
+            bound: Option<MessageId>,
+        }
+        let mut by_group = HashMap::<GroupId, Vec<LeaveHeaderRef>>::new();
+        for (index, batch) in batches.iter().enumerate() {
+            let AccountVisibilitySource::Outbound {
+                group_id: Some(group_id),
+                action: Some(AccountVisibilityOutboundAction::Leave),
+                action_message_id,
+                ..
+            } = &batch.source
+            else {
+                continue;
+            };
+            by_group
+                .entry(group_id.clone())
+                .or_default()
+                .push(LeaveHeaderRef {
+                    index,
+                    sequence: batch.sequence,
+                    operation_id: batch.operation_id.clone(),
+                    bound: action_message_id.clone(),
+                });
+        }
+        let mut repaired = Vec::new();
+        for (group_id, mut headers) in by_group {
+            headers.sort_by_key(|header| header.sequence);
+            let current_id = self
+                .visibility_storage
+                .leave_request(&group_id)
+                .map_err(|error| AccountError::Session(SessionError::Storage(error)))?
+                .and_then(|request| request.last_proposed_message_id);
+            let Some(current_id) = current_id else {
+                continue;
+            };
+            // One semantic owner per group. Prefer a Header already bound to
+            // the live Leave id, else the newest previously bound Header so
+            // M1 follows to M2, else the newest unbound pre-acceptance Header.
+            // A later LeaveAlreadyRequested Header must not also inherit.
+            let owner_operation_id = headers
+                .iter()
+                .find(|header| header.bound.as_ref() == Some(&current_id))
+                .map(|header| header.operation_id.clone())
+                .or_else(|| {
+                    headers
+                        .iter()
+                        .rev()
+                        .find(|header| header.bound.is_some())
+                        .map(|header| header.operation_id.clone())
+                })
+                .or_else(|| headers.last().map(|header| header.operation_id.clone()));
+            let Some(owner_operation_id) = owner_operation_id else {
+                continue;
+            };
+            for header in &headers {
+                let AccountVisibilitySource::Outbound {
+                    action_message_id, ..
+                } = &mut batches[header.index].source
+                else {
+                    continue;
+                };
+                let desired = if header.operation_id == owner_operation_id {
+                    Some(current_id.clone())
+                } else if action_message_id.as_ref() == Some(&current_id) {
+                    None
+                } else {
+                    continue;
+                };
+                if action_message_id != &desired {
+                    *action_message_id = desired;
+                    repaired.push(header.index);
+                }
+            }
+        }
+        self.persist_repaired_leave_sources(&batches, &repaired)?;
+        Ok(batches)
+    }
+
+    fn persist_repaired_leave_sources(
+        &self,
+        batches: &[AccountVisibilityBatch],
+        repaired: &[usize],
+    ) -> AccountResult<()> {
+        if repaired.is_empty() {
+            return Ok(());
+        }
+        let repaired_ids = repaired
+            .iter()
+            .map(|&index| batches[index].batch_id.clone())
+            .collect::<HashSet<_>>();
+        let rows = self
+            .visibility_storage
+            .load_account_visibility_journal()
+            .map_err(|error| AccountError::Session(SessionError::Storage(error)))?;
+        let mut upserts = Vec::new();
+        for row in rows {
+            if !repaired_ids.contains(&row.batch_id) {
+                continue;
+            }
+            let live = batches
+                .iter()
+                .find(|batch| batch.batch_id == row.batch_id)
+                .ok_or_else(|| {
+                    account_visibility_error("repaired visibility batch is missing from memory")
+                })?;
+            let mut record: StoredAccountVisibilityRecordV1 = serde_json::from_slice(&row.record)
+                .map_err(|error| {
+                account_visibility_error(format!("decode account visibility record: {error}"))
+            })?;
+            if record.source == live.source {
+                continue;
+            }
+            record.source = live.source.clone();
+            let encoded = serde_json::to_vec(&record).map_err(|error| {
+                account_visibility_error(format!("serialize account visibility record: {error}"))
+            })?;
+            upserts.push(AccountVisibilityJournalUpsert {
+                operation_id: row.operation_id,
+                ordinal: row.ordinal,
+                batch_id: row.batch_id,
+                record: encoded,
+            });
+        }
+        if !upserts.is_empty() {
+            self.visibility_storage
+                .upsert_account_visibility_journal_records(&upserts)
+                .map_err(|error| AccountError::Session(SessionError::Storage(error)))?;
+        }
+        Ok(())
+    }
+
+    fn record_terminal_outbound_action_outcome(
+        &self,
+        message_id: &MessageId,
+        published: bool,
+        output: &mut AccountDeviceEffects,
+    ) -> AccountResult<()> {
+        if let Some(existing) = output
+            .action_outcomes
+            .iter()
+            .find(|outcome| &outcome.message_id == message_id)
+        {
+            if existing.published != published {
+                return Err(account_visibility_error(
+                    "outbound action changed its terminal publish outcome",
+                ));
+            }
+            return Ok(());
+        }
+
+        let batches = self.load_visibility_batches()?;
+        if let Some(existing) = batches
+            .iter()
+            .flat_map(|batch| &batch.effects.action_outcomes)
+            .find(|outcome| &outcome.message_id == message_id)
+        {
+            if existing.published != published {
+                return Err(account_visibility_error(
+                    "durable outbound action changed its terminal publish outcome",
+                ));
+            }
+            return Ok(());
+        }
+        let mut pending = None::<AccountVisibilityActionOutcome>;
+        for batch in &batches {
+            let AccountVisibilitySource::Outbound {
+                group_id: Some(group_id),
+                action: Some(action),
+                action_message_id: Some(bound_message_id),
+                ..
+            } = &batch.source
+            else {
+                continue;
+            };
+            if bound_message_id != message_id {
+                continue;
+            }
+            let candidate = AccountVisibilityActionOutcome {
+                operation_id: batch.operation_id.clone(),
+                group_id: group_id.clone(),
+                message_id: message_id.clone(),
+                action: *action,
+                published,
+            };
+            match &pending {
+                Some(existing) if existing != &candidate => {
+                    return Err(account_visibility_error(
+                        "outbound action message is bound to multiple visibility operations",
+                    ));
+                }
+                Some(_) => {}
+                None => pending = Some(candidate),
+            }
+        }
+        if pending.is_none() {
+            // Provenance must outlive Header ACK. Terminal M1 failure deletes
+            // the Leave Header; an epoch-driven M2 still has the LeaveRequest
+            // naming this exact SelfRemove.
+            pending = self.leave_request_outcome_for_message(message_id, published)?;
+        }
+        if let Some(outcome) = pending {
+            output.action_outcomes.push(outcome);
+        }
+        Ok(())
+    }
+
+    fn leave_request_outcome_for_message(
+        &self,
+        message_id: &MessageId,
+        published: bool,
+    ) -> AccountResult<Option<AccountVisibilityActionOutcome>> {
+        let mut group_ids = Vec::new();
+        let fanouts = self.session.outbound_fanouts()?;
+        for fanout in fanouts {
+            if fanout.message_id() == message_id
+                && let Some(group_id) = fanout.group_id()
+                && !group_ids.contains(group_id)
+            {
+                group_ids.push(group_id.clone());
+            }
+        }
+        if let Some(operation_id) = self.active_visibility_operation
+            && let Some(operation) = self.durable_visibility_operations.get(&operation_id)
+            && let AccountVisibilitySource::Outbound {
+                group_id: Some(group_id),
+                action: Some(AccountVisibilityOutboundAction::Leave),
+                ..
+            } = &operation.source
+            && !group_ids.contains(group_id)
+        {
+            group_ids.push(group_id.clone());
+        }
+        for group_id in group_ids {
+            let owns_message = self
+                .visibility_storage
+                .leave_request(&group_id)
+                .map_err(|error| AccountError::Session(SessionError::Storage(error)))?
+                .and_then(|request| request.last_proposed_message_id)
+                .as_ref()
+                == Some(message_id);
+            if !owns_message {
+                continue;
+            }
+            let operation_id = self
+                .active_visibility_operation
+                .map(|operation_id| operation_id.to_vec())
+                .unwrap_or_else(|| message_id.as_slice().to_vec());
+            return Ok(Some(AccountVisibilityActionOutcome {
+                operation_id,
+                group_id,
+                message_id: message_id.clone(),
+                action: AccountVisibilityOutboundAction::Leave,
+                published,
+            }));
+        }
+        Ok(None)
+    }
+
+    fn leave_fanout_requires_action_outcome(&self, fanout: &OutboundFanout) -> AccountResult<bool> {
+        let Some(group_id) = fanout.group_id() else {
+            return Ok(false);
+        };
+        Ok(self
+            .visibility_storage
+            .leave_request(group_id)
+            .map_err(|error| AccountError::Session(SessionError::Storage(error)))?
+            .and_then(|request| request.last_proposed_message_id)
+            .as_ref()
+            == Some(fanout.message_id()))
+    }
+
+    fn leave_action_outcome_is_recorded(
+        &self,
+        message_id: &MessageId,
+        published: bool,
+        output: &AccountDeviceEffects,
+    ) -> AccountResult<bool> {
+        if let Some(existing) = output
+            .action_outcomes
+            .iter()
+            .find(|outcome| &outcome.message_id == message_id)
+        {
+            if existing.published != published {
+                return Err(account_visibility_error(
+                    "outbound action changed its terminal publish outcome",
+                ));
+            }
+            return Ok(true);
+        }
+        let batches = self.load_visibility_batches()?;
+        if let Some(existing) = batches
+            .iter()
+            .flat_map(|batch| &batch.effects.action_outcomes)
+            .find(|outcome| &outcome.message_id == message_id)
+        {
+            if existing.published != published {
+                return Err(account_visibility_error(
+                    "durable outbound action changed its terminal publish outcome",
+                ));
+            }
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    fn ensure_leave_fanout_outcome_recorded(
+        &self,
+        fanout: &OutboundFanout,
+        published: bool,
+        output: &AccountDeviceEffects,
+    ) -> AccountResult<()> {
+        if !self.leave_fanout_requires_action_outcome(fanout)? {
+            return Ok(());
+        }
+        if self.leave_action_outcome_is_recorded(fanout.message_id(), published, output)? {
+            return Ok(());
+        }
+        Err(account_visibility_error(
+            "leave fanout produced no durable action outcome",
+        ))
     }
 
     async fn publish_queue(
@@ -2119,6 +5105,7 @@ where
         output: &mut AccountDeviceEffects,
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
+        visibility_handoff: SessionVisibilityHandoff,
     ) -> AccountResult<()> {
         while let Some(work) = queue.pop_front() {
             match work {
@@ -2132,9 +5119,15 @@ where
                 } => {
                     let reports_before = output.reports.len();
                     let unresolved_before = output.unresolved_publishes.len();
-                    let status =
-                        Box::pin(self.publish_one(msg, None, output, queue, context.clone()))
-                            .await?;
+                    let status = Box::pin(self.publish_one(
+                        msg,
+                        None,
+                        output,
+                        queue,
+                        context.clone(),
+                        Some(visibility_handoff),
+                    ))
+                    .await?;
                     if status.accepted_by_any_endpoint {
                         if let Some(message_id) = output
                             .reports
@@ -2173,9 +5166,15 @@ where
                     self.resolve_regenerated_queued_intent(queued_intent, status);
                 }
                 PublishWork::Proposal { msg, queued_intent } => {
-                    let status =
-                        Box::pin(self.publish_one(msg, None, output, queue, context.clone()))
-                            .await?;
+                    let status = Box::pin(self.publish_one(
+                        msg,
+                        None,
+                        output,
+                        queue,
+                        context.clone(),
+                        Some(visibility_handoff),
+                    ))
+                    .await?;
                     self.resolve_regenerated_queued_intent(queued_intent, status);
                 }
                 PublishWork::GroupCreated { welcomes, pending } => {
@@ -2185,12 +5184,19 @@ where
                         output,
                         queue,
                         context.clone(),
+                        visibility_handoff,
                     ))
                     .await?;
                 }
                 PublishWork::FoundingGroupCreated { welcomes } => {
-                    self.publish_founding_group_created(welcomes, output, queue, context.clone())
-                        .await?;
+                    self.publish_founding_group_created(
+                        welcomes,
+                        output,
+                        queue,
+                        context.clone(),
+                        visibility_handoff,
+                    )
+                    .await?;
                 }
                 PublishWork::GroupEvolution {
                     msg,
@@ -2204,20 +5210,46 @@ where
                         output,
                         queue,
                         context.clone(),
+                        visibility_handoff,
                     ))
                     .await?;
                 }
                 PublishWork::AutoPublish { msg, pending } => {
-                    self.publish_pending(vec![msg], pending, output, queue, context.clone())
-                        .await?;
+                    self.publish_pending(
+                        vec![msg],
+                        pending,
+                        output,
+                        queue,
+                        context.clone(),
+                        visibility_handoff,
+                    )
+                    .await?;
                 }
             }
+            // This checkpoint is synchronous and is the final action before
+            // the loop can poll the next PublishWork. A later work item may
+            // block or fail, but every caller-visible field produced so far is
+            // now replayable without publishing the completed item again.
+            self.checkpoint_current_publish_visibility(visibility_handoff, output)?;
         }
         Ok(())
     }
 
     /// Resume every incomplete frozen fanout in original staging order.
     pub async fn resume_outbound_fanouts(&mut self) -> AccountResult<AccountDeviceEffects> {
+        self.start_account_visibility_operation(AccountVisibilitySource::Drain {
+            observed_at: self.wall_clock.now(),
+        })?;
+        let effects = self.resume_outbound_fanouts_in_current_operation().await?;
+        self.discard_active_visibility_operation()?;
+        Ok(effects)
+    }
+
+    async fn resume_outbound_fanouts_in_current_operation(
+        &mut self,
+    ) -> AccountResult<AccountDeviceEffects> {
+        let visibility_handoff = self.begin_session_visibility_handoff()?;
+        self.start_current_publish_visibility(visibility_handoff);
         let fanouts = self.session.outbound_fanouts()?;
         let mut output = AccountDeviceEffects::default();
         let mut queue = VecDeque::new();
@@ -2226,14 +5258,32 @@ where
             if outcome.outstanding_targets > 0
                 || matches!(fanout.mls_state(), FanoutMlsState::Pending(_))
             {
-                Box::pin(self.drive_outbound_fanout(fanout, &mut output, &mut queue, None)).await?;
+                Box::pin(self.drive_outbound_fanout(
+                    fanout,
+                    &mut output,
+                    &mut queue,
+                    None,
+                    Some(visibility_handoff),
+                ))
+                .await?;
+                self.checkpoint_current_publish_visibility(visibility_handoff, &output)?;
             } else {
+                let published = outcome.accepted_targets >= fanout.request().required_acks.max(1);
+                self.record_terminal_outbound_action_outcome(
+                    fanout.message_id(),
+                    published,
+                    &mut output,
+                )?;
+                self.ensure_leave_fanout_outcome_recorded(&fanout, published, &output)?;
+                self.checkpoint_current_publish_visibility(visibility_handoff, &output)?;
                 self.session.delete_outbound_fanout(fanout.message_id())?;
             }
         }
-        self.publish_queue(&mut output, &mut queue, None).await?;
+        self.publish_queue(&mut output, &mut queue, None, visibility_handoff)
+            .await?;
         self.reconcile_confirmed_own_leaf_rotations(&output.events)?;
         self.reconcile_superseded_maintenance(&output.events)?;
+        self.finish_current_visibility_handoff(visibility_handoff);
         Ok(output)
     }
 
@@ -2462,6 +5512,7 @@ where
         output: &mut AccountDeviceEffects,
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
+        visibility_handoff: SessionVisibilityHandoff,
     ) -> AccountResult<()> {
         let maintenance_evolution = messages.len() == 1
             && self
@@ -2488,9 +5539,16 @@ where
                 output
                     .pending
                     .push(PendingResolution::Confirmed { pending });
-                output.absorb_session_effects(effects, queue);
+                self.absorb_session_effects_retaining_visibility(
+                    output,
+                    effects,
+                    queue,
+                    visibility_handoff,
+                )?;
                 self.mark_transport_fanout_evolution_confirmed(&message.id);
-                self.finish_transport_fanout(&message.id, output).await?;
+                self.checkpoint_current_publish_visibility(visibility_handoff, output)?;
+                self.finish_transport_fanout(&message.id, output, Some(visibility_handoff))
+                    .await?;
                 return Ok(());
             }
 
@@ -2502,7 +5560,7 @@ where
             for message in messages {
                 message_ids.push(message.id.clone());
                 let status = self
-                    .publish_legacy_one(message, output, context.clone())
+                    .publish_legacy_one(message, output, context.clone(), Some(visibility_handoff))
                     .await?;
                 any_accepted |= status.accepted_by_any_endpoint;
                 all_published &= status.met_required_acks;
@@ -2515,17 +5573,29 @@ where
                 output
                     .pending
                     .push(PendingResolution::Confirmed { pending });
-                output.absorb_session_effects(effects, queue);
+                self.absorb_session_effects_retaining_visibility(
+                    output,
+                    effects,
+                    queue,
+                    visibility_handoff,
+                )?;
+                self.checkpoint_current_publish_visibility(visibility_handoff, output)?;
                 for message_id in message_ids {
                     self.mark_transport_fanout_evolution_confirmed(&message_id);
-                    self.finish_transport_fanout(&message_id, output).await?;
+                    self.finish_transport_fanout(&message_id, output, Some(visibility_handoff))
+                        .await?;
                 }
             } else if !ambiguous_exposure && !retry_deferred {
                 let effects = self.session.publish_failed(pending).await?;
                 output
                     .pending
                     .push(PendingResolution::RolledBack { pending });
-                output.absorb_session_effects(effects, queue);
+                self.absorb_session_effects_retaining_visibility(
+                    output,
+                    effects,
+                    queue,
+                    visibility_handoff,
+                )?;
             }
             return Ok(());
         }
@@ -2539,11 +5609,24 @@ where
             output
                 .pending
                 .push(PendingResolution::RolledBack { pending });
-            output.absorb_session_effects(effects, queue);
+            self.absorb_session_effects_retaining_visibility(
+                output,
+                effects,
+                queue,
+                visibility_handoff,
+            )?;
             return Ok(());
         };
         debug_assert!(messages.next().is_none());
-        Box::pin(self.publish_one(message, Some(pending), output, queue, context)).await?;
+        Box::pin(self.publish_one(
+            message,
+            Some(pending),
+            output,
+            queue,
+            context,
+            Some(visibility_handoff),
+        ))
+        .await?;
         Ok(())
     }
 
@@ -2554,6 +5637,7 @@ where
         output: &mut AccountDeviceEffects,
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
+        visibility_handoff: SessionVisibilityHandoff,
     ) -> AccountResult<()> {
         let mut welcomes = welcomes.into_iter();
         let Some(first_welcome) = welcomes.next() else {
@@ -2561,7 +5645,12 @@ where
             output
                 .pending
                 .push(PendingResolution::Confirmed { pending });
-            output.absorb_session_effects(effects, queue);
+            self.absorb_session_effects_retaining_visibility(
+                output,
+                effects,
+                queue,
+                visibility_handoff,
+            )?;
             return Ok(());
         };
         Box::pin(self.publish_one_with_post_confirmation_welcomes(
@@ -2574,6 +5663,7 @@ where
             output,
             queue,
             context,
+            Some(visibility_handoff),
         ))
         .await?;
         Ok(())
@@ -2585,13 +5675,21 @@ where
         output: &mut AccountDeviceEffects,
         _queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
+        visibility_handoff: SessionVisibilityHandoff,
     ) -> AccountResult<()> {
         let group_id = output.events.iter().find_map(|event| match event {
             GroupEvent::GroupCreated { group_id } => Some(group_id.clone()),
             _ => None,
         });
-        self.publish_welcome_fanout(welcomes, group_id, output, context, false)
-            .await
+        self.publish_welcome_fanout(
+            welcomes,
+            group_id,
+            output,
+            context,
+            false,
+            Some(visibility_handoff),
+        )
+        .await
     }
 
     /// Bounded-concurrency Welcome publication used by founding creates and by
@@ -2603,10 +5701,19 @@ where
         output: &mut AccountDeviceEffects,
         context: Option<AuditEventContext>,
         force_retry: bool,
+        visibility_handoff: Option<SessionVisibilityHandoff>,
     ) -> AccountResult<()> {
         let prepared = self.prepare_welcome_publish(welcomes, group_id, context, force_retry)?;
+        if visibility_handoff.is_some() {
+            let mut prepared_visibility = output.clone();
+            for metadata in &prepared.metadata {
+                prepared_visibility.extend(metadata.effects.clone());
+            }
+            self.checkpoint_optional_publish_visibility(visibility_handoff, &prepared_visibility)?;
+        }
         let completed = prepared.publish(&self.adapter).await;
-        self.finish_welcome_publish(completed, output).await
+        self.finish_welcome_publish(completed, output, visibility_handoff)
+            .await
     }
 
     fn prepare_welcome_publish(
@@ -2654,6 +5761,7 @@ where
         &mut self,
         completed: CompletedWelcomePublish,
         output: &mut AccountDeviceEffects,
+        visibility_handoff: Option<SessionVisibilityHandoff>,
     ) -> AccountResult<()> {
         let CompletedWelcomePublish {
             group_id,
@@ -2672,13 +5780,20 @@ where
             let WelcomePublishMetadata {
                 recipient,
                 welcome_id,
-                mut effects,
+                effects,
             } = metadata;
+            let failures_before = output.failures.len();
+            output.extend(effects);
             let status = match completion.expect("every Welcome publish completed") {
                 LegacyPublishCompletion::Complete(status) => Ok(status),
                 LegacyPublishCompletion::Network(attempt, result) => {
-                    self.finish_prepared_legacy_publish(*attempt, result, &mut effects)
-                        .await
+                    self.finish_prepared_legacy_publish(
+                        *attempt,
+                        result,
+                        output,
+                        visibility_handoff,
+                    )
+                    .await
                 }
             };
             let status = match status {
@@ -2694,16 +5809,16 @@ where
                 if status.met_required_acks {
                     self.mark_welcome_delivered_best_effort(&welcome_id);
                 } else if let Some(recipient) = recipient {
-                    effects.welcome_failures.push(self.welcome_delivery_failure(
+                    output.welcome_failures.push(self.welcome_delivery_failure(
                         welcome_id,
                         recipient,
                         group_id.clone(),
-                        &effects,
-                        0,
+                        output,
+                        failures_before,
                     ));
                 }
             }
-            output.extend(effects);
+            self.checkpoint_optional_publish_visibility(visibility_handoff, output)?;
         }
         match first_error {
             Some(error) => Err(error),
@@ -2711,6 +5826,7 @@ where
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn publish_group_evolution(
         &mut self,
         commit: TransportMessage,
@@ -2719,6 +5835,7 @@ where
         output: &mut AccountDeviceEffects,
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
+        visibility_handoff: SessionVisibilityHandoff,
     ) -> AccountResult<()> {
         let commit_id = commit.id.clone();
         let maintenance_evolution = self
@@ -2734,16 +5851,23 @@ where
             });
         if maintenance_evolution {
             let commit_status = self
-                .publish_legacy_one(commit, output, context.clone())
+                .publish_legacy_one(commit, output, context.clone(), Some(visibility_handoff))
                 .await?;
             if commit_status.met_required_acks || commit_status.accepted_by_any_endpoint {
                 let effects = self.confirm_published_retrying(pending).await?;
                 output
                     .pending
                     .push(PendingResolution::Confirmed { pending });
-                output.absorb_session_effects(effects, queue);
+                self.absorb_session_effects_retaining_visibility(
+                    output,
+                    effects,
+                    queue,
+                    visibility_handoff,
+                )?;
                 self.mark_transport_fanout_evolution_confirmed(&commit_id);
-                self.finish_transport_fanout(&commit_id, output).await?;
+                self.checkpoint_current_publish_visibility(visibility_handoff, output)?;
+                self.finish_transport_fanout(&commit_id, output, Some(visibility_handoff))
+                    .await?;
                 debug_assert!(welcomes.is_empty());
                 return Ok(());
             }
@@ -2752,7 +5876,12 @@ where
                 output
                     .pending
                     .push(PendingResolution::RolledBack { pending });
-                output.absorb_session_effects(effects, queue);
+                self.absorb_session_effects_retaining_visibility(
+                    output,
+                    effects,
+                    queue,
+                    visibility_handoff,
+                )?;
             }
             return Ok(());
         }
@@ -2767,6 +5896,7 @@ where
             output,
             queue,
             context,
+            Some(visibility_handoff),
         ))
         .await?;
         Ok(())
@@ -2788,8 +5918,9 @@ where
     }
 
     async fn retry_confirmed_transport_fanouts(
-        &self,
+        &mut self,
         output: &mut AccountDeviceEffects,
+        visibility_handoff: Option<SessionVisibilityHandoff>,
     ) -> AccountResult<()> {
         let now = self.wall_clock.now();
         for fanout in self.session.transport_fanouts()? {
@@ -2803,7 +5934,8 @@ where
             if fanout.evolution_id.is_some() && !fanout.evolution_confirmed {
                 continue;
             }
-            self.finish_transport_fanout(&fanout.id, output).await?;
+            self.finish_transport_fanout(&fanout.id, output, visibility_handoff)
+                .await?;
         }
         Ok(())
     }
@@ -2814,9 +5946,10 @@ where
     /// has been applied locally. These attempts therefore cannot reopen the MLS
     /// pending state or change the canonical branch.
     async fn finish_transport_fanout(
-        &self,
+        &mut self,
         message_id: &cgka_traits::MessageId,
         output: &mut AccountDeviceEffects,
+        visibility_handoff: Option<SessionVisibilityHandoff>,
     ) -> AccountResult<()> {
         if self.detached_welcome_publishes.contains(message_id) {
             return Ok(());
@@ -2882,6 +6015,7 @@ where
                     }
                 }
             }
+            self.checkpoint_optional_publish_visibility(visibility_handoff, output)?;
             self.session.put_transport_fanout(&fanout)?;
         }
         Ok(())
@@ -2909,7 +6043,7 @@ where
         // wait for the automatic fanout backoff window. The original exact
         // Welcome and target snapshot are still reused.
         let status = self
-            .publish_one_with_retry_policy(message, &mut output, None, true)
+            .publish_one_with_retry_policy(message, &mut output, None, true, None)
             .await?;
         if status.met_required_acks {
             self.mark_welcome_delivered_best_effort(message_id);
@@ -2993,6 +6127,7 @@ where
         output: &mut AccountDeviceEffects,
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
+        visibility_handoff: Option<SessionVisibilityHandoff>,
     ) -> AccountResult<PublishStatus> {
         let continuation = match pending {
             Some(pending) => Some(PendingFanoutContinuation {
@@ -3008,6 +6143,7 @@ where
             output,
             queue,
             context,
+            visibility_handoff,
         )
         .await
     }
@@ -3019,6 +6155,7 @@ where
         output: &mut AccountDeviceEffects,
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
+        visibility_handoff: Option<SessionVisibilityHandoff>,
     ) -> AccountResult<PublishStatus> {
         let (pending, pending_kind, post_confirmation_welcomes) = match continuation {
             Some(continuation) => (
@@ -3033,11 +6170,13 @@ where
                 Ok(target) => target,
                 Err(error) => {
                     output.failures.push(PublishFailure {
-                        message_id: message.id,
+                        message_id: message.id.clone(),
                         reason: error.to_string(),
                     });
-                    self.rollback_unstaged_pending(pending, output, queue)
+                    self.rollback_unstaged_pending(pending, output, queue, visibility_handoff)
                         .await?;
+                    self.record_terminal_outbound_action_outcome(&message.id, false, output)?;
+                    self.checkpoint_optional_publish_visibility(visibility_handoff, output)?;
                     return Ok(PublishStatus::default());
                 }
             };
@@ -3048,7 +6187,7 @@ where
             {
                 Ok(group_id) => group_id,
                 Err(error) => {
-                    self.rollback_unstaged_pending(pending, output, queue)
+                    self.rollback_unstaged_pending(pending, output, queue, visibility_handoff)
                         .await?;
                     return Err(error.into());
                 }
@@ -3063,7 +6202,7 @@ where
                 {
                     Ok(message_id) => message_id,
                     Err(error) => {
-                        self.rollback_unstaged_pending(pending, output, queue)
+                        self.rollback_unstaged_pending(pending, output, queue, visibility_handoff)
                             .await?;
                         return Err(error.into());
                     }
@@ -3085,19 +6224,21 @@ where
             ) {
                 Ok(fanout) => fanout,
                 Err(error) => {
-                    self.rollback_unstaged_pending(pending, output, queue)
+                    self.rollback_unstaged_pending(pending, output, queue, visibility_handoff)
                         .await?;
                     return Err(error.into());
                 }
             };
             if let Err(error) = self.session.put_outbound_fanout(&fanout) {
-                self.rollback_unstaged_pending(pending, output, queue)
+                self.rollback_unstaged_pending(pending, output, queue, visibility_handoff)
                     .await?;
                 return Err(error.into());
             }
-            Box::pin(self.drive_outbound_fanout(fanout, output, queue, context)).await
+            Box::pin(self.drive_outbound_fanout(fanout, output, queue, context, visibility_handoff))
+                .await
         } else {
-            self.publish_legacy_one(message, output, context).await
+            self.publish_legacy_one(message, output, context, visibility_handoff)
+                .await
         }
     }
 
@@ -3106,13 +6247,20 @@ where
         pending: Option<PendingStateRef>,
         output: &mut AccountDeviceEffects,
         queue: &mut VecDeque<PublishWork>,
+        visibility_handoff: Option<SessionVisibilityHandoff>,
     ) -> AccountResult<()> {
         if let Some(pending) = pending {
+            self.checkpoint_optional_publish_visibility(visibility_handoff, output)?;
             let effects = self.session.publish_failed(pending).await?;
             output
                 .pending
                 .push(PendingResolution::RolledBack { pending });
-            output.absorb_session_effects(effects, queue);
+            self.absorb_session_effects_retaining_optional_visibility(
+                output,
+                effects,
+                queue,
+                visibility_handoff,
+            )?;
         }
         Ok(())
     }
@@ -3123,9 +6271,17 @@ where
         output: &mut AccountDeviceEffects,
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
+        visibility_handoff: Option<SessionVisibilityHandoff>,
     ) -> AccountResult<PublishStatus> {
-        self.resolve_outbound_fanout_mls(&mut fanout, output, queue, context.clone())
-            .await?;
+        self.resolve_outbound_fanout_mls(
+            &mut fanout,
+            output,
+            queue,
+            context.clone(),
+            visibility_handoff,
+        )
+        .await?;
+        self.checkpoint_optional_publish_visibility(visibility_handoff, output)?;
         let endpoints = fanout.request().target.endpoints().to_vec();
         let now_ms = self.wall_clock.now().0.saturating_mul(1_000);
         let due = fanout
@@ -3210,6 +6366,10 @@ where
             // Record this artifact before confirmation releases any frozen
             // Welcome continuations, preserving transport chronology in the
             // returned effects while keeping the MLS edge atomic below.
+            // `EpochConfirmed` / `EpochRolledBack` records the MLS edge. This
+            // endpoint-free publish row records the separate terminal fanout
+            // edge; relay URLs stay solely in the encrypted fanout record and
+            // never enter this privacy-safe audit summary.
             self.session.record_audit_event(
                 fanout.group_id(),
                 context.clone(),
@@ -3226,8 +6386,14 @@ where
                 },
             );
             output.reports.push(report);
-            self.resolve_outbound_fanout_mls(&mut fanout, output, queue, context.clone())
-                .await?;
+            self.resolve_outbound_fanout_mls(
+                &mut fanout,
+                output,
+                queue,
+                context.clone(),
+                visibility_handoff,
+            )
+            .await?;
         }
 
         let report = frozen_fanout_report(&fanout);
@@ -3281,6 +6447,20 @@ where
             }
         }
         output.fanout.push(fanout_outcome.clone());
+        // Leave membership is authorized by `published: true`. Required ACKs
+        // can land while an optional target stays retryable, so emit durable
+        // true at quorum rather than waiting for complete fanout. `published:
+        // false` stays terminal: only a finished fanout that missed quorum.
+        if status.met_required_acks {
+            self.record_terminal_outbound_action_outcome(fanout.message_id(), true, output)?;
+        } else if fanout_outcome.fanout_complete {
+            self.record_terminal_outbound_action_outcome(fanout.message_id(), false, output)?;
+        }
+        if fanout_outcome.fanout_complete {
+            let published = status.met_required_acks;
+            self.ensure_leave_fanout_outcome_recorded(&fanout, published, output)?;
+        }
+        self.checkpoint_optional_publish_visibility(visibility_handoff, output)?;
         if fanout_outcome.fanout_complete
             && !matches!(fanout.mls_state(), FanoutMlsState::Pending(_))
         {
@@ -3295,6 +6475,7 @@ where
         output: &mut AccountDeviceEffects,
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
+        visibility_handoff: Option<SessionVisibilityHandoff>,
     ) -> AccountResult<()> {
         let outcome = fanout.outcome();
         if outcome.mls_confirmation_required {
@@ -3307,7 +6488,12 @@ where
             output
                 .pending
                 .push(PendingResolution::Confirmed { pending });
-            output.absorb_session_effects(effects, queue);
+            self.absorb_session_effects_retaining_optional_visibility(
+                output,
+                effects,
+                queue,
+                visibility_handoff,
+            )?;
         } else if outcome.fanout_complete
             && outcome.accepted_targets == 0
             && !fanout.possible_exposure()
@@ -3317,15 +6503,27 @@ where
             output
                 .pending
                 .push(PendingResolution::RolledBack { pending });
-            output.absorb_session_effects(effects, queue);
+            self.absorb_session_effects_retaining_optional_visibility(
+                output,
+                effects,
+                queue,
+                visibility_handoff,
+            )?;
         }
         if matches!(fanout.mls_state(), FanoutMlsState::Confirmed)
             && !fanout.pending_post_confirmation_welcomes().is_empty()
         {
             let welcomes = fanout.pending_post_confirmation_welcomes().to_vec();
             let group_id = fanout.group_id().cloned();
-            self.publish_welcome_fanout(welcomes, group_id, output, context, false)
-                .await?;
+            self.publish_welcome_fanout(
+                welcomes,
+                group_id,
+                output,
+                context,
+                false,
+                visibility_handoff,
+            )
+            .await?;
             if fanout.mark_post_confirmation_welcomes_released() {
                 self.session.put_outbound_fanout(fanout)?;
             }
@@ -3334,27 +6532,29 @@ where
     }
 
     async fn publish_legacy_one(
-        &self,
+        &mut self,
         message: TransportMessage,
         output: &mut AccountDeviceEffects,
         context: Option<AuditEventContext>,
+        visibility_handoff: Option<SessionVisibilityHandoff>,
     ) -> AccountResult<PublishStatus> {
-        self.publish_one_with_retry_policy(message, output, context, false)
+        self.publish_one_with_retry_policy(message, output, context, false, visibility_handoff)
             .await
     }
 
     async fn publish_one_with_retry_policy(
-        &self,
+        &mut self,
         message: TransportMessage,
         output: &mut AccountDeviceEffects,
         context: Option<AuditEventContext>,
         retry_immediately: bool,
+        visibility_handoff: Option<SessionVisibilityHandoff>,
     ) -> AccountResult<PublishStatus> {
         match self.prepare_legacy_publish(message, output, context, retry_immediately)? {
             PreparedLegacyPublish::Complete(status) => Ok(status),
             PreparedLegacyPublish::Network(attempt) => {
                 let result = self.adapter.publish(attempt.request.clone()).await;
-                self.finish_prepared_legacy_publish(*attempt, result, output)
+                self.finish_prepared_legacy_publish(*attempt, result, output, visibility_handoff)
                     .await
             }
         }
@@ -3565,10 +6765,11 @@ where
     }
 
     async fn finish_prepared_legacy_publish(
-        &self,
+        &mut self,
         attempt: PreparedLegacyPublishAttempt,
         result: Result<TransportPublishReport, TransportAdapterError>,
         output: &mut AccountDeviceEffects,
+        visibility_handoff: Option<SessionVisibilityHandoff>,
     ) -> AccountResult<PublishStatus> {
         let PreparedLegacyPublishAttempt {
             message_id,
@@ -3699,8 +6900,10 @@ where
             });
         }
         output.reports.push(report);
+        self.checkpoint_optional_publish_visibility(visibility_handoff, output)?;
         if !defers_remaining_fanout_until_confirmation {
-            self.finish_transport_fanout(&message_id, output).await?;
+            self.finish_transport_fanout(&message_id, output, visibility_handoff)
+                .await?;
         }
         Ok(PublishStatus {
             met_required_acks: published,
@@ -3758,6 +6961,104 @@ fn frozen_fanout_target_retry_due(fanout: &OutboundFanout, index: usize, now_ms:
         }
         Some(FanoutTargetStatus::Accepted | FanoutTargetStatus::Failed) | None => false,
     }
+}
+
+fn account_visibility_error(error: impl Into<String>) -> AccountError {
+    AccountError::Session(SessionError::Storage(StorageError::Backend(error.into())))
+}
+
+fn account_visibility_batch_id(operation_id: &[u8; 16], ordinal: u64) -> Vec<u8> {
+    use sha2::{Digest, Sha256};
+
+    let mut hasher = Sha256::new();
+    hasher.update(b"marmot-account-visibility-v1");
+    hasher.update(operation_id);
+    hasher.update(ordinal.to_be_bytes());
+    hasher.finalize().to_vec()
+}
+
+fn decode_account_visibility_row(
+    row: AccountVisibilityJournalRow,
+) -> AccountResult<AccountVisibilityBatch> {
+    let operation_id = <[u8; 16]>::try_from(row.operation_id.as_slice())
+        .map_err(|_| account_visibility_error("visibility operation id has invalid length"))?;
+    if row.batch_id != account_visibility_batch_id(&operation_id, row.ordinal) {
+        return Err(account_visibility_error(
+            "visibility batch id does not match its operation and ordinal",
+        ));
+    }
+    let record: StoredAccountVisibilityRecordV1 =
+        serde_json::from_slice(&row.record).map_err(|error| {
+            account_visibility_error(format!("decode account visibility record: {error}"))
+        })?;
+    if record.version != ACCOUNT_VISIBILITY_RECORD_VERSION {
+        return Err(account_visibility_error(format!(
+            "unsupported account visibility record version {}",
+            record.version
+        )));
+    }
+    let mut effects = AccountDeviceEffects::default();
+    let kind = match record.payload {
+        StoredAccountVisibilityPayloadV1::Header {
+            maintenance_disposition,
+        } => {
+            if row.ordinal != 0 {
+                return Err(account_visibility_error(
+                    "visibility header has a nonzero ordinal",
+                ));
+            }
+            effects.maintenance_disposition = maintenance_disposition;
+            AccountVisibilityRecordKind::Header
+        }
+        StoredAccountVisibilityPayloadV1::Event {
+            event,
+            engine_outbox_provenance,
+        } => {
+            if row.ordinal == 0 || row.ordinal >= ACCOUNT_VISIBILITY_CONTROL_ORDINAL {
+                return Err(account_visibility_error(
+                    "visibility event has a reserved ordinal",
+                ));
+            }
+            effects.events.push(event);
+            AccountVisibilityRecordKind::Event {
+                engine_outbox_provenance,
+            }
+        }
+        StoredAccountVisibilityPayloadV1::SessionControl(control) => {
+            if row.ordinal != ACCOUNT_VISIBILITY_CONTROL_ORDINAL {
+                return Err(account_visibility_error(
+                    "visibility session-control record has the wrong ordinal",
+                ));
+            }
+            effects.queued = control
+                .queued
+                .into_iter()
+                .map(|queued| QueuedIntentRef {
+                    group_id: queued.group_id,
+                    intent_id: queued.intent_id,
+                })
+                .collect();
+            effects.pending_convergence = control.pending_convergence;
+            AccountVisibilityRecordKind::SessionControl
+        }
+        StoredAccountVisibilityPayloadV1::NonSession(non_session) => {
+            if row.ordinal != ACCOUNT_VISIBILITY_NON_SESSION_ORDINAL {
+                return Err(account_visibility_error(
+                    "visibility non-session record has the wrong ordinal",
+                ));
+            }
+            effects = non_session.into_effects();
+            AccountVisibilityRecordKind::NonSession
+        }
+    };
+    Ok(AccountVisibilityBatch {
+        sequence: row.sequence,
+        operation_id: row.operation_id,
+        batch_id: row.batch_id,
+        source: record.source,
+        kind,
+        effects,
+    })
 }
 
 fn frozen_fanout_report(fanout: &OutboundFanout) -> TransportPublishReport {
@@ -3844,6 +7145,46 @@ fn apply_report_to_fanout(
     }
 }
 
+/// Whether durable teardown evidence says the live current revision was
+/// deleted. Pre-artifact lifecycle rows can carry only `authored_event_id`, so
+/// both identity representations are authoritative during upgrade recovery.
+fn current_key_package_revision_is_deleted(lifecycle: &KeyPackageLifecycleState) -> bool {
+    lifecycle
+        .authored_signed_event
+        .as_ref()
+        .is_some_and(|artifact| {
+            lifecycle
+                .deleted_live_revision_event_ids
+                .contains(&artifact.id)
+        })
+        || lifecycle
+            .authored_event_id
+            .as_ref()
+            .is_some_and(|event_id| lifecycle.deleted_live_revision_event_ids.contains(event_id))
+}
+
+fn current_key_package_artifact_precedes_authoring_high_water(
+    lifecycle: &KeyPackageLifecycleState,
+) -> bool {
+    lifecycle
+        .authored_signed_event
+        .as_ref()
+        .zip(lifecycle.authored_event_created_at)
+        .is_some_and(|(artifact, high_water)| artifact.created_at < high_water)
+}
+
+fn ensure_key_package_cutover_publication_allowed(
+    lifecycle: &KeyPackageLifecycleState,
+) -> AccountResult<()> {
+    if lifecycle.cutover_publication_blocked {
+        return Err(crate::key_package::KeyPackagePublishError::unexposed(
+            "key package publication is blocked until strict cutover discovery completes",
+        )
+        .into());
+    }
+    Ok(())
+}
+
 fn current_key_package_republish_blocker(
     lifecycle: &KeyPackageLifecycleState,
     now: Timestamp,
@@ -3868,7 +7209,18 @@ fn current_key_package_republish_blocker(
         Some("missing_authored_event_created_at")
     } else if lifecycle.authored_signed_event.is_none() {
         Some("missing_authored_signed_event")
-    } else if lifecycle.last_consumed_key_package_ref == lifecycle.current_key_package_ref {
+    } else if lifecycle
+        .authored_signed_event
+        .as_ref()
+        .zip(lifecycle.authored_event_created_at)
+        .is_some_and(|(artifact, high_water)| artifact.created_at < high_water)
+    {
+        Some("newer_stable_slot_revision_requires_semantic_replacement")
+    } else if lifecycle
+        .current_key_package_ref
+        .as_deref()
+        .is_some_and(|key_package_ref| lifecycle.key_package_ref_is_consumed(key_package_ref))
+    {
         Some("current_key_package_ref_consumed")
     } else if !lifecycle.upgrade_rotation_recorded {
         Some("upgrade_rotation_required")
@@ -3887,10 +7239,15 @@ fn merge_republish_publication_targets(
             .find(|target| target.endpoint == *endpoint)
         {
             if target.state == TransportFanoutAttemptState::PolicyProhibited {
-                target.state = TransportFanoutAttemptState::Unattempted;
-                target.attempt_count = 0;
-                target.last_attempt_at = None;
-                target.failure_code = None;
+                if target.attempt_count == 0 && target.last_attempt_at.is_none() {
+                    target.state = TransportFanoutAttemptState::Unattempted;
+                    target.failure_code = None;
+                } else {
+                    // Re-authorizing the same exact event at a formerly removed
+                    // endpoint must retain its historical exposure evidence.
+                    target.state = TransportFanoutAttemptState::AttemptedFailed;
+                    target.failure_code = Some("possible_exposure".into());
+                }
             }
             continue;
         }
@@ -3914,11 +7271,811 @@ fn merge_republish_publication_targets(
     }
 }
 
-fn note_key_package_attempt(
+fn key_package_publication_targets_need_policy_reconciliation(
+    targets: &[TransportFanoutTarget],
+    current_endpoints: &[TransportEndpoint],
+) -> bool {
+    current_endpoints.iter().any(|endpoint| {
+        !targets.iter().any(|target| {
+            target.endpoint == *endpoint
+                && target.state != TransportFanoutAttemptState::PolicyProhibited
+        })
+    }) || targets.iter().any(|target| {
+        target.state != TransportFanoutAttemptState::PolicyProhibited
+            && !current_endpoints.contains(&target.endpoint)
+    })
+}
+
+fn key_package_reauthor_created_at(
+    artifact: &SignedPublicationArtifact,
+    now: Timestamp,
+    reauthor_after_secs: Option<u64>,
+    ordering_high_water: Option<Timestamp>,
+    require_strictly_above_high_water: bool,
+) -> Result<Option<Timestamp>, ()> {
+    let ordering_requires_reauthor = ordering_high_water.is_some_and(|high_water| {
+        if require_strictly_above_high_water {
+            high_water >= artifact.created_at
+        } else {
+            high_water > artifact.created_at
+        }
+    });
+    if reauthor_after_secs.is_none() && !ordering_requires_reauthor {
+        return Ok(None);
+    }
+    if artifact.created_at.0 > now.0.saturating_add(KEY_PACKAGE_MAX_FUTURE_SKEW_SECS) {
+        return Err(());
+    }
+    let policy_requires_reauthor = reauthor_after_secs.is_some_and(|reauthor_after_secs| {
+        now.0.saturating_sub(artifact.created_at.0) >= reauthor_after_secs
+    });
+    if !policy_requires_reauthor && !ordering_requires_reauthor {
+        return Ok(None);
+    }
+    let strictly_newer = artifact.created_at.0.checked_add(1).ok_or(())?;
+    let strictly_above_high_water = ordering_high_water
+        .filter(|high_water| *high_water > artifact.created_at)
+        .map(|high_water| high_water.0.checked_add(1).ok_or(()))
+        .transpose()?
+        .unwrap_or(strictly_newer);
+    let created_at = Timestamp(now.0.max(strictly_newer).max(strictly_above_high_water));
+    if created_at.0 <= artifact.created_at.0
+        || created_at.0 > now.0.saturating_add(KEY_PACKAGE_MAX_FUTURE_SKEW_SECS)
+    {
+        return Err(());
+    }
+    Ok(Some(created_at))
+}
+
+fn validate_reauthored_key_package_artifact(
+    previous: &SignedPublicationArtifact,
+    requested_created_at: Timestamp,
+    replacement: &SignedPublicationArtifact,
+) -> AccountResult<()> {
+    if replacement.created_at != requested_created_at
+        || replacement.created_at <= previous.created_at
+        || replacement.id == previous.id
+        || replacement.bytes == previous.bytes
+    {
+        return Err(crate::key_package::KeyPackagePublishError::unexposed(
+            "reauthored KeyPackage event does not form a strictly newer signed revision",
+        )
+        .into());
+    }
+    Ok(())
+}
+
+fn replace_key_package_publication_targets(
+    targets: &mut Vec<TransportFanoutTarget>,
+    live_endpoints: &[TransportEndpoint],
+) {
+    *targets = live_endpoints
+        .iter()
+        .cloned()
+        .map(|endpoint| TransportFanoutTarget {
+            endpoint,
+            state: TransportFanoutAttemptState::Unattempted,
+            attempt_count: 0,
+            last_attempt_at: None,
+            failure_code: None,
+        })
+        .collect();
+}
+
+fn retired_key_package_publication(
+    artifact: &SignedPublicationArtifact,
+    key_package_ref: Option<&[u8]>,
+    package_not_after: Option<Timestamp>,
+    delete_without_successor: bool,
+    targets: &[TransportFanoutTarget],
+) -> Option<RetiredKeyPackagePublication> {
+    retired_key_package_publication_from_identity(
+        &artifact.id,
+        artifact.created_at,
+        key_package_ref,
+        package_not_after,
+        delete_without_successor,
+        targets,
+    )
+}
+
+/// Snapshot the exact current publication even for upgrade rows that predate
+/// durable signed-artifact bytes. `authored_event_id` plus the stable-slot
+/// high-water and endpoint fanout remain sufficient deletion evidence; losing
+/// that identity while superseding private material would make an exposed
+/// relay revision permanently unreachable.
+fn retired_current_key_package_publication(
+    lifecycle: &KeyPackageLifecycleState,
+    delete_without_successor: bool,
+) -> Option<RetiredKeyPackagePublication> {
+    let (event_id, authored_created_at) = match lifecycle.authored_signed_event.as_ref() {
+        Some(artifact) => (&artifact.id, artifact.created_at),
+        None => (
+            lifecycle.authored_event_id.as_ref()?,
+            lifecycle.authored_event_created_at.unwrap_or(Timestamp(0)),
+        ),
+    };
+    retired_key_package_publication_from_identity(
+        event_id,
+        authored_created_at,
+        lifecycle.current_key_package_ref.as_deref(),
+        lifecycle.current_not_after,
+        delete_without_successor,
+        &lifecycle.publication_targets,
+    )
+}
+
+fn retired_key_package_publication_from_identity(
+    event_id: &cgka_traits::MessageId,
+    authored_created_at: Timestamp,
+    key_package_ref: Option<&[u8]>,
+    package_not_after: Option<Timestamp>,
+    delete_without_successor: bool,
+    targets: &[TransportFanoutTarget],
+) -> Option<RetiredKeyPackagePublication> {
+    // Every snapshotted endpoint is a possible exposure. Publication records
+    // are updated only after the awaited network call returns, so cancellation
+    // or process death can leave a relay-held event marked `Unattempted` (and a
+    // later policy edit can turn that same ambiguous target `PolicyProhibited`).
+    let mut deletion_targets = targets
+        .iter()
+        .filter(|target| target.failure_code.as_deref() != Some("confirmed_absent"))
+        .map(|target| TransportFanoutTarget {
+            endpoint: target.endpoint.clone(),
+            state: TransportFanoutAttemptState::Unattempted,
+            attempt_count: 0,
+            last_attempt_at: None,
+            failure_code: None,
+        })
+        .collect::<Vec<_>>();
+    deletion_targets.sort_by(|left, right| left.endpoint.cmp(&right.endpoint));
+    deletion_targets.dedup_by(|left, right| left.endpoint == right.endpoint);
+    (!deletion_targets.is_empty()).then(|| RetiredKeyPackagePublication {
+        event_id: event_id.clone(),
+        authored_created_at,
+        key_package_ref: key_package_ref.map(ToOwned::to_owned),
+        package_not_after,
+        delete_without_successor,
+        deletion_targets,
+    })
+}
+
+fn manual_key_package_deletion_liability(
+    lifecycle: &KeyPackageLifecycleState,
+    event_id: &cgka_traits::MessageId,
+    endpoint: TransportEndpoint,
+) -> RetiredKeyPackagePublication {
+    let current_matches = lifecycle
+        .authored_signed_event
+        .as_ref()
+        .is_some_and(|artifact| artifact.id == *event_id)
+        || lifecycle.authored_event_id.as_ref() == Some(event_id);
+    let pending = lifecycle.pending_replacement.as_ref().filter(|pending| {
+        pending
+            .signed_event
+            .as_ref()
+            .is_some_and(|artifact| artifact.id == *event_id)
+    });
+    let existing = lifecycle
+        .retired_publications_pending_deletion
+        .iter()
+        .find(|retired| retired.event_id == *event_id);
+    let authored_created_at = existing
+        .map(|retired| retired.authored_created_at)
+        .or_else(|| {
+            current_matches.then(|| {
+                lifecycle
+                    .authored_signed_event
+                    .as_ref()
+                    .filter(|artifact| artifact.id == *event_id)
+                    .map(|artifact| artifact.created_at)
+                    .or(lifecycle.authored_event_created_at)
+                    .unwrap_or(Timestamp(0))
+            })
+        })
+        .or_else(|| pending.map(|pending| pending.authored_created_at))
+        .unwrap_or(Timestamp(0));
+    let key_package_ref = existing
+        .and_then(|retired| retired.key_package_ref.clone())
+        .or_else(|| {
+            current_matches
+                .then(|| lifecycle.current_key_package_ref.clone())
+                .flatten()
+        })
+        .or_else(|| pending.map(|pending| pending.key_package_ref.clone()));
+    let package_not_after = existing
+        .and_then(|retired| retired.package_not_after)
+        .or_else(|| {
+            current_matches
+                .then_some(lifecycle.current_not_after)
+                .flatten()
+        })
+        .or_else(|| pending.map(|pending| pending.not_after));
+    RetiredKeyPackagePublication {
+        event_id: event_id.clone(),
+        authored_created_at,
+        key_package_ref,
+        package_not_after,
+        delete_without_successor: true,
+        deletion_targets: vec![TransportFanoutTarget {
+            endpoint,
+            state: TransportFanoutAttemptState::Unattempted,
+            attempt_count: 0,
+            last_attempt_at: None,
+            failure_code: None,
+        }],
+    }
+}
+
+fn admit_manual_key_package_deletion_liabilities(
+    lifecycle: &mut KeyPackageLifecycleState,
+    event_id: &cgka_traits::MessageId,
+    mut endpoints: Vec<TransportEndpoint>,
+    liability_limit: usize,
+) -> (Vec<TransportEndpoint>, Vec<TransportEndpoint>) {
+    endpoints.sort();
+    endpoints.dedup();
+    let mut liability_count = key_package_signed_publication_liability_count(lifecycle);
+    let mut admitted = Vec::new();
+    let mut deferred = Vec::new();
+    for endpoint in endpoints {
+        let already_durable =
+            key_package_event_endpoint_is_liability(lifecycle, event_id, &endpoint);
+        if !already_durable && liability_count >= liability_limit {
+            deferred.push(endpoint);
+            continue;
+        }
+        if !already_durable {
+            liability_count = liability_count.saturating_add(1);
+        }
+        admitted.push(endpoint.clone());
+        let retired = manual_key_package_deletion_liability(lifecycle, event_id, endpoint);
+        retain_retired_key_package_publication(lifecycle, retired);
+    }
+    (admitted, deferred)
+}
+
+/// Admit one exact deletion set atomically while giving its event exclusive
+/// use of the small overflow above the ordinary signed-publication bound.
+///
+/// Requests that fit under the ordinary bound do not consume the reserve. The
+/// first request that crosses that bound becomes the durable owner; until its
+/// last deletion target is terminal, a different exact event is wholly
+/// deferred even if some ordinary capacity later becomes available. This
+/// prevents two independently atomic relay sets from sharing a reserve whose
+/// safety argument assumes one selected deletion.
+fn admit_atomic_exact_key_package_deletion_liabilities(
+    lifecycle: &mut KeyPackageLifecycleState,
+    event_id: &cgka_traits::MessageId,
+    mut endpoints: Vec<TransportEndpoint>,
+) -> (Vec<TransportEndpoint>, Vec<TransportEndpoint>) {
+    endpoints.sort();
+    endpoints.dedup();
+    release_settled_key_package_deletion_overflow_owner(lifecycle);
+
+    if lifecycle
+        .deletion_overflow_owner_event_id
+        .as_ref()
+        .is_some_and(|owner| owner != event_id)
+    {
+        return (Vec::new(), endpoints);
+    }
+
+    let additional_liabilities = endpoints
+        .iter()
+        .filter(|endpoint| !key_package_event_endpoint_is_liability(lifecycle, event_id, endpoint))
+        .count();
+    let projected = key_package_signed_publication_liability_count(lifecycle)
+        .saturating_add(additional_liabilities);
+    if projected > MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES_WITH_LIVE_DELETION_OVERFLOW {
+        return (Vec::new(), endpoints);
+    }
+    if projected > MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES
+        && lifecycle.deletion_overflow_owner_event_id.is_none()
+    {
+        lifecycle.deletion_overflow_owner_event_id = Some(event_id.clone());
+    }
+
+    let liability_limit = if lifecycle.deletion_overflow_owner_event_id.as_ref() == Some(event_id) {
+        MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES_WITH_LIVE_DELETION_OVERFLOW
+    } else {
+        MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES
+    };
+    let (admitted, deferred) = admit_manual_key_package_deletion_liabilities(
+        lifecycle,
+        event_id,
+        endpoints,
+        liability_limit,
+    );
+    debug_assert!(
+        deferred.is_empty(),
+        "atomic exact deletion was preflighted against its complete endpoint set"
+    );
+    (admitted, deferred)
+}
+
+fn release_settled_key_package_deletion_overflow_owner(lifecycle: &mut KeyPackageLifecycleState) {
+    let owner_is_settled = lifecycle
+        .deletion_overflow_owner_event_id
+        .as_ref()
+        .is_some_and(|owner| {
+            !lifecycle
+                .retired_publications_pending_deletion
+                .iter()
+                .any(|retired| {
+                    retired.event_id == *owner
+                        && retired.deletion_targets.iter().any(|target| {
+                            target.failure_code.as_deref() != Some("confirmed_absent")
+                        })
+                })
+        });
+    if owner_is_settled {
+        lifecycle.deletion_overflow_owner_event_id = None;
+    }
+}
+
+fn retain_retired_key_package_publication(
+    lifecycle: &mut KeyPackageLifecycleState,
+    retired: RetiredKeyPackagePublication,
+) {
+    if let Some(existing) = lifecycle
+        .retired_publications_pending_deletion
+        .iter_mut()
+        .find(|existing| existing.event_id == retired.event_id)
+    {
+        if existing.key_package_ref.is_none() {
+            existing.key_package_ref = retired.key_package_ref;
+        }
+        existing.package_not_after = match (existing.package_not_after, retired.package_not_after) {
+            (Some(left), Some(right)) => Some(left.min(right)),
+            (left @ Some(_), None) | (None, left @ Some(_)) => left,
+            (None, None) => None,
+        };
+        existing.delete_without_successor |= retired.delete_without_successor;
+        for target in retired.deletion_targets {
+            if !existing
+                .deletion_targets
+                .iter()
+                .any(|existing| existing.endpoint == target.endpoint)
+            {
+                existing.deletion_targets.push(target);
+            }
+        }
+        existing
+            .deletion_targets
+            .sort_by(|left, right| left.endpoint.cmp(&right.endpoint));
+        return;
+    }
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(retired);
+    lifecycle
+        .retired_publications_pending_deletion
+        .sort_by(|left, right| {
+            left.authored_created_at
+                .cmp(&right.authored_created_at)
+                .then_with(|| left.event_id.as_slice().cmp(right.event_id.as_slice()))
+        });
+}
+
+fn mark_retired_key_package_revisions_unusable(
+    lifecycle: &mut KeyPackageLifecycleState,
+    key_package_ref: &[u8],
+) {
+    for retired in &mut lifecycle.retired_publications_pending_deletion {
+        if retired.key_package_ref.as_deref() == Some(key_package_ref) {
+            retired.delete_without_successor = true;
+        }
+    }
+}
+
+/// Consume the ambiguous legacy single-ref marker by retiring every semantic
+/// KeyPackage it could have overwritten evidence for.
+///
+/// OpenMLS intentionally retains last-resort KeyPackage bundles after a
+/// Welcome, so local bundle presence cannot distinguish an unconsumed package
+/// from one whose older marker was overwritten. This one-time upgrade path
+/// therefore chooses privacy over availability and forces a fresh package.
+fn retire_legacy_only_consumption_projections(
+    lifecycle: &mut KeyPackageLifecycleState,
+    now: Timestamp,
+) -> Vec<KeyPackage> {
+    let mut retired_private_material = Vec::new();
+    let mut projected_refs = lifecycle.consumed_key_package_refs.clone();
+    let mut authored_high_water = lifecycle.authored_event_created_at;
+
+    if let Some(retired_publication) = retired_current_key_package_publication(lifecycle, true) {
+        retain_retired_key_package_publication(lifecycle, retired_publication);
+    }
+    if let Some(key_package_ref) = lifecycle.current_key_package_ref.clone() {
+        projected_refs.push(key_package_ref);
+    }
+    if let Some(created_at) = lifecycle
+        .authored_signed_event
+        .as_ref()
+        .map(|artifact| artifact.created_at)
+    {
+        authored_high_water = Some(
+            authored_high_water
+                .map(|current| current.max(created_at))
+                .unwrap_or(created_at),
+        );
+    }
+    if let Some(key_package) = lifecycle.current_key_package.take() {
+        retain_key_package_for_private_material_retirement(
+            &mut retired_private_material,
+            key_package,
+        );
+    }
+    lifecycle.current_key_package_ref = None;
+    lifecycle.current_not_before = None;
+    lifecycle.current_not_after = None;
+    lifecycle.authored_event_id = None;
+    lifecycle.authored_signed_event = None;
+    lifecycle.publication_targets.clear();
+
+    if let Some(pending) = lifecycle.pending_replacement.take() {
+        let pending_created_at = pending
+            .signed_event
+            .as_ref()
+            .map(|artifact| artifact.created_at)
+            .unwrap_or(pending.authored_created_at);
+        authored_high_water = Some(
+            authored_high_water
+                .map(|current| current.max(pending_created_at))
+                .unwrap_or(pending_created_at),
+        );
+        if let Some(retired_publication) = pending.signed_event.as_ref().and_then(|artifact| {
+            retired_key_package_publication(
+                artifact,
+                Some(&pending.key_package_ref),
+                Some(pending.not_after),
+                true,
+                &pending.targets,
+            )
+        }) {
+            retain_retired_key_package_publication(lifecycle, retired_publication);
+        }
+        projected_refs.push(pending.key_package_ref);
+        retain_key_package_for_private_material_retirement(
+            &mut retired_private_material,
+            pending.key_package,
+        );
+    }
+
+    for retained in std::mem::take(&mut lifecycle.retained_private_material) {
+        projected_refs.push(retained.key_package_ref);
+        retain_key_package_for_private_material_retirement(
+            &mut retired_private_material,
+            retained.key_package,
+        );
+    }
+    projected_refs.sort();
+    projected_refs.dedup();
+    for key_package_ref in projected_refs {
+        mark_retired_key_package_revisions_unusable(lifecycle, &key_package_ref);
+    }
+
+    lifecycle.authored_event_created_at = authored_high_water;
+    lifecycle.refresh_at = Some(now);
+    lifecycle.phase = MaintenancePhase::Retry;
+    lifecycle.consumed_key_package_refs.clear();
+    lifecycle.last_consumed_key_package_ref = None;
+    lifecycle.last_consumed_at = None;
+    retain_only_live_deleted_key_package_revision_ids(lifecycle);
+    retired_private_material
+}
+
+fn retain_key_package_for_private_material_retirement(
+    retired: &mut Vec<KeyPackage>,
+    key_package: KeyPackage,
+) {
+    if !retired.contains(&key_package) {
+        retired.push(key_package);
+    }
+}
+
+fn key_package_ref_has_live_private_material(
+    lifecycle: &KeyPackageLifecycleState,
+    key_package_ref: &[u8],
+) -> bool {
+    lifecycle.current_key_package_ref.as_deref() == Some(key_package_ref)
+        || lifecycle
+            .pending_replacement
+            .as_ref()
+            .is_some_and(|pending| pending.key_package_ref == key_package_ref)
+        || lifecycle
+            .retained_private_material
+            .iter()
+            .any(|retained| retained.key_package_ref == key_package_ref)
+}
+
+fn retain_only_live_deleted_key_package_revision_ids(lifecycle: &mut KeyPackageLifecycleState) {
+    let current_event_id = lifecycle
+        .authored_signed_event
+        .as_ref()
+        .map(|artifact| artifact.id.clone())
+        .or_else(|| lifecycle.authored_event_id.clone());
+    let pending_event_id = lifecycle
+        .pending_replacement
+        .as_ref()
+        .and_then(|pending| pending.signed_event.as_ref())
+        .map(|artifact| artifact.id.clone());
+    lifecycle
+        .deleted_live_revision_event_ids
+        .retain(|event_id| {
+            current_event_id.as_ref() == Some(event_id)
+                || pending_event_id.as_ref() == Some(event_id)
+        });
+}
+
+fn mark_live_key_package_revision_endpoints_absent(
+    lifecycle: &mut KeyPackageLifecycleState,
+    event_id: &cgka_traits::MessageId,
+    endpoints: &[TransportEndpoint],
+) {
+    if endpoints.is_empty() {
+        return;
+    }
+    if lifecycle
+        .authored_signed_event
+        .as_ref()
+        .is_some_and(|artifact| artifact.id == *event_id)
+        || lifecycle.authored_event_id.as_ref() == Some(event_id)
+    {
+        for target in &mut lifecycle.publication_targets {
+            if endpoints.contains(&target.endpoint) {
+                target.state = TransportFanoutAttemptState::AttemptedFailed;
+                target.failure_code = Some("confirmed_absent".into());
+            }
+        }
+    }
+    if let Some(pending) = lifecycle.pending_replacement.as_mut()
+        && pending
+            .signed_event
+            .as_ref()
+            .is_some_and(|artifact| artifact.id == *event_id)
+    {
+        for target in &mut pending.targets {
+            if endpoints.contains(&target.endpoint) {
+                target.state = TransportFanoutAttemptState::AttemptedFailed;
+                target.failure_code = Some("confirmed_absent".into());
+            }
+        }
+    }
+}
+
+fn key_package_signed_publication_liability_count(lifecycle: &KeyPackageLifecycleState) -> usize {
+    let mut liabilities = HashSet::new();
+    for retired in &lifecycle.retired_publications_pending_deletion {
+        insert_key_package_endpoint_liabilities(
+            &mut liabilities,
+            &retired.event_id,
+            &retired.deletion_targets,
+        );
+    }
+    if let Some(event_id) = lifecycle
+        .authored_signed_event
+        .as_ref()
+        .map(|artifact| &artifact.id)
+        .or(lifecycle.authored_event_id.as_ref())
+    {
+        insert_key_package_endpoint_liabilities(
+            &mut liabilities,
+            event_id,
+            &lifecycle.publication_targets,
+        );
+    }
+    if let Some(pending) = lifecycle.pending_replacement.as_ref()
+        && let Some(artifact) = pending.signed_event.as_ref()
+    {
+        insert_key_package_endpoint_liabilities(&mut liabilities, &artifact.id, &pending.targets);
+    }
+    liabilities.len()
+}
+
+fn projected_current_key_package_reauthor_liability_count(
+    lifecycle: &KeyPackageLifecycleState,
+    retired_publication: Option<&RetiredKeyPackagePublication>,
+    live_endpoints: &[TransportEndpoint],
+) -> usize {
+    let mut projected = lifecycle.clone();
+    if let Some(retired_publication) = retired_publication {
+        retain_retired_key_package_publication(&mut projected, retired_publication.clone());
+    }
+    let projected_event_id = unused_projected_key_package_event_id(&projected);
+    projected.authored_event_id = Some(projected_event_id.clone());
+    projected.authored_signed_event = Some(SignedPublicationArtifact {
+        id: projected_event_id,
+        created_at: Timestamp(0),
+        bytes: Vec::new(),
+    });
+    replace_key_package_publication_targets(&mut projected.publication_targets, live_endpoints);
+    key_package_signed_publication_liability_count(&projected)
+}
+
+fn projected_pending_key_package_reauthor_liability_count(
+    lifecycle: &KeyPackageLifecycleState,
+    retired_publication: Option<&RetiredKeyPackagePublication>,
+    live_endpoints: &[TransportEndpoint],
+) -> usize {
+    let mut projected = lifecycle.clone();
+    if let Some(retired_publication) = retired_publication {
+        retain_retired_key_package_publication(&mut projected, retired_publication.clone());
+    }
+    let projected_event_id = unused_projected_key_package_event_id(&projected);
+    if let Some(pending) = projected.pending_replacement.as_mut() {
+        pending.signed_event = Some(SignedPublicationArtifact {
+            id: projected_event_id,
+            created_at: Timestamp(0),
+            bytes: Vec::new(),
+        });
+        replace_key_package_publication_targets(&mut pending.targets, live_endpoints);
+    }
+    key_package_signed_publication_liability_count(&projected)
+}
+
+/// Model a future signed revision in capacity projections without depending on
+/// its not-yet-authored hash. The synthetic id never leaves memory and is
+/// chosen outside every identity currently represented in the lifecycle.
+fn unused_projected_key_package_event_id(lifecycle: &KeyPackageLifecycleState) -> MessageId {
+    let event_id_is_used = |candidate: &[u8]| {
+        lifecycle
+            .authored_signed_event
+            .as_ref()
+            .is_some_and(|artifact| artifact.id.as_slice() == candidate)
+            || lifecycle
+                .authored_event_id
+                .as_ref()
+                .is_some_and(|event_id| event_id.as_slice() == candidate)
+            || lifecycle
+                .pending_replacement
+                .as_ref()
+                .and_then(|pending| pending.signed_event.as_ref())
+                .is_some_and(|artifact| artifact.id.as_slice() == candidate)
+            || lifecycle
+                .retired_publications_pending_deletion
+                .iter()
+                .any(|retired| retired.event_id.as_slice() == candidate)
+    };
+    let mut candidate = vec![0_u8; 33];
+    while event_id_is_used(&candidate) {
+        candidate.push(0);
+    }
+    MessageId::new(candidate)
+}
+
+fn key_package_event_endpoint_is_liability(
+    lifecycle: &KeyPackageLifecycleState,
+    event_id: &cgka_traits::MessageId,
+    endpoint: &TransportEndpoint,
+) -> bool {
+    let target_is_liability = |target: &TransportFanoutTarget| {
+        target.endpoint == *endpoint && target.failure_code.as_deref() != Some("confirmed_absent")
+    };
+    lifecycle
+        .retired_publications_pending_deletion
+        .iter()
+        .any(|retired| {
+            retired.event_id == *event_id
+                && retired.deletion_targets.iter().any(target_is_liability)
+        })
+        || (lifecycle
+            .authored_signed_event
+            .as_ref()
+            .map(|artifact| &artifact.id)
+            .or(lifecycle.authored_event_id.as_ref())
+            == Some(event_id)
+            && lifecycle
+                .publication_targets
+                .iter()
+                .any(target_is_liability))
+        || lifecycle
+            .pending_replacement
+            .as_ref()
+            .is_some_and(|pending| {
+                pending
+                    .signed_event
+                    .as_ref()
+                    .is_some_and(|artifact| artifact.id == *event_id)
+                    && pending.targets.iter().any(target_is_liability)
+            })
+}
+
+fn insert_key_package_endpoint_liabilities(
+    liabilities: &mut HashSet<(Vec<u8>, TransportEndpoint)>,
+    event_id: &cgka_traits::MessageId,
+    targets: &[TransportFanoutTarget],
+) {
+    for target in targets {
+        if target.failure_code.as_deref() != Some("confirmed_absent") {
+            liabilities.insert((event_id.as_slice().to_vec(), target.endpoint.clone()));
+        }
+    }
+}
+
+fn retired_key_package_deletion_target_is_eligible(
+    lifecycle: &KeyPackageLifecycleState,
+    retired: &RetiredKeyPackagePublication,
+    target: &TransportFanoutTarget,
+    now: Timestamp,
+) -> bool {
+    if retired.delete_without_successor
+        || retired
+            .package_not_after
+            .is_some_and(|not_after| not_after <= now)
+    {
+        return true;
+    }
+    let Some(current_artifact) = lifecycle.authored_signed_event.as_ref() else {
+        return false;
+    };
+    if current_artifact.created_at <= retired.authored_created_at {
+        return false;
+    }
+    match lifecycle
+        .publication_targets
+        .iter()
+        .find(|current| current.endpoint == target.endpoint)
+    {
+        Some(current) => matches!(
+            current.state,
+            TransportFanoutAttemptState::Accepted | TransportFanoutAttemptState::PolicyProhibited
+        ),
+        None => true,
+    }
+}
+
+fn retired_key_package_deletion_pass_report(
+    lifecycle: &KeyPackageLifecycleState,
+    now: Timestamp,
+    mut terminal_endpoints: Vec<TransportEndpoint>,
+) -> RetiredKeyPackageDeletionPassReport {
+    terminal_endpoints.sort();
+    terminal_endpoints.dedup();
+    let has_uncovered_eligible_deletion = lifecycle
+        .retired_publications_pending_deletion
+        .iter()
+        .any(|retired| {
+            retired.deletion_targets.iter().any(|target| {
+                retired_key_package_deletion_target_is_eligible(lifecycle, retired, target, now)
+                    && !retired_key_package_deletion_target_has_accepted_newer_successor(
+                        lifecycle, retired, target,
+                    )
+            })
+        });
+    RetiredKeyPackageDeletionPassReport {
+        terminal_endpoints,
+        has_uncovered_eligible_deletion,
+    }
+}
+
+fn retired_key_package_deletion_target_has_accepted_newer_successor(
+    lifecycle: &KeyPackageLifecycleState,
+    retired: &RetiredKeyPackagePublication,
+    target: &TransportFanoutTarget,
+) -> bool {
+    let Some(current_artifact) = lifecycle.authored_signed_event.as_ref() else {
+        return false;
+    };
+    if current_artifact.created_at <= retired.authored_created_at
+        || lifecycle
+            .deleted_live_revision_event_ids
+            .contains(&current_artifact.id)
+    {
+        return false;
+    }
+    lifecycle.publication_targets.iter().any(|current| {
+        current.endpoint == target.endpoint
+            && current.state == TransportFanoutAttemptState::Accepted
+    })
+}
+
+/// Persist this before awaiting transport. A crash after the socket send then
+/// leaves durable possible-exposure evidence instead of an `Unattempted` lie.
+fn begin_key_package_attempt(
     targets: &mut [TransportFanoutTarget],
     attempted: &[TransportEndpoint],
-    accepted: &[TransportEndpoint],
-    failed: &[TransportEndpoint],
     attempted_at: Timestamp,
 ) {
     for target in targets {
@@ -3929,25 +8086,92 @@ fn note_key_package_attempt(
         }
         target.attempt_count = target.attempt_count.saturating_add(1);
         target.last_attempt_at = Some(attempted_at);
+        target.state = TransportFanoutAttemptState::AttemptedFailed;
+        target.failure_code = Some("possible_exposure".into());
+    }
+}
+
+/// Constrain an untrusted publication receipt to the exact fanout attempted by
+/// this call. A category may mention an endpoint at most once, and stronger
+/// evidence wins when a malformed adapter reports the same endpoint in more
+/// than one category. `confirmed_absent` is deletion-only evidence: a kind
+/// 30443 publication adapter cannot prove that no older delivery exists, so
+/// such a claim is conservatively demoted to an ambiguous failure.
+fn scope_key_package_publish_receipt(
+    mut receipt: crate::key_package::DetailedKeyPackagePublishReceipt,
+    attempted: &[TransportEndpoint],
+) -> crate::key_package::DetailedKeyPackagePublishReceipt {
+    let scope = attempted.iter().cloned().collect::<HashSet<_>>();
+    let normalize = |endpoints: &mut Vec<TransportEndpoint>| {
+        endpoints.retain(|endpoint| scope.contains(endpoint));
+        endpoints.sort();
+        endpoints.dedup();
+    };
+    normalize(&mut receipt.accepted);
+    normalize(&mut receipt.confirmed_absent);
+    normalize(&mut receipt.rejected);
+    normalize(&mut receipt.failed);
+    receipt
+        .rejected
+        .retain(|endpoint| !receipt.accepted.contains(endpoint));
+    receipt.failed.append(&mut receipt.confirmed_absent);
+    receipt.failed.sort();
+    receipt.failed.dedup();
+    receipt.failed.retain(|endpoint| {
+        !receipt.accepted.contains(endpoint) && !receipt.rejected.contains(endpoint)
+    });
+    receipt
+}
+
+fn finish_key_package_attempt(
+    targets: &mut [TransportFanoutTarget],
+    accepted: &[TransportEndpoint],
+    rejected: &[TransportEndpoint],
+    confirmed_absent: &[TransportEndpoint],
+    failed: &[TransportEndpoint],
+) {
+    for target in targets {
+        if target.state == TransportFanoutAttemptState::Accepted {
+            continue;
+        }
         if accepted.contains(&target.endpoint) {
             target.state = TransportFanoutAttemptState::Accepted;
             target.failure_code = None;
-        } else {
+        } else if confirmed_absent.contains(&target.endpoint) {
             target.state = TransportFanoutAttemptState::AttemptedFailed;
-            target.failure_code = Some(
-                if failed.contains(&target.endpoint) {
-                    "transport_rejected"
-                } else {
-                    "publish_failed"
-                }
-                .into(),
-            );
+            target.failure_code = Some("confirmed_absent".into());
+        } else if rejected.contains(&target.endpoint) {
+            target.state = TransportFanoutAttemptState::AttemptedFailed;
+            // A negative publication ACK does not prove absence. Older
+            // clients did not persist a pre-I/O marker, so a durable
+            // `Unattempted` row may already have escaped to this relay before
+            // a crash. Only a deletion-specific NotFound receipt is terminal.
+            target.failure_code = Some("transport_rejected".into());
+        } else if failed.contains(&target.endpoint) {
+            // The pre-I/O marker is already the conservative terminal state
+            // for a timeout, disconnect, or other ambiguous transport result.
+            target.state = TransportFanoutAttemptState::AttemptedFailed;
+            target.failure_code = Some("possible_exposure".into());
         }
     }
 }
 
 fn key_package_target_retry_due(target: &TransportFanoutTarget, now: Timestamp) -> bool {
+    if !key_package_target_is_retryable(target) {
+        return false;
+    }
     transport_fanout_target_retry_due(target, now)
+}
+
+fn key_package_target_is_terminal(target: &TransportFanoutTarget) -> bool {
+    matches!(
+        target.state,
+        TransportFanoutAttemptState::Accepted | TransportFanoutAttemptState::PolicyProhibited
+    ) || target.failure_code.as_deref() == Some("confirmed_absent")
+}
+
+fn key_package_target_is_retryable(target: &TransportFanoutTarget) -> bool {
+    !key_package_target_is_terminal(target)
 }
 
 fn transport_fanout_target_retry_due(target: &TransportFanoutTarget, now: Timestamp) -> bool {
@@ -3996,6 +8220,52 @@ fn supports_deferred_commit_publish(intent: &SendIntent) -> bool {
             | SendIntent::UpdateGroupData { .. }
             | SendIntent::EnableDisbanding { .. }
     )
+}
+
+fn send_intent_group_id(intent: &SendIntent) -> Option<GroupId> {
+    Some(match intent {
+        SendIntent::AppMessage { group_id, .. }
+        | SendIntent::Invite { group_id, .. }
+        | SendIntent::RemoveMembers { group_id, .. }
+        | SendIntent::Leave { group_id }
+        | SendIntent::SelfUpdate { group_id }
+        | SendIntent::UpdateAppComponents { group_id, .. }
+        | SendIntent::UpdateGroupData { group_id, .. }
+        | SendIntent::EnableDisbanding { group_id }
+        | SendIntent::Disband { group_id } => group_id.clone(),
+    })
+}
+
+fn account_visibility_outbound_action(
+    intent: &SendIntent,
+) -> Option<AccountVisibilityOutboundAction> {
+    match intent {
+        SendIntent::Leave { .. } => Some(AccountVisibilityOutboundAction::Leave),
+        _ => None,
+    }
+}
+
+fn outbound_action_message_id(
+    action: AccountVisibilityOutboundAction,
+    effects: &SessionEffects,
+) -> Option<MessageId> {
+    match action {
+        AccountVisibilityOutboundAction::Leave => effects.publish.iter().find_map(|work| {
+            if let PublishWork::Proposal { msg, .. } = work {
+                Some(msg.id.clone())
+            } else {
+                None
+            }
+        }),
+    }
+}
+
+fn engine_outbox_event_id(event: &GroupEvent) -> Option<MessageId> {
+    match event {
+        GroupEvent::MessageReceived { message_id, .. } => Some(message_id.clone()),
+        GroupEvent::GroupJoined { via_welcome, .. } => Some(via_welcome.clone()),
+        _ => None,
+    }
 }
 
 fn classify_prepared_session_send(
@@ -4052,6 +8322,79 @@ fn publish_wire_metadata(message: &TransportMessage) -> AuditTransportWire {
     }
 }
 
+/// Outbound action whose app-side tail must retain source semantics across
+/// cancellation and process restart.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AccountVisibilityOutboundAction {
+    Leave,
+}
+
+/// Terminal publish result for a source-attributed outbound action.
+///
+/// `operation_id` names the original operation whose Header remains pending;
+/// recovery may carry this outcome in a later Drain operation after resuming
+/// the exact frozen fanout.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccountVisibilityActionOutcome {
+    pub operation_id: Vec<u8>,
+    pub group_id: GroupId,
+    pub message_id: MessageId,
+    pub action: AccountVisibilityOutboundAction,
+    pub published: bool,
+}
+
+/// Fixed attribution for one durable visibility operation.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+#[allow(clippy::large_enum_variant)]
+pub enum AccountVisibilitySource {
+    Inbound {
+        delivery: TransportDelivery,
+        outcome: IngestOutcome,
+        observed_at: Timestamp,
+    },
+    Drain {
+        observed_at: Timestamp,
+    },
+    Convergence {
+        group_id: GroupId,
+        observed_at: Timestamp,
+    },
+    Maintenance {
+        observed_at: Timestamp,
+    },
+    Outbound {
+        group_id: Option<GroupId>,
+        observed_at: Timestamp,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        action: Option<AccountVisibilityOutboundAction>,
+        /// Exact engine message id bound atomically after acceptance and before
+        /// relay I/O. A pending pre-acceptance Header leaves this absent.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        action_message_id: Option<MessageId>,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AccountVisibilityRecordKind {
+    Header,
+    Event { engine_outbox_provenance: bool },
+    SessionControl,
+    NonSession,
+}
+
+/// One independently acknowledgeable, source-attributed durable visibility row.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AccountVisibilityBatch {
+    pub sequence: u64,
+    pub operation_id: Vec<u8>,
+    pub batch_id: Vec<u8>,
+    pub source: AccountVisibilitySource,
+    pub kind: AccountVisibilityRecordKind,
+    pub effects: AccountDeviceEffects,
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AccountDeviceEffects {
     pub events: Vec<GroupEvent>,
@@ -4068,6 +8411,9 @@ pub struct AccountDeviceEffects {
     /// Application-message identity attached to unresolved publication so app
     /// consumers can keep exactly the affected local row in a sending state.
     pub unresolved_app_messages: Vec<UnresolvedApplicationMessage>,
+    /// Terminal source-action results, including recovered fanouts whose
+    /// originating visibility Header belongs to an older operation.
+    pub action_outcomes: Vec<AccountVisibilityActionOutcome>,
     /// Application messages accepted by at least one transport endpoint,
     /// carrying source-state metadata captured by the exact MLS encryption
     /// operation and the adapter-visible transport id.
@@ -4081,7 +8427,7 @@ pub struct AccountDeviceEffects {
     pub maintenance_disposition: SendMaintenanceDisposition,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PublishedApplicationMessage {
     pub group_id: GroupId,
     pub app_event_id: String,
@@ -4091,6 +8437,22 @@ pub struct PublishedApplicationMessage {
 }
 
 impl AccountDeviceEffects {
+    fn non_session_visibility_clone(&self) -> Self {
+        Self {
+            reports: self.reports.clone(),
+            fanout: self.fanout.clone(),
+            failures: self.failures.clone(),
+            unresolved_publishes: self.unresolved_publishes.clone(),
+            unresolved_app_messages: self.unresolved_app_messages.clone(),
+            action_outcomes: self.action_outcomes.clone(),
+            published_app_messages: self.published_app_messages.clone(),
+            welcome_failures: self.welcome_failures.clone(),
+            pending: self.pending.clone(),
+            maintenance_disposition: self.maintenance_disposition,
+            ..Self::default()
+        }
+    }
+
     fn extend(&mut self, mut other: Self) {
         self.fanout.append(&mut other.fanout);
         self.absorb_account_effects(other);
@@ -4118,6 +8480,7 @@ impl AccountDeviceEffects {
             .append(&mut other.unresolved_publishes);
         self.unresolved_app_messages
             .append(&mut other.unresolved_app_messages);
+        self.action_outcomes.append(&mut other.action_outcomes);
         self.published_app_messages
             .append(&mut other.published_app_messages);
         self.welcome_failures.append(&mut other.welcome_failures);
@@ -4126,6 +8489,33 @@ impl AccountDeviceEffects {
             == SendMaintenanceDisposition::PostJoinRotationPendingRetryable
         {
             self.maintenance_disposition = other.maintenance_disposition;
+        }
+    }
+}
+
+impl StoredNonSessionEffectsV1 {
+    fn from_effects(effects: &AccountDeviceEffects) -> Self {
+        Self {
+            reports: effects.reports.clone(),
+            fanout: effects.fanout.clone(),
+            failures: effects.failures.clone(),
+            action_outcomes: effects.action_outcomes.clone(),
+            published_app_messages: effects.published_app_messages.clone(),
+            welcome_failures: effects.welcome_failures.clone(),
+            pending: effects.pending.clone(),
+        }
+    }
+
+    fn into_effects(self) -> AccountDeviceEffects {
+        AccountDeviceEffects {
+            reports: self.reports,
+            fanout: self.fanout,
+            failures: self.failures,
+            action_outcomes: self.action_outcomes,
+            published_app_messages: self.published_app_messages,
+            welcome_failures: self.welcome_failures,
+            pending: self.pending,
+            ..AccountDeviceEffects::default()
         }
     }
 }
@@ -4139,7 +8529,36 @@ pub struct AccountIngestEffects {
     pub effects: AccountDeviceEffects,
 }
 
+/// Account effects retained by [`AccountDeviceRuntime`] until the app
+/// explicitly acknowledges projection/V1 ownership.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[must_use = "acknowledge `lease` only after the effects are durably staged"]
+pub struct LeasedAccountDeviceEffects {
+    pub effects: AccountDeviceEffects,
+    pub batches: Vec<AccountVisibilityBatch>,
+    pub lease: AccountVisibilityLease,
+    /// Operation produced by the command that returned this lease. `None`
+    /// identifies replay-only handoffs, where every batch predates the caller.
+    pub current_operation_id: Option<Vec<u8>>,
+}
+
+/// Ingest outcome plus account effects retained until the app explicitly
+/// acknowledges projection/V1 ownership.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[must_use = "acknowledge `lease` only after the effects are durably staged"]
+pub struct LeasedAccountIngestEffects {
+    pub outcome: IngestOutcome,
+    /// The engine kept no durable trace of this delivery's transport object.
+    /// Carried verbatim from [`AccountIngestEffects::left_object_unpersisted`].
+    pub left_object_unpersisted: bool,
+    pub effects: AccountDeviceEffects,
+    pub batches: Vec<AccountVisibilityBatch>,
+    pub lease: AccountVisibilityLease,
+    /// Operation produced by the inbound delivery that returned this lease.
+    pub current_operation_id: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PublishFailure {
     pub message_id: cgka_traits::MessageId,
     pub reason: String,
@@ -4171,7 +8590,7 @@ pub struct UnresolvedApplicationMessage {
 /// cannot be rolled back (it is already confirmed and externally visible), so
 /// re-delivery is the only repair. The wrapped welcome stays available in the
 /// engine's sent-message store under `message_id`.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WelcomeDeliveryFailure {
     pub message_id: cgka_traits::MessageId,
     pub recipient: MemberId,
@@ -4181,7 +8600,7 @@ pub struct WelcomeDeliveryFailure {
     pub reason: String,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PendingResolution {
     Confirmed { pending: PendingStateRef },
     RolledBack { pending: PendingStateRef },
@@ -4190,6 +8609,275 @@ pub enum PendingResolution {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn signed_artifact_at(created_at: u64) -> SignedPublicationArtifact {
+        SignedPublicationArtifact {
+            id: cgka_traits::MessageId::new(created_at.to_be_bytes().to_vec()),
+            created_at: Timestamp(created_at),
+            bytes: created_at.to_be_bytes().to_vec(),
+        }
+    }
+
+    #[test]
+    fn key_package_reauthor_policy_is_opt_in_and_uses_an_inclusive_age_boundary() {
+        let artifact = signed_artifact_at(10_000);
+        assert_eq!(
+            key_package_reauthor_created_at(&artifact, Timestamp(1), None, None, false),
+            Ok(None),
+            "publishers that do not opt in preserve exact retries across clock rollback"
+        );
+        assert_eq!(
+            key_package_reauthor_created_at(&artifact, Timestamp(10_599), Some(600), None, false),
+            Ok(None)
+        );
+        assert_eq!(
+            key_package_reauthor_created_at(&artifact, Timestamp(10_600), Some(600), None, false),
+            Ok(Some(Timestamp(10_600)))
+        );
+        assert_eq!(
+            key_package_reauthor_created_at(&artifact, Timestamp(1), Some(600), None, false),
+            Err(()),
+            "an opted-in transport fails closed after a large wall-clock rollback"
+        );
+        assert_eq!(
+            key_package_reauthor_created_at(
+                &artifact,
+                Timestamp(10_000),
+                None,
+                Some(Timestamp(10_020)),
+                false,
+            ),
+            Ok(Some(Timestamp(10_021))),
+            "a relay-discovered same-slot high-water forces a strictly newer revision"
+        );
+        assert_eq!(
+            key_package_reauthor_created_at(
+                &signed_artifact_at(u64::MAX),
+                Timestamp(u64::MAX),
+                Some(0),
+                None,
+                false,
+            ),
+            Err(()),
+            "a strictly newer timestamp must be representable"
+        );
+    }
+
+    #[test]
+    fn reauthor_replacement_targets_only_the_current_live_policy() {
+        let prohibited_endpoint = TransportEndpoint("wss://removed.example".into());
+        let live_endpoint = TransportEndpoint("wss://live.example".into());
+        let mut targets = vec![
+            TransportFanoutTarget {
+                endpoint: prohibited_endpoint.clone(),
+                state: TransportFanoutAttemptState::PolicyProhibited,
+                attempt_count: 7,
+                last_attempt_at: Some(Timestamp(9)),
+                failure_code: Some("endpoint_removed_from_policy".into()),
+            },
+            TransportFanoutTarget {
+                endpoint: live_endpoint.clone(),
+                state: TransportFanoutAttemptState::Accepted,
+                attempt_count: 3,
+                last_attempt_at: Some(Timestamp(8)),
+                failure_code: None,
+            },
+        ];
+
+        replace_key_package_publication_targets(&mut targets, std::slice::from_ref(&live_endpoint));
+
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].endpoint, live_endpoint);
+        assert_eq!(targets[0].state, TransportFanoutAttemptState::Unattempted);
+        assert_eq!(targets[0].attempt_count, 0);
+        assert!(targets[0].last_attempt_at.is_none());
+        assert!(targets[0].failure_code.is_none());
+    }
+
+    #[test]
+    fn retired_key_package_publication_keeps_every_possibly_exposed_target() {
+        let artifact = signed_artifact_at(10);
+        let target =
+            |endpoint: &str,
+             state: TransportFanoutAttemptState,
+             attempt_count: u32,
+             last_attempt_at: Option<Timestamp>| TransportFanoutTarget {
+                endpoint: TransportEndpoint(endpoint.into()),
+                state,
+                attempt_count,
+                last_attempt_at,
+                failure_code: None,
+            };
+        let retired = retired_key_package_publication(
+            &artifact,
+            Some(b"key-package-ref"),
+            Some(Timestamp(20)),
+            false,
+            &[
+                target(
+                    "wss://accepted.example",
+                    TransportFanoutAttemptState::Accepted,
+                    1,
+                    Some(Timestamp(1)),
+                ),
+                target(
+                    "wss://failed.example",
+                    TransportFanoutAttemptState::AttemptedFailed,
+                    1,
+                    Some(Timestamp(1)),
+                ),
+                target(
+                    "wss://removed-after-attempt.example",
+                    TransportFanoutAttemptState::PolicyProhibited,
+                    2,
+                    Some(Timestamp(2)),
+                ),
+                target(
+                    "wss://never-attempted.example",
+                    TransportFanoutAttemptState::Unattempted,
+                    0,
+                    None,
+                ),
+                target(
+                    "wss://prohibited-before-attempt.example",
+                    TransportFanoutAttemptState::PolicyProhibited,
+                    0,
+                    None,
+                ),
+            ],
+        )
+        .expect("attempted targets create a deletion obligation");
+
+        assert_eq!(retired.event_id, artifact.id);
+        assert_eq!(retired.authored_created_at, artifact.created_at);
+        assert_eq!(
+            retired.key_package_ref.as_deref(),
+            Some(&b"key-package-ref"[..])
+        );
+        assert_eq!(retired.package_not_after, Some(Timestamp(20)));
+        assert!(!retired.delete_without_successor);
+        assert_eq!(
+            retired
+                .deletion_targets
+                .iter()
+                .map(|target| target.endpoint.clone())
+                .collect::<Vec<_>>(),
+            vec![
+                TransportEndpoint("wss://accepted.example".into()),
+                TransportEndpoint("wss://failed.example".into()),
+                TransportEndpoint("wss://never-attempted.example".into()),
+                TransportEndpoint("wss://prohibited-before-attempt.example".into()),
+                TransportEndpoint("wss://removed-after-attempt.example".into()),
+            ]
+        );
+        assert!(retired.deletion_targets.iter().all(|target| {
+            target.state == TransportFanoutAttemptState::Unattempted
+                && target.attempt_count == 0
+                && target.last_attempt_at.is_none()
+        }));
+    }
+
+    #[test]
+    fn key_package_liability_counter_counts_each_event_endpoint_pair() {
+        let endpoints = (0..256)
+            .map(|index| TransportFanoutTarget {
+                endpoint: TransportEndpoint(format!("wss://liability-{index}.example")),
+                state: TransportFanoutAttemptState::Unattempted,
+                attempt_count: 0,
+                last_attempt_at: None,
+                failure_code: None,
+            })
+            .collect::<Vec<_>>();
+        let mut lifecycle = KeyPackageLifecycleState::slot_only("slot".into());
+        lifecycle
+            .retired_publications_pending_deletion
+            .push(RetiredKeyPackagePublication {
+                event_id: cgka_traits::MessageId::new(vec![0x73; 32]),
+                authored_created_at: Timestamp(1),
+                key_package_ref: None,
+                package_not_after: None,
+                delete_without_successor: true,
+                deletion_targets: endpoints,
+            });
+
+        assert_eq!(
+            key_package_signed_publication_liability_count(&lifecycle),
+            MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES
+        );
+    }
+
+    #[test]
+    fn deletion_pass_report_dedupes_terminals_and_ignores_backoff_for_uncovered_work() {
+        let covered_endpoint = TransportEndpoint("wss://covered.example".into());
+        let uncovered_endpoint = TransportEndpoint("wss://uncovered.example".into());
+        let deletion_target = |endpoint: TransportEndpoint| TransportFanoutTarget {
+            endpoint,
+            state: TransportFanoutAttemptState::AttemptedFailed,
+            attempt_count: 9,
+            last_attempt_at: Some(Timestamp(50)),
+            failure_code: Some("possible_exposure".into()),
+        };
+        let current_artifact = signed_artifact_at(20);
+        let mut lifecycle = KeyPackageLifecycleState::slot_only("slot".into());
+        lifecycle.authored_signed_event = Some(current_artifact.clone());
+        lifecycle.publication_targets = vec![
+            TransportFanoutTarget {
+                endpoint: covered_endpoint.clone(),
+                state: TransportFanoutAttemptState::Accepted,
+                attempt_count: 1,
+                last_attempt_at: Some(Timestamp(20)),
+                failure_code: None,
+            },
+            TransportFanoutTarget {
+                endpoint: uncovered_endpoint.clone(),
+                state: TransportFanoutAttemptState::PolicyProhibited,
+                attempt_count: 0,
+                last_attempt_at: None,
+                failure_code: Some("endpoint_removed_from_policy".into()),
+            },
+        ];
+        lifecycle
+            .retired_publications_pending_deletion
+            .push(RetiredKeyPackagePublication {
+                event_id: MessageId::new(vec![0x7a; 32]),
+                authored_created_at: Timestamp(10),
+                key_package_ref: None,
+                package_not_after: Some(Timestamp(1_000)),
+                delete_without_successor: false,
+                deletion_targets: vec![
+                    deletion_target(covered_endpoint.clone()),
+                    deletion_target(uncovered_endpoint.clone()),
+                ],
+            });
+
+        let report = retired_key_package_deletion_pass_report(
+            &lifecycle,
+            Timestamp(50),
+            vec![covered_endpoint.clone(), covered_endpoint.clone()],
+        );
+        assert_eq!(report.terminal_endpoints, vec![covered_endpoint]);
+        assert!(
+            report.has_uncovered_eligible_deletion,
+            "a policy-removed target remains eligible without an accepted successor even during retry backoff"
+        );
+
+        lifecycle.publication_targets[1].state = TransportFanoutAttemptState::Accepted;
+        lifecycle.publication_targets[1].failure_code = None;
+        assert!(
+            !retired_key_package_deletion_pass_report(&lifecycle, Timestamp(50), Vec::new())
+                .has_uncovered_eligible_deletion,
+            "strictly newer accepted successors cover every eligible deletion"
+        );
+
+        lifecycle
+            .deleted_live_revision_event_ids
+            .push(current_artifact.id);
+        assert!(
+            retired_key_package_deletion_pass_report(&lifecycle, Timestamp(50), Vec::new())
+                .has_uncovered_eligible_deletion,
+            "a live revision already marked for deletion cannot cover its predecessors"
+        );
+    }
 
     fn published_message(id: u8) -> PublishedApplicationMessage {
         PublishedApplicationMessage {
@@ -4256,6 +8944,101 @@ mod tests {
                 members: Vec::new(),
             }
         ));
+    }
+
+    #[test]
+    fn outbound_visibility_action_is_typed_and_legacy_json_defaults_to_none() {
+        let group_id = GroupId::new(vec![7]);
+        let source = AccountVisibilitySource::Outbound {
+            group_id: Some(group_id.clone()),
+            observed_at: Timestamp(42),
+            action: Some(AccountVisibilityOutboundAction::Leave),
+            action_message_id: Some(MessageId::new(vec![4])),
+        };
+        let mut json = serde_json::to_value(&source).expect("serialize outbound source");
+        assert_eq!(json.get("action"), Some(&serde_json::json!("leave")));
+        assert!(json.get("action_message_id").is_some());
+        assert_eq!(
+            serde_json::from_value::<AccountVisibilitySource>(json.clone())
+                .expect("decode typed outbound action"),
+            source
+        );
+
+        json.as_object_mut()
+            .expect("tagged source is an object")
+            .remove("action");
+        json.as_object_mut()
+            .expect("tagged source is an object")
+            .remove("action_message_id");
+        let legacy = serde_json::from_value::<AccountVisibilitySource>(json)
+            .expect("legacy outbound source without action still decodes");
+        assert_eq!(
+            legacy,
+            AccountVisibilitySource::Outbound {
+                group_id: Some(group_id),
+                observed_at: Timestamp(42),
+                action: None,
+                action_message_id: None,
+            }
+        );
+        assert!(
+            serde_json::to_value(legacy)
+                .expect("serialize legacy-compatible source")
+                .get("action")
+                .is_none(),
+            "None keeps the exact legacy JSON shape"
+        );
+    }
+
+    #[test]
+    fn legacy_outbound_visibility_record_decodes_without_a_version_bump() {
+        let operation_id = [0x5a; 16];
+        let group_id = GroupId::new(vec![8]);
+        let record = StoredAccountVisibilityRecordV1 {
+            version: ACCOUNT_VISIBILITY_RECORD_VERSION,
+            source: AccountVisibilitySource::Outbound {
+                group_id: Some(group_id.clone()),
+                observed_at: Timestamp(77),
+                action: Some(AccountVisibilityOutboundAction::Leave),
+                action_message_id: Some(MessageId::new(vec![5])),
+            },
+            payload: StoredAccountVisibilityPayloadV1::Header {
+                maintenance_disposition: SendMaintenanceDisposition::Ready,
+            },
+        };
+        let mut json = serde_json::to_value(record).expect("serialize visibility record");
+        json.get_mut("source")
+            .and_then(serde_json::Value::as_object_mut)
+            .expect("visibility source is an object")
+            .remove("action");
+        json.get_mut("source")
+            .and_then(serde_json::Value::as_object_mut)
+            .expect("visibility source is an object")
+            .remove("action_message_id");
+        assert_eq!(
+            json.get("version"),
+            Some(&serde_json::json!(1)),
+            "adding source semantics must not bump the decodable V1 record"
+        );
+
+        let decoded = decode_account_visibility_row(AccountVisibilityJournalRow {
+            sequence: 1,
+            operation_id: operation_id.to_vec(),
+            ordinal: 0,
+            batch_id: account_visibility_batch_id(&operation_id, 0),
+            record: serde_json::to_vec(&json).expect("encode legacy visibility row"),
+        })
+        .expect("decode legacy V1 visibility row");
+        assert_eq!(decoded.kind, AccountVisibilityRecordKind::Header);
+        assert_eq!(
+            decoded.source,
+            AccountVisibilitySource::Outbound {
+                group_id: Some(group_id),
+                observed_at: Timestamp(77),
+                action: None,
+                action_message_id: None,
+            }
+        );
     }
 
     #[tokio::test]

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -8557,11 +8557,8 @@ async fn zero_accept_best_effort_leave_does_not_publish_on_restart() {
     let (bob, bob_path, bob_identity, group_id) =
         joined_selfremove_member(dir.path(), &key, "zero-ack-leave").await;
     let adapter = RecordingAdapter::default();
+    let gate = adapter.gate_all_publishes();
     let group_endpoint = TransportEndpoint("wss://zero-ack-leave-group.example".into());
-    adapter.fail_endpoints_as(
-        vec![group_endpoint.clone()],
-        TransportEndpointFailureKind::TerminalRejected,
-    );
     let route = || {
         StaticTransportRouting::new(vec![TransportEndpoint(
             "wss://zero-ack-leave-inbox.example".into(),
@@ -8573,23 +8570,56 @@ async fn zero_accept_best_effort_leave_does_not_publish_on_restart() {
             vec![group_endpoint.clone()],
         )
     };
-    let mut runtime =
-        AccountDeviceRuntime::new(bob, adapter, route(), RecordingKeyPackages::default());
+    let mut runtime = AccountDeviceRuntime::new(
+        bob,
+        adapter.clone(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
     runtime.pause_maintenance();
-    let leased = runtime
-        .send_leased(SendIntent::Leave {
-            group_id: group_id.clone(),
-        })
-        .await
+    let mut cancelled = Box::pin(runtime.send_leased(SendIntent::Leave {
+        group_id: group_id.clone(),
+    }));
+    tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::select! {
+            result = &mut cancelled => panic!("Leave returned before the terminal-fanout crash window: {result:?}"),
+            () = async {
+                while adapter.publishes().is_empty() {
+                    tokio::task::yield_now().await;
+                }
+            } => {}
+        }
+    })
+    .await
+    .expect("Leave reaches the blocked relay publish");
+    drop(cancelled);
+
+    let mut fanouts = runtime.session().outbound_fanouts().unwrap();
+    assert_eq!(
+        fanouts.len(),
+        1,
+        "cancelled Leave retains its frozen fanout"
+    );
+    let mut fanout = fanouts.pop().unwrap();
+    assert_eq!(fanout.request().required_acks, 0);
+    fanout
+        .record_target_failure(
+            0,
+            TransportEndpointFailure {
+                endpoint: group_endpoint.clone(),
+                reason: "injected terminal rejection before outcome checkpoint".into(),
+                kind: TransportEndpointFailureKind::TerminalRejected,
+                rejection_category: None,
+            },
+        )
         .unwrap();
     assert!(
-        leased
-            .effects
-            .action_outcomes
-            .iter()
-            .all(|outcome| !outcome.published),
-        "required_acks=0 still needs at least one accept"
+        fanout.outcome().fanout_complete && fanout.outcome().accepted_targets == 0,
+        "the persisted crash window must contain one terminal zero-accept fanout"
     );
+    let leave_message_id = fanout.message_id().clone();
+    runtime.session_mut().put_outbound_fanout(&fanout).unwrap();
+    drop(gate);
     drop(runtime);
 
     let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
@@ -8600,26 +8630,12 @@ async fn zero_accept_best_effort_leave_does_not_publish_on_restart() {
         RecordingKeyPackages::default(),
     );
     restarted.pause_maintenance();
-    if let Some(replayed) = restarted.replay_visibility_leased().unwrap() {
-        assert!(
-            flatten_visibility_batches(&replayed.batches)
-                .action_outcomes
-                .iter()
-                .all(|outcome| !outcome.published),
-            "restart must not upgrade a zero-accept Leave to published:true"
-        );
-        assert!(restarted.acknowledge_visibility_lease(replayed.lease));
-    }
+    let fanouts = restarted.session().outbound_fanouts().unwrap();
+    assert_eq!(fanouts.len(), 1, "restart must recover the terminal fanout");
+    assert_eq!(fanouts[0].message_id(), &leave_message_id);
     assert!(
-        restarted
-            .session()
-            .outbound_fanouts()
-            .unwrap()
-            .iter()
-            .all(|fanout| {
-                fanout.outcome().accepted_targets < fanout.request().required_acks.max(1)
-            }),
-        "a surviving terminal zero-accept fanout must still miss required_acks.max(1)"
+        fanouts[0].outcome().accepted_targets < fanouts[0].request().required_acks.max(1),
+        "the recovered zero-accept fanout must miss required_acks.max(1)"
     );
     let drained = restarted.drain_leased().await.unwrap();
     assert!(
@@ -8627,13 +8643,35 @@ async fn zero_accept_best_effort_leave_does_not_publish_on_restart() {
             .effects
             .action_outcomes
             .iter()
-            .all(|outcome| !outcome.published),
-        "resuming a terminal zero-accept Leave must not authorize Left"
+            .any(|outcome| outcome.message_id == leave_message_id && !outcome.published),
+        "terminal-fanout recovery must durably record unpublished, not authorize Left"
     );
     assert!(
         restarted.session().outbound_fanouts().unwrap().is_empty(),
         "terminal zero-accept resume must finish the Leave fanout without publishing"
     );
+    drop(restarted);
+
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    let mut recovered = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    recovered.pause_maintenance();
+    let replayed = recovered
+        .replay_visibility_leased()
+        .unwrap()
+        .expect("unpublished Leave outcome must survive fanout deletion and restart");
+    assert!(
+        flatten_visibility_batches(&replayed.batches)
+            .action_outcomes
+            .iter()
+            .any(|outcome| outcome.message_id == leave_message_id && !outcome.published),
+        "restart must replay the exact terminal zero-accept outcome"
+    );
+    assert!(recovered.acknowledge_visibility_lease(replayed.lease));
 }
 
 #[tokio::test]
@@ -8720,23 +8758,24 @@ async fn leave_m1_to_m2_repair_persists_every_row_so_cleared_request_does_not_sp
         }
     }
     assert!(
-        unique_source_by_operation
-            .values()
-            .any(|bound| bound.as_ref() == Some(&later_id)),
-        "repaired Leave source must name the live M2 id: {leave_sources:?}"
+        !unique_source_by_operation.is_empty()
+            && unique_source_by_operation
+                .values()
+                .all(|bound| bound.as_ref() == Some(&later_id)),
+        "repaired Leave source must name the live M2 id on every row: {leave_sources:?}"
     );
     drop(replayed);
     drop(repaired);
 
-    let storage_session =
-        session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
-    storage_session
+    // Open the engine first, then clear the request on that same session. A
+    // second engine reopen would legitimately rehydrate M1 from its retained
+    // SelfRemove and mask whether the repaired journal itself persisted M2.
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    reopened
         .storage_handle()
         .clear_leave_request(&group_id)
         .unwrap();
-    drop(storage_session);
 
-    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
     let mut restarted = AccountDeviceRuntime::new(
         reopened,
         RecordingAdapter::default(),
@@ -8779,8 +8818,8 @@ async fn leave_m1_to_m2_repair_persists_every_row_so_cleared_request_does_not_sp
         !unique_source_by_operation.is_empty()
             && unique_source_by_operation
                 .values()
-                .all(|bound| bound.is_some()),
-        "cleared LeaveRequest must not resurrect a split or unbound Leave source: {leave_sources:?}"
+                .all(|bound| bound.as_ref() == Some(&later_id)),
+        "cleared LeaveRequest must retain the exact M2 source on every row: {leave_sources:?}"
     );
 }
 
@@ -9343,8 +9382,14 @@ async fn leave_quorum_records_published_true_while_optional_target_stays_retryab
             vec![required.clone(), optional.clone()],
         )
     };
+    let wall = Arc::new(TestWallClock::new(10_000));
     let mut runtime =
-        AccountDeviceRuntime::new(bob, adapter, route(), RecordingKeyPackages::default());
+        AccountDeviceRuntime::new(bob, adapter, route(), RecordingKeyPackages::default())
+            .with_maintenance_sources(
+                wall.clone(),
+                Arc::new(TestMonotonicClock::default()),
+                Arc::new(TestRandom::new(0)),
+            );
     runtime.pause_maintenance();
     let leased = runtime
         .send_leased(SendIntent::Leave {
@@ -9353,6 +9398,7 @@ async fn leave_quorum_records_published_true_while_optional_target_stays_retryab
         .await
         .unwrap();
     assert_eq!(leased.effects.action_outcomes.len(), 1);
+    let published_message_id = leased.effects.action_outcomes[0].message_id.clone();
     assert!(
         leased.effects.action_outcomes[0].published,
         "meeting required ACKs must authorize Left even if an optional target is still retryable"
@@ -9366,6 +9412,7 @@ async fn leave_quorum_records_published_true_while_optional_target_stays_retryab
         "the optional target must remain outstanding so this is not the complete-fanout path"
     );
     drop(runtime);
+    wall.set(20_000);
 
     let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
     let mut restarted = AccountDeviceRuntime::new(
@@ -9373,6 +9420,11 @@ async fn leave_quorum_records_published_true_while_optional_target_stays_retryab
         RecordingAdapter::default(),
         route(),
         RecordingKeyPackages::default(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(0)),
     );
     restarted.pause_maintenance();
     let replayed = restarted
@@ -9392,12 +9444,15 @@ async fn leave_quorum_records_published_true_while_optional_target_stays_retryab
         .await
         .expect("optional Leave completion must accept an already-durable published outcome");
     assert!(
-        drained
-            .effects
+        flatten_visibility_batches(&drained.batches)
             .action_outcomes
             .iter()
-            .all(|outcome| outcome.published),
-        "completing the optional target must not rewrite the durable published:true outcome"
+            .any(|outcome| { outcome.message_id == published_message_id && outcome.published }),
+        "the superseding lease must contain the exact durable published:true outcome"
+    );
+    assert!(
+        restarted.session().outbound_fanouts().unwrap().is_empty(),
+        "optional completion must delete the fanout after preserving its durable outcome"
     );
     if !restarted.acknowledge_visibility_lease(replayed.lease) {
         assert!(restarted.acknowledge_visibility_lease(drained.lease));

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -20,23 +20,30 @@ use cgka_traits::group::ProtocolProfile;
 use cgka_traits::group_context::GroupContextSnapshot;
 use cgka_traits::ingest::{PeeledContent, PeeledMessage};
 use cgka_traits::peeler::TransportPeeler;
-use cgka_traits::storage::{KeyPackageBundleStorage, MaintenanceStorage, OutboundFanoutStorage};
+use cgka_traits::storage::{
+    KeyPackageBundleStorage, LeaveRequestStorage, MaintenanceStorage, MessageStorage,
+    OutboundFanoutStorage,
+};
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
 };
 use cgka_traits::{
     EpochId, FanoutMlsState, FanoutTargetStatus, GroupId, MemberId, MessageId, OutboundFanout,
-    TransportAccountActivation, TransportAdapter, TransportAdapterError, TransportDelivery,
-    TransportDeliveryPlane, TransportDeliverySource, TransportEndpoint, TransportEndpointFailure,
-    TransportEndpointFailureKind, TransportEndpointReceipt, TransportEndpointRejectionCategory,
-    TransportGroupSync, TransportPublishFailure, TransportPublishReport, TransportPublishRequest,
-    TransportPublishTarget,
+    RetiredKeyPackagePublication, TransportAccountActivation, TransportAdapter,
+    TransportAdapterError, TransportDelivery, TransportDeliveryPlane, TransportDeliverySource,
+    TransportEndpoint, TransportEndpointFailure, TransportEndpointFailureKind,
+    TransportEndpointReceipt, TransportEndpointRejectionCategory, TransportFanoutAttemptState,
+    TransportFanoutTarget, TransportGroupSync, TransportPublishFailure, TransportPublishReport,
+    TransportPublishRequest, TransportPublishTarget,
 };
 use marmot_account::{
-    AccountDeviceRuntime, AccountError, KeyPackagePublication, KeyPackagePublishError,
-    KeyPackagePublishReceipt, KeyPackagePublisher, MaintenanceRandom, MonotonicClock,
-    NoopKeyPackagePublisher, PendingResolution, PublishedApplicationMessage,
-    StaticTransportRouting, TransportRoutingError, TransportRoutingPolicy, WallClock,
+    AccountDeviceEffects, AccountDeviceRuntime, AccountError, AccountVisibilityBatch,
+    AccountVisibilityOutboundAction, AccountVisibilitySource,
+    DetailedKeyPackagePublishReceipt as KeyPackagePublishReceipt, KeyPackagePublication,
+    KeyPackagePublishError, KeyPackagePublishReceipt as LegacyKeyPackagePublishReceipt,
+    KeyPackagePublisher, MaintenanceRandom, MonotonicClock, NoopKeyPackagePublisher,
+    PendingResolution, PublishedApplicationMessage, StaticTransportRouting, TransportRoutingError,
+    TransportRoutingPolicy, WallClock,
 };
 use storage_sqlite::{SqlCipherKey, SqliteAccountStorage};
 
@@ -92,6 +99,32 @@ fn hash_id(bytes: &[u8]) -> MessageId {
     let mut h = DefaultHasher::new();
     bytes.hash(&mut h);
     MessageId::new(h.finish().to_be_bytes().to_vec())
+}
+
+fn flatten_visibility_batches(batches: &[AccountVisibilityBatch]) -> AccountDeviceEffects {
+    let mut effects = AccountDeviceEffects::default();
+    for batch in batches {
+        effects.events.extend(batch.effects.events.clone());
+        effects.queued.extend(batch.effects.queued.clone());
+        effects
+            .pending_convergence
+            .extend(batch.effects.pending_convergence.clone());
+        effects.reports.extend(batch.effects.reports.clone());
+        effects.fanout.extend(batch.effects.fanout.clone());
+        effects.failures.extend(batch.effects.failures.clone());
+        effects
+            .action_outcomes
+            .extend(batch.effects.action_outcomes.clone());
+        effects
+            .published_app_messages
+            .extend(batch.effects.published_app_messages.clone());
+        effects
+            .welcome_failures
+            .extend(batch.effects.welcome_failures.clone());
+        effects.pending.extend(batch.effects.pending.clone());
+        effects.maintenance_disposition = batch.effects.maintenance_disposition;
+    }
+    effects
 }
 
 struct MockPeeler;
@@ -329,6 +362,39 @@ fn selfremove_registry() -> FeatureRegistry {
     registry
 }
 
+async fn joined_selfremove_member(
+    directory: &std::path::Path,
+    key: &SqlCipherKey,
+    tag: &str,
+) -> (AccountDeviceSession, std::path::PathBuf, Vec<u8>, GroupId) {
+    let alice_identity = format!("alice-{tag}").into_bytes();
+    let bob_identity = format!("bob-{tag}").into_bytes();
+    let alice_path = directory.join(format!("alice-{tag}.sqlite"));
+    let bob_path = directory.join(format!("bob-{tag}.sqlite"));
+    let mut alice = session_with_registry(alice_path, key, &alice_identity, selfremove_registry());
+    let mut bob = session_with_registry(&bob_path, key, &bob_identity, selfremove_registry());
+    let bob_key_package = bob.fresh_key_package().await.unwrap();
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: format!("selfremove {tag}"),
+            description: String::new(),
+            members: vec![bob_key_package],
+            required_features: Vec::new(),
+            app_components: Vec::new(),
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id;
+    let (pending, welcome) = match created.effects.publish.as_slice() {
+        [PublishWork::GroupCreated { pending, welcomes }] => (*pending, welcomes[0].clone()),
+        other => panic!("expected one GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.ingest(welcome).await.unwrap();
+    (bob, bob_path, bob_identity, group_id)
+}
+
 #[derive(Clone, Default)]
 struct RecordingAdapter {
     inner: Arc<RecordingAdapterInner>,
@@ -346,6 +412,7 @@ struct RecordingAdapterInner {
     publish_errors: Mutex<VecDeque<bool>>,
     reported_message_ids: Mutex<VecDeque<MessageId>>,
     welcome_gate: Mutex<Option<Arc<WelcomePublishGate>>>,
+    all_publish_gate: Mutex<Option<Arc<WelcomePublishGate>>>,
 }
 
 struct WelcomePublishGate {
@@ -368,6 +435,12 @@ impl RecordingAdapter {
     fn gate_welcome_publishes(&self) -> Arc<WelcomePublishGate> {
         let gate = Arc::new(WelcomePublishGate::default());
         *self.inner.welcome_gate.lock().unwrap() = Some(gate.clone());
+        gate
+    }
+
+    fn gate_all_publishes(&self) -> Arc<WelcomePublishGate> {
+        let gate = Arc::new(WelcomePublishGate::default());
+        *self.inner.all_publish_gate.lock().unwrap() = Some(gate.clone());
         gate
     }
 
@@ -457,13 +530,18 @@ impl TransportAdapter for RecordingAdapter {
         request: TransportPublishRequest,
     ) -> Result<TransportPublishReport, TransportAdapterError> {
         self.inner.publishes.lock().unwrap().push(request.clone());
-        let welcome_gate = if matches!(&request.message.envelope, TransportEnvelope::Welcome { .. })
-        {
-            self.inner.welcome_gate.lock().unwrap().clone()
-        } else {
-            None
-        };
-        if let Some(gate) = welcome_gate {
+        let publish_gate = self
+            .inner
+            .all_publish_gate
+            .lock()
+            .unwrap()
+            .clone()
+            .or_else(|| {
+                matches!(&request.message.envelope, TransportEnvelope::Welcome { .. })
+                    .then(|| self.inner.welcome_gate.lock().unwrap().clone())
+                    .flatten()
+            });
+        if let Some(gate) = publish_gate {
             let active = gate.active.fetch_add(1, Ordering::SeqCst) + 1;
             gate.max_active.fetch_max(active, Ordering::SeqCst);
             let permit = gate.release.acquire().await.unwrap();
@@ -665,9 +743,9 @@ impl KeyPackagePublisher for RecordingKeyPackages {
         &self,
         publication: &KeyPackagePublication,
         _artifact: &cgka_traits::SignedPublicationArtifact,
-    ) -> Result<KeyPackagePublishReceipt, KeyPackagePublishError> {
+    ) -> Result<LegacyKeyPackagePublishReceipt, KeyPackagePublishError> {
         self.publications.lock().unwrap().push(publication.clone());
-        Ok(KeyPackagePublishReceipt {
+        Ok(LegacyKeyPackagePublishReceipt {
             accepted: publication.endpoints.clone(),
             failed: Vec::new(),
         })
@@ -690,9 +768,15 @@ struct PartialFanoutKeyPackages {
             )>,
         >,
     >,
+    reauthor_after_secs: Option<u64>,
 }
 
 impl PartialFanoutKeyPackages {
+    fn reauthor_after_secs(mut self, seconds: u64) -> Self {
+        self.reauthor_after_secs = Some(seconds);
+        self
+    }
+
     fn publications(
         &self,
     ) -> Vec<(
@@ -712,6 +796,10 @@ impl KeyPackagePublisher for PartialFanoutKeyPackages {
         Ok(Some(test_key_package_slot(account_id)))
     }
 
+    fn signed_artifact_reauthor_at_age_secs(&self) -> Option<u64> {
+        self.reauthor_after_secs
+    }
+
     async fn prepare_key_package(
         &self,
         publication: KeyPackagePublication,
@@ -723,19 +811,19 @@ impl KeyPackagePublisher for PartialFanoutKeyPackages {
         &self,
         publication: &KeyPackagePublication,
         artifact: &cgka_traits::SignedPublicationArtifact,
-    ) -> Result<KeyPackagePublishReceipt, KeyPackagePublishError> {
+    ) -> Result<LegacyKeyPackagePublishReceipt, KeyPackagePublishError> {
         let call_index = self.publications.lock().unwrap().len();
         self.publications
             .lock()
             .unwrap()
             .push((publication.clone(), artifact.clone()));
         if call_index == 0 {
-            Ok(KeyPackagePublishReceipt {
+            Ok(LegacyKeyPackagePublishReceipt {
                 accepted: publication.endpoints.iter().take(1).cloned().collect(),
                 failed: publication.endpoints.iter().skip(1).cloned().collect(),
             })
         } else {
-            Ok(KeyPackagePublishReceipt {
+            Ok(LegacyKeyPackagePublishReceipt {
                 accepted: publication.endpoints.clone(),
                 failed: Vec::new(),
             })
@@ -777,8 +865,53 @@ impl KeyPackagePublisher for PrepareFailsKeyPackages {
         &self,
         _publication: &KeyPackagePublication,
         _artifact: &cgka_traits::SignedPublicationArtifact,
-    ) -> Result<KeyPackagePublishReceipt, KeyPackagePublishError> {
+    ) -> Result<LegacyKeyPackagePublishReceipt, KeyPackagePublishError> {
         panic!("an unsigned replacement must never reach the network")
+    }
+}
+
+#[derive(Clone, Default)]
+struct ReauthorPrepareFailsKeyPackages {
+    preparations: Arc<Mutex<Vec<KeyPackagePublication>>>,
+    publications: Arc<Mutex<Vec<KeyPackagePublication>>>,
+}
+
+#[async_trait]
+impl KeyPackagePublisher for ReauthorPrepareFailsKeyPackages {
+    fn legacy_slot_id(
+        &self,
+        account_id: &MemberId,
+    ) -> Result<Option<String>, KeyPackagePublishError> {
+        Ok(Some(test_key_package_slot(account_id)))
+    }
+
+    fn signed_artifact_reauthor_at_age_secs(&self) -> Option<u64> {
+        Some(600)
+    }
+
+    async fn prepare_key_package(
+        &self,
+        publication: KeyPackagePublication,
+    ) -> Result<cgka_traits::SignedPublicationArtifact, KeyPackagePublishError> {
+        let mut preparations = self.preparations.lock().unwrap();
+        preparations.push(publication.clone());
+        if preparations.len() > 1 {
+            return Err(KeyPackagePublishError::unexposed(
+                "injected reauthor signing failure",
+            ));
+        }
+        Ok(test_key_package_artifact(&publication))
+    }
+
+    async fn publish_prepared_key_package(
+        &self,
+        publication: &KeyPackagePublication,
+        _artifact: &cgka_traits::SignedPublicationArtifact,
+    ) -> Result<LegacyKeyPackagePublishReceipt, KeyPackagePublishError> {
+        self.publications.lock().unwrap().push(publication.clone());
+        Err(KeyPackagePublishError::unexposed(
+            "injected initial publish failure",
+        ))
     }
 }
 
@@ -787,19 +920,32 @@ impl KeyPackagePublisher for PrepareFailsKeyPackages {
 #[derive(Clone)]
 struct FlakyKeyPackages {
     publications: Arc<Mutex<Vec<KeyPackagePublication>>>,
+    artifacts: Arc<Mutex<Vec<cgka_traits::SignedPublicationArtifact>>>,
     remaining_failures: Arc<Mutex<usize>>,
+    reauthor_after_secs: Option<u64>,
 }
 
 impl FlakyKeyPackages {
     fn new(fail_first: usize) -> Self {
         Self {
             publications: Arc::new(Mutex::new(Vec::new())),
+            artifacts: Arc::new(Mutex::new(Vec::new())),
             remaining_failures: Arc::new(Mutex::new(fail_first)),
+            reauthor_after_secs: None,
         }
+    }
+
+    fn reauthor_after_secs(mut self, seconds: u64) -> Self {
+        self.reauthor_after_secs = Some(seconds);
+        self
     }
 
     fn publications(&self) -> Vec<KeyPackagePublication> {
         self.publications.lock().unwrap().clone()
+    }
+
+    fn artifacts(&self) -> Vec<cgka_traits::SignedPublicationArtifact> {
+        self.artifacts.lock().unwrap().clone()
     }
 }
 
@@ -812,6 +958,10 @@ impl KeyPackagePublisher for FlakyKeyPackages {
         Ok(Some(test_key_package_slot(account_id)))
     }
 
+    fn signed_artifact_reauthor_at_age_secs(&self) -> Option<u64> {
+        self.reauthor_after_secs
+    }
+
     async fn prepare_key_package(
         &self,
         publication: KeyPackagePublication,
@@ -822,9 +972,10 @@ impl KeyPackagePublisher for FlakyKeyPackages {
     async fn publish_prepared_key_package(
         &self,
         publication: &KeyPackagePublication,
-        _artifact: &cgka_traits::SignedPublicationArtifact,
-    ) -> Result<KeyPackagePublishReceipt, KeyPackagePublishError> {
+        artifact: &cgka_traits::SignedPublicationArtifact,
+    ) -> Result<LegacyKeyPackagePublishReceipt, KeyPackagePublishError> {
         self.publications.lock().unwrap().push(publication.clone());
+        self.artifacts.lock().unwrap().push(artifact.clone());
         let mut remaining = self.remaining_failures.lock().unwrap();
         if *remaining > 0 {
             *remaining -= 1;
@@ -832,7 +983,7 @@ impl KeyPackagePublisher for FlakyKeyPackages {
                 "injected publish failure",
             ));
         }
-        Ok(KeyPackagePublishReceipt {
+        Ok(LegacyKeyPackagePublishReceipt {
             accepted: publication.endpoints.clone(),
             failed: Vec::new(),
         })
@@ -875,13 +1026,228 @@ impl KeyPackagePublisher for ExposedThenFailsKeyPackages {
         &self,
         publication: &KeyPackagePublication,
         _artifact: &cgka_traits::SignedPublicationArtifact,
-    ) -> Result<KeyPackagePublishReceipt, KeyPackagePublishError> {
+    ) -> Result<LegacyKeyPackagePublishReceipt, KeyPackagePublishError> {
         self.publications.lock().unwrap().push(publication.clone());
         // External publish succeeded; a subsequent local step (e.g. cache write)
         // failed. The KeyPackage is already exposed.
         Err(KeyPackagePublishError::exposed(
             "injected post-exposure failure (e.g. local cache write)",
         ))
+    }
+}
+
+/// Publisher that crosses the external-send boundary and then deliberately
+/// remains pending. Dropping the caller future deterministically models task
+/// cancellation between socket I/O and receipt persistence.
+#[derive(Clone)]
+struct BlockingAfterSendKeyPackages {
+    sent: Arc<tokio::sync::Semaphore>,
+    release: Arc<tokio::sync::Semaphore>,
+    publications: Arc<Mutex<Vec<KeyPackagePublication>>>,
+    artifacts: Arc<Mutex<Vec<cgka_traits::SignedPublicationArtifact>>>,
+}
+
+impl Default for BlockingAfterSendKeyPackages {
+    fn default() -> Self {
+        Self {
+            sent: Arc::new(tokio::sync::Semaphore::new(0)),
+            release: Arc::new(tokio::sync::Semaphore::new(0)),
+            publications: Arc::new(Mutex::new(Vec::new())),
+            artifacts: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+#[async_trait]
+impl KeyPackagePublisher for BlockingAfterSendKeyPackages {
+    fn legacy_slot_id(
+        &self,
+        account_id: &MemberId,
+    ) -> Result<Option<String>, KeyPackagePublishError> {
+        Ok(Some(test_key_package_slot(account_id)))
+    }
+
+    fn signed_artifact_reauthor_at_age_secs(&self) -> Option<u64> {
+        Some(600)
+    }
+
+    async fn prepare_key_package(
+        &self,
+        publication: KeyPackagePublication,
+    ) -> Result<cgka_traits::SignedPublicationArtifact, KeyPackagePublishError> {
+        Ok(test_key_package_artifact(&publication))
+    }
+
+    async fn publish_prepared_key_package(
+        &self,
+        publication: &KeyPackagePublication,
+        artifact: &cgka_traits::SignedPublicationArtifact,
+    ) -> Result<LegacyKeyPackagePublishReceipt, KeyPackagePublishError> {
+        self.publications.lock().unwrap().push(publication.clone());
+        self.artifacts.lock().unwrap().push(artifact.clone());
+        self.sent.add_permits(1);
+        let permit = self
+            .release
+            .acquire()
+            .await
+            .expect("test release semaphore remains open");
+        permit.forget();
+        Ok(LegacyKeyPackagePublishReceipt {
+            accepted: publication.endpoints.clone(),
+            failed: Vec::new(),
+        })
+    }
+}
+
+/// Scriptable transport boundary for privacy-journal recovery tests. Empty
+/// receipt queues default to successful endpoint acknowledgements.
+type KeyPackageDeletionCall = (MessageId, Vec<TransportEndpoint>);
+
+#[derive(Clone, Default)]
+struct JournalKeyPackages {
+    publications: Arc<Mutex<Vec<KeyPackagePublication>>>,
+    artifacts: Arc<Mutex<Vec<cgka_traits::SignedPublicationArtifact>>>,
+    publication_receipts: Arc<Mutex<VecDeque<KeyPackagePublishReceipt>>>,
+    deletions: Arc<Mutex<Vec<KeyPackageDeletionCall>>>,
+    deletion_receipts: Arc<Mutex<VecDeque<KeyPackagePublishReceipt>>>,
+    reauthor_after_secs: Option<u64>,
+    reject_empty_prepares: bool,
+}
+
+impl JournalKeyPackages {
+    fn reauthor_after_secs(mut self, seconds: u64) -> Self {
+        self.reauthor_after_secs = Some(seconds);
+        self
+    }
+
+    fn reject_empty_prepares(mut self) -> Self {
+        self.reject_empty_prepares = true;
+        self
+    }
+
+    fn with_publication_receipts(self, receipts: Vec<KeyPackagePublishReceipt>) -> Self {
+        *self.publication_receipts.lock().unwrap() = receipts.into();
+        self
+    }
+
+    fn with_deletion_receipts(self, receipts: Vec<KeyPackagePublishReceipt>) -> Self {
+        *self.deletion_receipts.lock().unwrap() = receipts.into();
+        self
+    }
+
+    fn artifacts(&self) -> Vec<cgka_traits::SignedPublicationArtifact> {
+        self.artifacts.lock().unwrap().clone()
+    }
+
+    fn publications(&self) -> Vec<KeyPackagePublication> {
+        self.publications.lock().unwrap().clone()
+    }
+
+    fn deletions(&self) -> Vec<KeyPackageDeletionCall> {
+        self.deletions.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl KeyPackagePublisher for JournalKeyPackages {
+    fn legacy_slot_id(
+        &self,
+        account_id: &MemberId,
+    ) -> Result<Option<String>, KeyPackagePublishError> {
+        Ok(Some(test_key_package_slot(account_id)))
+    }
+
+    fn signed_artifact_reauthor_at_age_secs(&self) -> Option<u64> {
+        self.reauthor_after_secs
+    }
+
+    async fn prepare_key_package(
+        &self,
+        publication: KeyPackagePublication,
+    ) -> Result<cgka_traits::SignedPublicationArtifact, KeyPackagePublishError> {
+        if self.reject_empty_prepares && publication.endpoints.is_empty() {
+            return Err(KeyPackagePublishError::unexposed(
+                "test publisher refuses to sign an empty relay fanout",
+            ));
+        }
+        Ok(test_key_package_artifact(&publication))
+    }
+
+    async fn publish_prepared_key_package(
+        &self,
+        publication: &KeyPackagePublication,
+        artifact: &cgka_traits::SignedPublicationArtifact,
+    ) -> Result<LegacyKeyPackagePublishReceipt, KeyPackagePublishError> {
+        self.publish_prepared_key_package_detailed(publication, artifact)
+            .await
+            .map(Into::into)
+    }
+
+    async fn publish_prepared_key_package_detailed(
+        &self,
+        publication: &KeyPackagePublication,
+        artifact: &cgka_traits::SignedPublicationArtifact,
+    ) -> Result<KeyPackagePublishReceipt, KeyPackagePublishError> {
+        self.publications.lock().unwrap().push(publication.clone());
+        self.artifacts.lock().unwrap().push(artifact.clone());
+        Ok(self
+            .publication_receipts
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or_else(|| KeyPackagePublishReceipt {
+                accepted: publication.endpoints.clone(),
+                rejected: Vec::new(),
+                confirmed_absent: Vec::new(),
+                failed: Vec::new(),
+            }))
+    }
+
+    async fn delete_key_package_revision(
+        &self,
+        event_id: &MessageId,
+        endpoints: &[TransportEndpoint],
+    ) -> Result<KeyPackagePublishReceipt, KeyPackagePublishError> {
+        self.deletions
+            .lock()
+            .unwrap()
+            .push((event_id.clone(), endpoints.to_vec()));
+        Ok(self
+            .deletion_receipts
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or_else(|| KeyPackagePublishReceipt {
+                accepted: endpoints.to_vec(),
+                rejected: Vec::new(),
+                confirmed_absent: Vec::new(),
+                failed: Vec::new(),
+            }))
+    }
+}
+
+fn deletion_target(endpoint: &TransportEndpoint) -> TransportFanoutTarget {
+    TransportFanoutTarget {
+        endpoint: endpoint.clone(),
+        state: TransportFanoutAttemptState::Unattempted,
+        attempt_count: 0,
+        last_attempt_at: None,
+        failure_code: None,
+    }
+}
+
+fn retired_revision(
+    event_id: MessageId,
+    authored_created_at: Timestamp,
+    endpoints: &[TransportEndpoint],
+) -> RetiredKeyPackagePublication {
+    RetiredKeyPackagePublication {
+        event_id,
+        authored_created_at,
+        key_package_ref: None,
+        package_not_after: None,
+        delete_without_successor: true,
+        deletion_targets: endpoints.iter().map(deletion_target).collect(),
     }
 }
 
@@ -966,6 +1332,240 @@ async fn publish_fresh_key_package_uses_directory_boundary() {
         runtime.durably_owned_key_packages().unwrap(),
         vec![key_package],
         "a generated package is local only when its OpenMLS private bundle is present"
+    );
+}
+
+#[tokio::test]
+async fn durable_cutover_gate_blocks_manual_and_automatic_publication_but_not_exact_deletion() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot durable cutover publication gate key").unwrap();
+    let endpoint_a = TransportEndpoint("wss://keys-a.example".into());
+    let endpoint_b = TransportEndpoint("wss://keys-b.example".into());
+    let routing = StaticTransportRouting::new(vec![])
+        .key_package_endpoints(vec![endpoint_a.clone(), endpoint_b.clone()]);
+    let publisher = JournalKeyPackages::default().with_publication_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint_a.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: vec![endpoint_b.clone()],
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint_b.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    let wall = Arc::new(TestWallClock::new(10_000));
+    let mut runtime = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(23)),
+    );
+
+    runtime.publish_fresh_key_package().await.unwrap();
+    let deletion_id = MessageId::new(vec![0x81; 32]);
+    runtime
+        .prepare_key_package_deletion_recovery(&deletion_id, vec![endpoint_a.clone()])
+        .unwrap();
+    runtime
+        .set_key_package_cutover_publication_blocked(true)
+        .unwrap();
+    assert!(!runtime.key_package_network_maintenance_due().unwrap());
+    assert!(!runtime.key_package_has_pending_fanout().unwrap());
+
+    runtime.run_due_maintenance().await.unwrap();
+    assert_eq!(publisher.publications().len(), 1);
+    assert_eq!(
+        publisher.deletions(),
+        vec![(deletion_id, vec![endpoint_a.clone()])],
+        "the publication gate must not suppress durable exact deletion retry"
+    );
+    for error in [
+        runtime.republish_key_package().await.unwrap_err(),
+        runtime.publish_fresh_key_package().await.unwrap_err(),
+    ] {
+        assert!(error.to_string().contains("cutover discovery"));
+    }
+    assert_eq!(publisher.publications().len(), 1);
+    drop(runtime);
+
+    let mut restarted = AccountDeviceRuntime::new(
+        session(database, &key, b"alice"),
+        RecordingAdapter::default(),
+        routing,
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(23)),
+    );
+    assert!(
+        restarted
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .cutover_publication_blocked
+    );
+    assert!(
+        restarted.publish_fresh_key_package().await.is_err(),
+        "restart must not clear the durable cutover interlock"
+    );
+
+    wall.set(10_031);
+    restarted
+        .set_key_package_cutover_publication_blocked(false)
+        .unwrap();
+    assert!(restarted.key_package_has_pending_fanout().unwrap());
+    restarted.run_due_maintenance().await.unwrap();
+    let publications = publisher.publications();
+    assert_eq!(publications.len(), 2);
+    assert_eq!(publications[1].endpoints, vec![endpoint_b]);
+}
+
+#[tokio::test]
+async fn observing_exact_live_revision_preserves_relay_ordering_high_water() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot live revision high-water key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let publisher = JournalKeyPackages::default();
+    let wall = Arc::new(TestWallClock::new(10_000));
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(29)),
+    );
+
+    runtime.publish_fresh_key_package().await.unwrap();
+    runtime
+        .set_key_package_cutover_publication_blocked(true)
+        .unwrap();
+    let lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let live_event_id = lifecycle.authored_event_id.unwrap();
+    let stable_slot_id = lifecycle.stable_slot_id;
+    let observed_created_at = Timestamp(10_025);
+    let observed_endpoint = TransportEndpoint("wss://historical-keys.example".into());
+    assert!(
+        runtime
+            .observe_live_key_package_publication(
+                stable_slot_id.clone(),
+                &MessageId::new(vec![0xa1; 32]),
+                observed_created_at,
+                vec![observed_endpoint.clone()],
+            )
+            .is_err(),
+        "an unrelated same-slot event may not rewrite live lifecycle metadata"
+    );
+    let (admitted, deferred) = runtime
+        .observe_live_key_package_publication(
+            stable_slot_id,
+            &live_event_id,
+            observed_created_at,
+            vec![observed_endpoint.clone()],
+        )
+        .unwrap();
+    assert_eq!(admitted, vec![observed_endpoint.clone()]);
+    assert!(deferred.is_empty());
+    let observed = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        observed.authored_event_created_at,
+        Some(observed_created_at)
+    );
+    assert!(observed.publication_targets.iter().any(|target| {
+        target.endpoint == observed_endpoint
+            && target.state == TransportFanoutAttemptState::Accepted
+    }));
+
+    runtime
+        .set_key_package_cutover_publication_blocked(false)
+        .unwrap();
+    runtime.publish_fresh_key_package().await.unwrap();
+    assert_eq!(publisher.artifacts()[1].created_at, Timestamp(10_026));
+}
+
+#[tokio::test]
+async fn unparsed_same_slot_discovery_preserves_ordering_high_water_with_failed_deletion() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot unparsed discovery high-water key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let publisher =
+        JournalKeyPackages::default().with_deletion_receipts(vec![KeyPackagePublishReceipt {
+            accepted: Vec::new(),
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: vec![endpoint.clone()],
+        }]);
+    let wall = Arc::new(TestWallClock::new(10_000));
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(31)),
+    );
+
+    runtime.publish_fresh_key_package().await.unwrap();
+    runtime
+        .set_key_package_cutover_publication_blocked(true)
+        .unwrap();
+    let lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let stable_slot_id = lifecycle.stable_slot_id;
+    let discovered_id = MessageId::new(vec![0x91; 32]);
+    let discovered_created_at = Timestamp(10_025);
+    let (admitted, deferred) = runtime
+        .journal_discovered_unparsed_key_package_publication(
+            stable_slot_id,
+            discovered_id.clone(),
+            discovered_created_at,
+            vec![endpoint.clone()],
+        )
+        .unwrap();
+    assert_eq!(admitted, vec![endpoint.clone()]);
+    assert!(deferred.is_empty());
+    assert_eq!(
+        runtime
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .authored_event_created_at,
+        Some(discovered_created_at)
+    );
+
+    runtime
+        .set_key_package_cutover_publication_blocked(false)
+        .unwrap();
+    runtime.publish_fresh_key_package().await.unwrap();
+    let artifacts = publisher.artifacts();
+    assert_eq!(artifacts.len(), 2);
+    assert_eq!(artifacts[1].created_at, Timestamp(10_026));
+    let repaired = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(
+        repaired
+            .retired_publications_pending_deletion
+            .iter()
+            .any(|retired| retired.event_id == discovered_id
+                && retired.authored_created_at == discovered_created_at
+                && retired.deletion_targets.len() == 1),
+        "an ambiguous deletion keeps the exact discovered liability durable"
     );
 }
 
@@ -1063,6 +1663,2059 @@ async fn publish_fresh_key_package_retries_the_same_durable_replacement() {
         vec![key_package],
         "publish failure and retry must retain the staged private bundle"
     );
+}
+
+#[tokio::test]
+async fn stale_pending_key_package_is_reauthored_once_and_survives_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot stale pending key package key").unwrap();
+    let wall = Arc::new(TestWallClock::new(10_000));
+    let policy = StaticTransportRouting::new(vec![])
+        .key_package_endpoints(vec![TransportEndpoint("wss://keys.example".into())]);
+    let publisher = FlakyKeyPackages::new(3).reauthor_after_secs(600);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        policy.clone(),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(31)),
+    );
+
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("first publication is intentionally unacknowledged");
+    wall.set(10_599);
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("an artifact younger than the policy boundary stays exact");
+    wall.set(10_600);
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("the first publication of the reauthored revision is injected to fail");
+
+    let publications = publisher.publications();
+    let artifacts = publisher.artifacts();
+    assert_eq!(publications.len(), 3);
+    assert_eq!(artifacts.len(), 3);
+    assert_eq!(publications[0], publications[1]);
+    assert_eq!(artifacts[0], artifacts[1]);
+    assert_eq!(publications[2].key_package, publications[0].key_package);
+    assert_eq!(publications[2].slot_id, publications[0].slot_id);
+    assert_eq!(publications[2].created_at, Timestamp(10_600));
+    assert_ne!(artifacts[2], artifacts[0]);
+
+    let pending = runtime
+        .key_package_maintenance_status()
+        .unwrap()
+        .unwrap()
+        .pending_replacement
+        .expect("failed reauthored publication remains durable");
+    assert_eq!(pending.authored_created_at, Timestamp(10_600));
+    assert_eq!(pending.signed_event, Some(artifacts[2].clone()));
+    assert_eq!(pending.targets[0].attempt_count, 1);
+    drop(runtime);
+
+    wall.set(10_601);
+    let mut restarted = AccountDeviceRuntime::new(
+        session(database, &key, b"alice"),
+        RecordingAdapter::default(),
+        policy,
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(31)),
+    );
+    restarted
+        .publish_fresh_key_package()
+        .await
+        .expect("restart retries the durable reauthored revision exactly");
+
+    let publications = publisher.publications();
+    let artifacts = publisher.artifacts();
+    assert_eq!(publications.len(), 4);
+    assert_eq!(publications[3], publications[2]);
+    assert_eq!(artifacts[3], artifacts[2]);
+    let current = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert!(current.pending_replacement.is_none());
+    assert_eq!(current.authored_event_id, Some(artifacts[2].id.clone()));
+    assert_eq!(current.authored_event_created_at, Some(Timestamp(10_600)));
+    assert_eq!(current.authored_signed_event, Some(artifacts[2].clone()));
+}
+
+#[tokio::test]
+async fn cancelled_key_package_send_keeps_possible_exposure_and_retires_old_revision_after_restart()
+{
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot cancelled key package send key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let routing = StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]);
+    let wall = Arc::new(TestWallClock::new(10_000));
+    let blocking = BlockingAfterSendKeyPackages::default();
+    let sent = blocking.sent.clone();
+    let mut runtime = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        blocking.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(53)),
+    );
+
+    let mut publish = Box::pin(runtime.publish_fresh_key_package());
+    let sent_permit = tokio::select! {
+        permit = sent.acquire() => permit.expect("send marker semaphore remains open"),
+        result = &mut publish => panic!("publisher returned before cancellation boundary: {result:?}"),
+    };
+    sent_permit.forget();
+    drop(publish);
+
+    let old_artifact = blocking.artifacts.lock().unwrap()[0].clone();
+    let after_cancel = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let pending = after_cancel
+        .pending_replacement
+        .expect("cancelled send retains its durable pending replacement");
+    assert_eq!(pending.signed_event, Some(old_artifact.clone()));
+    assert_eq!(pending.targets.len(), 1);
+    assert_eq!(
+        pending.targets[0].state,
+        TransportFanoutAttemptState::AttemptedFailed
+    );
+    assert_eq!(pending.targets[0].attempt_count, 1);
+    assert_eq!(
+        pending.targets[0].failure_code.as_deref(),
+        Some("possible_exposure")
+    );
+    drop(runtime);
+
+    wall.set(10_600);
+    let succeeding = JournalKeyPackages::default().reauthor_after_secs(600);
+    let mut restarted = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        succeeding.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(53)),
+    );
+    restarted
+        .publish_fresh_key_package()
+        .await
+        .expect("stale cancelled revision is reauthored and published");
+    let reauthored = succeeding.artifacts();
+    assert_eq!(reauthored.len(), 1);
+    assert_ne!(reauthored[0].id, old_artifact.id);
+    let lifecycle = restarted.key_package_maintenance_status().unwrap().unwrap();
+    let retired = lifecycle
+        .retired_publications_pending_deletion
+        .iter()
+        .find(|retired| retired.event_id == old_artifact.id)
+        .expect("old ambiguously exposed event remains a durable deletion obligation");
+    assert_eq!(retired.deletion_targets.len(), 1);
+    assert_eq!(retired.deletion_targets[0].endpoint, endpoint);
+    drop(restarted);
+
+    let reopened = AccountDeviceRuntime::new(
+        session(database, &key, b"alice"),
+        RecordingAdapter::default(),
+        routing,
+        succeeding,
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(53)),
+    );
+    let after_second_restart = reopened.key_package_maintenance_status().unwrap().unwrap();
+    assert!(
+        after_second_restart
+            .retired_publications_pending_deletion
+            .iter()
+            .any(|retired| {
+                retired.event_id == old_artifact.id
+                    && retired
+                        .deletion_targets
+                        .iter()
+                        .any(|target| target.endpoint == endpoint)
+            })
+    );
+}
+
+#[tokio::test]
+async fn publication_negative_ack_never_proves_the_signed_event_absent() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot publication negative ack key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let wall = Arc::new(TestWallClock::new(20_000));
+    let publisher = JournalKeyPackages::default()
+        .reauthor_after_secs(600)
+        .with_publication_receipts(vec![
+            KeyPackagePublishReceipt {
+                accepted: Vec::new(),
+                rejected: vec![endpoint.clone()],
+                confirmed_absent: Vec::new(),
+                failed: Vec::new(),
+            },
+            KeyPackagePublishReceipt {
+                accepted: vec![endpoint.clone()],
+                rejected: Vec::new(),
+                confirmed_absent: Vec::new(),
+                failed: Vec::new(),
+            },
+        ]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(59)),
+    );
+
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("a negative publication acknowledgement accepts no endpoint");
+    let old_artifact = publisher.artifacts()[0].clone();
+    let after_negative = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        after_negative.pending_replacement.as_ref().unwrap().targets[0]
+            .failure_code
+            .as_deref(),
+        Some("transport_rejected"),
+        "normal publication cannot distinguish a truly first attempt from legacy possible exposure"
+    );
+
+    wall.set(20_600);
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect("a stale negatively acknowledged revision may be replaced");
+    assert!(
+        runtime
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .retired_publications_pending_deletion
+            .iter()
+            .any(|retired| {
+                retired.event_id == old_artifact.id
+                    && retired
+                        .deletion_targets
+                        .iter()
+                        .any(|target| target.endpoint == endpoint)
+            }),
+        "the negative acknowledgement cannot erase possible pre-upgrade relay exposure"
+    );
+}
+
+#[tokio::test]
+async fn fresh_publication_ignores_extraneous_acceptance_and_retries_deletion_only_absence_claim() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot scoped fresh publication receipt key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let extraneous = TransportEndpoint("wss://not-attempted.example".into());
+    let wall = Arc::new(TestWallClock::new(21_000));
+    let publisher = JournalKeyPackages::default().with_publication_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: vec![extraneous.clone(), extraneous],
+            rejected: Vec::new(),
+            confirmed_absent: vec![endpoint.clone(), endpoint.clone()],
+            failed: Vec::new(),
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(60)),
+    );
+
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("an acceptance outside the attempted fanout cannot promote a replacement");
+    let pending = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(pending.current_key_package.is_none());
+    let target = &pending.pending_replacement.as_ref().unwrap().targets[0];
+    assert_eq!(target.endpoint, endpoint);
+    assert_eq!(target.state, TransportFanoutAttemptState::AttemptedFailed);
+    assert_eq!(target.failure_code.as_deref(), Some("possible_exposure"));
+    assert_ne!(target.failure_code.as_deref(), Some("confirmed_absent"));
+
+    runtime.pause_maintenance();
+    wall.set(21_030);
+    runtime
+        .run_due_maintenance()
+        .await
+        .expect("the pending revision remains automatically retryable");
+    let promoted = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(promoted.pending_replacement.is_none());
+    assert!(promoted.current_key_package.is_some());
+    assert_eq!(publisher.publications().len(), 2);
+    assert_eq!(publisher.publications()[1].endpoints, vec![endpoint]);
+}
+
+#[tokio::test]
+async fn current_republication_ignores_extraneous_acceptance_and_retries_absence_claim() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot scoped current publication receipt key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let extraneous = TransportEndpoint("wss://not-attempted.example".into());
+    let wall = Arc::new(TestWallClock::new(22_000));
+    let publisher = JournalKeyPackages::default().with_publication_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![extraneous],
+            rejected: Vec::new(),
+            confirmed_absent: vec![endpoint.clone()],
+            failed: Vec::new(),
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(62)),
+    );
+    runtime.publish_fresh_key_package().await.unwrap();
+    let mut lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let artifact = lifecycle.authored_signed_event.clone().unwrap();
+    let republish_at = lifecycle.current_not_before.unwrap().0;
+    lifecycle.publication_targets[0].state = TransportFanoutAttemptState::Unattempted;
+    lifecycle.publication_targets[0].attempt_count = 0;
+    lifecycle.publication_targets[0].last_attempt_at = None;
+    lifecycle.publication_targets[0].failure_code = None;
+    runtime
+        .session()
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+    wall.set(republish_at);
+
+    runtime
+        .republish_key_package()
+        .await
+        .expect_err("an out-of-scope acceptance cannot make republication succeed");
+    let retrying = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(retrying.authored_signed_event, Some(artifact.clone()));
+    assert_eq!(
+        (
+            retrying.publication_targets[0].state,
+            retrying.publication_targets[0].failure_code.as_deref(),
+        ),
+        (
+            TransportFanoutAttemptState::AttemptedFailed,
+            Some("possible_exposure"),
+        )
+    );
+    assert_ne!(
+        retrying.publication_targets[0].failure_code.as_deref(),
+        Some("confirmed_absent")
+    );
+
+    runtime.pause_maintenance();
+    wall.set(republish_at.saturating_add(30));
+    runtime
+        .run_due_maintenance()
+        .await
+        .expect("the current exact revision remains automatically retryable");
+    let completed = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(completed.authored_signed_event, Some(artifact));
+    assert_eq!(
+        completed.publication_targets[0].state,
+        TransportFanoutAttemptState::Accepted
+    );
+    assert_eq!(publisher.publications().len(), 3);
+    assert_eq!(publisher.publications()[2].endpoints, vec![endpoint]);
+}
+
+#[tokio::test]
+async fn legacy_signed_unattempted_revision_negative_retry_remains_deletable_after_reauthor() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot legacy unattempted upgrade key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let routing = StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]);
+    let wall = Arc::new(TestWallClock::new(30_000));
+
+    let mut legacy = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        JournalKeyPackages::default(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(61)),
+    );
+    legacy
+        .prepare_fresh_key_package(vec![endpoint.clone()])
+        .await
+        .expect("legacy fixture has a durable signed revision before network I/O");
+    let legacy_lifecycle = legacy.key_package_maintenance_status().unwrap().unwrap();
+    let legacy_pending = legacy_lifecycle.pending_replacement.unwrap();
+    let old_artifact = legacy_pending.signed_event.unwrap();
+    assert_eq!(legacy_pending.targets.len(), 1);
+    assert_eq!(
+        legacy_pending.targets[0].state,
+        TransportFanoutAttemptState::Unattempted
+    );
+    assert_eq!(legacy_pending.targets[0].attempt_count, 0);
+    assert!(legacy_pending.targets[0].last_attempt_at.is_none());
+    drop(legacy);
+
+    let upgraded_publisher = JournalKeyPackages::default()
+        .reauthor_after_secs(600)
+        .with_publication_receipts(vec![
+            KeyPackagePublishReceipt {
+                accepted: Vec::new(),
+                rejected: vec![endpoint.clone()],
+                confirmed_absent: Vec::new(),
+                failed: Vec::new(),
+            },
+            KeyPackagePublishReceipt {
+                accepted: vec![endpoint.clone()],
+                rejected: Vec::new(),
+                confirmed_absent: Vec::new(),
+                failed: Vec::new(),
+            },
+        ]);
+    let mut upgraded = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        upgraded_publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(61)),
+    );
+    upgraded
+        .publish_fresh_key_package()
+        .await
+        .expect_err("the legacy revision retry is negatively acknowledged");
+    let after_negative = upgraded.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        after_negative
+            .pending_replacement
+            .as_ref()
+            .unwrap()
+            .signed_event,
+        Some(old_artifact.clone())
+    );
+    assert_eq!(
+        after_negative.pending_replacement.as_ref().unwrap().targets[0]
+            .failure_code
+            .as_deref(),
+        Some("transport_rejected")
+    );
+    drop(upgraded);
+
+    wall.set(30_600);
+    let mut restarted = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        upgraded_publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(61)),
+    );
+    restarted
+        .publish_fresh_key_package()
+        .await
+        .expect("the stale legacy revision is reauthored after restart");
+    let upgraded_artifacts = upgraded_publisher.artifacts();
+    assert_eq!(upgraded_artifacts[0], old_artifact);
+    assert_ne!(upgraded_artifacts[1].id, old_artifact.id);
+    let retired = restarted
+        .key_package_maintenance_status()
+        .unwrap()
+        .unwrap()
+        .retired_publications_pending_deletion
+        .into_iter()
+        .find(|retired| retired.event_id == old_artifact.id)
+        .expect("legacy possibly exposed event id remains durably deletable");
+    assert_eq!(retired.deletion_targets.len(), 1);
+    assert_eq!(retired.deletion_targets[0].endpoint, endpoint);
+    drop(restarted);
+
+    let reopened = AccountDeviceRuntime::new(
+        session(database, &key, b"alice"),
+        RecordingAdapter::default(),
+        routing,
+        upgraded_publisher,
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(61)),
+    );
+    assert!(
+        reopened
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .retired_publications_pending_deletion
+            .iter()
+            .any(|retired| {
+                retired.event_id == old_artifact.id
+                    && retired
+                        .deletion_targets
+                        .iter()
+                        .any(|target| target.endpoint == endpoint)
+            })
+    );
+}
+
+#[tokio::test]
+async fn due_maintenance_retries_all_rejected_pending_key_package_after_backoff() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot all rejected worker retry key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let wall = Arc::new(TestWallClock::new(35_000));
+    let publisher = JournalKeyPackages::default().with_publication_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: Vec::new(),
+            rejected: vec![endpoint.clone()],
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(63)),
+    );
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("the first normal publication is rejected everywhere");
+    let first = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        first.pending_replacement.as_ref().unwrap().targets[0]
+            .failure_code
+            .as_deref(),
+        Some("transport_rejected")
+    );
+    runtime.pause_maintenance();
+
+    wall.set(35_030);
+    runtime
+        .run_due_maintenance()
+        .await
+        .expect("worker-shaped maintenance retries the durable pending revision");
+    let artifacts = publisher.artifacts();
+    assert_eq!(artifacts.len(), 2);
+    assert_eq!(artifacts[0], artifacts[1]);
+    let recovered = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(recovered.pending_replacement.is_none());
+    assert_eq!(recovered.authored_signed_event, Some(artifacts[0].clone()));
+    assert!(recovered.publication_targets.iter().all(|target| {
+        target.endpoint == endpoint
+            && target.state == TransportFanoutAttemptState::Accepted
+            && target.failure_code.is_none()
+    }));
+}
+
+#[tokio::test]
+async fn due_maintenance_finishes_partially_accepted_key_package_fanout_after_backoff() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot partial worker fanout key").unwrap();
+    let endpoint_a = TransportEndpoint("wss://keys-a.example".into());
+    let endpoint_b = TransportEndpoint("wss://keys-b.example".into());
+    let wall = Arc::new(TestWallClock::new(36_000));
+    let publisher = JournalKeyPackages::default().with_publication_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint_a.clone()],
+            rejected: vec![endpoint_b.clone()],
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint_b.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![])
+            .key_package_endpoints(vec![endpoint_a.clone(), endpoint_b.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(65)),
+    );
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect("one accepted endpoint promotes the current key package");
+    let partial = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(partial.phase, cgka_traits::MaintenancePhase::Fanout);
+    let rejected = partial
+        .publication_targets
+        .iter()
+        .find(|target| target.endpoint == endpoint_b)
+        .unwrap();
+    assert_eq!(rejected.failure_code.as_deref(), Some("transport_rejected"));
+    runtime.pause_maintenance();
+
+    wall.set(36_030);
+    runtime
+        .run_due_maintenance()
+        .await
+        .expect("worker-shaped maintenance retries only the rejected endpoint");
+    let publications = publisher.publications();
+    assert_eq!(publications.len(), 2);
+    assert_eq!(publications[1].endpoints, vec![endpoint_b.clone()]);
+    let artifacts = publisher.artifacts();
+    assert_eq!(artifacts.len(), 2);
+    assert_eq!(artifacts[0], artifacts[1]);
+    let completed = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(completed.phase, cgka_traits::MaintenancePhase::Complete);
+    assert!(completed.publication_targets.iter().all(|target| {
+        (target.endpoint == endpoint_a || target.endpoint == endpoint_b)
+            && target.state == TransportFanoutAttemptState::Accepted
+            && target.failure_code.is_none()
+    }));
+}
+
+#[tokio::test]
+async fn due_maintenance_reconciles_current_fanout_to_authoritative_routes_after_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot current fanout route reconcile key").unwrap();
+    let endpoint_a = TransportEndpoint("wss://keys-a.example".into());
+    let removed_endpoint = TransportEndpoint("wss://keys-b.example".into());
+    let added_endpoint = TransportEndpoint("wss://keys-c.example".into());
+    let wall = Arc::new(TestWallClock::new(36_500));
+    let publisher = PartialFanoutKeyPackages::default();
+
+    let original_artifact;
+    {
+        let mut runtime = AccountDeviceRuntime::new(
+            session(&database, &key, b"alice"),
+            RecordingAdapter::default(),
+            StaticTransportRouting::new(vec![])
+                .key_package_endpoints(vec![endpoint_a.clone(), removed_endpoint.clone()]),
+            publisher.clone(),
+        )
+        .with_maintenance_sources(
+            wall.clone(),
+            Arc::new(TestMonotonicClock::default()),
+            Arc::new(TestRandom::new(67)),
+        );
+        runtime.publish_fresh_key_package().await.unwrap();
+        let partial = runtime.key_package_maintenance_status().unwrap().unwrap();
+        original_artifact = partial.authored_signed_event.unwrap();
+        assert!(partial.publication_targets.iter().any(|target| {
+            target.endpoint == removed_endpoint
+                && target.state == TransportFanoutAttemptState::AttemptedFailed
+        }));
+    }
+
+    wall.set(36_530);
+    let mut restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![])
+            .key_package_endpoints(vec![endpoint_a.clone(), added_endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(67)),
+    );
+    restarted.pause_maintenance();
+    restarted.run_due_maintenance().await.unwrap();
+
+    let publications = publisher.publications();
+    assert_eq!(publications.len(), 2);
+    assert_eq!(publications[1].0.endpoints, vec![added_endpoint.clone()]);
+    assert_eq!(publications[1].1, original_artifact);
+    assert!(!publications[1].0.endpoints.contains(&removed_endpoint));
+
+    let reconciled = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert!(reconciled.publication_targets.iter().any(|target| {
+        target.endpoint == removed_endpoint
+            && target.state == TransportFanoutAttemptState::PolicyProhibited
+    }));
+    assert!(reconciled.publication_targets.iter().any(|target| {
+        target.endpoint == added_endpoint && target.state == TransportFanoutAttemptState::Accepted
+    }));
+}
+
+#[tokio::test]
+async fn pending_replacement_reconciles_a_to_b_policy_and_cannot_promote_from_stale_a_ack() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot pending route switch key").unwrap();
+    let endpoint_a = TransportEndpoint("wss://keys-a.example".into());
+    let endpoint_b = TransportEndpoint("wss://keys-b.example".into());
+    let publisher = JournalKeyPackages::default().with_publication_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: Vec::new(),
+            rejected: vec![endpoint_a.clone()],
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint_a.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: vec![endpoint_b.clone()],
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint_b.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    {
+        let mut runtime = AccountDeviceRuntime::new(
+            session(&database, &key, b"alice"),
+            RecordingAdapter::default(),
+            StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint_a.clone()]),
+            publisher.clone(),
+        );
+        runtime
+            .publish_fresh_key_package()
+            .await
+            .expect_err("the original A-only route rejects the pending revision");
+    }
+
+    let mut restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint_b.clone()]),
+        publisher.clone(),
+    );
+    restarted
+        .publish_fresh_key_package()
+        .await
+        .expect_err("an acknowledgement for removed A is outside the B-only attempted fanout");
+    let pending = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert!(pending.current_key_package.is_none());
+    let pending = pending.pending_replacement.unwrap();
+    let removed_a = pending
+        .targets
+        .iter()
+        .find(|target| target.endpoint == endpoint_a)
+        .unwrap();
+    assert_eq!(
+        removed_a.state,
+        TransportFanoutAttemptState::PolicyProhibited
+    );
+    let live_b = pending
+        .targets
+        .iter()
+        .find(|target| target.endpoint == endpoint_b)
+        .unwrap();
+    assert_eq!(live_b.state, TransportFanoutAttemptState::AttemptedFailed);
+    assert_eq!(live_b.failure_code.as_deref(), Some("possible_exposure"));
+
+    restarted
+        .publish_fresh_key_package()
+        .await
+        .expect("the pending revision promotes only after authoritative B acknowledges");
+    let promoted = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert!(promoted.pending_replacement.is_none());
+    assert!(promoted.publication_targets.iter().any(|target| {
+        target.endpoint == endpoint_b && target.state == TransportFanoutAttemptState::Accepted
+    }));
+    assert_eq!(
+        publisher
+            .publications()
+            .into_iter()
+            .map(|publication| publication.endpoints)
+            .collect::<Vec<_>>(),
+        vec![vec![endpoint_a], vec![endpoint_b.clone()], vec![endpoint_b]]
+    );
+}
+
+#[tokio::test]
+async fn zero_target_pending_replacement_publishes_when_an_authoritative_route_appears() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot pending zero route recovery key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let publisher = JournalKeyPackages::default().reject_empty_prepares();
+    {
+        let mut runtime = AccountDeviceRuntime::new(
+            session(&database, &key, b"alice"),
+            RecordingAdapter::default(),
+            StaticTransportRouting::new(vec![]),
+            publisher.clone(),
+        );
+        runtime
+            .publish_fresh_key_package()
+            .await
+            .expect_err("a prepared zero-target revision cannot yet be acknowledged");
+        let pending = runtime.key_package_maintenance_status().unwrap().unwrap();
+        assert!(
+            pending
+                .pending_replacement
+                .as_ref()
+                .unwrap()
+                .targets
+                .is_empty()
+        );
+        assert!(
+            pending
+                .pending_replacement
+                .as_ref()
+                .unwrap()
+                .signed_event
+                .is_none(),
+            "the transport-like empty-route failure must leave an unsigned durable draft"
+        );
+    }
+
+    let mut restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    );
+    restarted
+        .publish_fresh_key_package()
+        .await
+        .expect("the newly authoritative route is persisted and receives the exact pending event");
+    assert!(
+        restarted
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .pending_replacement
+            .is_none()
+    );
+    assert_eq!(
+        publisher
+            .publications()
+            .into_iter()
+            .map(|publication| publication.endpoints)
+            .collect::<Vec<_>>(),
+        vec![vec![endpoint]]
+    );
+}
+
+#[tokio::test]
+async fn saturated_pending_route_addition_fails_without_persisting_the_257th_pair() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot pending route capacity key").unwrap();
+    let endpoint = TransportEndpoint("wss://new.example".into());
+    let publisher = JournalKeyPackages::default();
+    {
+        let mut runtime = AccountDeviceRuntime::new(
+            session(&database, &key, b"alice"),
+            RecordingAdapter::default(),
+            StaticTransportRouting::new(vec![]),
+            publisher.clone(),
+        );
+        runtime.prepare_fresh_key_package(Vec::new()).await.unwrap();
+        let mut lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+        let full_endpoints = (0..256)
+            .map(|index| TransportEndpoint(format!("wss://retired-{index}.example")))
+            .collect::<Vec<_>>();
+        lifecycle
+            .retired_publications_pending_deletion
+            .push(RetiredKeyPackagePublication {
+                event_id: MessageId::new(vec![0x7d; 32]),
+                authored_created_at: Timestamp(u64::MAX),
+                key_package_ref: None,
+                package_not_after: None,
+                delete_without_successor: false,
+                deletion_targets: full_endpoints.iter().map(deletion_target).collect(),
+            });
+        runtime
+            .session()
+            .put_key_package_lifecycle(&lifecycle)
+            .unwrap();
+    }
+
+    let mut restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint]),
+        publisher.clone(),
+    );
+    let error = restarted
+        .publish_fresh_key_package()
+        .await
+        .expect_err("adding a distinct pending endpoint above the global cap must fail");
+    assert!(
+        error
+            .to_string()
+            .contains("signed-publication endpoint-liability journal is full")
+    );
+    let unchanged = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert!(
+        unchanged
+            .pending_replacement
+            .as_ref()
+            .unwrap()
+            .targets
+            .is_empty(),
+        "the over-cap authoritative endpoint must not partially persist"
+    );
+    assert!(publisher.publications().is_empty());
+}
+
+#[test]
+fn discovered_retired_key_package_admission_is_idempotent_bounded_and_io_free() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot discovered revision admission key").unwrap();
+    let publisher = JournalKeyPackages::default();
+    let mut lifecycle = cgka_traits::KeyPackageLifecycleState::slot_only("stable-slot".into());
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(RetiredKeyPackagePublication {
+            event_id: MessageId::new(vec![0x81; 32]),
+            authored_created_at: Timestamp(1),
+            key_package_ref: None,
+            package_not_after: None,
+            delete_without_successor: false,
+            deletion_targets: (0
+                ..cgka_traits::maintenance::MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES - 1)
+                .map(|index| {
+                    deletion_target(&TransportEndpoint(format!(
+                        "wss://existing-{index}.example"
+                    )))
+                })
+                .collect(),
+        });
+    session(&database, &key, b"alice")
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+
+    let event_id = MessageId::new(vec![0x82; 32]);
+    let key_package_ref = vec![0x83; 32];
+    let endpoint_a = TransportEndpoint("wss://discovered-a.example".into());
+    let endpoint_b = TransportEndpoint("wss://discovered-b.example".into());
+    let mut runtime = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        publisher.clone(),
+    );
+    let (admitted, deferred) = runtime
+        .journal_discovered_retired_key_package_publication(
+            "stable-slot".into(),
+            event_id.clone(),
+            Timestamp(200),
+            key_package_ref.clone(),
+            Timestamp(900),
+            vec![endpoint_b.clone(), endpoint_a.clone(), endpoint_a.clone()],
+        )
+        .unwrap();
+    assert_eq!(admitted, vec![endpoint_a.clone()]);
+    assert_eq!(deferred, vec![endpoint_b.clone()]);
+    let journaled = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        journaled.authored_event_created_at,
+        Some(Timestamp(200)),
+        "relay-discovered same-slot revisions advance the authoring high-water"
+    );
+    let discovered = journaled
+        .retired_publications_pending_deletion
+        .iter()
+        .find(|retired| retired.event_id == event_id)
+        .unwrap();
+    assert_eq!(discovered.authored_created_at, Timestamp(200));
+    assert_eq!(discovered.key_package_ref, Some(key_package_ref.clone()));
+    assert_eq!(discovered.package_not_after, Some(Timestamp(900)));
+    assert!(!discovered.delete_without_successor);
+    assert_eq!(discovered.deletion_targets.len(), 1);
+    assert_eq!(discovered.deletion_targets[0].endpoint, endpoint_a);
+    assert!(publisher.publications().is_empty());
+    assert!(publisher.deletions().is_empty());
+    drop(runtime);
+
+    let mut restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        publisher.clone(),
+    );
+    let (admitted, deferred) = restarted
+        .journal_discovered_retired_key_package_publication(
+            "stable-slot".into(),
+            event_id.clone(),
+            Timestamp(200),
+            key_package_ref,
+            Timestamp(900),
+            vec![endpoint_b.clone(), endpoint_a.clone()],
+        )
+        .unwrap();
+    assert_eq!(admitted, vec![endpoint_a]);
+    assert_eq!(deferred, vec![endpoint_b.clone()]);
+
+    let wrong_slot_error = restarted
+        .journal_discovered_retired_key_package_publication(
+            "sibling-device-slot".into(),
+            MessageId::new(vec![0x86; 32]),
+            Timestamp(201),
+            vec![0x87; 32],
+            Timestamp(901),
+            vec![endpoint_b.clone()],
+        )
+        .expect_err("a sibling-device stable slot must never enter the local deletion journal");
+    assert!(wrong_slot_error.to_string().contains("local stable slot"));
+
+    let live_event_id = MessageId::new(vec![0x84; 32]);
+    let mut live = restarted.key_package_maintenance_status().unwrap().unwrap();
+    live.authored_event_id = Some(live_event_id.clone());
+    restarted
+        .session()
+        .put_key_package_lifecycle(&live)
+        .unwrap();
+    let error = restarted
+        .journal_discovered_retired_key_package_publication(
+            "stable-slot".into(),
+            live_event_id,
+            Timestamp(201),
+            vec![0x85; 32],
+            Timestamp(901),
+            vec![endpoint_b],
+        )
+        .expect_err("a selected live revision cannot be imported as retired");
+    assert!(error.to_string().contains("live key package revision"));
+    assert!(publisher.publications().is_empty());
+    assert!(publisher.deletions().is_empty());
+}
+
+#[tokio::test]
+async fn discovered_consumed_revision_is_deletable_without_a_successor_after_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot consumed discovered revision key").unwrap();
+    let event_id = MessageId::new(vec![0x88; 32]);
+    let key_package_ref = vec![0x89; 32];
+    let endpoint = TransportEndpoint("wss://consumed-discovered.example".into());
+    let publisher = JournalKeyPackages::default();
+    let mut lifecycle = cgka_traits::KeyPackageLifecycleState::slot_only("stable-slot".into());
+    lifecycle.cutover_publication_blocked = true;
+    lifecycle.consumed_key_package_refs = vec![key_package_ref.clone()];
+    session(&database, &key, b"alice")
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+
+    let mut runtime = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        publisher.clone(),
+    );
+    runtime
+        .journal_discovered_retired_key_package_publication(
+            "stable-slot".into(),
+            event_id.clone(),
+            Timestamp(300),
+            key_package_ref,
+            Timestamp(900),
+            vec![endpoint.clone()],
+        )
+        .unwrap();
+    let admitted = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(
+        admitted
+            .retired_publications_pending_deletion
+            .iter()
+            .find(|retired| retired.event_id == event_id)
+            .unwrap()
+            .delete_without_successor,
+        "durable Welcome evidence must transfer onto the exact relay revision"
+    );
+    assert!(publisher.deletions().is_empty());
+    drop(runtime);
+
+    let mut restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        publisher.clone(),
+    );
+    restarted
+        .retry_retired_key_package_deletions_once()
+        .await
+        .unwrap();
+    assert_eq!(
+        publisher.deletions(),
+        vec![(event_id.clone(), vec![endpoint])]
+    );
+    assert!(publisher.publications().is_empty());
+    assert!(
+        restarted
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .retired_publications_pending_deletion
+            .iter()
+            .all(|retired| retired.event_id != event_id),
+        "the exact accepted deletion acknowledgement must settle the liability"
+    );
+}
+
+#[tokio::test]
+async fn live_revision_deletion_uses_only_the_bounded_atomic_overflow_reserve() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot live deletion atomic capacity key").unwrap();
+    let live_event_id = MessageId::new(vec![0xa1; 32]);
+    let existing_event_id = MessageId::new(vec![0xa2; 32]);
+    let mut live_endpoints = (0
+        ..=cgka_traits::maintenance::MAX_KEY_PACKAGE_LIVE_DELETION_OVERFLOW_LIABILITIES)
+        .map(|index| TransportEndpoint(format!("wss://live-{index}.example")))
+        .collect::<Vec<_>>();
+    live_endpoints.sort();
+    let existing_endpoints = (0
+        ..cgka_traits::maintenance::MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES)
+        .map(|index| TransportEndpoint(format!("wss://existing-{index}.example")))
+        .collect::<Vec<_>>();
+    let mut lifecycle = cgka_traits::KeyPackageLifecycleState::slot_only("stable-slot".into());
+    lifecycle.authored_event_id = Some(live_event_id.clone());
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(RetiredKeyPackagePublication {
+            event_id: existing_event_id.clone(),
+            authored_created_at: Timestamp(1),
+            key_package_ref: None,
+            package_not_after: None,
+            delete_without_successor: true,
+            deletion_targets: existing_endpoints.iter().map(deletion_target).collect(),
+        });
+    session(&database, &key, b"alice")
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+    let admitted_live_endpoints = live_endpoints
+        [..cgka_traits::maintenance::MAX_KEY_PACKAGE_LIVE_DELETION_OVERFLOW_LIABILITIES]
+        .to_vec();
+    let publisher =
+        JournalKeyPackages::default().with_deletion_receipts(vec![KeyPackagePublishReceipt {
+            accepted: Vec::new(),
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: admitted_live_endpoints.clone(),
+        }]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        publisher.clone(),
+    );
+
+    let (admitted, deferred) = runtime
+        .prepare_key_package_deletion_recovery(&live_event_id, live_endpoints.clone())
+        .unwrap();
+    assert!(admitted.is_empty());
+    assert_eq!(deferred, live_endpoints);
+    let before_admission = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(
+        !before_admission
+            .deleted_live_revision_event_ids
+            .contains(&live_event_id)
+    );
+    assert!(
+        before_admission
+            .retired_publications_pending_deletion
+            .iter()
+            .all(|retired| retired.event_id != live_event_id),
+        "a request larger than the reserve must not admit a live endpoint subset"
+    );
+
+    let (receipt, deferred) = runtime
+        .delete_key_package_revision_durably(&live_event_id, admitted_live_endpoints.clone())
+        .await
+        .unwrap();
+    assert_eq!(receipt.failed, admitted_live_endpoints);
+    assert!(deferred.is_empty());
+    assert_eq!(publisher.deletions().len(), 1);
+    assert_eq!(publisher.deletions()[0].0, live_event_id);
+    let retained = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(
+        retained
+            .deleted_live_revision_event_ids
+            .contains(&live_event_id)
+    );
+    let live_retired = retained
+        .retired_publications_pending_deletion
+        .iter()
+        .find(|retired| retired.event_id == live_event_id)
+        .expect("every failed live endpoint remains durably retryable");
+    assert_eq!(
+        live_retired.deletion_targets.len(),
+        cgka_traits::maintenance::MAX_KEY_PACKAGE_LIVE_DELETION_OVERFLOW_LIABILITIES
+    );
+    assert_eq!(
+        retained
+            .retired_publications_pending_deletion
+            .iter()
+            .map(|retired| retired.deletion_targets.len())
+            .sum::<usize>(),
+        cgka_traits::maintenance::MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES_WITH_LIVE_DELETION_OVERFLOW
+    );
+    assert_eq!(
+        retained.deletion_overflow_owner_event_id,
+        Some(live_event_id.clone())
+    );
+
+    drop(runtime);
+    let mut restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        publisher,
+    );
+    let (admitted, deferred) = restarted
+        .prepare_key_package_deletion_recovery(
+            &live_event_id,
+            vec![live_endpoints.last().unwrap().clone()],
+        )
+        .unwrap();
+    assert!(admitted.is_empty());
+    assert_eq!(deferred, vec![live_endpoints.last().unwrap().clone()]);
+    let restarted_status = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert!(
+        restarted_status
+            .deleted_live_revision_event_ids
+            .contains(&live_event_id),
+        "restart must retain both the live-delete marker and the full reserve"
+    );
+    assert_eq!(
+        restarted_status.deletion_overflow_owner_event_id,
+        Some(live_event_id),
+        "the full reserve must retain its exact owner after restart"
+    );
+}
+
+#[tokio::test]
+async fn unknown_exact_deletion_uses_the_reserve_instead_of_partial_admission() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot unknown exact deletion reserve key").unwrap();
+    let existing_event_id = MessageId::new(vec![0xb1; 32]);
+    let deleting_event_id = MessageId::new(vec![0xb2; 32]);
+    let existing_endpoints = (0
+        ..cgka_traits::maintenance::MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES - 1)
+        .map(|index| TransportEndpoint(format!("wss://existing-{index}.example")))
+        .collect::<Vec<_>>();
+    let mut deleting_endpoints = vec![
+        TransportEndpoint("wss://delete-b.example".into()),
+        TransportEndpoint("wss://delete-a.example".into()),
+    ];
+    deleting_endpoints.sort();
+    let mut lifecycle = cgka_traits::KeyPackageLifecycleState::slot_only("stable-slot".into());
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(RetiredKeyPackagePublication {
+            event_id: existing_event_id,
+            authored_created_at: Timestamp(1),
+            key_package_ref: None,
+            package_not_after: None,
+            delete_without_successor: true,
+            deletion_targets: existing_endpoints.iter().map(deletion_target).collect(),
+        });
+    session(&database, &key, b"alice")
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+    let mut runtime = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        JournalKeyPackages::default(),
+    );
+
+    let (admitted, deferred) = runtime
+        .prepare_key_package_deletion_recovery(&deleting_event_id, deleting_endpoints.clone())
+        .unwrap();
+    assert_eq!(admitted, deleting_endpoints);
+    assert!(deferred.is_empty());
+    let retained = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        retained
+            .retired_publications_pending_deletion
+            .iter()
+            .map(|retired| retired.deletion_targets.len())
+            .sum::<usize>(),
+        cgka_traits::maintenance::MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES + 1
+    );
+    assert_eq!(
+        retained
+            .retired_publications_pending_deletion
+            .iter()
+            .find(|retired| retired.event_id == deleting_event_id)
+            .unwrap()
+            .deletion_targets
+            .len(),
+        2,
+        "an unprojected id can still be an older same-slot revision, so its relay set is atomic"
+    );
+    assert_eq!(
+        retained.deletion_overflow_owner_event_id,
+        Some(deleting_event_id.clone()),
+        "the exact event that crossed the ordinary bound must durably own the reserve"
+    );
+    drop(runtime);
+
+    let restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        JournalKeyPackages::default(),
+    );
+    let restarted = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        restarted
+            .retired_publications_pending_deletion
+            .iter()
+            .find(|retired| retired.event_id == deleting_event_id)
+            .unwrap()
+            .deletion_targets
+            .len(),
+        2
+    );
+    assert_eq!(
+        restarted.deletion_overflow_owner_event_id,
+        Some(deleting_event_id),
+        "reserve ownership must survive reopening the account database"
+    );
+}
+
+#[tokio::test]
+async fn exact_deletion_overflow_owner_blocks_siblings_until_all_targets_are_terminal() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot exact deletion reserve owner key").unwrap();
+    let existing_event_id = MessageId::new(vec![0xc1; 32]);
+    let owner_event_id = MessageId::new(vec![0xc2; 32]);
+    let sibling_event_id = MessageId::new(vec![0xc3; 32]);
+    let existing_endpoints = (0
+        ..cgka_traits::maintenance::MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES - 1)
+        .map(|index| TransportEndpoint(format!("wss://existing-owner-{index}.example")))
+        .collect::<Vec<_>>();
+    let owner_a = TransportEndpoint("wss://owner-a.example".into());
+    let owner_b = TransportEndpoint("wss://owner-b.example".into());
+    let owner_c = TransportEndpoint("wss://owner-c.example".into());
+    let sibling_a = TransportEndpoint("wss://sibling-a.example".into());
+    let sibling_b = TransportEndpoint("wss://sibling-b.example".into());
+    let mut lifecycle = cgka_traits::KeyPackageLifecycleState::slot_only("stable-slot".into());
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(RetiredKeyPackagePublication {
+            event_id: existing_event_id,
+            authored_created_at: Timestamp(1),
+            key_package_ref: None,
+            package_not_after: None,
+            delete_without_successor: true,
+            deletion_targets: existing_endpoints.iter().map(deletion_target).collect(),
+        });
+    session(&database, &key, b"alice")
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+    let publisher = JournalKeyPackages::default().with_deletion_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: vec![owner_a.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: vec![owner_b.clone(), owner_c.clone()],
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![owner_b.clone(), owner_c.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        publisher.clone(),
+    );
+
+    let (admitted, deferred) = runtime
+        .prepare_key_package_deletion_recovery(
+            &owner_event_id,
+            vec![owner_b.clone(), owner_a.clone()],
+        )
+        .unwrap();
+    assert_eq!(admitted, vec![owner_a.clone(), owner_b.clone()]);
+    assert!(deferred.is_empty());
+    assert_eq!(
+        runtime
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .deletion_overflow_owner_event_id,
+        Some(owner_event_id.clone())
+    );
+    drop(runtime);
+
+    let mut restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        publisher.clone(),
+    );
+    let (admitted, deferred) = restarted
+        .prepare_key_package_deletion_recovery(
+            &owner_event_id,
+            vec![owner_c.clone(), owner_b.clone(), owner_a.clone()],
+        )
+        .unwrap();
+    assert_eq!(
+        admitted,
+        vec![owner_a.clone(), owner_b.clone(), owner_c.clone()],
+        "same-event retries must return already durable targets and atomically add new ones"
+    );
+    assert!(deferred.is_empty());
+
+    let (admitted, deferred) = restarted
+        .prepare_key_package_deletion_recovery(&sibling_event_id, vec![sibling_a.clone()])
+        .unwrap();
+    assert!(admitted.is_empty());
+    assert_eq!(deferred, vec![sibling_a.clone()]);
+
+    let (receipt, deferred) = restarted
+        .delete_key_package_revision_durably(
+            &owner_event_id,
+            vec![owner_c.clone(), owner_b.clone(), owner_a.clone()],
+        )
+        .await
+        .unwrap();
+    assert_eq!(receipt.accepted, vec![owner_a.clone()]);
+    assert_eq!(receipt.failed, vec![owner_b.clone(), owner_c.clone()]);
+    assert!(deferred.is_empty());
+    assert_eq!(
+        restarted
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .deletion_overflow_owner_event_id,
+        Some(owner_event_id.clone()),
+        "partial terminal receipts must not release the reserve owner"
+    );
+    let (admitted, deferred) = restarted
+        .prepare_key_package_deletion_recovery(&sibling_event_id, vec![sibling_a.clone()])
+        .unwrap();
+    assert!(admitted.is_empty());
+    assert_eq!(deferred, vec![sibling_a.clone()]);
+
+    let (receipt, deferred) = restarted
+        .delete_key_package_revision_durably(
+            &owner_event_id,
+            vec![owner_c.clone(), owner_b.clone()],
+        )
+        .await
+        .unwrap();
+    assert_eq!(receipt.accepted, vec![owner_b.clone(), owner_c.clone()]);
+    assert!(deferred.is_empty());
+    assert!(
+        restarted
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .deletion_overflow_owner_event_id
+            .is_none(),
+        "the final terminal receipt must release the durable owner"
+    );
+
+    let (admitted, deferred) = restarted
+        .prepare_key_package_deletion_recovery(
+            &sibling_event_id,
+            vec![sibling_b.clone(), sibling_a.clone()],
+        )
+        .unwrap();
+    assert_eq!(admitted, vec![sibling_a, sibling_b]);
+    assert!(deferred.is_empty());
+    assert_eq!(
+        restarted
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .deletion_overflow_owner_event_id,
+        Some(sibling_event_id),
+        "a later exact deletion may claim the reserve only after release"
+    );
+}
+
+#[tokio::test]
+async fn maintenance_retry_releases_the_overflow_owner_after_its_terminal_receipt() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot maintenance deletion reserve release key").unwrap();
+    let owner_event_id = MessageId::new(vec![0xd1; 32]);
+    let ordinary_event_id = MessageId::new(vec![0xd2; 32]);
+    let owner_endpoint = TransportEndpoint("wss://maintenance-owner.example".into());
+    let ordinary_endpoints = (0
+        ..cgka_traits::maintenance::MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES)
+        .map(|index| TransportEndpoint(format!("wss://maintenance-ordinary-{index}.example")))
+        .collect::<Vec<_>>();
+    let mut lifecycle = cgka_traits::KeyPackageLifecycleState::slot_only("stable-slot".into());
+    lifecycle.deletion_overflow_owner_event_id = Some(owner_event_id.clone());
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(retired_revision(
+            owner_event_id.clone(),
+            Timestamp(0),
+            std::slice::from_ref(&owner_endpoint),
+        ));
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(retired_revision(
+            ordinary_event_id,
+            Timestamp(1),
+            &ordinary_endpoints,
+        ));
+    session(&database, &key, b"alice")
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+    let publisher = JournalKeyPackages::default();
+    let mut restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        publisher.clone(),
+    );
+
+    restarted
+        .retry_retired_key_package_deletions_once()
+        .await
+        .unwrap();
+    assert_eq!(
+        publisher.deletions(),
+        vec![(owner_event_id.clone(), vec![owner_endpoint])]
+    );
+    let settled = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert!(settled.deletion_overflow_owner_event_id.is_none());
+    assert!(
+        settled
+            .retired_publications_pending_deletion
+            .iter()
+            .all(|retired| retired.event_id != owner_event_id)
+    );
+    assert_eq!(
+        settled
+            .retired_publications_pending_deletion
+            .iter()
+            .map(|retired| retired.deletion_targets.len())
+            .sum::<usize>(),
+        cgka_traits::maintenance::MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES
+    );
+}
+
+#[test]
+fn unparsed_exact_discovery_claims_the_overflow_and_blocks_another_exact_event() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot unparsed deletion reserve owner key").unwrap();
+    let existing_event_id = MessageId::new(vec![0xe1; 32]);
+    let owner_event_id = MessageId::new(vec![0xe2; 32]);
+    let sibling_event_id = MessageId::new(vec![0xe3; 32]);
+    let existing_endpoints = (0
+        ..cgka_traits::maintenance::MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES)
+        .map(|index| TransportEndpoint(format!("wss://unparsed-existing-{index}.example")))
+        .collect::<Vec<_>>();
+    let owner_endpoint = TransportEndpoint("wss://unparsed-owner.example".into());
+    let sibling_endpoint = TransportEndpoint("wss://unparsed-sibling.example".into());
+    let mut lifecycle = cgka_traits::KeyPackageLifecycleState::slot_only("stable-slot".into());
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(retired_revision(
+            existing_event_id,
+            Timestamp(1),
+            &existing_endpoints,
+        ));
+    session(&database, &key, b"alice")
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+    let mut runtime = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        JournalKeyPackages::default(),
+    );
+
+    let (admitted, deferred) = runtime
+        .journal_discovered_unparsed_key_package_publication(
+            "stable-slot".into(),
+            owner_event_id.clone(),
+            Timestamp(2),
+            vec![owner_endpoint.clone()],
+        )
+        .unwrap();
+    assert_eq!(admitted, vec![owner_endpoint]);
+    assert!(deferred.is_empty());
+    assert_eq!(
+        runtime
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .deletion_overflow_owner_event_id,
+        Some(owner_event_id)
+    );
+
+    let (admitted, deferred) = runtime
+        .journal_discovered_unparsed_key_package_publication(
+            "stable-slot".into(),
+            sibling_event_id.clone(),
+            Timestamp(3),
+            vec![sibling_endpoint.clone()],
+        )
+        .unwrap();
+    assert!(admitted.is_empty());
+    assert_eq!(deferred, vec![sibling_endpoint]);
+    let retained = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(retained.authored_event_created_at, Some(Timestamp(3)));
+    assert!(
+        retained
+            .retired_publications_pending_deletion
+            .iter()
+            .all(|retired| retired.event_id != sibling_event_id),
+        "a sibling exact set must remain wholly outside the durable journal"
+    );
+}
+
+#[test]
+fn active_overflow_owner_allows_only_ordinary_refill_to_the_base_bound() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot ordinary refill with reserve owner key").unwrap();
+    let owner_event_id = MessageId::new(vec![0xf1; 32]);
+    let existing_event_id = MessageId::new(vec![0xf2; 32]);
+    let ordinary_event_id = MessageId::new(vec![0xf3; 32]);
+    let sibling_exact_event_id = MessageId::new(vec![0xf4; 32]);
+    let existing_endpoints = (0..250)
+        .map(|index| TransportEndpoint(format!("wss://refill-existing-{index}.example")))
+        .collect::<Vec<_>>();
+    let owner_endpoints = (0..4)
+        .map(|index| TransportEndpoint(format!("wss://refill-owner-{index}.example")))
+        .collect::<Vec<_>>();
+    let mut ordinary_endpoints = vec![
+        TransportEndpoint("wss://refill-ordinary-c.example".into()),
+        TransportEndpoint("wss://refill-ordinary-a.example".into()),
+        TransportEndpoint("wss://refill-ordinary-b.example".into()),
+    ];
+    ordinary_endpoints.sort();
+    let sibling_endpoint = TransportEndpoint("wss://refill-sibling-exact.example".into());
+    let mut lifecycle = cgka_traits::KeyPackageLifecycleState::slot_only("stable-slot".into());
+    lifecycle.deletion_overflow_owner_event_id = Some(owner_event_id.clone());
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(retired_revision(
+            owner_event_id.clone(),
+            Timestamp(0),
+            &owner_endpoints,
+        ));
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(retired_revision(
+            existing_event_id,
+            Timestamp(1),
+            &existing_endpoints,
+        ));
+    session(&database, &key, b"alice")
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+    let mut runtime = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        JournalKeyPackages::default(),
+    );
+
+    let (admitted, deferred) = runtime
+        .journal_discovered_retired_key_package_publication(
+            "stable-slot".into(),
+            ordinary_event_id,
+            Timestamp(2),
+            vec![0x55; 32],
+            Timestamp(900),
+            ordinary_endpoints.clone(),
+        )
+        .unwrap();
+    assert_eq!(admitted, ordinary_endpoints[..2]);
+    assert_eq!(deferred, ordinary_endpoints[2..]);
+    let retained = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        retained.deletion_overflow_owner_event_id,
+        Some(owner_event_id)
+    );
+    assert_eq!(
+        retained
+            .retired_publications_pending_deletion
+            .iter()
+            .map(|retired| retired.deletion_targets.len())
+            .sum::<usize>(),
+        cgka_traits::maintenance::MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES
+    );
+
+    let (admitted, deferred) = runtime
+        .prepare_key_package_deletion_recovery(
+            &sibling_exact_event_id,
+            vec![sibling_endpoint.clone()],
+        )
+        .unwrap();
+    assert!(admitted.is_empty());
+    assert_eq!(deferred, vec![sibling_endpoint]);
+}
+
+#[tokio::test]
+async fn discovered_high_water_forces_pending_revision_strictly_newer_before_retry() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot discovered high-water pending key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let publisher = JournalKeyPackages::default().with_publication_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: Vec::new(),
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: vec![endpoint.clone()],
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    let wall = Arc::new(TestWallClock::new(10_000));
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(103)),
+    );
+
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("the first pending revision remains ambiguously exposed");
+    let original = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let original_pending = original.pending_replacement.as_ref().unwrap();
+    let original_artifact = original_pending.signed_event.clone().unwrap();
+    let discovered_event_id = MessageId::new(vec![0x91; 32]);
+    let discovered_created_at = Timestamp(original_artifact.created_at.0 + 25);
+    runtime
+        .journal_discovered_retired_key_package_publication(
+            original.stable_slot_id,
+            discovered_event_id.clone(),
+            discovered_created_at,
+            vec![0x92; 32],
+            Timestamp(20_000),
+            vec![endpoint.clone()],
+        )
+        .unwrap();
+    assert!(
+        runtime.key_package_network_maintenance_due().unwrap(),
+        "ordering repair must not wait for the failed target's ordinary backoff"
+    );
+
+    runtime
+        .run_due_maintenance()
+        .await
+        .expect("maintenance must supersede the relay-discovered high-water");
+    runtime
+        .retry_retired_key_package_deletions_once()
+        .await
+        .expect("the bounded follow-up pass deletes the second eligible predecessor");
+
+    let artifacts = publisher.artifacts();
+    assert_eq!(artifacts.len(), 2);
+    assert_eq!(artifacts[0], original_artifact);
+    assert!(artifacts[1].created_at > discovered_created_at);
+    assert_ne!(artifacts[1].id, original_artifact.id);
+    let repaired = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(repaired.pending_replacement.is_none());
+    assert_eq!(repaired.authored_signed_event, Some(artifacts[1].clone()));
+    assert_eq!(
+        repaired.authored_event_created_at,
+        Some(artifacts[1].created_at)
+    );
+    assert!(
+        repaired
+            .retired_publications_pending_deletion
+            .iter()
+            .all(|retired| retired.event_id != discovered_event_id),
+        "the accepted strictly newer successor makes the discovered revision deletable"
+    );
+    assert!(
+        publisher
+            .deletions()
+            .iter()
+            .any(|(event_id, endpoints)| event_id == &discovered_event_id
+                && endpoints == std::slice::from_ref(&endpoint))
+    );
+}
+
+#[tokio::test]
+async fn repeated_ambiguous_stale_retries_keep_every_predecessor_and_continue_forward() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot ambiguous stale chain key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let failed_receipt = || KeyPackagePublishReceipt {
+        accepted: Vec::new(),
+        rejected: Vec::new(),
+        confirmed_absent: Vec::new(),
+        failed: vec![endpoint.clone()],
+    };
+    let publisher = JournalKeyPackages::default()
+        .reauthor_after_secs(600)
+        .with_publication_receipts(vec![failed_receipt(), failed_receipt(), failed_receipt()]);
+    let wall = Arc::new(TestWallClock::new(40_000));
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(67)),
+    );
+
+    for now in [40_000, 40_600, 41_200] {
+        wall.set(now);
+        runtime
+            .publish_fresh_key_package()
+            .await
+            .expect_err("each ambiguous relay attempt remains unacknowledged");
+    }
+
+    let artifacts = publisher.artifacts();
+    assert_eq!(artifacts.len(), 3);
+    assert_ne!(artifacts[0].id, artifacts[1].id);
+    assert_ne!(artifacts[1].id, artifacts[2].id);
+    let lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let retired_ids = lifecycle
+        .retired_publications_pending_deletion
+        .iter()
+        .map(|retired| retired.event_id.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        retired_ids,
+        vec![artifacts[0].id.clone(), artifacts[1].id.clone()]
+    );
+    assert!(
+        lifecycle
+            .retired_publications_pending_deletion
+            .iter()
+            .all(|retired| retired.deletion_targets.len() == 1
+                && retired.deletion_targets[0].endpoint == endpoint)
+    );
+    assert_eq!(
+        lifecycle
+            .pending_replacement
+            .as_ref()
+            .and_then(|pending| pending.signed_event.as_ref())
+            .map(|artifact| artifact.id.clone()),
+        Some(artifacts[2].id.clone())
+    );
+}
+
+#[tokio::test]
+async fn stale_pending_reauthor_prepare_failure_keeps_prior_lifecycle_unchanged() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot failed pending reauthor key").unwrap();
+    let wall = Arc::new(TestWallClock::new(20_000));
+    let publisher = ReauthorPrepareFailsKeyPackages::default();
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![])
+            .key_package_endpoints(vec![TransportEndpoint("wss://keys.example".into())]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(47)),
+    );
+
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("initial publication is injected to fail");
+    let before = runtime.key_package_maintenance_status().unwrap().unwrap();
+    wall.set(20_600);
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("reauthor signing failure must propagate before network exposure");
+
+    assert_eq!(
+        runtime.key_package_maintenance_status().unwrap(),
+        Some(before),
+        "signing precedes mutation, so the old durable revision remains exactly retryable"
+    );
+    assert_eq!(publisher.preparations.lock().unwrap().len(), 2);
+    assert_eq!(
+        publisher.publications.lock().unwrap().len(),
+        1,
+        "a failed replacement signature must never reach the transport"
+    );
+}
+
+#[tokio::test]
+async fn opted_in_pending_key_package_retry_blocks_on_large_clock_rollback() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot pending retry rollback key").unwrap();
+    let wall = Arc::new(TestWallClock::new(50_000));
+    let publisher = FlakyKeyPackages::new(1).reauthor_after_secs(600);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![])
+            .key_package_endpoints(vec![TransportEndpoint("wss://keys.example".into())]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(37)),
+    );
+
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("first publication is intentionally unacknowledged");
+    let original = runtime
+        .key_package_maintenance_status()
+        .unwrap()
+        .unwrap()
+        .pending_replacement
+        .unwrap()
+        .signed_event
+        .unwrap();
+    wall.set(1);
+    let error = runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("a far-future durable artifact must not be sent after clock rollback");
+    assert!(matches!(error, AccountError::ClockSkewBlocked));
+    assert_eq!(publisher.publications().len(), 1);
+    let lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        lifecycle.phase,
+        cgka_traits::MaintenancePhase::ClockSkewBlocked
+    );
+    assert_eq!(
+        lifecycle.pending_replacement.unwrap().signed_event,
+        Some(original)
+    );
+}
+
+#[tokio::test]
+async fn publisher_without_reauthor_policy_preserves_exact_retry_across_clock_rollback() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot exact retry rollback key").unwrap();
+    let wall = Arc::new(TestWallClock::new(50_000));
+    let publisher = FlakyKeyPackages::new(1);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![])
+            .key_package_endpoints(vec![TransportEndpoint("wss://keys.example".into())]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(41)),
+    );
+
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("first publication is intentionally unacknowledged");
+    wall.set(1);
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect("a publisher that did not opt in retains legacy exact-retry behavior");
+
+    let publications = publisher.publications();
+    let artifacts = publisher.artifacts();
+    assert_eq!(publications.len(), 2);
+    assert_eq!(publications[0], publications[1]);
+    assert_eq!(artifacts[0], artifacts[1]);
 }
 
 #[tokio::test]
@@ -1256,10 +3909,146 @@ async fn key_package_rotation_reuses_stable_slot_and_monotonically_advances_crea
     assert_ne!(first, second);
 
     let lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let first_event_id = test_key_package_artifact(&publications[0]).id;
+    let retired = lifecycle
+        .retired_publications_pending_deletion
+        .iter()
+        .find(|retired| retired.event_id == first_event_id)
+        .expect("routine rotation retains the superseded signed event id");
+    assert_eq!(
+        retired
+            .deletion_targets
+            .iter()
+            .map(|target| target.endpoint.clone())
+            .collect::<Vec<_>>(),
+        publications[0].endpoints
+    );
     assert_eq!(lifecycle.retained_private_material.len(), 1);
     assert_eq!(
         lifecycle.retained_private_material[0].key_package,
         publications[0].key_package
+    );
+}
+
+#[tokio::test]
+async fn legacy_current_without_signed_bytes_is_retired_across_partial_rotation_and_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot legacy current rotation journal key").unwrap();
+    let endpoint_a = TransportEndpoint("wss://keys-a.example".into());
+    let endpoint_b = TransportEndpoint("wss://keys-b.example".into());
+    let routing = StaticTransportRouting::new(vec![])
+        .key_package_endpoints(vec![endpoint_a.clone(), endpoint_b.clone()]);
+    let wall = Arc::new(TestWallClock::new(23_000));
+    let publisher = JournalKeyPackages::default().with_publication_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint_a.clone(), endpoint_b.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint_a.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: vec![endpoint_b.clone()],
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint_b.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    let old_event_id;
+    let old_created_at;
+    let old_key_package_ref;
+    {
+        let mut runtime = AccountDeviceRuntime::new(
+            session(&database, &key, b"alice"),
+            RecordingAdapter::default(),
+            routing.clone(),
+            publisher.clone(),
+        )
+        .with_maintenance_sources(
+            wall.clone(),
+            Arc::new(TestMonotonicClock::default()),
+            Arc::new(TestRandom::new(12)),
+        );
+        runtime.publish_fresh_key_package().await.unwrap();
+        let mut legacy = runtime.key_package_maintenance_status().unwrap().unwrap();
+        old_event_id = legacy.authored_event_id.clone().unwrap();
+        old_created_at = legacy.authored_event_created_at.unwrap();
+        old_key_package_ref = legacy.current_key_package_ref.clone().unwrap();
+        legacy.authored_signed_event = None;
+        runtime
+            .session()
+            .put_key_package_lifecycle(&legacy)
+            .unwrap();
+
+        runtime
+            .publish_fresh_key_package()
+            .await
+            .expect("one successor ACK promotes despite partial fanout");
+        let rotated = runtime.key_package_maintenance_status().unwrap().unwrap();
+        let retired = rotated
+            .retired_publications_pending_deletion
+            .iter()
+            .find(|retired| retired.event_id == old_event_id)
+            .expect("legacy authored id is snapshotted before promotion overwrites it");
+        assert_eq!(retired.authored_created_at, old_created_at);
+        assert_eq!(retired.key_package_ref, Some(old_key_package_ref.clone()));
+        assert!(!retired.delete_without_successor);
+        assert_eq!(
+            retired
+                .deletion_targets
+                .iter()
+                .map(|target| target.endpoint.clone())
+                .collect::<Vec<_>>(),
+            vec![endpoint_a.clone(), endpoint_b.clone()]
+        );
+    }
+
+    wall.set(23_030);
+    let mut restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(12)),
+    );
+    restarted.pause_maintenance();
+    restarted.run_due_maintenance().await.unwrap();
+    assert_eq!(
+        publisher.deletions(),
+        vec![(old_event_id.clone(), vec![endpoint_a.clone()])],
+        "the replacement first completes fanout, then one old endpoint drains per call"
+    );
+    let after_first = restarted.key_package_maintenance_status().unwrap().unwrap();
+    let retired = after_first
+        .retired_publications_pending_deletion
+        .iter()
+        .find(|retired| retired.event_id == old_event_id)
+        .expect("the second endpoint remains durable across the restarted call boundary");
+    assert_eq!(retired.deletion_targets.len(), 1);
+    assert_eq!(retired.deletion_targets[0].endpoint, endpoint_b);
+    restarted.run_due_maintenance().await.unwrap();
+    assert_eq!(
+        publisher.deletions()[1],
+        (old_event_id.clone(), vec![endpoint_b])
+    );
+    assert!(
+        restarted
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .retired_publications_pending_deletion
+            .iter()
+            .all(|retired| retired.event_id != old_event_id)
     );
 }
 
@@ -1343,6 +4132,306 @@ async fn key_package_first_ack_promotes_then_paused_maintenance_finishes_exact_f
             .iter()
             .all(|target| { target.state == cgka_traits::TransportFanoutAttemptState::Accepted })
     );
+}
+
+#[tokio::test]
+async fn stale_current_key_package_reauthor_resets_and_fans_out_to_every_live_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot stale current fanout key").unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let publisher = PartialFanoutKeyPackages::default().reauthor_after_secs(600);
+    let wall = Arc::new(TestWallClock::new(70_000));
+    let routing = StaticTransportRouting::new(vec![]).key_package_endpoints(vec![
+        TransportEndpoint("wss://keys-a.example".into()),
+        TransportEndpoint("wss://keys-b.example".into()),
+    ]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(43)),
+    );
+
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect("one acknowledgement promotes the first revision");
+    let before = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let before_artifact = before.authored_signed_event.clone().unwrap();
+    assert_eq!(
+        before
+            .publication_targets
+            .iter()
+            .filter(|target| target.state == cgka_traits::TransportFanoutAttemptState::Accepted)
+            .count(),
+        1
+    );
+    drop(runtime);
+
+    wall.set(70_600);
+    let mut restarted = AccountDeviceRuntime::new(
+        session(database, &key, b"alice"),
+        RecordingAdapter::default(),
+        routing,
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(43)),
+    );
+    restarted.pause_maintenance();
+    restarted
+        .run_due_maintenance()
+        .await
+        .expect("stale current revision is reauthored and fanned out");
+
+    let calls = publisher.publications();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[1].0.key_package, calls[0].0.key_package);
+    assert_eq!(calls[1].0.slot_id, calls[0].0.slot_id);
+    assert_eq!(calls[1].0.created_at, Timestamp(70_600));
+    assert_ne!(calls[1].1, before_artifact);
+    assert_eq!(
+        calls[1].0.endpoints,
+        vec![
+            TransportEndpoint("wss://keys-a.example".into()),
+            TransportEndpoint("wss://keys-b.example".into()),
+        ],
+        "a newer replaceable revision must supersede the old event on every live relay"
+    );
+    let after = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(after.authored_event_id, Some(calls[1].1.id.clone()));
+    assert_eq!(after.authored_event_created_at, Some(Timestamp(70_600)));
+    assert_eq!(after.authored_signed_event, Some(calls[1].1.clone()));
+    assert!(after.publication_targets.iter().all(|target| {
+        target.state == cgka_traits::TransportFanoutAttemptState::Accepted
+            && target.attempt_count == 1
+            && target.failure_code.is_none()
+    }));
+}
+
+#[tokio::test]
+async fn retired_deletion_prunes_only_acked_endpoint_and_restart_retries_the_failed_endpoint() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot retired endpoint deletion key").unwrap();
+    let endpoint_a = TransportEndpoint("wss://keys-a.example".into());
+    let endpoint_b = TransportEndpoint("wss://keys-b.example".into());
+    let unknown_provenance_id = MessageId::new(vec![0x70; 32]);
+    let retired_id = MessageId::new(vec![0x71; 32]);
+    let wall = Arc::new(TestWallClock::new(50_000));
+    let publisher = JournalKeyPackages::default().with_deletion_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint_a.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+        KeyPackagePublishReceipt {
+            accepted: Vec::new(),
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: vec![endpoint_b.clone()],
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint_b.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    let routing = StaticTransportRouting::new(vec![])
+        .key_package_endpoints(vec![endpoint_a.clone(), endpoint_b.clone()]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(71)),
+    );
+    runtime.publish_fresh_key_package().await.unwrap();
+    let mut lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(retired_revision(
+            unknown_provenance_id.clone(),
+            Timestamp(48_000),
+            &[],
+        ));
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(retired_revision(
+            retired_id.clone(),
+            Timestamp(49_000),
+            &[endpoint_a.clone(), endpoint_b.clone()],
+        ));
+    runtime
+        .session()
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+    runtime.pause_maintenance();
+
+    runtime.run_due_maintenance().await.unwrap();
+    assert_eq!(
+        publisher.deletions(),
+        vec![(retired_id.clone(), vec![endpoint_a.clone()])],
+        "one maintenance call is bounded to one endpoint deletion attempt"
+    );
+    let after_a = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let retained = after_a
+        .retired_publications_pending_deletion
+        .iter()
+        .find(|retired| retired.event_id == retired_id)
+        .unwrap();
+    assert_eq!(retained.deletion_targets.len(), 1);
+    assert_eq!(retained.deletion_targets[0].endpoint, endpoint_b);
+
+    runtime.run_due_maintenance().await.unwrap();
+    assert_eq!(
+        publisher.deletions()[1],
+        (retired_id.clone(), vec![endpoint_b.clone()])
+    );
+    let after_failure = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let failed_target = &after_failure
+        .retired_publications_pending_deletion
+        .iter()
+        .find(|retired| retired.event_id == retired_id)
+        .unwrap()
+        .deletion_targets[0];
+    assert_eq!(
+        failed_target.state,
+        TransportFanoutAttemptState::AttemptedFailed
+    );
+    assert_eq!(failed_target.attempt_count, 1);
+    assert_eq!(
+        failed_target.failure_code.as_deref(),
+        Some("possible_exposure")
+    );
+    drop(runtime);
+
+    wall.set(50_030);
+    let mut restarted = AccountDeviceRuntime::new(
+        session(database, &key, b"alice"),
+        RecordingAdapter::default(),
+        routing,
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(71)),
+    );
+    restarted.pause_maintenance();
+    restarted.run_due_maintenance().await.unwrap();
+    assert_eq!(
+        publisher.deletions()[2],
+        (retired_id.clone(), vec![endpoint_b])
+    );
+    assert!(
+        restarted
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .retired_publications_pending_deletion
+            .iter()
+            .all(|retired| retired.event_id != retired_id)
+    );
+    let unknown_provenance = restarted
+        .key_package_maintenance_status()
+        .unwrap()
+        .unwrap()
+        .retired_publications_pending_deletion
+        .into_iter()
+        .find(|retired| retired.event_id == unknown_provenance_id)
+        .expect("unrelated deletion ACKs must preserve unknown-provenance evidence across restart");
+    assert!(unknown_provenance.deletion_targets.is_empty());
+}
+
+#[tokio::test]
+async fn retired_deletion_confirmed_absent_is_terminal_and_cleanup_calls_drain_one_target_each() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot retired deletion budget key").unwrap();
+    let endpoints = (0..3)
+        .map(|index| TransportEndpoint(format!("wss://keys-{index}.example")))
+        .collect::<Vec<_>>();
+    let retired_id = MessageId::new(vec![0x72; 32]);
+    let wall = Arc::new(TestWallClock::new(60_000));
+    let publisher = JournalKeyPackages::default().with_deletion_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: Vec::new(),
+            rejected: Vec::new(),
+            confirmed_absent: vec![endpoints[0].clone()],
+            failed: Vec::new(),
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoints[1].clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoints[2].clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(endpoints.clone()),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(73)),
+    );
+    runtime.publish_fresh_key_package().await.unwrap();
+    let mut lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(retired_revision(
+            retired_id.clone(),
+            Timestamp(59_000),
+            &endpoints,
+        ));
+    runtime
+        .session()
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+    runtime.pause_maintenance();
+
+    for expected_call_count in 1..=3 {
+        runtime.run_due_maintenance().await.unwrap();
+        let calls = publisher.deletions();
+        assert_eq!(calls.len(), expected_call_count);
+        assert_eq!(calls.last().unwrap().1.len(), 1);
+        assert_eq!(
+            calls.last().unwrap().1[0],
+            endpoints[expected_call_count - 1]
+        );
+        let remaining = runtime
+            .key_package_maintenance_status()
+            .unwrap()
+            .unwrap()
+            .retired_publications_pending_deletion
+            .iter()
+            .find(|retired| retired.event_id == retired_id)
+            .map(|retired| retired.deletion_targets.len())
+            .unwrap_or(0);
+        assert_eq!(remaining, 3 - expected_call_count);
+    }
 }
 
 #[tokio::test]
@@ -1661,8 +4750,13 @@ async fn republish_key_package_falls_back_when_current_ref_is_consumed() {
     assert_eq!(publications.len(), 2);
     assert_ne!(first, second);
     let after = runtime.key_package_maintenance_status().unwrap().unwrap();
-    assert_ne!(after.current_key_package_ref, Some(consumed_ref));
-    assert!(after.last_consumed_key_package_ref.is_none());
+    assert_ne!(after.current_key_package_ref, Some(consumed_ref.clone()));
+    assert_eq!(
+        after.last_consumed_key_package_ref,
+        Some(consumed_ref.clone()),
+        "legacy-only consumption evidence stays durable until strict relay cutover transfers it"
+    );
+    assert!(after.consumed_key_package_refs.contains(&consumed_ref));
     assert_eq!(after.retained_private_material.len(), 0);
 }
 
@@ -1825,8 +4919,105 @@ async fn republish_key_package_reauthorizes_previously_removed_endpoint() {
         reauthorized.state,
         cgka_traits::TransportFanoutAttemptState::Accepted
     );
-    assert_eq!(reauthorized.attempt_count, 1);
+    assert_eq!(
+        reauthorized.attempt_count, 2,
+        "the first attempt plus the conservative pre-I/O reauthorization marker are durable"
+    );
     assert!(reauthorized.failure_code.is_none());
+}
+
+#[tokio::test]
+async fn accepted_endpoint_removed_then_readded_keeps_exposure_after_negative_ack() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot readded endpoint exposure key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let wall = Arc::new(TestWallClock::new(70_000));
+    let publisher = JournalKeyPackages::default().with_publication_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: vec![endpoint.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+        KeyPackagePublishReceipt {
+            accepted: Vec::new(),
+            rejected: vec![endpoint.clone()],
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    let mut initial = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(79)),
+    );
+    initial.publish_fresh_key_package().await.unwrap();
+    let current_not_before = initial
+        .key_package_maintenance_status()
+        .unwrap()
+        .unwrap()
+        .current_not_before
+        .unwrap();
+    wall.set(current_not_before.0);
+    drop(initial);
+
+    let mut removed = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(79)),
+    );
+    removed
+        .republish_key_package()
+        .await
+        .expect_err("removed policy has no authoritative endpoint");
+    let prohibited = removed.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        prohibited.publication_targets[0].state,
+        TransportFanoutAttemptState::PolicyProhibited
+    );
+    assert_eq!(prohibited.publication_targets[0].attempt_count, 1);
+    drop(removed);
+
+    let mut restored = AccountDeviceRuntime::new(
+        session(database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher,
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(79)),
+    );
+    restored
+        .republish_key_package()
+        .await
+        .expect_err("negative acknowledgement has no accepted endpoint");
+    let target = restored
+        .key_package_maintenance_status()
+        .unwrap()
+        .unwrap()
+        .publication_targets
+        .into_iter()
+        .find(|target| target.endpoint == endpoint)
+        .unwrap();
+    assert_eq!(target.state, TransportFanoutAttemptState::AttemptedFailed);
+    assert_eq!(target.attempt_count, 2);
+    assert_eq!(target.failure_code.as_deref(), Some("transport_rejected"));
+    assert_ne!(target.failure_code.as_deref(), Some("confirmed_absent"));
 }
 
 #[tokio::test]
@@ -1904,11 +5095,14 @@ async fn key_package_expiry_sweep_deletes_private_material_while_network_mainten
     );
 
     runtime.publish_fresh_key_package().await.unwrap();
-    let not_after = runtime
-        .key_package_maintenance_status()
-        .unwrap()
-        .unwrap()
-        .current_not_after
+    let mut before_expiry = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let not_after = before_expiry.current_not_after.unwrap();
+    let expired_event_id = before_expiry.authored_event_id.clone().unwrap();
+    let authored_created_at = before_expiry.authored_event_created_at.unwrap();
+    before_expiry.authored_signed_event = None;
+    runtime
+        .session()
+        .put_key_package_lifecycle(&before_expiry)
         .unwrap();
 
     runtime.pause_maintenance();
@@ -1925,7 +5119,657 @@ async fn key_package_expiry_sweep_deletes_private_material_while_network_mainten
     assert!(expired.current_key_package_ref.is_none());
     assert!(expired.authored_signed_event.is_none());
     assert!(expired.publication_targets.is_empty());
+    let retired = expired
+        .retired_publications_pending_deletion
+        .iter()
+        .find(|retired| retired.event_id == expired_event_id)
+        .expect("expiry retains a legacy authored id even when signed bytes are unavailable");
+    assert_eq!(retired.authored_created_at, authored_created_at);
+    assert!(retired.delete_without_successor);
+    assert_eq!(retired.package_not_after, Some(not_after));
+    assert_eq!(retired.deletion_targets.len(), 1);
     assert!(runtime.key_package_network_maintenance_due().unwrap());
+}
+
+#[tokio::test]
+async fn paused_maintenance_still_reauthors_a_deleted_live_current_revision() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot paused deleted current recovery key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let wall = Arc::new(TestWallClock::new(82_000));
+    let publisher = JournalKeyPackages::default();
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(31)),
+    );
+
+    let current_key_package = runtime.publish_fresh_key_package().await.unwrap();
+    let mut before_delete = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let unknown_provenance_event_id = MessageId::new(vec![0x75; 32]);
+    before_delete
+        .retired_publications_pending_deletion
+        .push(retired_revision(
+            unknown_provenance_event_id.clone(),
+            Timestamp(81_000),
+            &[],
+        ));
+    runtime
+        .session()
+        .put_key_package_lifecycle(&before_delete)
+        .unwrap();
+    wall.set(
+        before_delete
+            .current_not_before
+            .expect("published current KeyPackage must persist its validity start")
+            .0,
+    );
+    let deleted_event_id = before_delete.authored_event_id.clone().unwrap();
+    runtime.pause_maintenance();
+    let (deletion, deferred) = runtime
+        .delete_key_package_revision_durably(&deleted_event_id, vec![endpoint.clone()])
+        .await
+        .unwrap();
+    assert_eq!(deletion.accepted, vec![endpoint]);
+    assert!(deferred.is_empty());
+    assert!(runtime.key_package_network_maintenance_due().unwrap());
+
+    runtime
+        .run_due_maintenance()
+        .await
+        .expect("privacy recovery must cross the process-local maintenance pause");
+
+    let publications = publisher.publications();
+    let artifacts = publisher.artifacts();
+    assert_eq!(publications.len(), 2);
+    assert_eq!(artifacts.len(), 2);
+    assert_eq!(publications[1].key_package, current_key_package);
+    assert_ne!(artifacts[1].id, deleted_event_id);
+    assert!(artifacts[1].created_at > artifacts[0].created_at);
+    let recovered = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(recovered.authored_event_id, Some(artifacts[1].id.clone()));
+    assert!(recovered.deleted_live_revision_event_ids.is_empty());
+    assert!(
+        recovered
+            .retired_publications_pending_deletion
+            .iter()
+            .any(|retired| retired.event_id == unknown_provenance_event_id
+                && retired.deletion_targets.is_empty())
+    );
+    assert!(runtime.maintenance_is_paused());
+}
+
+#[tokio::test]
+async fn paused_maintenance_reauthors_a_deleted_live_current_revision_after_refresh_is_due() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot paused overdue deleted current recovery key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let wall = Arc::new(TestWallClock::new(83_000));
+    let publisher = JournalKeyPackages::default();
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(33)),
+    );
+
+    let current_key_package = runtime.publish_fresh_key_package().await.unwrap();
+    let before_delete = runtime.key_package_maintenance_status().unwrap().unwrap();
+    wall.set(before_delete.refresh_at.unwrap().0);
+    let deleted_event_id = before_delete.authored_event_id.clone().unwrap();
+    runtime.pause_maintenance();
+    let (deletion, deferred) = runtime
+        .delete_key_package_revision_durably(&deleted_event_id, vec![endpoint.clone()])
+        .await
+        .unwrap();
+    assert_eq!(deletion.accepted, vec![endpoint]);
+    assert!(deferred.is_empty());
+
+    runtime
+        .run_due_maintenance()
+        .await
+        .expect("deleted-revision recovery must override pause even after refresh is due");
+
+    let publications = publisher.publications();
+    let artifacts = publisher.artifacts();
+    assert_eq!(publications.len(), 2);
+    assert_eq!(artifacts.len(), 2);
+    assert_eq!(publications[1].key_package, current_key_package);
+    assert_ne!(artifacts[1].id, deleted_event_id);
+    assert!(artifacts[1].created_at > artifacts[0].created_at);
+    let recovered = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(recovered.authored_event_id, Some(artifacts[1].id.clone()));
+    assert!(recovered.deleted_live_revision_event_ids.is_empty());
+    assert!(runtime.maintenance_is_paused());
+    assert!(runtime.key_package_network_maintenance_due().unwrap());
+}
+
+#[tokio::test]
+async fn pending_key_package_expiry_retains_signed_event_deletion_obligation() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot pending key package expiry key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let wall = Arc::new(TestWallClock::new(85_000));
+    let publisher = FlakyKeyPackages::new(1);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(83)),
+    );
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("pending publication is intentionally unacknowledged");
+    let pending = runtime
+        .key_package_maintenance_status()
+        .unwrap()
+        .unwrap()
+        .pending_replacement
+        .unwrap();
+    let pending_event_id = pending.signed_event.unwrap().id;
+    wall.set(pending.not_after.0);
+
+    assert_eq!(
+        runtime
+            .sweep_expired_key_package_private_material()
+            .unwrap(),
+        1
+    );
+    let expired = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(expired.pending_replacement.is_none());
+    let retired = expired
+        .retired_publications_pending_deletion
+        .iter()
+        .find(|retired| retired.event_id == pending_event_id)
+        .expect("expired pending signed event remains durably deletable");
+    assert!(retired.delete_without_successor);
+    assert_eq!(retired.package_not_after, Some(pending.not_after));
+    assert_eq!(retired.deletion_targets[0].endpoint, endpoint);
+}
+
+#[tokio::test]
+async fn deleted_current_expiry_prunes_exact_marker_before_fresh_129_endpoint_publication() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot expired deleted current marker key").unwrap();
+    let endpoints = (0..129)
+        .map(|index| TransportEndpoint(format!("wss://fresh-{index}.example")))
+        .collect::<Vec<_>>();
+    let publisher = JournalKeyPackages::default();
+    let wall = Arc::new(TestWallClock::new(150_000));
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(endpoints.clone()),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(101)),
+    );
+
+    runtime.publish_fresh_key_package().await.unwrap();
+    for cycle in 0..3 {
+        let before_delete = runtime.key_package_maintenance_status().unwrap().unwrap();
+        let deleted_event_id = before_delete.authored_event_id.clone().unwrap();
+        let deleted_key_package = before_delete.current_key_package.clone().unwrap();
+        let (deletion, deferred) = runtime
+            .delete_key_package_revision_durably(&deleted_event_id, endpoints.clone())
+            .await
+            .unwrap();
+        let mut expected_deleted_endpoints = endpoints.clone();
+        expected_deleted_endpoints.sort();
+        assert_eq!(deletion.accepted, expected_deleted_endpoints);
+        assert!(deferred.is_empty());
+
+        // Model terminal deletion acknowledgements from all 129 relays. The
+        // exact-id marker still exists until the corresponding live artifact
+        // is expired and removed by the account sweep.
+        let mut marked = runtime.key_package_maintenance_status().unwrap().unwrap();
+        assert_eq!(
+            marked.deleted_live_revision_event_ids,
+            vec![deleted_event_id.clone()]
+        );
+        assert!(marked.publication_targets.iter().all(|target| {
+            target.state == TransportFanoutAttemptState::AttemptedFailed
+                && target.failure_code.as_deref() == Some("confirmed_absent")
+        }));
+        let expires_at = Timestamp(150_001 + cycle);
+        marked.current_not_after = Some(expires_at);
+        runtime
+            .session()
+            .put_key_package_lifecycle(&marked)
+            .unwrap();
+        wall.set(expires_at.0);
+
+        assert_eq!(
+            runtime
+                .sweep_expired_key_package_private_material()
+                .unwrap(),
+            1
+        );
+        let expired = runtime.key_package_maintenance_status().unwrap().unwrap();
+        assert!(expired.current_key_package.is_none());
+        assert!(expired.deleted_live_revision_event_ids.is_empty());
+        assert!(
+            expired
+                .retired_publications_pending_deletion
+                .iter()
+                .all(|retired| retired.event_id != deleted_event_id),
+            "confirmed deletion must not leave a phantom endpoint liability"
+        );
+
+        let fresh = runtime
+            .publish_fresh_key_package()
+            .await
+            .expect("the first genuinely fresh 129-endpoint event must fit below the cap");
+        assert_ne!(fresh, deleted_key_package);
+        let replacement = runtime.key_package_maintenance_status().unwrap().unwrap();
+        assert!(replacement.deleted_live_revision_event_ids.is_empty());
+        assert_eq!(replacement.publication_targets.len(), 129);
+    }
+    assert_eq!(publisher.publications().len(), 4);
+    assert_eq!(publisher.artifacts().len(), 4);
+}
+
+#[tokio::test]
+async fn deleted_current_survives_failed_forced_pending_until_expiry_recovery_publishes_fresh() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot deleted current pending expiry recovery key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let wall = Arc::new(TestWallClock::new(160_000));
+    let accepted = || KeyPackagePublishReceipt {
+        accepted: vec![endpoint.clone()],
+        rejected: Vec::new(),
+        confirmed_absent: Vec::new(),
+        failed: Vec::new(),
+    };
+    let failed = || KeyPackagePublishReceipt {
+        accepted: Vec::new(),
+        rejected: Vec::new(),
+        confirmed_absent: Vec::new(),
+        failed: vec![endpoint.clone()],
+    };
+    let publisher = JournalKeyPackages::default().with_publication_receipts(vec![
+        accepted(),
+        failed(),
+        failed(),
+        accepted(),
+    ]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(103)),
+    );
+
+    let current_key_package = runtime.publish_fresh_key_package().await.unwrap();
+    let current = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let current_event_id = current.authored_event_id.clone().unwrap();
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("the pending semantic successor never acknowledges");
+    let mut with_pending = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let pending = with_pending.pending_replacement.as_ref().unwrap();
+    let pending_key_package = pending.key_package.clone();
+    let pending_event_id = pending.signed_event.as_ref().unwrap().id.clone();
+    with_pending.pending_replacement.as_mut().unwrap().not_after = Timestamp(160_060);
+    runtime
+        .session()
+        .put_key_package_lifecycle(&with_pending)
+        .unwrap();
+    let (current_admitted, current_deferred) = runtime
+        .prepare_key_package_deletion_recovery(&current_event_id, vec![endpoint.clone()])
+        .unwrap();
+    let (pending_admitted, pending_deferred) = runtime
+        .prepare_key_package_deletion_recovery(&pending_event_id, vec![endpoint])
+        .unwrap();
+    assert_eq!(current_admitted.len(), 1);
+    assert!(current_deferred.is_empty());
+    assert_eq!(pending_admitted.len(), 1);
+    assert!(pending_deferred.is_empty());
+    let both_deleted = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(
+        both_deleted
+            .deleted_live_revision_event_ids
+            .contains(&current_event_id)
+    );
+    assert!(
+        both_deleted
+            .deleted_live_revision_event_ids
+            .contains(&pending_event_id)
+    );
+
+    runtime.run_due_maintenance().await.unwrap();
+    let forced = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let forced_pending = forced.pending_replacement.as_ref().unwrap();
+    let forced_pending_event_id = forced_pending.signed_event.as_ref().unwrap().id.clone();
+    assert_ne!(forced_pending_event_id, pending_event_id);
+    assert_eq!(forced_pending.key_package, pending_key_package);
+    assert!(
+        forced
+            .deleted_live_revision_event_ids
+            .contains(&current_event_id),
+        "forcing the exact pending successor must not erase the deleted-current recovery marker"
+    );
+    assert!(
+        !forced
+            .deleted_live_revision_event_ids
+            .contains(&pending_event_id)
+    );
+    assert_eq!(publisher.publications().len(), 3);
+
+    wall.set(160_060);
+    assert_eq!(
+        runtime
+            .sweep_expired_key_package_private_material()
+            .unwrap(),
+        1
+    );
+    let after_pending_expiry = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(after_pending_expiry.pending_replacement.is_none());
+    assert_eq!(
+        after_pending_expiry.current_key_package,
+        Some(current_key_package.clone())
+    );
+    assert!(
+        after_pending_expiry
+            .deleted_live_revision_event_ids
+            .contains(&current_event_id),
+        "pending expiry must retain the independent exact current recovery marker"
+    );
+
+    runtime.run_due_maintenance().await.unwrap();
+    let publications = publisher.publications();
+    let artifacts = publisher.artifacts();
+    assert_eq!(publications.len(), 4);
+    assert_eq!(artifacts.len(), 4);
+    assert_ne!(publications[3].key_package, pending_key_package);
+    assert_ne!(publications[3].key_package, current_key_package);
+    assert!(artifacts[3].created_at > artifacts[2].created_at);
+    let recovered = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(recovered.pending_replacement.is_none());
+    assert_eq!(recovered.authored_event_id, Some(artifacts[3].id.clone()));
+    assert!(recovered.deleted_live_revision_event_ids.is_empty());
+}
+
+#[tokio::test]
+async fn legacy_deleted_current_id_without_signed_bytes_restarts_into_fresh_semantic_recovery() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot legacy deleted current recovery key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let wall = Arc::new(TestWallClock::new(170_000));
+    let publisher = JournalKeyPackages::default();
+
+    let original_key_package;
+    let deleted_event_id;
+    {
+        let mut runtime = AccountDeviceRuntime::new(
+            session(&database, &key, b"alice"),
+            RecordingAdapter::default(),
+            StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]),
+            publisher.clone(),
+        )
+        .with_maintenance_sources(
+            wall.clone(),
+            Arc::new(TestMonotonicClock::default()),
+            Arc::new(TestRandom::new(107)),
+        );
+        original_key_package = runtime.publish_fresh_key_package().await.unwrap();
+        let mut lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+        deleted_event_id = lifecycle.authored_event_id.clone().unwrap();
+
+        // Model a pre-artifact upgrade row, then exercise the durable deletion
+        // path so its terminal ACK must match the authored-id fallback rather
+        // than signed bytes that this legacy row does not contain.
+        lifecycle.authored_signed_event = None;
+        lifecycle.refresh_at = Some(Timestamp(180_000));
+        lifecycle.upgrade_rotation_recorded = true;
+        runtime
+            .session()
+            .put_key_package_lifecycle(&lifecycle)
+            .unwrap();
+        let (deletion, deferred) = runtime
+            .delete_key_package_revision_durably(&deleted_event_id, vec![endpoint.clone()])
+            .await
+            .unwrap();
+        assert_eq!(deletion.accepted, vec![endpoint.clone()]);
+        assert!(deferred.is_empty());
+        let marked = runtime.key_package_maintenance_status().unwrap().unwrap();
+        assert_eq!(
+            marked.deleted_live_revision_event_ids,
+            vec![deleted_event_id.clone()]
+        );
+        assert_eq!(
+            marked.publication_targets[0].failure_code.as_deref(),
+            Some("confirmed_absent")
+        );
+    }
+
+    let mut reopened = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(109)),
+    );
+    assert!(
+        reopened.key_package_network_maintenance_due().unwrap(),
+        "authored_event_id must keep a deleted pre-artifact current revision due after restart"
+    );
+    reopened.run_due_maintenance().await.unwrap();
+
+    let publications = publisher.publications();
+    let artifacts = publisher.artifacts();
+    assert_eq!(publications.len(), 2);
+    assert_eq!(artifacts.len(), 2);
+    assert_ne!(publications[1].key_package, original_key_package);
+    assert_ne!(artifacts[1].id, deleted_event_id);
+    let recovered = reopened.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        recovered.current_key_package,
+        Some(publications[1].key_package.clone())
+    );
+    assert_eq!(recovered.authored_event_id, Some(artifacts[1].id.clone()));
+    assert_eq!(
+        recovered
+            .authored_signed_event
+            .as_ref()
+            .map(|artifact| artifact.id.clone()),
+        Some(artifacts[1].id.clone())
+    );
+    assert!(recovered.pending_replacement.is_none());
+    assert!(
+        recovered.deleted_live_revision_event_ids.is_empty(),
+        "successful semantic replacement must clear the deleted-live upgrade marker"
+    );
+}
+
+#[tokio::test]
+async fn key_package_endpoint_liability_limit_blocks_new_signature_without_evicting_deletions() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot key package liability bound key").unwrap();
+    let endpoints = (0..256)
+        .map(|index| TransportEndpoint(format!("wss://liability-{index}.example")))
+        .collect::<Vec<_>>();
+    let publisher =
+        JournalKeyPackages::default().with_deletion_receipts(vec![KeyPackagePublishReceipt {
+            accepted: Vec::new(),
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: vec![endpoints[0].clone()],
+        }]);
+    let session = session(dir.path().join("alice.sqlite"), &key, b"alice");
+    let slot = publisher
+        .legacy_slot_id(&session.self_id())
+        .unwrap()
+        .unwrap();
+    let mut lifecycle = cgka_traits::KeyPackageLifecycleState::slot_only(slot);
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(retired_revision(
+            MessageId::new(vec![0x73; 32]),
+            Timestamp(1),
+            &endpoints,
+        ));
+    session.put_key_package_lifecycle(&lifecycle).unwrap();
+    let mut runtime = AccountDeviceRuntime::new(
+        session,
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        publisher,
+    );
+    let durable_before = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        durable_before
+            .retired_publications_pending_deletion
+            .iter()
+            .map(|retired| retired.deletion_targets.len())
+            .sum::<usize>(),
+        256
+    );
+
+    let result = runtime
+        .prepare_fresh_key_package(vec![TransportEndpoint("wss://new.example".into())])
+        .await;
+    let blocked = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        blocked
+            .pending_replacement
+            .as_ref()
+            .map(|pending| pending.targets.len()),
+        Some(1)
+    );
+    assert_eq!(
+        blocked
+            .retired_publications_pending_deletion
+            .iter()
+            .map(|retired| retired.deletion_targets.len())
+            .sum::<usize>(),
+        256,
+        "staging must preserve every existing privacy obligation"
+    );
+    let error = result.expect_err("the 257th endpoint liability must not be signed");
+    assert!(
+        error
+            .to_string()
+            .contains("signed-publication endpoint-liability journal is full"),
+        "unexpected capacity error: {error:?}"
+    );
+    assert_eq!(
+        blocked
+            .retired_publications_pending_deletion
+            .iter()
+            .map(|retired| retired.deletion_targets.len())
+            .sum::<usize>(),
+        256,
+        "privacy obligations must never be evicted to make capacity"
+    );
+    assert!(
+        blocked
+            .pending_replacement
+            .as_ref()
+            .is_some_and(|pending| pending.signed_event.is_none()),
+        "capacity is checked before signing the newly staged package"
+    );
+}
+
+#[tokio::test]
+async fn stale_current_reauthor_projects_exact_pair_cap_when_live_targets_are_duplicated() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot duplicate current reauthor cap key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let other_endpoints = (0..255)
+        .map(|index| TransportEndpoint(format!("wss://retired-{index}.example")))
+        .collect::<Vec<_>>();
+    let wall = Arc::new(TestWallClock::new(175_000));
+    let publisher = JournalKeyPackages::default().reauthor_after_secs(600);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(111)),
+    );
+    runtime.publish_fresh_key_package().await.unwrap();
+    let mut lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let old_artifact = lifecycle.authored_signed_event.clone().unwrap();
+    let duplicate = lifecycle.publication_targets[0].clone();
+    lifecycle.publication_targets.push(duplicate);
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(RetiredKeyPackagePublication {
+            event_id: MessageId::new(vec![0x74; 32]),
+            // A current publication at the same timestamp is not a strictly
+            // newer successor, so the pre-reauthor cleanup cannot free one of
+            // these 255 liabilities before the projection check.
+            authored_created_at: old_artifact.created_at,
+            key_package_ref: None,
+            package_not_after: None,
+            delete_without_successor: false,
+            deletion_targets: other_endpoints.iter().map(deletion_target).collect(),
+        });
+    runtime
+        .session()
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+
+    wall.set(175_600);
+    let error = runtime
+        .republish_key_package()
+        .await
+        .expect_err("retired old(A) plus new(A) would exceed the exact-pair cap");
+    assert!(
+        error
+            .to_string()
+            .contains("signed-publication endpoint-liability journal is full"),
+        "unexpected capacity error: {error:?}"
+    );
+    assert_eq!(
+        publisher.artifacts(),
+        vec![old_artifact.clone()],
+        "capacity must be checked before signing a replacement revision"
+    );
+    let blocked = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(blocked.authored_signed_event, Some(old_artifact));
+    assert_eq!(blocked.publication_targets.len(), 2);
+    assert_eq!(
+        blocked.retired_publications_pending_deletion.len(),
+        1,
+        "the rejected projection must not partially retire the current revision"
+    );
 }
 
 #[tokio::test]
@@ -2142,6 +5986,618 @@ async fn publish_fresh_key_package_retains_bundle_when_publish_fails_after_expos
             .len(),
         2
     );
+}
+
+#[tokio::test]
+async fn consumed_ambiguous_pending_is_swept_across_restart_without_exact_republication() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot consumed ambiguous pending key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let routing = StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint.clone()]);
+    let wall = Arc::new(TestWallClock::new(100_000));
+    let exposed = ExposedThenFailsKeyPackages::default();
+    let mut runtime = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        exposed,
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(89)),
+    );
+
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("the pending KeyPackage is exposed before transport returns ambiguously");
+    let pending_before_welcome = runtime
+        .key_package_maintenance_status()
+        .unwrap()
+        .unwrap()
+        .pending_replacement
+        .unwrap();
+    let consumed_ref = pending_before_welcome.key_package_ref.clone();
+    let consumed_key_package = pending_before_welcome.key_package.clone();
+    let consumed_artifact = pending_before_welcome.signed_event.clone().unwrap();
+    let alice_id = runtime.session().self_id();
+    let mut bob = session(dir.path().join("bob.sqlite"), &key, b"bob");
+    let welcome = welcome_for_key_package(
+        &mut bob,
+        &alice_id,
+        consumed_key_package.clone(),
+        "ambiguous pending invite",
+    )
+    .await;
+    runtime
+        .session_mut()
+        .ingest(welcome)
+        .await
+        .expect("the ambiguously published pending private bundle remains joinable");
+    let consumed = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        consumed.consumed_key_package_refs,
+        vec![consumed_ref.clone()]
+    );
+    assert_eq!(
+        consumed.last_consumed_key_package_ref,
+        Some(consumed_ref.clone())
+    );
+    drop(runtime);
+
+    let cleanup =
+        JournalKeyPackages::default().with_deletion_receipts(vec![KeyPackagePublishReceipt {
+            accepted: Vec::new(),
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: vec![endpoint.clone()],
+        }]);
+    let mut restarted = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        cleanup.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(89)),
+    );
+    restarted.pause_maintenance();
+    restarted.run_due_maintenance().await.unwrap();
+
+    assert!(
+        cleanup.publications().is_empty(),
+        "paused cleanup must never republish the exact consumed pending artifact"
+    );
+    let swept = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert!(swept.pending_replacement.is_none());
+    assert!(swept.current_key_package.is_none());
+    assert_eq!(
+        swept.authored_event_created_at,
+        Some(consumed_artifact.created_at),
+        "the consumed pending revision remains the stable-slot authoring high-water"
+    );
+    assert!(swept.consumed_key_package_refs.is_empty());
+    assert!(swept.last_consumed_key_package_ref.is_none());
+    let retired = swept
+        .retired_publications_pending_deletion
+        .iter()
+        .find(|retired| retired.event_id == consumed_artifact.id)
+        .expect("possible relay exposure remains durably deletable after the bundle is consumed");
+    assert!(retired.delete_without_successor);
+    assert_eq!(retired.key_package_ref, Some(consumed_ref));
+    assert_eq!(retired.deletion_targets.len(), 1);
+    assert!(restarted.durably_owned_key_packages().unwrap().is_empty());
+    drop(restarted);
+
+    let mut reopened = AccountDeviceRuntime::new(
+        session(database, &key, b"alice"),
+        RecordingAdapter::default(),
+        routing,
+        cleanup.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(89)),
+    );
+    reopened.pause_maintenance();
+    reopened.run_due_maintenance().await.unwrap();
+    assert!(
+        cleanup.publications().is_empty(),
+        "restart while paused must not resurrect the consumed exact revision"
+    );
+
+    reopened.resume_maintenance();
+    wall.set(100_030);
+    reopened.run_due_maintenance().await.unwrap();
+    let recovery_publications = cleanup.publications();
+    let recovery_artifacts = cleanup.artifacts();
+    assert_eq!(recovery_publications.len(), 1);
+    assert_ne!(recovery_publications[0].key_package, consumed_key_package);
+    assert_eq!(recovery_artifacts.len(), 1);
+    assert_ne!(recovery_artifacts[0].id, consumed_artifact.id);
+    assert!(recovery_artifacts[0].created_at > consumed_artifact.created_at);
+}
+
+#[tokio::test]
+async fn welcome_without_legacy_lifecycle_row_preserves_consumed_ref_in_synthesized_state() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot legacy lifecycle-less Welcome key").unwrap();
+    let mut alice = session(&database, &key, b"alice");
+    let alice_id = alice.self_id();
+    let key_package = alice.fresh_key_package().await.unwrap();
+    let key_package_ref = hex::decode(
+        alice
+            .key_package_metadata(&key_package)
+            .unwrap()
+            .key_package_ref_hex,
+    )
+    .unwrap();
+    assert!(alice.key_package_lifecycle().unwrap().is_none());
+
+    let mut bob = session(dir.path().join("bob.sqlite"), &key, b"bob");
+    let welcome = welcome_for_key_package(
+        &mut bob,
+        &alice_id,
+        key_package.clone(),
+        "legacy lifecycle-less invite",
+    )
+    .await;
+    alice.ingest(welcome).await.unwrap();
+
+    let lifecycle = alice
+        .key_package_lifecycle()
+        .unwrap()
+        .expect("Welcome ingest synthesizes compatibility lifecycle state");
+    assert!(lifecycle.stable_slot_id.is_empty());
+    assert_eq!(
+        lifecycle.consumed_key_package_refs,
+        vec![key_package_ref.clone()],
+        "newly proven legacy consumption must survive even without a projected current/pending row"
+    );
+    assert_eq!(
+        lifecycle.last_consumed_key_package_ref,
+        Some(key_package_ref.clone())
+    );
+    assert!(
+        alice
+            .durably_owned_key_packages()
+            .unwrap()
+            .contains(&key_package)
+    );
+    drop(alice);
+
+    let mut restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        JournalKeyPackages::default(),
+    );
+    assert_eq!(
+        restarted
+            .sweep_expired_key_package_private_material()
+            .unwrap(),
+        1,
+        "the lifecycle-less consumed bundle is correlated and deleted after restart"
+    );
+    assert!(restarted.durably_owned_key_packages().unwrap().is_empty());
+    let swept = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert!(swept.consumed_key_package_refs.is_empty());
+    assert!(swept.last_consumed_key_package_ref.is_none());
+}
+
+#[tokio::test]
+async fn welcome_fails_closed_when_consumed_ref_journal_is_full_without_evicting_evidence() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot full consumed ref journal key").unwrap();
+    let mut alice = session(dir.path().join("alice.sqlite"), &key, b"alice");
+    let alice_id = alice.self_id();
+    let key_package = alice.fresh_key_package().await.unwrap();
+    let key_package_ref = hex::decode(
+        alice
+            .key_package_metadata(&key_package)
+            .unwrap()
+            .key_package_ref_hex,
+    )
+    .unwrap();
+    let mut lifecycle = cgka_traits::KeyPackageLifecycleState::slot_only("stable-slot".into());
+    lifecycle.consumed_key_package_refs = (0
+        ..cgka_traits::maintenance::MAX_CONSUMED_KEY_PACKAGE_REFS_PENDING_CLEANUP)
+        .map(|index| u64::try_from(index).unwrap().to_be_bytes().to_vec())
+        .collect();
+    let evidence_before = lifecycle.consumed_key_package_refs.clone();
+    assert!(!evidence_before.contains(&key_package_ref));
+    alice.put_key_package_lifecycle(&lifecycle).unwrap();
+
+    let mut bob = session(dir.path().join("bob.sqlite"), &key, b"bob");
+    let welcome = welcome_for_key_package(
+        &mut bob,
+        &alice_id,
+        key_package.clone(),
+        "full consumed journal invite",
+    )
+    .await;
+    let error = alice
+        .ingest(welcome)
+        .await
+        .expect_err("the 257th unswept consumption ref must fail the Welcome transaction");
+    assert!(
+        error
+            .to_string()
+            .contains("consumed KeyPackage cleanup journal is full"),
+        "unexpected capacity error: {error:?}"
+    );
+
+    let after = alice.key_package_lifecycle().unwrap().unwrap();
+    assert_eq!(after.consumed_key_package_refs, evidence_before);
+    assert!(
+        alice
+            .durably_owned_key_packages()
+            .unwrap()
+            .contains(&key_package),
+        "transaction rollback must retain the private bundle when consumption evidence cannot commit"
+    );
+}
+
+#[tokio::test]
+async fn legacy_overwritten_consumption_marker_is_swept_before_startup_transport() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot overwritten consumed marker key").unwrap();
+    let relay_a = TransportEndpoint("wss://a.keys.example".into());
+    let relay_b = TransportEndpoint("wss://b.keys.example".into());
+    let routing = StaticTransportRouting::new(vec![])
+        .key_package_endpoints(vec![relay_a.clone(), relay_b.clone()]);
+    let publisher = JournalKeyPackages::default().with_publication_receipts(vec![
+        KeyPackagePublishReceipt {
+            accepted: vec![relay_a.clone(), relay_b.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![relay_a.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: vec![relay_b.clone()],
+        },
+        KeyPackagePublishReceipt {
+            accepted: vec![relay_a.clone(), relay_b.clone()],
+            rejected: Vec::new(),
+            confirmed_absent: Vec::new(),
+            failed: Vec::new(),
+        },
+    ]);
+    let wall = Arc::new(TestWallClock::new(130_000));
+    let mut runtime = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(101)),
+    );
+
+    // This package predates lifecycle projection entirely. A schema-51
+    // writer could overwrite its consumption marker with a later Welcome, so
+    // upgrade recovery must not limit conservative retirement to current /
+    // retained lifecycle fields.
+    let unprojected_key_package = runtime.session_mut().fresh_key_package().await.unwrap();
+    let unprojected_ref = hex::decode(
+        runtime
+            .session()
+            .key_package_metadata(&unprojected_key_package)
+            .unwrap()
+            .key_package_ref_hex,
+    )
+    .unwrap();
+    let retained_key_package = runtime.publish_fresh_key_package().await.unwrap();
+    let retained = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let retained_ref = retained.current_key_package_ref.clone().unwrap();
+    let current_key_package = runtime.publish_fresh_key_package().await.unwrap();
+    let current = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let current_ref = current.current_key_package_ref.clone().unwrap();
+    let current_artifact = current.authored_signed_event.clone().unwrap();
+    assert_ne!(retained_ref, current_ref);
+    assert_eq!(current.retained_private_material.len(), 1);
+    assert!(
+        current
+            .publication_targets
+            .iter()
+            .any(|target| target.endpoint == relay_b
+                && target.state == TransportFanoutAttemptState::AttemptedFailed),
+        "the live exact revision must retain a partial-relay retry before consumption"
+    );
+
+    let alice_id = runtime.session().self_id();
+    let mut bob = session(dir.path().join("bob.sqlite"), &key, b"bob");
+    let mut carol = session(dir.path().join("carol.sqlite"), &key, b"carol");
+    let mut dave = session(dir.path().join("dave.sqlite"), &key, b"dave");
+    // This third Welcome is already in flight when the upgraded process starts.
+    // Its pre-lifecycle package is intentionally not consumed yet: startup must
+    // retire it before transport can deliver this message and overwrite the
+    // legacy-only ambiguity sentinel.
+    let startup_welcome = welcome_for_key_package(
+        &mut bob,
+        &alice_id,
+        unprojected_key_package.clone(),
+        "unprojected startup Welcome",
+    )
+    .await;
+    let current_welcome = welcome_for_key_package(
+        &mut carol,
+        &alice_id,
+        current_key_package.clone(),
+        "current consumed first",
+    )
+    .await;
+    let retained_welcome = welcome_for_key_package(
+        &mut dave,
+        &alice_id,
+        retained_key_package.clone(),
+        "retained consumed last",
+    )
+    .await;
+    runtime.session_mut().ingest(current_welcome).await.unwrap();
+    runtime
+        .session_mut()
+        .ingest(retained_welcome)
+        .await
+        .unwrap();
+
+    let mut legacy = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        legacy.consumed_key_package_refs,
+        vec![current_ref.clone(), retained_ref.clone()]
+    );
+    assert_eq!(
+        legacy.last_consumed_key_package_ref,
+        Some(retained_ref.clone())
+    );
+    assert_eq!(
+        runtime.durably_owned_key_packages().unwrap().len(),
+        3,
+        "OpenMLS intentionally retains lifecycle-less and projected last-resort bundles"
+    );
+    // Simulate the pre-journal serialized shape: only the legacy last marker
+    // survives, so the first consumed current ref has been overwritten.
+    legacy.consumed_key_package_refs.clear();
+    runtime
+        .session()
+        .put_key_package_lifecycle(&legacy)
+        .unwrap();
+    drop(runtime);
+
+    let adapter = RecordingAdapter::default();
+    let mut restarted = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        adapter.clone(),
+        routing.clone(),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(101)),
+    );
+    assert!(
+        adapter.activations().is_empty(),
+        "transport must still be unopened at the synchronous startup sweep boundary"
+    );
+    assert!(adapter.publishes().is_empty());
+    let publications_before_sweep = publisher.publications().len();
+    assert_eq!(
+        restarted
+            .sweep_expired_key_package_private_material()
+            .unwrap(),
+        3,
+        "legacy-only evidence conservatively retires every possibly consumed durable bundle"
+    );
+    assert!(
+        adapter.activations().is_empty(),
+        "private-material startup reconciliation performs no transport I/O"
+    );
+    assert!(adapter.publishes().is_empty());
+    assert_eq!(publisher.publications().len(), publications_before_sweep);
+    let swept = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert!(swept.current_key_package.is_none());
+    assert!(swept.current_key_package_ref.is_none());
+    assert!(swept.authored_event_id.is_none());
+    assert!(swept.authored_signed_event.is_none());
+    assert!(swept.publication_targets.is_empty());
+    assert!(swept.retained_private_material.is_empty());
+    assert!(swept.pending_replacement.is_none());
+    let mut expected_consumed_refs = vec![
+        unprojected_ref.clone(),
+        current_ref.clone(),
+        retained_ref.clone(),
+    ];
+    expected_consumed_refs.sort();
+    assert_eq!(swept.consumed_key_package_refs, expected_consumed_refs);
+    assert_eq!(swept.last_consumed_key_package_ref, Some(retained_ref));
+    assert_eq!(
+        swept.authored_event_created_at,
+        Some(current_artifact.created_at),
+        "the unusable live revision remains the stable-slot authoring high-water"
+    );
+    let retired_current = swept
+        .retired_publications_pending_deletion
+        .iter()
+        .find(|retired| retired.event_id == current_artifact.id)
+        .expect("the exact partially published current revision remains durably deletable");
+    assert!(retired_current.delete_without_successor);
+    assert_eq!(retired_current.key_package_ref, Some(current_ref));
+    assert_eq!(retired_current.deletion_targets.len(), 2);
+    assert_eq!(
+        publisher.publications().len(),
+        2,
+        "the atomic sentinel transition performs no exact network retry"
+    );
+    restarted.activate_transport(None).await.unwrap();
+    assert_eq!(adapter.activations().len(), 1);
+    let rejected = restarted
+        .session_mut()
+        .ingest(startup_welcome)
+        .await
+        .expect("missing private material is a classified rejection");
+    assert!(matches!(
+        rejected.outcome,
+        cgka_traits::IngestOutcome::Ignored {
+            category: cgka_traits::ingest::InputRejectionCategory::InvalidEncoding
+        }
+    ));
+    assert_eq!(
+        restarted.key_package_maintenance_status().unwrap(),
+        Some(swept.clone()),
+        "failed startup Welcome ingest must not overwrite the reconciled lifecycle"
+    );
+    assert!(restarted.durably_owned_key_packages().unwrap().is_empty());
+    restarted
+        .finalize_key_package_cutover_consumption_evidence()
+        .unwrap();
+    let finalized = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert!(finalized.consumed_key_package_refs.is_empty());
+    assert!(finalized.last_consumed_key_package_ref.is_none());
+    drop(restarted);
+
+    let mut recovered = AccountDeviceRuntime::new(
+        session(&database, &key, b"alice"),
+        RecordingAdapter::default(),
+        routing,
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(101)),
+    );
+    let recovered_state = recovered.key_package_maintenance_status().unwrap().unwrap();
+    assert!(recovered_state.last_consumed_key_package_ref.is_none());
+    assert!(recovered_state.current_key_package.is_none());
+    recovered.run_due_maintenance().await.unwrap();
+    let publications = publisher.publications();
+    let artifacts = publisher.artifacts();
+    assert_eq!(publications.len(), 3);
+    assert_eq!(artifacts.len(), 3);
+    assert_ne!(publications[2].key_package, current_key_package);
+    assert_ne!(publications[2].key_package, retained_key_package);
+    assert_ne!(publications[2].key_package, unprojected_key_package);
+    assert_ne!(artifacts[2].id, current_artifact.id);
+    assert!(artifacts[2].created_at > current_artifact.created_at);
+}
+
+#[tokio::test]
+async fn two_welcome_refs_survive_until_one_sweep_and_prune_only_removed_private_material() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot two consumed welcome refs key").unwrap();
+    let endpoint = TransportEndpoint("wss://keys.example".into());
+    let publisher = JournalKeyPackages::default();
+    let wall = Arc::new(TestWallClock::new(120_000));
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![endpoint]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(97)),
+    );
+
+    let first_key_package = runtime.publish_fresh_key_package().await.unwrap();
+    let first = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let first_ref = first.current_key_package_ref.clone().unwrap();
+    let first_event_id = first.authored_event_id.clone().unwrap();
+    let second_key_package = runtime.publish_fresh_key_package().await.unwrap();
+    let mut second = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let second_ref = second.current_key_package_ref.clone().unwrap();
+    let second_event_id = second.authored_event_id.clone().unwrap();
+    assert_ne!(first_ref, second_ref);
+    assert_ne!(first_event_id, second_event_id);
+    assert_eq!(second.retained_private_material.len(), 1);
+    second.authored_signed_event = None;
+    runtime
+        .session()
+        .put_key_package_lifecycle(&second)
+        .unwrap();
+
+    let alice_id = runtime.session().self_id();
+    let mut bob = session(dir.path().join("bob.sqlite"), &key, b"bob");
+    let mut carol = session(dir.path().join("carol.sqlite"), &key, b"carol");
+    let first_welcome =
+        welcome_for_key_package(&mut bob, &alice_id, first_key_package, "first consumed ref").await;
+    let second_welcome = welcome_for_key_package(
+        &mut carol,
+        &alice_id,
+        second_key_package.clone(),
+        "second consumed ref",
+    )
+    .await;
+    runtime.session_mut().ingest(first_welcome).await.unwrap();
+    runtime.session_mut().ingest(second_welcome).await.unwrap();
+
+    let before_sweep = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        before_sweep.consumed_key_package_refs,
+        vec![first_ref.clone(), second_ref.clone()],
+        "a second Welcome must append instead of overwriting unswept evidence"
+    );
+    assert_eq!(
+        before_sweep.last_consumed_key_package_ref,
+        Some(second_ref.clone())
+    );
+
+    assert_eq!(
+        runtime
+            .sweep_expired_key_package_private_material()
+            .unwrap(),
+        1,
+        "the consumed retained package is deleted while the consumed current remains blocked"
+    );
+    let after_sweep = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        after_sweep.current_key_package_ref,
+        Some(second_ref.clone())
+    );
+    assert!(after_sweep.retained_private_material.is_empty());
+    assert_eq!(
+        after_sweep.consumed_key_package_refs,
+        vec![second_ref.clone()]
+    );
+    assert_eq!(
+        after_sweep.last_consumed_key_package_ref,
+        Some(second_ref.clone())
+    );
+    for event_id in [&first_event_id, &second_event_id] {
+        let retired = after_sweep
+            .retired_publications_pending_deletion
+            .iter()
+            .find(|retired| &retired.event_id == event_id)
+            .expect("each consumed signed revision remains durably deletable");
+        assert!(retired.delete_without_successor);
+    }
+    assert!(runtime.key_package_network_maintenance_due().unwrap());
+    assert!(!runtime.key_package_has_pending_fanout().unwrap());
+
+    runtime
+        .republish_key_package()
+        .await
+        .expect("a consumed current reference must force semantic replacement");
+    let replacement = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_ne!(replacement.current_key_package_ref, Some(second_ref));
+    assert!(replacement.consumed_key_package_refs.is_empty());
+    assert!(replacement.last_consumed_key_package_ref.is_none());
+    assert_eq!(publisher.publications().len(), 3);
+    assert_ne!(publisher.publications()[2].key_package, second_key_package);
 }
 
 #[tokio::test]
@@ -3366,6 +7822,134 @@ async fn group_evolution_confirms_commit_when_welcome_publish_fails() {
     assert_eq!(adapter.publishes().len(), 3);
 }
 
+#[tokio::test]
+async fn cancelled_post_confirmation_welcome_publish_replays_nested_session_events() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot nested visibility cancellation key").unwrap();
+    let mut alice = session(
+        dir.path().join("alice.sqlite"),
+        &key,
+        b"alice-nested-visibility",
+    );
+    let mut bob = session(
+        dir.path().join("bob.sqlite"),
+        &key,
+        b"bob-nested-visibility",
+    );
+    let mut carol = session(
+        dir.path().join("carol.sqlite"),
+        &key,
+        b"carol-nested-visibility",
+    );
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let carol_id = carol.self_id();
+
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "nested visibility".into(),
+            description: String::new(),
+            members: vec![bob_kp],
+            required_features: Vec::new(),
+            app_components: Vec::new(),
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id;
+    let create_pending = match created.effects.publish.as_slice() {
+        [PublishWork::GroupCreated { pending, .. }] => *pending,
+        other => panic!("expected one GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(create_pending).await.unwrap();
+
+    let adapter = RecordingAdapter::default();
+    let gate = adapter.gate_welcome_publishes();
+    let policy =
+        StaticTransportRouting::new(vec![TransportEndpoint("wss://nested-inbox.example".into())])
+            .with_group_route(
+                group_id.clone(),
+                group_id.as_slice().to_vec(),
+                vec![TransportEndpoint("wss://nested-group.example".into())],
+            )
+            .with_inbox_route(
+                carol_id,
+                vec![TransportEndpoint("wss://nested-carol.example".into())],
+            );
+    let mut runtime = AccountDeviceRuntime::new(
+        alice,
+        adapter.clone(),
+        policy,
+        RecordingKeyPackages::default(),
+    );
+
+    // The group commit publishes first and is confirmed locally. Confirmation
+    // drains EpochChanged into the account output, then the recipient Welcome
+    // crosses the blocking adapter await. Cancelling there used to discard the
+    // only live copy of that newly generated event.
+    let mut cancelled = Box::pin(runtime.send(SendIntent::Invite {
+        group_id: group_id.clone(),
+        key_packages: vec![carol_kp],
+        initial_admins: Vec::new(),
+    }));
+    tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::select! {
+            result = &mut cancelled => {
+                panic!("invite returned before Welcome cancellation boundary: {result:?}")
+            }
+            () = async {
+                while adapter.publishes().len() < 2 {
+                    tokio::task::yield_now().await;
+                }
+            } => {}
+        }
+    })
+    .await
+    .expect("invite reaches the blocking Welcome publish");
+    drop(cancelled);
+    let commit_id = adapter.publishes()[0].message.id.clone();
+
+    gate.release.add_permits(1);
+    let recovered = tokio::time::timeout(Duration::from_secs(5), runtime.drain())
+        .await
+        .expect("retained runtime drain completes")
+        .unwrap();
+    assert!(recovered.events.iter().any(|event| matches!(
+        event,
+        GroupEvent::EpochChanged { group_id: changed, .. } if changed == &group_id
+    )));
+    assert!(
+        recovered
+            .pending
+            .iter()
+            .any(|resolution| matches!(resolution, PendingResolution::Confirmed { .. }))
+    );
+    assert_eq!(
+        recovered
+            .reports
+            .iter()
+            .filter(|report| report.message_id == commit_id)
+            .count(),
+        1,
+        "the completed commit report must survive cancellation inside its Welcome loop"
+    );
+    assert_eq!(
+        adapter
+            .publishes()
+            .iter()
+            .filter(|request| request.message.id == commit_id)
+            .count(),
+        1,
+        "visibility replay must not publish the already-confirmed commit again"
+    );
+
+    let handed_off = runtime.drain().await.unwrap();
+    assert!(!handed_off.events.iter().any(|event| matches!(
+        event,
+        GroupEvent::EpochChanged { group_id: changed, .. } if changed == &group_id
+    )));
+}
+
 // mdk#499 regression: an explicit group-evolution commit that a relay
 // accepted but that missed `required_acks` has already been exposed to peers.
 // Rolling it back locally diverges the sender from recipients; mirror the
@@ -3575,6 +8159,1767 @@ async fn drain_surfaces_hydration_quarantine_without_inbound_delivery() {
     );
 }
 
+#[tokio::test]
+async fn visibility_lease_replays_drain_in_order_through_maintenance_until_acknowledged() {
+    use cgka_traits::GroupStorage;
+    use cgka_traits::engine::GroupHydrationQuarantineReason;
+    use cgka_traits::group::Group;
+
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot leased visibility key").unwrap();
+    let db_path = dir.path().join("alice-leased.sqlite");
+    drop(session(&db_path, &key, b"alice-leased"));
+
+    let broken_groups = [
+        GroupId::new(b"leased-broken-a".to_vec()),
+        GroupId::new(b"leased-broken-b".to_vec()),
+    ];
+    {
+        let storage = SqliteAccountStorage::open_encrypted(&db_path, &key).unwrap();
+        for group_id in &broken_groups {
+            storage
+                .put_group(&Group {
+                    id: group_id.clone(),
+                    name: "broken".into(),
+                    description: String::new(),
+                    members: Vec::new(),
+                    epoch: EpochId(9),
+                    required_capabilities: cgka_traits::GroupCapabilities::default(),
+                    protocol_profile: ProtocolProfile::Legacy,
+                    removed: false,
+                    unrecoverable: false,
+                    disbanded: None,
+                    join_epoch: EpochId(0),
+                })
+                .unwrap();
+        }
+    }
+
+    let reopened = session(&db_path, &key, b"alice-leased");
+    let policy =
+        StaticTransportRouting::new(vec![TransportEndpoint("wss://leased-inbox.example".into())]);
+    let mut runtime = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        policy,
+        RecordingKeyPackages::default(),
+    );
+    runtime.pause_maintenance();
+
+    let first = runtime.drain_leased().await.unwrap();
+    let quarantine_order = |effects: &marmot_account::AccountDeviceEffects| {
+        effects
+            .events
+            .iter()
+            .filter_map(|event| match event {
+                GroupEvent::GroupHydrationQuarantined {
+                    group_id,
+                    reason: GroupHydrationQuarantineReason::OpenMlsGroupMissing,
+                } => Some(group_id.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+    };
+    let first_order = quarantine_order(&first.effects);
+    assert_eq!(first_order.len(), 2);
+
+    // Maintenance itself has no new work while paused. Older unacknowledged
+    // visibility is source-attributed in `batches`, while the command-local
+    // `effects` remains empty and cannot inherit an old command's failures.
+    let replayed = runtime.run_due_maintenance_leased().await.unwrap();
+    assert!(quarantine_order(&replayed.effects).is_empty());
+    assert_eq!(
+        quarantine_order(&flatten_visibility_batches(&replayed.batches)),
+        first_order
+    );
+    assert!(!runtime.acknowledge_visibility_lease(first.lease));
+    assert!(runtime.acknowledge_visibility_lease(replayed.lease));
+
+    let after_ack = runtime.drain_leased().await.unwrap();
+    assert!(quarantine_order(&after_ack.effects).is_empty());
+    assert!(runtime.acknowledge_visibility_lease(after_ack.lease));
+}
+
+#[tokio::test]
+async fn durably_acknowledged_visibility_lease_advances_after_storage_closes() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot post-commit visibility lease key").unwrap();
+    let database = dir.path().join("alice-post-commit-visibility.sqlite");
+    let account = session(&database, &key, b"alice-post-commit-visibility");
+    let mut runtime = AccountDeviceRuntime::new(
+        account,
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://post-commit-visibility.example".into(),
+        )]),
+        RecordingKeyPackages::default(),
+    );
+    runtime.pause_maintenance();
+
+    let leased = runtime.drain_leased().await.unwrap();
+    let batch_ids = runtime
+        .visibility_lease_batch_ids(leased.lease)
+        .expect("the returned visibility rows remain leased until app commit");
+    assert!(!batch_ids.is_empty());
+    let storage = runtime.session().storage_handle();
+    assert_eq!(
+        storage
+            .delete_account_visibility_journal_batches(&batch_ids)
+            .unwrap(),
+        batch_ids.len(),
+        "the app-side transaction must delete every leased row before advancing memory",
+    );
+
+    // Terminal shutdown may close the shared handle immediately after the app
+    // projection transaction commits. Lease advancement is therefore a pure
+    // in-memory post-commit step and must not attempt another storage read.
+    storage.close().unwrap();
+    assert!(
+        runtime
+            .forget_durably_acknowledged_visibility_batches(leased.lease, &batch_ids)
+            .unwrap(),
+        "the matching fully acknowledged lease must advance after storage closes",
+    );
+    assert_eq!(runtime.visibility_lease_batch_ids(leased.lease), None);
+}
+
+#[tokio::test]
+async fn rejected_leave_header_replays_without_false_acceptance() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot rejected leave source key").unwrap();
+    let database = dir.path().join("rejected-leave-source.sqlite");
+    let unknown_group = GroupId::new(b"unknown-leave-source".to_vec());
+    let account = session(&database, &key, b"rejected-leave-source");
+    let adapter = RecordingAdapter::default();
+    let mut runtime = AccountDeviceRuntime::new(
+        account,
+        adapter.clone(),
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://rejected-leave-source.example".into(),
+        )]),
+        RecordingKeyPackages::default(),
+    )
+    .with_maintenance_sources(
+        Arc::new(TestWallClock::new(31337)),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(0)),
+    );
+    runtime.pause_maintenance();
+
+    assert!(
+        runtime
+            .send_leased(SendIntent::Leave {
+                group_id: unknown_group.clone(),
+            })
+            .await
+            .is_err(),
+        "an unknown-group Leave must fail before engine acceptance"
+    );
+    assert!(adapter.publishes().is_empty());
+    drop(runtime);
+
+    let reopened = session(&database, &key, b"rejected-leave-source");
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://rejected-leave-source.example".into(),
+        )]),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    let replayed = restarted
+        .replay_visibility_leased()
+        .unwrap()
+        .expect("the pre-acceptance Header remains crash-visible");
+    assert!(!replayed.batches.is_empty());
+    assert!(replayed.batches.iter().all(|batch| {
+        batch.source
+            == (AccountVisibilitySource::Outbound {
+                group_id: Some(unknown_group.clone()),
+                observed_at: Timestamp(31337),
+                action: Some(AccountVisibilityOutboundAction::Leave),
+                action_message_id: None,
+            })
+    }));
+    assert!(restarted.acknowledge_visibility_lease(replayed.lease));
+}
+
+#[tokio::test]
+async fn leave_visibility_source_survives_restart_until_acknowledged() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot leave visibility source key").unwrap();
+    let alice_path = dir.path().join("alice-leave-source.sqlite");
+    let bob_path = dir.path().join("bob-leave-source.sqlite");
+    let mut alice = session_with_registry(
+        &alice_path,
+        &key,
+        b"alice-leave-source",
+        selfremove_registry(),
+    );
+    let mut bob =
+        session_with_registry(&bob_path, &key, b"bob-leave-source", selfremove_registry());
+    let bob_key_package = bob.fresh_key_package().await.unwrap();
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "leave visibility source".into(),
+            description: String::new(),
+            members: vec![bob_key_package],
+            required_features: Vec::new(),
+            app_components: Vec::new(),
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id;
+    let (pending, welcome) = match created.effects.publish.as_slice() {
+        [PublishWork::GroupCreated { pending, welcomes }] => (*pending, welcomes[0].clone()),
+        other => panic!("expected one GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.ingest(welcome).await.unwrap();
+
+    let route = || {
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://leave-source-inbox.example".into(),
+        )])
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            vec![TransportEndpoint("wss://leave-source-group.example".into())],
+        )
+    };
+    let mut runtime = AccountDeviceRuntime::new(
+        bob,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    )
+    .with_maintenance_sources(
+        Arc::new(TestWallClock::new(4242)),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(0)),
+    );
+    runtime.pause_maintenance();
+
+    let leased = runtime
+        .send_leased(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    assert!(leased.current_operation_id.is_some());
+    assert!(!leased.batches.is_empty());
+    let action_outcome = leased
+        .effects
+        .action_outcomes
+        .as_slice()
+        .first()
+        .expect("a terminal Leave publish emits its typed action outcome");
+    assert_eq!(leased.effects.action_outcomes.len(), 1);
+    assert_eq!(
+        action_outcome.operation_id,
+        leased.current_operation_id.clone().unwrap()
+    );
+    assert_eq!(action_outcome.group_id, group_id);
+    assert_eq!(
+        action_outcome.action,
+        AccountVisibilityOutboundAction::Leave
+    );
+    assert!(action_outcome.published);
+    let leave_message_id = action_outcome.message_id.clone();
+    assert!(leased.batches.iter().all(|batch| {
+        batch.source
+            == (AccountVisibilitySource::Outbound {
+                group_id: Some(group_id.clone()),
+                observed_at: Timestamp(4242),
+                action: Some(AccountVisibilityOutboundAction::Leave),
+                action_message_id: Some(leave_message_id.clone()),
+            })
+    }));
+    let original_batch_ids = leased
+        .batches
+        .iter()
+        .map(|batch| batch.batch_id.clone())
+        .collect::<Vec<_>>();
+    drop(runtime);
+
+    let restarted_adapter = RecordingAdapter::default();
+    let reopened =
+        session_with_registry(&bob_path, &key, b"bob-leave-source", selfremove_registry());
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        restarted_adapter.clone(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    let replayed = restarted
+        .replay_visibility_leased()
+        .unwrap()
+        .expect("unacknowledged Leave visibility replays after restart");
+    assert_eq!(replayed.current_operation_id, None);
+    assert_eq!(
+        replayed
+            .batches
+            .iter()
+            .map(|batch| batch.batch_id.clone())
+            .collect::<Vec<_>>(),
+        original_batch_ids
+    );
+    assert!(replayed.batches.iter().all(|batch| {
+        batch.source
+            == (AccountVisibilitySource::Outbound {
+                group_id: Some(group_id.clone()),
+                observed_at: Timestamp(4242),
+                action: Some(AccountVisibilityOutboundAction::Leave),
+                action_message_id: Some(leave_message_id.clone()),
+            })
+    }));
+    assert_eq!(
+        flatten_visibility_batches(&replayed.batches).action_outcomes,
+        vec![action_outcome.clone()]
+    );
+    assert!(
+        restarted_adapter.publishes().is_empty(),
+        "visibility replay must not repeat the already-completed Leave publish"
+    );
+    assert!(restarted.acknowledge_visibility_lease(replayed.lease));
+    assert!(restarted.replay_visibility_leased().unwrap().is_none());
+}
+
+#[tokio::test]
+async fn terminal_leave_publish_failure_is_durable_and_does_not_authorize_left() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot failed leave outcome key").unwrap();
+    let (bob, bob_path, bob_identity, group_id) =
+        joined_selfremove_member(dir.path(), &key, "failed-leave-outcome").await;
+    let adapter = RecordingAdapter::default();
+    let group_endpoint = TransportEndpoint("wss://failed-leave-group.example".into());
+    adapter.fail_endpoints_as(
+        vec![group_endpoint.clone()],
+        TransportEndpointFailureKind::TerminalRejected,
+    );
+    let route = || {
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://failed-leave-inbox.example".into(),
+        )])
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            vec![group_endpoint.clone()],
+        )
+    };
+    let mut runtime =
+        AccountDeviceRuntime::new(bob, adapter, route(), RecordingKeyPackages::default());
+    runtime.pause_maintenance();
+    let leased = runtime
+        .send_leased(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(leased.effects.action_outcomes.len(), 1);
+    let outcome = leased.effects.action_outcomes[0].clone();
+    assert_eq!(outcome.operation_id, leased.current_operation_id.unwrap());
+    assert_eq!(outcome.group_id, group_id);
+    assert_eq!(outcome.action, AccountVisibilityOutboundAction::Leave);
+    assert!(
+        !outcome.published,
+        "an unmet required-ACK policy must not authorize the app's Left tail"
+    );
+    assert!(!leased.effects.failures.is_empty());
+    drop(runtime);
+
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    let replayed = restarted
+        .replay_visibility_leased()
+        .unwrap()
+        .expect("terminal failed Leave outcome survives restart");
+    assert_eq!(
+        flatten_visibility_batches(&replayed.batches).action_outcomes,
+        vec![outcome]
+    );
+    assert!(restarted.acknowledge_visibility_lease(replayed.lease));
+}
+
+#[tokio::test]
+async fn zero_accept_best_effort_leave_does_not_publish_on_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot zero ack leave key").unwrap();
+    let (bob, bob_path, bob_identity, group_id) =
+        joined_selfremove_member(dir.path(), &key, "zero-ack-leave").await;
+    let adapter = RecordingAdapter::default();
+    let group_endpoint = TransportEndpoint("wss://zero-ack-leave-group.example".into());
+    adapter.fail_endpoints_as(
+        vec![group_endpoint.clone()],
+        TransportEndpointFailureKind::TerminalRejected,
+    );
+    let route = || {
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://zero-ack-leave-inbox.example".into(),
+        )])
+        .required_acks(0)
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            vec![group_endpoint.clone()],
+        )
+    };
+    let mut runtime =
+        AccountDeviceRuntime::new(bob, adapter, route(), RecordingKeyPackages::default());
+    runtime.pause_maintenance();
+    let leased = runtime
+        .send_leased(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    assert!(
+        leased
+            .effects
+            .action_outcomes
+            .iter()
+            .all(|outcome| !outcome.published),
+        "required_acks=0 still needs at least one accept"
+    );
+    drop(runtime);
+
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    if let Some(replayed) = restarted.replay_visibility_leased().unwrap() {
+        assert!(
+            flatten_visibility_batches(&replayed.batches)
+                .action_outcomes
+                .iter()
+                .all(|outcome| !outcome.published),
+            "restart must not upgrade a zero-accept Leave to published:true"
+        );
+        assert!(restarted.acknowledge_visibility_lease(replayed.lease));
+    }
+    assert!(
+        restarted
+            .session()
+            .outbound_fanouts()
+            .unwrap()
+            .iter()
+            .all(|fanout| {
+                fanout.outcome().accepted_targets < fanout.request().required_acks.max(1)
+            }),
+        "a surviving terminal zero-accept fanout must still miss required_acks.max(1)"
+    );
+    let drained = restarted.drain_leased().await.unwrap();
+    assert!(
+        drained
+            .effects
+            .action_outcomes
+            .iter()
+            .all(|outcome| !outcome.published),
+        "resuming a terminal zero-accept Leave must not authorize Left"
+    );
+    assert!(
+        restarted.session().outbound_fanouts().unwrap().is_empty(),
+        "terminal zero-accept resume must finish the Leave fanout without publishing"
+    );
+}
+
+#[tokio::test]
+async fn leave_m1_to_m2_repair_persists_every_row_so_cleared_request_does_not_split_source() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot torn leave source key").unwrap();
+    let (bob, bob_path, bob_identity, group_id) =
+        joined_selfremove_member(dir.path(), &key, "torn-leave-source").await;
+    let route = || {
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://torn-leave-inbox.example".into(),
+        )])
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            vec![TransportEndpoint("wss://torn-leave-group.example".into())],
+        )
+    };
+    let mut runtime = AccountDeviceRuntime::new(
+        bob,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    runtime.pause_maintenance();
+    let _leased = runtime
+        .send_leased(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    let later_id = MessageId::new(b"leave-m2-torn-source".to_vec());
+    let mut request = runtime
+        .session()
+        .storage_handle()
+        .leave_request(&group_id)
+        .unwrap()
+        .expect("accepted Leave writes a durable request");
+    request.last_proposed_message_id = Some(later_id.clone());
+    runtime
+        .session()
+        .storage_handle()
+        .put_leave_request(&request)
+        .unwrap();
+    drop(runtime);
+
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    let mut repaired = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    repaired.pause_maintenance();
+    let replayed = repaired
+        .replay_visibility_leased()
+        .unwrap()
+        .expect("unacked Leave remains crash-visible for M1→M2 repair");
+    let leave_sources = replayed
+        .batches
+        .iter()
+        .filter_map(|batch| match &batch.source {
+            AccountVisibilitySource::Outbound {
+                group_id: Some(source_group),
+                action: Some(AccountVisibilityOutboundAction::Leave),
+                action_message_id,
+                ..
+            } if source_group == &group_id => {
+                Some((batch.operation_id.clone(), action_message_id.clone()))
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let mut unique_source_by_operation =
+        std::collections::HashMap::<Vec<u8>, Option<MessageId>>::new();
+    for (operation_id, action_message_id) in &leave_sources {
+        if let Some(existing) = unique_source_by_operation.get(operation_id) {
+            assert_eq!(
+                existing, action_message_id,
+                "M1→M2 repair must persist one source per operation, got {leave_sources:?}"
+            );
+        } else {
+            unique_source_by_operation.insert(operation_id.clone(), action_message_id.clone());
+        }
+    }
+    assert!(
+        unique_source_by_operation
+            .values()
+            .any(|bound| bound.as_ref() == Some(&later_id)),
+        "repaired Leave source must name the live M2 id: {leave_sources:?}"
+    );
+    drop(replayed);
+    drop(repaired);
+
+    let storage_session =
+        session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    storage_session
+        .storage_handle()
+        .clear_leave_request(&group_id)
+        .unwrap();
+    drop(storage_session);
+
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    let replayed = restarted
+        .replay_visibility_leased()
+        .expect("Header+suffix M2 repair must persist every row so reopen cannot split source")
+        .expect("repaired Leave source must survive LeaveRequest clear");
+    let leave_sources = replayed
+        .batches
+        .iter()
+        .filter_map(|batch| match &batch.source {
+            AccountVisibilitySource::Outbound {
+                group_id: Some(source_group),
+                action: Some(AccountVisibilityOutboundAction::Leave),
+                action_message_id,
+                ..
+            } if source_group == &group_id => {
+                Some((batch.operation_id.clone(), action_message_id.clone()))
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let mut unique_source_by_operation =
+        std::collections::HashMap::<Vec<u8>, Option<MessageId>>::new();
+    for (operation_id, action_message_id) in &leave_sources {
+        if let Some(existing) = unique_source_by_operation.get(operation_id) {
+            assert_eq!(
+                existing, action_message_id,
+                "cleared LeaveRequest must not resurrect a split M1/M2 source: {leave_sources:?}"
+            );
+        } else {
+            unique_source_by_operation.insert(operation_id.clone(), action_message_id.clone());
+        }
+    }
+    assert!(
+        !unique_source_by_operation.is_empty()
+            && unique_source_by_operation
+                .values()
+                .all(|bound| bound.is_some()),
+        "cleared LeaveRequest must not resurrect a split or unbound Leave source: {leave_sources:?}"
+    );
+}
+
+#[tokio::test]
+async fn terminal_m1_failure_ack_then_engine_m2_records_published_true() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot m1 ack engine m2 leave key").unwrap();
+    let tag = "engine-m2-leave";
+    let (bob, bob_path, bob_identity, group_id) =
+        joined_selfremove_member(dir.path(), &key, tag).await;
+    let bob_id = bob.self_id();
+    let adapter = RecordingAdapter::default();
+    let group_endpoint = TransportEndpoint("wss://engine-m2-group.example".into());
+    adapter.fail_endpoints_as(
+        vec![group_endpoint.clone()],
+        TransportEndpointFailureKind::TerminalRejected,
+    );
+    let route = || {
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://engine-m2-inbox.example".into(),
+        )])
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            vec![group_endpoint.clone()],
+        )
+    };
+    let mut runtime =
+        AccountDeviceRuntime::new(bob, adapter, route(), RecordingKeyPackages::default());
+    runtime.pause_maintenance();
+    let leased = runtime
+        .send_leased(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    let m1_id = leased
+        .effects
+        .action_outcomes
+        .iter()
+        .find(|outcome| !outcome.published)
+        .map(|outcome| outcome.message_id.clone())
+        .expect("terminal M1 Header failure records unpublished Leave");
+    assert!(
+        leased
+            .effects
+            .action_outcomes
+            .iter()
+            .all(|outcome| !outcome.published)
+    );
+    assert!(runtime.acknowledge_visibility_lease(leased.lease));
+    drop(runtime);
+
+    let alice_identity = format!("alice-{tag}").into_bytes();
+    let alice_path = dir.path().join(format!("alice-{tag}.sqlite"));
+    let alice = session_with_registry(&alice_path, &key, &alice_identity, selfremove_registry());
+    let alice_adapter = RecordingAdapter::default();
+    let mut alice_runtime = AccountDeviceRuntime::new(
+        alice,
+        alice_adapter.clone(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    alice_runtime.pause_maintenance();
+    alice_runtime
+        .send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some("engine m2 epoch".to_owned()),
+            description: None,
+        })
+        .await
+        .expect("alice must advance the epoch so Bob's LeaveRequest can auto-repropose");
+    let commit = alice_adapter
+        .publishes()
+        .into_iter()
+        .map(|publish| publish.message)
+        .find(|message| matches!(message.envelope, TransportEnvelope::GroupMessage { .. }))
+        .expect("alice epoch-advancing commit is published");
+    let commit = TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..commit
+    };
+    drop(alice_runtime);
+
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    let recovered_adapter = RecordingAdapter::default();
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        recovered_adapter.clone(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    assert!(
+        restarted.replay_visibility_leased().unwrap().is_none(),
+        "terminal M1 Header ACK must drop Leave provenance from the journal"
+    );
+    let ingested = restarted
+        .ingest_delivery_leased(TransportDelivery {
+            account_id: bob_id,
+            group_id_hint: Some(group_id.clone()),
+            message: commit,
+            received_at: Timestamp(0),
+            source: TransportDeliverySource {
+                transport: TransportSource("marmot-account-test".into()),
+                plane: TransportDeliveryPlane::Group,
+                endpoint: None,
+                subscription_id: None,
+                wire: None,
+            },
+        })
+        .await
+        .expect("bob must ingest alice's epoch-advancing commit");
+    let mut published_outcomes = ingested.effects.action_outcomes.clone();
+    if matches!(
+        ingested.outcome,
+        cgka_traits::ingest::IngestOutcome::Buffered { .. }
+    ) || restarted.has_pending_convergence_inputs(&group_id).unwrap()
+        || ingested
+            .effects
+            .pending_convergence
+            .iter()
+            .any(|pending| pending == &group_id)
+    {
+        tokio::time::sleep(Duration::from_millis(
+            cgka_engine::canonicalization::V1_SETTLEMENT_QUIESCENCE_MS + 50,
+        ))
+        .await;
+        let converged = restarted
+            .advance_convergence_leased(&group_id)
+            .await
+            .expect("buffered epoch-advancing commit must converge");
+        published_outcomes.extend(converged.effects.action_outcomes);
+    }
+    let drained = restarted.drain_leased().await.unwrap();
+    published_outcomes.extend(drained.effects.action_outcomes.clone());
+    let m2 = published_outcomes
+        .into_iter()
+        .find(|outcome| outcome.published)
+        .expect(
+            "engine-driven M2 success must record published:true even with no surviving M1 Header",
+        );
+    assert_ne!(
+        m2.message_id, m1_id,
+        "engine-driven Leave success must bind the new SelfRemove, not the failed M1 Header"
+    );
+    drop(restarted);
+
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    let mut recovered = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    recovered.pause_maintenance();
+    let replayed = recovered
+        .replay_visibility_leased()
+        .unwrap()
+        .expect("engine-driven M2 published outcome must survive restart");
+    assert!(
+        flatten_visibility_batches(&replayed.batches)
+            .action_outcomes
+            .iter()
+            .any(|outcome| outcome.published && outcome.message_id == m2.message_id),
+        "restart must replay the exact engine-driven M2 Leave"
+    );
+    assert!(recovered.acknowledge_visibility_lease(replayed.lease));
+}
+
+#[tokio::test]
+async fn mixed_leave_headers_select_one_owner_without_duplicate_bind() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot mixed leave header key").unwrap();
+    let (bob, bob_path, bob_identity, group_id) =
+        joined_selfremove_member(dir.path(), &key, "mixed-leave-header").await;
+    let route = || {
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://mixed-leave-inbox.example".into(),
+        )])
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            vec![TransportEndpoint("wss://mixed-leave-group.example".into())],
+        )
+    };
+    let mut runtime = AccountDeviceRuntime::new(
+        bob,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    runtime.pause_maintenance();
+    let first = runtime
+        .send_leased(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    let first_id = first.effects.action_outcomes[0].message_id.clone();
+    let second = runtime
+        .send_leased(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await;
+    assert!(
+        second.is_err(),
+        "a second Leave in the same epoch must fail closed as already requested"
+    );
+    drop(runtime);
+
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    let replayed = restarted
+        .replay_visibility_leased()
+        .unwrap()
+        .expect("mixed Leave Headers remain crash-visible");
+    let leave_bindings = replayed
+        .batches
+        .iter()
+        .filter_map(|batch| match &batch.source {
+            AccountVisibilitySource::Outbound {
+                group_id: Some(source_group),
+                action: Some(AccountVisibilityOutboundAction::Leave),
+                action_message_id,
+                ..
+            } if source_group == &group_id => {
+                Some((batch.operation_id.clone(), action_message_id.clone()))
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let bound_operations = leave_bindings
+        .iter()
+        .filter(|(_, bound)| bound.as_ref() == Some(&first_id))
+        .map(|(operation_id, _)| operation_id.clone())
+        .collect::<std::collections::HashSet<_>>();
+    assert_eq!(
+        bound_operations.len(),
+        1,
+        "exactly one visibility operation may own the live Leave id; mixed Some(M1)+None must not duplicate: {leave_bindings:?}"
+    );
+    let recovered = restarted
+        .drain_leased()
+        .await
+        .expect("mixed Some(M1)+None Headers must not hard-fail terminal outcome recording");
+    assert!(restarted.acknowledge_visibility_lease(recovered.lease));
+}
+
+#[tokio::test]
+async fn cancelled_leave_fanout_recovery_emits_outcome_for_original_operation() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot cancelled leave outcome key").unwrap();
+    let (bob, bob_path, bob_identity, group_id) =
+        joined_selfremove_member(dir.path(), &key, "cancelled-leave-outcome").await;
+    let adapter = RecordingAdapter::default();
+    let gate = adapter.gate_all_publishes();
+    let route = || {
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://cancelled-leave-inbox.example".into(),
+        )])
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            vec![TransportEndpoint(
+                "wss://cancelled-leave-group.example".into(),
+            )],
+        )
+    };
+    let mut runtime = AccountDeviceRuntime::new(
+        bob,
+        adapter.clone(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    runtime.pause_maintenance();
+    let mut cancelled = Box::pin(runtime.send_leased(SendIntent::Leave {
+        group_id: group_id.clone(),
+    }));
+    tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::select! {
+            result = &mut cancelled => panic!("Leave returned before cancellation boundary: {result:?}"),
+            () = async {
+                while adapter.publishes().is_empty() {
+                    tokio::task::yield_now().await;
+                }
+            } => {}
+        }
+    })
+    .await
+    .expect("Leave reaches the blocked relay publish");
+    let leave_message_id = adapter.publishes()[0].message.id.clone();
+    drop(cancelled);
+    drop(runtime);
+    gate.release.add_permits(1);
+
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    let recovered_adapter = RecordingAdapter::default();
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        recovered_adapter.clone(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    let pending = restarted
+        .replay_visibility_leased()
+        .unwrap()
+        .expect("bound original Leave Header survives cancellation");
+    assert!(
+        flatten_visibility_batches(&pending.batches)
+            .action_outcomes
+            .is_empty(),
+        "an unresolved Attempting fanout must not invent a terminal action outcome"
+    );
+    let original_operation_id = pending
+        .batches
+        .iter()
+        .find_map(|batch| match &batch.source {
+            AccountVisibilitySource::Outbound {
+                group_id: Some(source_group),
+                action: Some(AccountVisibilityOutboundAction::Leave),
+                action_message_id: Some(source_message),
+                ..
+            } if source_group == &group_id && source_message == &leave_message_id => {
+                Some(batch.operation_id.clone())
+            }
+            _ => None,
+        })
+        .expect("original Header binds the exact SelfRemove message");
+
+    let recovered = restarted.drain_leased().await.unwrap();
+    assert_eq!(recovered.effects.action_outcomes.len(), 1);
+    assert_eq!(
+        recovered.effects.action_outcomes[0],
+        marmot_account::AccountVisibilityActionOutcome {
+            operation_id: original_operation_id,
+            group_id: group_id.clone(),
+            message_id: leave_message_id,
+            action: AccountVisibilityOutboundAction::Leave,
+            published: true,
+        }
+    );
+    assert_eq!(recovered_adapter.publishes().len(), 1);
+    assert!(
+        !restarted.acknowledge_visibility_lease(pending.lease),
+        "the recovery lease supersedes the pre-recovery generation"
+    );
+    assert!(restarted.acknowledge_visibility_lease(recovered.lease));
+    assert!(restarted.replay_visibility_leased().unwrap().is_none());
+}
+
+#[tokio::test]
+async fn legacy_cancelled_operation_drain_acks_recovered_rows_so_reopen_does_not_redeliver() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot cancelled drain ack key").unwrap();
+    let (bob, bob_path, bob_identity, group_id) =
+        joined_selfremove_member(dir.path(), &key, "cancelled-drain-ack").await;
+    let adapter = RecordingAdapter::default();
+    let gate = adapter.gate_all_publishes();
+    let route = || {
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://cancelled-drain-inbox.example".into(),
+        )])
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            vec![TransportEndpoint(
+                "wss://cancelled-drain-group.example".into(),
+            )],
+        )
+    };
+    let mut runtime = AccountDeviceRuntime::new(
+        bob,
+        adapter.clone(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    runtime.pause_maintenance();
+    let mut cancelled = Box::pin(runtime.send_leased(SendIntent::Leave {
+        group_id: group_id.clone(),
+    }));
+    tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::select! {
+            result = &mut cancelled => panic!("Leave returned before cancellation boundary: {result:?}"),
+            () = async {
+                while adapter.publishes().is_empty() {
+                    tokio::task::yield_now().await;
+                }
+            } => {}
+        }
+    })
+    .await
+    .expect("Leave reaches the blocked relay publish");
+    drop(cancelled);
+    gate.release.add_permits(1);
+    let drained = runtime.drain().await.unwrap();
+    assert!(
+        !drained.events.is_empty()
+            || !drained.action_outcomes.is_empty()
+            || !drained.reports.is_empty(),
+        "legacy drain must hand off the cancelled Leave effects"
+    );
+    drop(runtime);
+
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    assert!(
+        restarted.replay_visibility_leased().unwrap().is_none(),
+        "legacy drain must ACK every handed-off cancelled operation"
+    );
+    let second = restarted.drain().await.unwrap();
+    assert!(
+        second.action_outcomes.is_empty(),
+        "reopen must not redeliver a cancelled Leave already returned by drain"
+    );
+}
+
+#[tokio::test]
+async fn legacy_ingest_delivery_acks_engine_outbox_so_reopen_does_not_redeliver() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot legacy ingest ack key").unwrap();
+    let alice_path = dir.path().join("alice-legacy-ingest.sqlite");
+    let bob_path = dir.path().join("bob-legacy-ingest.sqlite");
+    let mut alice = session_with_registry(
+        &alice_path,
+        &key,
+        b"alice-legacy-ingest",
+        selfremove_registry(),
+    );
+    let mut bob =
+        session_with_registry(&bob_path, &key, b"bob-legacy-ingest", selfremove_registry());
+    let bob_id = bob.self_id();
+    let bob_key_package = bob.fresh_key_package().await.unwrap();
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "legacy ingest ack".into(),
+            description: String::new(),
+            members: vec![bob_key_package],
+            required_features: Vec::new(),
+            app_components: Vec::new(),
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let (pending, welcome) = match created.effects.publish.as_slice() {
+        [PublishWork::GroupCreated { pending, welcomes }] => (*pending, welcomes[0].clone()),
+        other => panic!("expected one GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+
+    let mut runtime = AccountDeviceRuntime::new(
+        bob,
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://legacy-ingest-inbox.example".into(),
+        )]),
+        RecordingKeyPackages::default(),
+    );
+    runtime.pause_maintenance();
+    let ingested = runtime
+        .ingest_delivery(TransportDelivery {
+            account_id: bob_id,
+            group_id_hint: None,
+            message: welcome,
+            received_at: Timestamp(0),
+            source: TransportDeliverySource {
+                transport: TransportSource("marmot-account-test".into()),
+                plane: TransportDeliveryPlane::AccountInbox,
+                endpoint: None,
+                subscription_id: None,
+                wire: None,
+            },
+        })
+        .await
+        .unwrap();
+    assert!(
+        ingested
+            .effects
+            .events
+            .iter()
+            .any(|event| matches!(event, GroupEvent::GroupJoined { .. })),
+        "legacy ingest must return the Welcome application event"
+    );
+    assert!(
+        runtime
+            .session()
+            .storage_handle()
+            .list_pending_application_events()
+            .unwrap()
+            .is_empty(),
+        "legacy ingest must ACK engine outbox ids with the visibility discard"
+    );
+    drop(runtime);
+
+    let reopened =
+        session_with_registry(&bob_path, &key, b"bob-legacy-ingest", selfremove_registry());
+    assert!(
+        reopened
+            .storage_handle()
+            .list_pending_application_events()
+            .unwrap()
+            .is_empty(),
+        "reopen must not hydrate a returned Welcome back into the engine outbox"
+    );
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://legacy-ingest-inbox.example".into(),
+        )]),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    let drained = restarted.drain().await.unwrap();
+    assert!(
+        drained
+            .events
+            .iter()
+            .all(|event| !matches!(event, GroupEvent::GroupJoined { .. })),
+        "a returned GroupJoined must not reappear after every reopen"
+    );
+}
+
+#[tokio::test]
+async fn leave_quorum_records_published_true_while_optional_target_stays_retryable() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot leave quorum outcome key").unwrap();
+    let (bob, bob_path, bob_identity, group_id) =
+        joined_selfremove_member(dir.path(), &key, "leave-quorum-outcome").await;
+    let required = TransportEndpoint("wss://leave-quorum-required.example".into());
+    let optional = TransportEndpoint("wss://leave-quorum-optional.example".into());
+    let adapter = RecordingAdapter::default();
+    adapter.fail_endpoints_as(
+        vec![optional.clone()],
+        TransportEndpointFailureKind::RetryableUnavailable,
+    );
+    let route = || {
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://leave-quorum-inbox.example".into(),
+        )])
+        .required_acks(1)
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            vec![required.clone(), optional.clone()],
+        )
+    };
+    let mut runtime =
+        AccountDeviceRuntime::new(bob, adapter, route(), RecordingKeyPackages::default());
+    runtime.pause_maintenance();
+    let leased = runtime
+        .send_leased(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(leased.effects.action_outcomes.len(), 1);
+    assert!(
+        leased.effects.action_outcomes[0].published,
+        "meeting required ACKs must authorize Left even if an optional target is still retryable"
+    );
+    assert!(
+        leased
+            .effects
+            .fanout
+            .iter()
+            .any(|outcome| outcome.outstanding_targets > 0 && !outcome.fanout_complete),
+        "the optional target must remain outstanding so this is not the complete-fanout path"
+    );
+    drop(runtime);
+
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    let replayed = restarted
+        .replay_visibility_leased()
+        .unwrap()
+        .expect("quorum Leave outcome survives restart");
+    assert_eq!(
+        flatten_visibility_batches(&replayed.batches)
+            .action_outcomes
+            .iter()
+            .filter(|outcome| outcome.published)
+            .count(),
+        1
+    );
+    let drained = restarted
+        .drain_leased()
+        .await
+        .expect("optional Leave completion must accept an already-durable published outcome");
+    assert!(
+        drained
+            .effects
+            .action_outcomes
+            .iter()
+            .all(|outcome| outcome.published),
+        "completing the optional target must not rewrite the durable published:true outcome"
+    );
+    if !restarted.acknowledge_visibility_lease(replayed.lease) {
+        assert!(restarted.acknowledge_visibility_lease(drained.lease));
+    }
+}
+
+#[tokio::test]
+async fn leave_reproposal_rebinds_header_to_the_new_self_remove() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot leave reproposal provenance key").unwrap();
+    let (bob, bob_path, bob_identity, group_id) =
+        joined_selfremove_member(dir.path(), &key, "leave-reproposal-provenance").await;
+    let route = || {
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://leave-reproposal-inbox.example".into(),
+        )])
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            vec![TransportEndpoint(
+                "wss://leave-reproposal-group.example".into(),
+            )],
+        )
+    };
+    let mut runtime = AccountDeviceRuntime::new(
+        bob,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    runtime.pause_maintenance();
+    let leased = runtime
+        .send_leased(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    let original = leased
+        .effects
+        .action_outcomes
+        .first()
+        .expect("the original Leave binds an exact SelfRemove");
+    let first_id = original.message_id.clone();
+    let later_id = MessageId::new(b"leave-reproposal-m2".to_vec());
+    assert_ne!(first_id, later_id);
+    let mut request = runtime
+        .session()
+        .storage_handle()
+        .leave_request(&group_id)
+        .unwrap()
+        .expect("accepted Leave writes a durable request");
+    request.last_proposed_message_id = Some(later_id.clone());
+    runtime
+        .session()
+        .storage_handle()
+        .put_leave_request(&request)
+        .unwrap();
+    drop(runtime);
+
+    let reopened = session_with_registry(&bob_path, &key, &bob_identity, selfremove_registry());
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    let replayed = restarted
+        .replay_visibility_leased()
+        .unwrap()
+        .expect("Leave Header survives the message-id move");
+    assert!(replayed.batches.iter().any(|batch| {
+        matches!(
+            &batch.source,
+            AccountVisibilitySource::Outbound {
+                group_id: Some(source_group),
+                action: Some(AccountVisibilityOutboundAction::Leave),
+                action_message_id: Some(bound),
+                ..
+            } if source_group == &group_id && bound == &later_id
+        )
+    }));
+    assert!(restarted.acknowledge_visibility_lease(replayed.lease));
+}
+
+#[tokio::test]
+async fn older_pre_acceptance_leave_header_does_not_bind_a_later_leave_id() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot stale leave header key").unwrap();
+    let database = dir.path().join("stale-leave-header.sqlite");
+    let mut alice = session_with_registry(
+        &database,
+        &key,
+        b"stale-leave-header",
+        selfremove_registry(),
+    );
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "stale leave header".into(),
+            description: String::new(),
+            members: Vec::new(),
+            required_features: Vec::new(),
+            app_components: Vec::new(),
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id;
+    let pending = match created.effects.publish.as_slice() {
+        [PublishWork::GroupCreated { pending, .. }] => *pending,
+        other => panic!("expected one GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    let route = || {
+        StaticTransportRouting::new(vec![TransportEndpoint(
+            "wss://stale-leave-header.example".into(),
+        )])
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            vec![TransportEndpoint(
+                "wss://stale-leave-header-group.example".into(),
+            )],
+        )
+    };
+    let mut runtime = AccountDeviceRuntime::new(
+        alice,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    runtime.pause_maintenance();
+    assert!(
+        runtime
+            .send_leased(SendIntent::Leave {
+                group_id: group_id.clone(),
+            })
+            .await
+            .is_err(),
+        "an admin SelfRemove must fail before engine acceptance"
+    );
+    assert!(
+        runtime
+            .send_leased(SendIntent::Leave {
+                group_id: group_id.clone(),
+            })
+            .await
+            .is_err(),
+        "a second pre-acceptance Leave must leave a newer Header"
+    );
+    let later_id = MessageId::new(b"later-leave".to_vec());
+    runtime
+        .session()
+        .storage_handle()
+        .put_leave_request(&cgka_traits::storage::LeaveRequest {
+            group_id: group_id.clone(),
+            requested_at_ms: 1,
+            last_proposed_epoch: None,
+            last_proposed_message_id: Some(later_id.clone()),
+        })
+        .unwrap();
+    drop(runtime);
+
+    let reopened = session_with_registry(
+        &database,
+        &key,
+        b"stale-leave-header",
+        selfremove_registry(),
+    );
+    let mut restarted = AccountDeviceRuntime::new(
+        reopened,
+        RecordingAdapter::default(),
+        route(),
+        RecordingKeyPackages::default(),
+    );
+    restarted.pause_maintenance();
+    let replayed = restarted
+        .replay_visibility_leased()
+        .unwrap()
+        .expect("both pre-acceptance Headers remain crash-visible");
+    let leave_headers = replayed
+        .batches
+        .iter()
+        .filter_map(|batch| match &batch.source {
+            AccountVisibilitySource::Outbound {
+                group_id: Some(source_group),
+                action: Some(AccountVisibilityOutboundAction::Leave),
+                action_message_id,
+                ..
+            } if source_group == &group_id => Some((batch.sequence, action_message_id.clone())),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(leave_headers.len(), 2);
+    let max_seq = leave_headers
+        .iter()
+        .map(|(sequence, _)| *sequence)
+        .max()
+        .unwrap();
+    for (sequence, bound) in &leave_headers {
+        if *sequence == max_seq {
+            assert_eq!(bound.as_ref(), Some(&later_id));
+        } else {
+            assert_eq!(
+                bound, &None,
+                "an older unacknowledged pre-acceptance Header must not inherit a later Leave id"
+            );
+        }
+    }
+    assert!(restarted.acknowledge_visibility_lease(replayed.lease));
+}
+
+// A startup drain can contain both a one-shot hydration/application event and
+// restored durable publish work. Cancelling while that publish is in flight
+// must not require rebuilding the whole AccountDeviceRuntime to see the event
+// again: the retained runtime's following no-inbound drain is the handoff
+// recovery surface.
+#[tokio::test]
+async fn cancelled_drain_replays_visibility_after_restored_publish_blocks() {
+    use cgka_traits::GroupStorage;
+    use cgka_traits::engine::GroupHydrationQuarantineReason;
+    use cgka_traits::group::Group;
+
+    let dir = tempfile::tempdir().unwrap();
+    let key_text = "marmot cancelled drain visibility key";
+    let key = SqlCipherKey::new(key_text).unwrap();
+    let db_path = dir.path().join("alice.sqlite");
+    let mut alice = session(&db_path, &key, b"alice-cancelled-drain");
+
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "cancelled drain source".into(),
+            description: String::new(),
+            members: Vec::new(),
+            required_features: Vec::new(),
+            app_components: Vec::new(),
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id;
+    let create_pending = match created.effects.publish.as_slice() {
+        [PublishWork::GroupCreated { pending, .. }] => *pending,
+        other => panic!("expected one GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(create_pending).await.unwrap();
+
+    // Leave an exact signed evolution and its frozen fanout durable but
+    // unpublished. Reopening recovers the pending evolution, and `drain()`
+    // resumes that fanout in the same call as the hydration event below.
+    let staged = alice
+        .send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some("restored publish".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let (message, pending) = match staged.publish.as_slice() {
+        [PublishWork::GroupEvolution { msg, pending, .. }] => (msg.clone(), *pending),
+        other => panic!("expected one GroupEvolution publish work, got {other:?}"),
+    };
+    let transport_group_id = match &message.envelope {
+        TransportEnvelope::GroupMessage { transport_group_id } => transport_group_id.clone(),
+        other => panic!("expected group-message evolution, got {other:?}"),
+    };
+    let group_endpoint = TransportEndpoint("wss://cancelled-drain-group.example".into());
+    let frozen_request = TransportPublishRequest {
+        account_id: alice.self_id().clone(),
+        message,
+        target: TransportPublishTarget::Group {
+            group_id: group_id.clone(),
+            transport_group_id,
+            endpoints: vec![group_endpoint.clone()],
+        },
+        required_acks: 1,
+    };
+    let frozen_fanout =
+        OutboundFanout::stage(frozen_request, Some(pending), Some(group_id.clone()), 0).unwrap();
+    alice.put_outbound_fanout(&frozen_fanout).unwrap();
+    drop(alice);
+
+    let broken_group = GroupId::new(b"cancelled-drain-broken-group".to_vec());
+    {
+        let storage =
+            SqliteAccountStorage::open_encrypted(&db_path, &SqlCipherKey::new(key_text).unwrap())
+                .unwrap();
+        storage
+            .put_group(&Group {
+                id: broken_group.clone(),
+                name: "broken".into(),
+                description: String::new(),
+                members: Vec::new(),
+                epoch: EpochId(9),
+                required_capabilities: cgka_traits::GroupCapabilities::default(),
+                protocol_profile: ProtocolProfile::Legacy,
+                removed: false,
+                unrecoverable: false,
+                disbanded: None,
+                join_epoch: EpochId(0),
+            })
+            .unwrap();
+    }
+
+    let reopened = session(
+        &db_path,
+        &SqlCipherKey::new(key_text).unwrap(),
+        b"alice-cancelled-drain",
+    );
+    let adapter = RecordingAdapter::default();
+    let gate = adapter.gate_all_publishes();
+    let policy = StaticTransportRouting::new(vec![TransportEndpoint(
+        "wss://cancelled-drain-inbox.example".into(),
+    )])
+    .with_group_route(
+        group_id.clone(),
+        group_id.as_slice().to_vec(),
+        vec![group_endpoint],
+    );
+    let mut runtime = AccountDeviceRuntime::new(
+        reopened,
+        adapter.clone(),
+        policy,
+        RecordingKeyPackages::default(),
+    );
+
+    let mut cancelled = Box::pin(runtime.drain());
+    tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::select! {
+            result = &mut cancelled => {
+                panic!("startup publish returned before cancellation boundary: {result:?}")
+            }
+            () = async {
+                while adapter.publishes().is_empty() {
+                    tokio::task::yield_now().await;
+                }
+            } => {}
+        }
+    })
+    .await
+    .expect("restored publish reaches the blocking adapter");
+    drop(cancelled);
+
+    // The first blocked adapter future was dropped with the drain. Let its
+    // durable exact fanout retry complete on the next call.
+    gate.release.add_permits(1);
+    let recovered = tokio::time::timeout(Duration::from_secs(5), runtime.drain())
+        .await
+        .expect("retained runtime drain completes")
+        .unwrap();
+    assert!(recovered.events.iter().any(|event| matches!(
+        event,
+        GroupEvent::GroupHydrationQuarantined {
+            group_id,
+            reason: GroupHydrationQuarantineReason::OpenMlsGroupMissing,
+        } if group_id == &broken_group
+    )));
+
+    let handed_off = runtime.drain().await.unwrap();
+    assert!(!handed_off.events.iter().any(|event| matches!(
+        event,
+        GroupEvent::GroupHydrationQuarantined { group_id, .. } if group_id == &broken_group
+    )));
+}
+
+#[tokio::test]
+async fn cancelled_later_publish_work_replays_completed_application_effects_without_republishing() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot multi-work visibility key").unwrap();
+    let mut alice = session(
+        dir.path().join("alice-multi-work.sqlite"),
+        &key,
+        b"alice-multi-work",
+    );
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "multi-work visibility".into(),
+            description: String::new(),
+            members: Vec::new(),
+            required_features: Vec::new(),
+            app_components: Vec::new(),
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id;
+    let create_pending = match created.effects.publish.as_slice() {
+        [PublishWork::GroupCreated { pending, .. }] => *pending,
+        other => panic!("expected one GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(create_pending).await.unwrap();
+
+    let mut combined = alice
+        .send(SendIntent::AppMessage {
+            group_id: group_id.clone(),
+            payload: app_payload_for(&hex::encode(alice.self_id().as_slice()), "first"),
+        })
+        .await
+        .unwrap();
+    let second = alice
+        .send(SendIntent::AppMessage {
+            group_id: group_id.clone(),
+            payload: app_payload_for(&hex::encode(alice.self_id().as_slice()), "second"),
+        })
+        .await
+        .unwrap();
+    combined.events.extend(second.events);
+    combined.publish.extend(second.publish);
+    combined.queued.extend(second.queued);
+    combined
+        .pending_convergence
+        .extend(second.pending_convergence);
+
+    let (first_message_id, first_app_event_id) = match &combined.publish[0] {
+        PublishWork::ApplicationMessage {
+            msg, app_event_id, ..
+        } => (msg.id.clone(), app_event_id.clone()),
+        other => panic!("expected first ApplicationMessage, got {other:?}"),
+    };
+    let second_message_id = match &combined.publish[1] {
+        PublishWork::ApplicationMessage { msg, .. } => msg.id.clone(),
+        other => panic!("expected second ApplicationMessage, got {other:?}"),
+    };
+
+    let adapter = RecordingAdapter::default();
+    let gate = adapter.gate_all_publishes();
+    gate.release.add_permits(1);
+    let endpoint = TransportEndpoint("wss://multi-work-group.example".into());
+    let routing = StaticTransportRouting::new(vec![TransportEndpoint(
+        "wss://multi-work-inbox.example".into(),
+    )])
+    .with_group_route(
+        group_id.clone(),
+        group_id.as_slice().to_vec(),
+        vec![endpoint],
+    );
+    let mut runtime = AccountDeviceRuntime::new(
+        alice,
+        adapter.clone(),
+        routing,
+        RecordingKeyPackages::default(),
+    );
+
+    let mut cancelled = Box::pin(runtime.publish_session_effects(combined));
+    tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::select! {
+            result = &mut cancelled => {
+                panic!("both publish work items completed before cancellation: {result:?}")
+            }
+            () = async {
+                while adapter.publishes().len() < 2 {
+                    tokio::task::yield_now().await;
+                }
+            } => {}
+        }
+    })
+    .await
+    .expect("second application publish reaches its blocking adapter");
+    drop(cancelled);
+
+    // The second exact fanout remains durable and retryable. Completing it may
+    // not re-run the first PublishWork; its report and app-acceptance metadata
+    // must instead come from the runtime visibility journal.
+    gate.release.add_permits(1);
+    let recovered = tokio::time::timeout(Duration::from_secs(5), runtime.drain_leased())
+        .await
+        .expect("durable second fanout retry completes")
+        .unwrap();
+    let recovered_visibility = flatten_visibility_batches(&recovered.batches);
+    assert_eq!(
+        recovered_visibility
+            .reports
+            .iter()
+            .filter(|report| report.message_id == first_message_id)
+            .count(),
+        1
+    );
+    assert_eq!(
+        recovered_visibility
+            .published_app_messages
+            .iter()
+            .filter(|published| published.app_event_id == first_app_event_id)
+            .count(),
+        1
+    );
+    let publishes = adapter.publishes();
+    assert_eq!(
+        publishes
+            .iter()
+            .filter(|request| request.message.id == first_message_id)
+            .count(),
+        1,
+        "replay must not publish the completed first item again"
+    );
+    assert_eq!(
+        publishes
+            .iter()
+            .filter(|request| request.message.id == second_message_id)
+            .count(),
+        2,
+        "only the cancelled second fanout should retry"
+    );
+
+    let replayed = runtime.drain_leased().await.unwrap();
+    let replayed_visibility = flatten_visibility_batches(&replayed.batches);
+    assert_eq!(
+        replayed_visibility
+            .published_app_messages
+            .iter()
+            .filter(|published| published.app_event_id == first_app_event_id)
+            .count(),
+        1,
+        "an unacknowledged full-effects lease must replay without duplication"
+    );
+    assert!(!runtime.acknowledge_visibility_lease(recovered.lease));
+    assert!(runtime.acknowledge_visibility_lease(replayed.lease));
+
+    let after_ack = runtime.drain_leased().await.unwrap();
+    assert!(after_ack.effects.published_app_messages.is_empty());
+    assert!(runtime.acknowledge_visibility_lease(after_ack.lease));
+}
+
 // mdk#483 regression: an auto-published commit (here, the admin's
 // auto-commit of a peer self-remove proposal) that a relay *accepted* but that
 // did not meet `required_acks` must be CONFIRMED, not rolled back. Rolling it
@@ -3677,7 +10022,7 @@ async fn auto_publish_confirms_pending_when_commit_was_partially_exposed() {
         },
     };
 
-    let ingested = runtime.ingest_delivery(delivery).await.unwrap();
+    let ingested = runtime.ingest_delivery_leased(delivery).await.unwrap();
     assert_eq!(ingested.effects.pending_convergence, vec![group_id.clone()]);
     assert!(
         ingested.effects.pending.is_empty(),
@@ -3685,20 +10030,40 @@ async fn auto_publish_confirms_pending_when_commit_was_partially_exposed() {
     );
 
     tokio::time::sleep(std::time::Duration::from_millis(75)).await;
-    let advanced = runtime.advance_convergence(&group_id).await.unwrap();
+    let advanced = runtime.advance_convergence_leased(&group_id).await.unwrap();
+
+    assert_eq!(
+        flatten_visibility_batches(&advanced.batches).pending_convergence,
+        vec![group_id.clone()],
+        "the unacknowledged ingest visibility must precede convergence output"
+    );
+    assert!(
+        !runtime.acknowledge_visibility_lease(ingested.lease),
+        "a later lease supersedes the ingest generation"
+    );
 
     // The auto-published commit was accepted by a relay but missed required_acks
     // — it must be confirmed (kept), not rolled back.
-    assert_eq!(advanced.pending.len(), 1);
+    assert_eq!(advanced.effects.pending.len(), 1);
     assert!(
-        matches!(advanced.pending[0], PendingResolution::Confirmed { .. }),
+        matches!(
+            advanced.effects.pending[0],
+            PendingResolution::Confirmed { .. }
+        ),
         "relay-accepted auto-publish must be confirmed, got {:?}",
-        advanced.pending[0]
+        advanced.effects.pending[0]
     );
     // The commit publish was attempted and reported under-threshold acceptance.
-    assert_eq!(advanced.reports.len(), 1);
-    assert_eq!(advanced.reports[0].accepted_count(), 1);
-    assert!(!advanced.reports[0].met_required_acks());
+    assert_eq!(advanced.effects.reports.len(), 1);
+    assert_eq!(advanced.effects.reports[0].accepted_count(), 1);
+    assert!(!advanced.effects.reports[0].met_required_acks());
+    assert!(runtime.acknowledge_visibility_lease(advanced.lease));
+
+    let after_ack = runtime.drain_leased().await.unwrap();
+    assert!(after_ack.effects.pending_convergence.is_empty());
+    assert!(after_ack.effects.pending.is_empty());
+    assert!(after_ack.effects.reports.is_empty());
+    assert!(runtime.acknowledge_visibility_lease(after_ack.lease));
     // The removal was applied locally: epoch advanced and bob is gone.
     assert_eq!(runtime.session().epoch(&group_id).unwrap().0, 2);
     assert_eq!(runtime.session().members(&group_id).unwrap().len(), 1);

--- a/crates/marmot-app/src/client/epoch_stall.rs
+++ b/crates/marmot-app/src/client/epoch_stall.rs
@@ -583,6 +583,15 @@ impl EpochStallDetector {
         self
     }
 
+    /// Override the same-epoch re-arm interval without rebuilding restored
+    /// detector state. Unit tests use this after reopen so their wall-clock
+    /// pacing scenarios stay testable even when the production-policy feature
+    /// set deliberately ignores development config overrides.
+    #[cfg(test)]
+    pub(crate) fn set_wedge_rearm_interval_ms_for_test(&mut self, interval_ms: u64) {
+        self.wedge_rearm_interval_ms = interval_ms;
+    }
+
     /// Escalate a wedged group after `threshold` fruitless end-of-stored-events
     /// completions instead of the production
     /// [`EPOCH_STALL_FRUITLESS_COMPLETION_THRESHOLD`].

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -34,8 +34,8 @@ use zeroize::Zeroizing;
 
 use crate::app_telemetry::AppPerformanceOperation;
 use crate::groups::{
-    EventGroupProjection, GroupConfirmationProjection, add_group, fail_if_publish_failed,
-    publish_failure_error, send_summary_from_effects, validate_group_profile,
+    EventGroupProjection, GroupConfirmationProjection, add_group, publish_failure_error,
+    send_summary_from_effects, validate_group_profile,
 };
 use crate::ids::{admin_pubkey_from_account_id_hex, admin_pubkey_from_member_id};
 use crate::media::{
@@ -47,11 +47,12 @@ use crate::media::{
 use crate::messages::{AppMessageIntent, build_inner_event, encode_inner_event};
 use crate::notifications;
 use crate::{
-    AccountState, AgentOperationEventRequest, AgentTextStreamFinishRequest, AppBlobEndpoint,
-    AppCreateGroupOptions, AppDisbandRequest, AppError, AppGroupAdminPolicyComponent,
-    AppGroupAvatarUrlComponent, AppGroupEncryptedMediaComponent, AppGroupImageComponent,
-    AppGroupImageInput, AppGroupMemberRecord, AppGroupMessageRetentionComponent, AppGroupMlsState,
-    AppGroupRecord, AppInitialGroupImage, AppPerformanceTelemetry, AppPreparedGroupImageUpload,
+    AccountRelayListBootstrap, AccountState, AgentOperationEventRequest,
+    AgentTextStreamFinishRequest, AppBlobEndpoint, AppCreateGroupOptions, AppDisbandRequest,
+    AppError, AppGroupAdminPolicyComponent, AppGroupAvatarUrlComponent,
+    AppGroupEncryptedMediaComponent, AppGroupImageComponent, AppGroupImageInput,
+    AppGroupMemberRecord, AppGroupMessageRetentionComponent, AppGroupMlsState, AppGroupRecord,
+    AppInitialGroupImage, AppPerformanceTelemetry, AppPreparedGroupImageUpload,
     AppPreparedGroupImageUploadState, AppQuarantinedGroup, AppRoutingState, AppRuntime,
     AppTransportRouting, CanonicalCreatedGroup, GroupInviteDeclineResult, MarmotApp,
     MarmotRelayPlane, MarmotRelayPlaneAccountAdapter, MediaAttachmentReference,
@@ -284,9 +285,30 @@ pub(crate) struct GroupRouteRefresh {
     pub(crate) state_pruned: bool,
 }
 
+/// Durable account-runtime effects currently leased to this app client.
+///
+/// A newer runtime handoff supersedes the lease generation but contains every
+/// still-unacknowledged row, so staged ids are retained only when they remain
+/// present in the replacement batch set. `projection_operation_id` selects the
+/// source-attributed operation whose event rows the app is presently applying.
+pub(crate) struct PendingAccountVisibilityLease {
+    pub(crate) lease: marmot_account::AccountVisibilityLease,
+    pub(crate) batches: Vec<marmot_account::AccountVisibilityBatch>,
+    pub(crate) staged_batch_ids: Vec<Vec<u8>>,
+    pub(crate) projection_operation_id: Option<Vec<u8>>,
+}
+
 pub struct AppClient {
     pub(crate) app: MarmotApp,
     pub(crate) runtime: AppRuntime,
+    /// Exact account identity admitted when this exclusive session opened.
+    /// A label may be removed and later recreated, so stale-client boundaries
+    /// must compare both fields against the live AccountHome record.
+    pub(crate) account_id_hex: String,
+    /// Monotonic process-local capability captured before this session's
+    /// unabortable open. Sign-out advances and closes the generation, so this
+    /// client stays stale after any later explicit sign-in.
+    pub(crate) session_admission: crate::AccountSessionAdmission,
     // Struct fields drop in declaration order. Keep the engine-owning runtime
     // before this guard so ownership is released only after engine teardown.
     pub(crate) _session_guard: crate::AppAccountSessionGuard,
@@ -322,12 +344,21 @@ pub struct AppClient {
     /// sync summary so live chat-list/group-state subscriptions observe the
     /// applied commits.
     pub(crate) pending_applied_sync_summary: crate::SyncSummary,
-    /// App-visible outputs ingested during a sync whose account-projection
-    /// checkpoint failed. A retained client keeps the matching projected state
-    /// and outbox acknowledgements, then returns this summary after its next
-    /// successful checkpoint. A reopened client recovers the same outputs from
-    /// the durable engine outbox instead.
-    pub(crate) pending_failed_sync_summary: crate::SyncSummary,
+    /// App-visible output projected since the last successful account-state
+    /// checkpoint. `Some` is an occupied aggregate, including a meaningful
+    /// empty wake batch. Projection state and engine-outbox acknowledgements
+    /// remain staged beside it, so a retained client can checkpoint it later
+    /// and a reopened client can recover it from the durable engine outbox.
+    pub(crate) pending_uncheckpointed_sync_summary: Option<crate::SyncSummary>,
+    /// App-visible output whose projection and engine-outbox acknowledgements
+    /// committed, but which no outer seam has taken for return or publication
+    /// yet. This bounded aggregate is process-local ownership (visibility V2):
+    /// cancellation and unrelated saves cannot strand it, but a process restart
+    /// does not replay it because its engine outbox row is already acknowledged.
+    /// The runtime handoff is an at-most-once broadcast attempt, not subscriber
+    /// receipt; lagged/new subscribers recover materialized state by snapshot.
+    /// Durable engine replay protects only the uncheckpointed V1 slot above.
+    pub(crate) pending_checkpointed_sync_summary: Option<crate::SyncSummary>,
     /// Epoch-stall escalations the detector has raised but no caller has been
     /// handed yet.
     ///
@@ -346,12 +377,21 @@ pub struct AppClient {
     /// acknowledged on the durable engine-to-app outbox. The acknowledgement is
     /// committed with the account projection and any frontier clear.
     pub(crate) pending_application_event_acks: HashSet<MessageId>,
-    /// A live ingest changed the in-memory transport routing table after its
-    /// durable projection was committed. The account worker publishes the
-    /// resulting app summary before it asks the relay plane to rebuild its
-    /// ordinary group subscriptions; failures remain armed here for bounded
-    /// background retry instead of turning the already-applied ingest into an
-    /// apparent receive failure.
+    /// Complete lower account-effects rows awaiting the same projection
+    /// transaction. Stable row ids move here only after their source-specific
+    /// projection semantics complete; the save deletes them atomically with
+    /// projection state and engine application-event acknowledgements.
+    pub(crate) pending_account_visibility_lease: Option<PendingAccountVisibilityLease>,
+    /// A projected-but-uncheckpointed batch changed group routing. A successful
+    /// common state save transfers this intent to the runtime retry bit in the
+    /// same synchronous promotion that moves visibility V1 to V2.
+    pub(crate) pending_uncheckpointed_runtime_group_subscription_refresh: bool,
+    /// A live ingest or no-inbound engine drain changed the in-memory transport
+    /// routing table after its durable projection was committed. The account
+    /// worker publishes the resulting app summary before it asks the relay
+    /// plane to rebuild ordinary group subscriptions; failures remain armed
+    /// here for bounded background retry instead of turning already-applied
+    /// output into an apparent receive failure.
     pub(crate) pending_runtime_group_subscription_refresh: bool,
     /// Last transport cursor promoted by a completed drain checkpoint. Live
     /// one-at-a-time worker ingests may advance `state` for diagnostics, but
@@ -363,11 +403,35 @@ pub struct AppClient {
     /// and EOSE-gated recovery must complete before the cursor is trusted.
     pub(crate) delivery_overflow_recovery_pending: bool,
     pub(crate) delivery_overflow_recovery_marker_token: Option<u64>,
+    /// New-message notification fanout deferred until the worker has published
+    /// the send-applied visibility summary. Keeping only group ids deduplicates
+    /// a burst of sends without placing acknowledged app visibility behind a
+    /// best-effort network await.
+    pub(crate) pending_new_message_notification_groups: HashSet<GroupId>,
     /// Unit-test fault injection for the account-open replay path. This keeps
     /// the live protocol group intact while exercising a missing best-effort
     /// app projection.
     #[cfg(test)]
     pub(crate) force_event_group_projection_unavailable: bool,
+    /// Deterministically pause a catch-up pass after one delivery's projection
+    /// has entered visibility V1 and before the next receive/checkpoint.
+    #[cfg(test)]
+    pub(crate) block_after_sync_delivery_projection:
+        Option<(Arc<tokio::sync::Notify>, Arc<tokio::sync::Notify>)>,
+    /// Deterministically pause a sync after its relay prefix checkpoint,
+    /// exercising visibility V2 cancellation without adding a production
+    /// await after that checkpoint.
+    #[cfg(test)]
+    pub(crate) block_after_sync_prefix_checkpoint:
+        Option<(Arc<tokio::sync::Notify>, Arc<tokio::sync::Notify>)>,
+    /// Fail after a convergence retry has durably finalized timeline rows but
+    /// before the method returns to its worker.
+    #[cfg(test)]
+    pub(crate) fail_after_convergence_retry_finalize: bool,
+    /// Skip singleton-journal prune after a committed local delete so tests can
+    /// inject the crash window between wipe and backfill cleanup.
+    #[cfg(test)]
+    pub(crate) skip_epoch_backfill_prune_on_delete: bool,
     /// Welcomes queued for re-delivery during the most recent create/invite.
     /// The runtime account worker drains this after the command and broadcasts a
     /// `WelcomeDeliveryPending` event so callers learn a member is unjoinable
@@ -383,12 +447,22 @@ pub struct AppClient {
     /// Earliest instant an automatic seam may retry a pending epoch-gap
     /// backfill whose last attempt could not confirm its replay.
     ///
-    /// Process-local on purpose: the intent it paces is durable, so a restart
-    /// costs at most one unpaced attempt, while persisting a monotonic deadline
-    /// would mean durable schema for a scheduling hint.
+    /// Restored from the singleton intent journal so a restart cannot spin a
+    /// fruitless replay at full speed. The remaining duration is stored as a
+    /// wall-clock deadline beside the durable intent set.
     pub(crate) epoch_backfill_retry_not_before: Option<Instant>,
     /// Armed epoch-gap recovery intent awaiting its account-wide replay.
     pub(crate) pending_epoch_backfill: Option<epoch_stall::PendingEpochBackfill>,
+    /// Recovery intent currently owned by an in-flight replay. Unlike the
+    /// future-local execution timer/snapshot, this copy is persisted and stays
+    /// client-owned until terminal finish. Cancellation therefore turns it
+    /// back into pending work instead of forgetting the replay.
+    pub(crate) active_epoch_backfill: Option<epoch_stall::PendingEpochBackfill>,
+    /// The in-memory intent set has not yet been durably mirrored. A failed
+    /// journal write must stay retryable even after the detector latched the
+    /// arm that produced it; otherwise a later worker abort could forget the
+    /// only executable repair intent.
+    pub(crate) epoch_backfill_intent_journal_dirty: bool,
     /// Additional armed intents queued behind [`Self::pending_epoch_backfill`]
     /// when a replay failure must not overwrite a newer arm minted in flight.
     pub(crate) queued_epoch_backfills:
@@ -596,6 +670,149 @@ fn record_app_performance(
 }
 
 impl AppClient {
+    fn active_session_admission_token(
+        &self,
+    ) -> Result<crate::AccountSessionAdmissionToken, AppError> {
+        match &self.session_admission {
+            crate::AccountSessionAdmission::Active(token) => Ok(token.clone()),
+            crate::AccountSessionAdmission::Teardown(_) => Err(AppError::Publish(
+                "teardown cleanup clients cannot perform active-account operations".into(),
+            )),
+        }
+    }
+
+    pub(crate) fn ensure_session_account(&self) -> Result<(), AppError> {
+        match &self.session_admission {
+            crate::AccountSessionAdmission::Active(_) => self.ensure_active_signing_account(),
+            crate::AccountSessionAdmission::Teardown(_) => self.ensure_teardown_cleanup_account(),
+        }
+    }
+
+    pub(crate) fn ensure_active_signing_account(&self) -> Result<(), AppError> {
+        let crate::AccountSessionAdmission::Active(session_admission) = &self.session_admission
+        else {
+            return Err(AppError::Publish(
+                "teardown cleanup clients cannot perform active-account operations".into(),
+            ));
+        };
+        let live_account_matches = self
+            .app
+            .account_home()
+            .account(&self.state.label)
+            .is_ok_and(|account| {
+                account.is_active_signing() && account.account_id_hex == self.account_id_hex
+            });
+        if live_account_matches
+            && self
+                .app
+                .account_session_admission_is_current(&self.state.label, session_admission)
+        {
+            Ok(())
+        } else {
+            Err(AppError::Publish(
+                "account is signed out, removed, or no longer matches this client session".into(),
+            ))
+        }
+    }
+
+    pub(crate) fn ensure_teardown_cleanup_account(&self) -> Result<(), AppError> {
+        let crate::AccountSessionAdmission::Teardown(session_admission) = &self.session_admission
+        else {
+            return Err(AppError::AccountWorkerBusy);
+        };
+        let live_account_matches = self
+            .app
+            .account_home()
+            .account(&self.state.label)
+            .is_ok_and(|account| {
+                account.signed_out && account.account_id_hex == self.account_id_hex
+            });
+        if live_account_matches
+            && self
+                .app
+                .account_teardown_session_admission_is_current(&self.state.label, session_admission)
+        {
+            Ok(())
+        } else {
+            Err(AppError::AccountWorkerBusy)
+        }
+    }
+
+    pub(crate) async fn publish_account_nip65_relay_set(
+        &mut self,
+        read_relays: Vec<TransportEndpoint>,
+        write_relays: Vec<TransportEndpoint>,
+        bootstrap_relays: Vec<TransportEndpoint>,
+    ) -> Result<crate::AccountRelayListStatus, AppError> {
+        self.ensure_active_signing_account()?;
+        let session_admission = self.active_session_admission_token()?;
+        let status = self
+            .app
+            .publish_account_nip65_relay_set_for_session(
+                &self.state.label,
+                read_relays,
+                write_relays,
+                bootstrap_relays,
+                &session_admission,
+            )
+            .await?;
+        self.refresh_routing()?;
+        let app = self.app.clone();
+        app.finish_client_open_network_maintenance(self).await;
+        Ok(status)
+    }
+
+    pub(crate) async fn set_account_nip65_relays(
+        &mut self,
+        relays: Vec<TransportEndpoint>,
+        bootstrap_relays: Vec<TransportEndpoint>,
+    ) -> Result<crate::AccountRelayListStatus, AppError> {
+        // Keep the role-preserving read behind worker admission. A signed-out
+        // caller must fail before reopening the per-account directory cache.
+        self.ensure_active_signing_account()?;
+        let current = self.app.account_relay_list_status(&self.state.label)?.nip65;
+        let relay_set = crate::nip65_relay_set_preserving_roles(&current, relays);
+        self.publish_account_nip65_relay_set(
+            relay_set.read_relays,
+            relay_set.write_relays,
+            bootstrap_relays,
+        )
+        .await
+    }
+
+    pub(crate) async fn publish_account_inbox_relays(
+        &mut self,
+        relays: Vec<TransportEndpoint>,
+        bootstrap_relays: Vec<TransportEndpoint>,
+    ) -> Result<crate::AccountRelayListStatus, AppError> {
+        self.ensure_active_signing_account()?;
+        let session_admission = self.active_session_admission_token()?;
+        self.app
+            .publish_account_inbox_relays_for_session(
+                &self.state.label,
+                relays,
+                bootstrap_relays,
+                &session_admission,
+            )
+            .await
+    }
+
+    pub(crate) async fn ingest_self_nip65_relay_event(
+        &mut self,
+        record: crate::relay_plane::DirectoryRelayEventRecord,
+    ) -> Result<crate::AccountRelayListStatus, AppError> {
+        let route_lock = self.app.key_package_route_lock(&self.state.label);
+        let status = {
+            let _route_guard = route_lock.lock().await;
+            self.app
+                .ingest_local_nip65_relay_event_unlocked(&self.state.label, record)?
+        };
+        self.refresh_routing()?;
+        let app = self.app.clone();
+        app.finish_client_open_network_maintenance(self).await;
+        Ok(status)
+    }
+
     /// Persist the exact first KeyPackage and signed publication artifact
     /// without activating transport or contacting a relay.
     pub(crate) async fn prepare_initial_key_package(
@@ -606,10 +823,45 @@ impl AppClient {
     }
 
     pub async fn publish_key_package(&mut self) -> Result<KeyPackage, AppError> {
+        // Reject stale sessions before any route refresh, lifecycle read, or
+        // cache open. The final publisher repeats this proof under the route
+        // lock to close the race with a concurrent sign-out/removal commit.
+        self.ensure_active_signing_account()?;
+        let session_admission = self.active_session_admission_token()?;
+        // This public call is the explicit user action that supersedes a
+        // generated setup's durable initial-publication hold. While setup is
+        // still incomplete, recover its context-bound route before releasing
+        // that hold; a direct client must never reinterpret the app fallback
+        // as the generated account's requested authority.
+        if self
+            .app
+            .generated_initial_key_package_publication_held(&self.state.label)?
+        {
+            let generated_setup_incomplete = self
+                .app
+                .account_home()
+                .account_setup_state(&self.state.label)?
+                .is_some_and(|state| {
+                    state.kind == marmot_account::AccountSetupKind::GeneratedIdentity
+                });
+            if generated_setup_incomplete {
+                self.recover_generated_setup_nip65_authority_inner(false)
+                    .await?;
+            } else {
+                self.app
+                    .clear_generated_initial_key_package_publication_hold_for_session(
+                        &self.state.label,
+                        &session_admission,
+                    )
+                    .await?;
+            }
+        }
         self.app
-            .ensure_local_account_relay_lists(&self.state.label)
+            .ensure_local_account_relay_lists_for_session(&self.state.label, &session_admission)
             .await?;
         self.refresh_routing()?;
+        self.ensure_key_package_cutover_ready_for_publication()
+            .await?;
         self.runtime.activate_transport(None).await?;
         self.publish_key_package_from_lifecycle().await
     }
@@ -619,11 +871,77 @@ impl AppClient {
     /// managed worker runs this only for `KeyPackagePublicationStarted`; all
     /// general publication continues through [`Self::publish_key_package`].
     pub(crate) async fn publish_setup_key_package(&mut self) -> Result<KeyPackage, AppError> {
-        self.app
-            .ensure_local_account_relay_lists(&self.state.label)
-            .await?;
+        let generated_fresh_replacement = self
+            .runtime
+            .key_package_maintenance_status()?
+            .as_ref()
+            .map(|lifecycle| {
+                self.app
+                    .generated_account_fresh_replacement_can_open_cutover_gate(
+                        &self.state.label,
+                        lifecycle,
+                    )
+            })
+            .transpose()?
+            .unwrap_or(false);
+        if !generated_fresh_replacement {
+            let session_admission = self.active_session_admission_token()?;
+            self.app
+                .ensure_local_account_relay_lists_for_session(&self.state.label, &session_admission)
+                .await?;
+        }
         self.refresh_routing()?;
         self.publish_key_package_from_lifecycle().await
+    }
+
+    /// Recover the exact route intent persisted by generated-account local
+    /// preparation before the setup-priority KeyPackage publisher runs. The
+    /// generic app fallback is never route authority for this lane.
+    pub(crate) async fn recover_generated_setup_nip65_authority(&mut self) -> Result<(), AppError> {
+        self.recover_generated_setup_nip65_authority_inner(true)
+            .await
+    }
+
+    async fn recover_generated_setup_nip65_authority_inner(
+        &mut self,
+        require_setup_publication_intent: bool,
+    ) -> Result<(), AppError> {
+        let session_admission = self.active_session_admission_token()?;
+        let context = self
+            .app
+            .account_home()
+            .account_setup_context(&self.state.label)?
+            .ok_or(AppError::AccountSetupRetryRequired)
+            .and_then(|bytes| {
+                serde_json::from_slice::<crate::runtime::GeneratedAccountSetupContext>(&bytes)
+                    .map_err(AppError::from)
+            })?;
+        if require_setup_publication_intent && !context.publish_initial_key_package() {
+            return Err(AppError::Publish(
+                "generated setup did not authorize initial KeyPackage publication".into(),
+            ));
+        }
+        let request = context.request();
+        let bootstrap =
+            AccountRelayListBootstrap::new(request.default_relays, request.bootstrap_relays);
+        let proof = self
+            .app
+            .recover_generated_account_nip65_route_authority_for_session(
+                &self.state.label,
+                &bootstrap,
+                self.transport_signer.clone(),
+                &session_admission,
+            )
+            .await?;
+        self.refresh_routing()?;
+        self.app
+            .open_generated_account_key_package_publication_gate(
+                &self.state.label,
+                &bootstrap,
+                &proof,
+                &session_admission,
+            )
+            .await
     }
 
     async fn publish_key_package_from_lifecycle(&mut self) -> Result<KeyPackage, AppError> {
@@ -642,6 +960,63 @@ impl AppClient {
         }
     }
 
+    async fn ensure_key_package_cutover_ready_for_publication(&mut self) -> Result<(), AppError> {
+        let lifecycle = self.runtime.key_package_maintenance_status()?;
+        let durable_gate_open = lifecycle
+            .as_ref()
+            .is_some_and(|lifecycle| !lifecycle.cutover_publication_blocked);
+        let generated_fresh_admission = lifecycle
+            .as_ref()
+            .map(|lifecycle| {
+                self.app
+                    .generated_account_fresh_replacement_can_open_cutover_gate(
+                        &self.state.label,
+                        lifecycle,
+                    )
+            })
+            .transpose()?
+            .unwrap_or(false)
+            && self
+                .app
+                .generated_initial_key_package_publication_held(&self.state.label)
+                .is_ok_and(|held| !held);
+        if durable_gate_open
+            && self
+                .app
+                .key_package_cutover_publication_allowed(&self.state.label)
+            && (!self
+                .app
+                .key_package_cutover_replacement_pending(&self.state.label)
+                || generated_fresh_admission)
+        {
+            return Ok(());
+        }
+
+        // This runs under the AppClient/account-worker single-writer boundary.
+        // Arm before discovery so a failed or cancelled scan cannot leave a
+        // later maintenance tick publication-open.
+        self.runtime
+            .set_key_package_cutover_publication_blocked(true)?;
+        let app = self.app.clone();
+        app.finish_client_open_network_maintenance(self).await;
+        let durable_gate_open = self
+            .runtime
+            .key_package_maintenance_status()?
+            .is_some_and(|lifecycle| !lifecycle.cutover_publication_blocked);
+        if durable_gate_open
+            && self
+                .app
+                .key_package_cutover_publication_allowed(&self.state.label)
+        {
+            Ok(())
+        } else {
+            Err(AppError::Publish(
+                "key package publication remains blocked until strict relay cutover completes"
+                    .into(),
+            ))
+        }
+    }
+
     pub fn maintenance_status(
         &self,
         group_id: &GroupId,
@@ -654,6 +1029,74 @@ impl AppClient {
         &self,
     ) -> Result<Option<cgka_traits::KeyPackageLifecycleState>, AppError> {
         Ok(self.runtime.key_package_maintenance_status()?)
+    }
+
+    pub(crate) async fn delete_key_package_revision_durably(
+        &mut self,
+        event_id: &cgka_traits::MessageId,
+        relays: Vec<TransportEndpoint>,
+    ) -> Result<usize, AppError> {
+        // Reject a stale worker/client before any relay-list read can reopen
+        // account or directory storage after sign-out.
+        self.ensure_active_signing_account()?;
+        let endpoints = if relays.is_empty() {
+            let relay_lists = self
+                .app
+                .account_relay_list_status_for_account_id(&self.account_id_hex)?;
+            self.app.key_package_endpoints(&relay_lists)
+        } else {
+            relays
+        };
+        if endpoints.is_empty() {
+            return Err(AppError::MissingRelayLists(vec![
+                crate::MissingRelayListKind::Nip65,
+            ]));
+        }
+        let endpoints = self
+            .app
+            .relay_plane
+            .sanitize_relay_endpoints(endpoints, "key package deletion publish")
+            .map_err(|error| {
+                AppError::Transport(cgka_traits::TransportAdapterError::Publish(error))
+            })?;
+        if endpoints.is_empty() {
+            return Err(AppError::MissingRelayLists(vec![
+                crate::MissingRelayListKind::Nip65,
+            ]));
+        }
+        let mut requested = endpoints.clone();
+        requested.sort();
+        requested.dedup();
+        let deletion = self
+            .runtime
+            .delete_key_package_revision_durably(event_id, endpoints)
+            .await;
+        // The deletion publisher arms the relay-history frontier before any
+        // kind-5 I/O. Repair it even when the receipt was partial or failed so
+        // the live worker does not require a restart before its next safe
+        // KeyPackage publication.
+        let repair = self.repair_key_package_history_frontier().await;
+        let (receipt, deferred) = deletion?;
+        repair?;
+        let terminal = receipt
+            .accepted
+            .len()
+            .saturating_add(receipt.confirmed_absent.len());
+        let accounted = terminal
+            .saturating_add(receipt.rejected.len())
+            .saturating_add(receipt.failed.len())
+            .saturating_add(deferred.len());
+        if !receipt.rejected.is_empty()
+            || !receipt.failed.is_empty()
+            || !deferred.is_empty()
+            || terminal == 0
+            || accounted != requested.len()
+        {
+            return Err(AppError::Publish(
+                "one or more relay key package deletions remain retryable".to_owned(),
+            ));
+        }
+        Ok(terminal)
     }
 
     pub fn durably_owned_key_packages(&self) -> Result<Vec<KeyPackage>, AppError> {
@@ -691,6 +1134,19 @@ impl AppClient {
     }
 
     pub async fn run_due_maintenance(&mut self) -> Result<crate::MaintenanceRunSummary, AppError> {
+        self.run_due_maintenance_with_intermediate_handoff(|client, summary| {
+            // A direct caller has no runtime event publisher. Keep V2 on the
+            // retained client so its next sync/worker seam can hand it off.
+            client.retain_checkpointed_sync_summary(summary);
+        })
+        .await
+    }
+
+    pub(crate) async fn run_due_maintenance_with_intermediate_handoff(
+        &mut self,
+        mut handoff: impl FnMut(&mut Self, crate::SyncSummary),
+    ) -> Result<crate::MaintenanceRunSummary, AppError> {
+        self.replay_pending_account_visibility().await?;
         if self.app.cursor_persistence() == crate::CursorPersistence::Frozen {
             self.runtime.sweep_expired_key_package_private_material()?;
             let summary = self
@@ -698,8 +1154,135 @@ impl AppClient {
                 .maintenance_run_summary(&marmot_account::AccountDeviceEffects::default())?;
             return Ok(maintenance_run_summary_from_account(summary));
         }
-        let effects = self.runtime.run_due_maintenance().await?;
-        self.observe_recovery_evidence_then_summarize_maintenance(&effects)
+        // A previous interrupted maintenance tick may have left a strict
+        // post-delete replay pending. Repair before the tick so its first
+        // publication is not spuriously blocked, and again afterward because
+        // this tick can perform another exact retired-revision deletion.
+        let _ = self.repair_key_package_history_frontier().await;
+        let effects = self.runtime.run_due_maintenance_leased().await?;
+        self.install_account_visibility_lease(
+            effects.lease,
+            effects.batches,
+            effects.current_operation_id,
+        );
+        let effects = effects.effects;
+        // Transfer one-shot engine effects into AppClient-owned detector and
+        // projection state before the post-delete relay repair can await,
+        // error, or be cancelled by worker shutdown.
+        let summary = self.checkpoint_maintenance_effects(&effects)?;
+        if let Some(visibility) = self.take_pending_checkpointed_sync_summary() {
+            // No await may intervene between V2 ownership and this handoff.
+            handoff(self, visibility);
+        }
+        self.repair_key_package_history_frontier().await?;
+        Ok(summary)
+    }
+
+    fn checkpoint_maintenance_effects(
+        &mut self,
+        effects: &marmot_account::AccountDeviceEffects,
+    ) -> Result<crate::MaintenanceRunSummary, AppError> {
+        self.checkpoint_maintenance_effects_at(
+            effects,
+            self.current_account_visibility_observed_at(),
+        )
+    }
+
+    fn checkpoint_maintenance_effects_at(
+        &mut self,
+        effects: &marmot_account::AccountDeviceEffects,
+        source_received_at: u64,
+    ) -> Result<crate::MaintenanceRunSummary, AppError> {
+        // Compute the aggregate before mutating app projection state. A summary
+        // decode/storage error must leave the durable lower visibility rows
+        // untouched for replay.
+        let summary = self.runtime.maintenance_run_summary(effects)?;
+        self.observe_recovery_evidence(effects)?;
+        let affected_groups = self.project_current_account_non_session_visibility(effects, None)?;
+
+        // Maintenance reports failures as counts rather than failing the tick.
+        // Reuse the no-inbound projector with only that gate suppressed; its
+        // event-local V1/ACK semantics remain identical to startup drains.
+        let mut projectable = effects.clone();
+        projectable.failures.clear();
+        if let Err(error) =
+            self.observe_drained_session_events_staged_at(&projectable, source_received_at)
+        {
+            self.checkpoint_pending_sync_visibility()?;
+            return Err(error);
+        }
+        for group_id in &affected_groups {
+            self.refresh_group(group_id);
+            if let Err(error) = self.prune_plaintext_retention_for_group(group_id) {
+                self.checkpoint_pending_sync_visibility()?;
+                return Err(error);
+            }
+        }
+        self.stage_current_account_visibility_header_batch();
+        self.checkpoint_pending_sync_visibility()?;
+        Ok(maintenance_run_summary_from_account(summary))
+    }
+
+    async fn repair_key_package_history_frontier(&mut self) -> Result<(), AppError> {
+        let lifecycle = self.runtime.key_package_maintenance_status()?;
+        let gate_is_blocked = lifecycle
+            .as_ref()
+            .is_some_and(|lifecycle| lifecycle.cutover_publication_blocked);
+        if self
+            .app
+            .key_package_cutover_relay_frontier(&self.state.label)?
+            .is_empty()
+            && !gate_is_blocked
+            && self
+                .app
+                .key_package_cutover_publication_allowed(&self.state.label)
+        {
+            return Ok(());
+        }
+        let route_lock = self.app.key_package_route_lock(&self.state.label);
+        let route_guard = route_lock.lock().await;
+        let lifecycle = self.runtime.key_package_maintenance_status()?;
+        let gate_is_blocked = lifecycle
+            .as_ref()
+            .is_some_and(|lifecycle| lifecycle.cutover_publication_blocked);
+        if self
+            .app
+            .key_package_cutover_relay_frontier(&self.state.label)?
+            .is_empty()
+            && !gate_is_blocked
+            && self
+                .app
+                .key_package_cutover_publication_allowed(&self.state.label)
+        {
+            return Ok(());
+        }
+        // The deletion publisher owns the active route lock at its lowest
+        // signer/network boundary. Release this focused repair snapshot before
+        // retirement invokes it, then reacquire for the completion proof.
+        drop(route_guard);
+        let app = self.app.clone();
+        if !app
+            .retire_relay_non_current_key_packages(&self.state.label, &mut self.runtime)
+            .await
+        {
+            return Err(AppError::Publish(
+                "key package relay-history repair remains retryable".into(),
+            ));
+        }
+        let _route_guard = route_lock.lock().await;
+        if !app.key_package_cutover_publication_allowed(&self.state.label) {
+            return Err(AppError::Publish(
+                "key package relay-history repair did not establish a durable completion proof"
+                    .into(),
+            ));
+        }
+        // Preserve the SQL gate byte-for-byte. The durable frontier/marker and
+        // route/history locks already fence every final kind-30443 boundary,
+        // while this focused helper cannot determine whether a pre-existing
+        // gate belongs to cached legacy ambiguity or another full-open repair.
+        // It therefore proves relay history only; the full maintenance path is
+        // the sole owner of SQL-gate reconciliation.
+        Ok(())
     }
 
     /// Observe one maintenance tick's recovery evidence, then summarize the
@@ -724,11 +1307,12 @@ impl AppClient {
     /// pending backfill after a tick, so the intent waits for the next
     /// delivery-driven seam to drain it. The arm and its audit row are durable
     /// meanwhile, so the wait costs latency, not the recovery.
+    #[cfg(test)]
     pub(crate) fn observe_recovery_evidence_then_summarize_maintenance(
         &mut self,
         effects: &marmot_account::AccountDeviceEffects,
     ) -> Result<crate::MaintenanceRunSummary, AppError> {
-        self.observe_recovery_evidence(effects);
+        self.observe_recovery_evidence(effects)?;
         self.queue_own_group_system_projection_updates(effects);
         let summary = self.runtime.maintenance_run_summary(effects)?;
         Ok(maintenance_run_summary_from_account(summary))
@@ -920,10 +1504,17 @@ impl AppClient {
     }
 
     pub async fn rotate_key_package(&mut self) -> Result<KeyPackage, AppError> {
+        // Match explicit publish: a retained client must fail before route
+        // refresh or cache access once sign-out/removal (or same-label
+        // replacement) invalidates the session.
+        self.ensure_active_signing_account()?;
+        let session_admission = self.active_session_admission_token()?;
         self.app
-            .ensure_local_account_relay_lists(&self.state.label)
+            .ensure_local_account_relay_lists_for_session(&self.state.label, &session_admission)
             .await?;
         self.refresh_routing()?;
+        self.ensure_key_package_cutover_ready_for_publication()
+            .await?;
         self.runtime.activate_transport(None).await?;
         // SQLCipher lifecycle state is authoritative. On first rollout the
         // publisher imports only the legacy JSON `d` slot, then performs the
@@ -1971,20 +2562,26 @@ impl AppClient {
             Ok(PreparedSessionSend::Commit(prepared)) => prepared,
             Ok(PreparedSessionSend::Queued(session_effects)) => {
                 let queued = self
-                    .runtime
-                    .publish_prepared_session_effects_with_audit_context(
+                    .publish_prepared_session_effects_with_visibility(
                         session_effects,
                         audit_context,
                     )
-                    .await
-                    .map_err(AppError::from);
+                    .await;
                 record_app_performance(
                     telemetry,
                     AppPerformanceOperation::GroupInviteEnginePublish,
                     engine_publish_started_at.elapsed(),
                     queued.is_ok(),
                 );
-                return queued.map(|effects| send_summary_from_effects(&effects));
+                let effects = queued?;
+                let visibility_complete = self
+                    .project_current_outbound_visibility(&effects, None)
+                    .await?;
+                if visibility_complete {
+                    self.stage_current_account_visibility_header_batch();
+                }
+                self.save_state_with_pending_local_group_deletion_frontier_clears()?;
+                return Ok(send_summary_from_effects(&effects));
             }
             Err(error) => {
                 record_app_performance(
@@ -2014,17 +2611,43 @@ impl AppClient {
             Err(error) => {
                 let rollback = self
                     .runtime
-                    .rollback_prepared_session_commit(prepared)
+                    .rollback_prepared_session_commit_leased(prepared)
                     .await
                     .map_err(AppError::from);
+                let rollback = rollback.map(|leased| {
+                    self.install_account_visibility_lease(
+                        leased.lease,
+                        leased.batches,
+                        leased.current_operation_id,
+                    );
+                    leased.effects
+                });
                 record_app_performance(
                     telemetry,
                     AppPerformanceOperation::GroupInviteEnginePublish,
                     engine_publish_started_at.elapsed(),
                     false,
                 );
-                rollback?;
+                let rollback = rollback?;
+                let visibility_complete = match self
+                    .project_current_outbound_visibility(&rollback, None)
+                    .await
+                {
+                    Ok(complete) => complete,
+                    Err(projection_error) => {
+                        tracing::warn!(
+                            target: "marmot_app::client",
+                            method = "invite_members_intent_failure_rollback",
+                            error_kind = projection_error.privacy_safe_kind(),
+                            "rolled back staged invite but kept its incomplete visibility durable"
+                        );
+                        false
+                    }
+                };
                 self.refresh_group(group_id);
+                if visibility_complete {
+                    self.stage_current_account_visibility_header_batch();
+                }
                 if let Err(refresh_error) =
                     self.save_state_with_pending_local_group_deletion_frontier_clears()
                 {
@@ -2049,13 +2672,11 @@ impl AppClient {
         });
 
         let published = match self
-            .runtime
-            .publish_prepared_session_effects_with_audit_context(
+            .publish_prepared_session_effects_with_visibility(
                 session_effects,
                 audit_context.clone(),
             )
             .await
-            .map_err(AppError::from)
         {
             // Matched rather than chained so the gate can arm first: it
             // previously sat in a combinator closure that could not reach
@@ -2083,8 +2704,12 @@ impl AppClient {
             }
         };
 
+        let visibility_projection = self
+            .project_current_outbound_visibility(&effects, None)
+            .await;
         let local_refresh_started_at = Instant::now();
         let local_refresh = (|| {
+            let visibility_complete = visibility_projection?;
             if cfg!(feature = "test-policy-overrides")
                 && self.app.config.dev_fail_invite_local_refresh
             {
@@ -2092,13 +2717,13 @@ impl AppClient {
                     "injected invite local refresh failure".into(),
                 ));
             }
-            self.record_welcome_delivery_failures(&hex::encode(group_id.as_slice()), &effects)?;
             self.record_human_action_succeeded(group_id, &audit_context, &effects);
-            self.remember_published_reports(&effects);
             self.refresh_group(group_id);
             self.prune_plaintext_retention_for_group(group_id)?;
+            if visibility_complete {
+                self.stage_current_account_visibility_header_batch();
+            }
             self.save_state_with_pending_local_group_deletion_frontier_clears()?;
-            self.queue_own_group_system_projection_updates(&effects);
             Ok::<_, AppError>(())
         })();
         record_app_performance(
@@ -2151,22 +2776,25 @@ impl AppClient {
         self.sync_runtime_groups().await?;
         let wake_snapshot = self.snapshot_group_push_tokens_for_members(group_id, &target_hexes);
         let effects = self
-            .runtime
-            .send_with_audit_context(
+            .send_account_intent_with_visibility(
                 SendIntent::RemoveMembers {
                     group_id: group_id.clone(),
                     members,
                 },
-                audit_context.clone(),
+                Some(audit_context.clone()),
             )
             .await?;
         self.observe_recovery_evidence_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
-        self.remember_published_reports(&effects);
+        let visibility_complete = self
+            .project_current_outbound_visibility(&effects, None)
+            .await?;
         self.refresh_group(group_id);
         self.cleanup_stale_push_tokens_best_effort(group_id);
+        if visibility_complete {
+            self.stage_current_account_visibility_header_batch();
+        }
         self.save_state_with_pending_local_group_deletion_frontier_clears()?;
-        self.queue_own_group_system_projection_updates(&effects);
         self.publish_targeted_group_state_wake_best_effort(
             group_id,
             wake_snapshot,
@@ -2177,14 +2805,41 @@ impl AppClient {
     }
 
     pub async fn leave_group(&mut self, group_id: &GroupId) -> Result<SendSummary, AppError> {
+        let mut handoff = |client: &mut Self| client.retain_direct_send_applied_visibility();
+        self.leave_group_with_handoff(group_id, &mut handoff).await
+    }
+
+    pub(crate) async fn leave_group_with_handoff(
+        &mut self,
+        group_id: &GroupId,
+        visibility_handoff: &mut impl FnMut(&mut Self),
+    ) -> Result<SendSummary, AppError> {
         let audit_context = Self::local_human_action_context(
             "leave_group",
             vec!["membership"],
             Vec::new(),
             Some(1),
         );
-        self.leave_group_with_audit_context(group_id, audit_context)
+        self.leave_group_with_audit_context(group_id, audit_context, visibility_handoff)
             .await
+    }
+
+    pub(crate) async fn leave_group_for_teardown(
+        &mut self,
+        group_id: &GroupId,
+    ) -> Result<SendSummary, AppError> {
+        self.ensure_teardown_cleanup_account()?;
+        let audit_context = Self::local_human_action_context(
+            "leave_group",
+            vec!["membership"],
+            Vec::new(),
+            Some(1),
+        );
+        let result = self
+            .leave_group_with_audit_context(group_id, audit_context, &mut |_| {})
+            .await;
+        self.ensure_teardown_cleanup_account()?;
+        result
     }
 
     /// Atomically install lifecycle-v1 and make it required for this group.
@@ -2204,18 +2859,22 @@ impl AppClient {
         );
         self.sync_runtime_groups().await?;
         let effects = self
-            .runtime
-            .send_with_audit_context(
+            .send_account_intent_with_visibility(
                 SendIntent::EnableDisbanding {
                     group_id: group_id.clone(),
                 },
-                audit_context.clone(),
+                Some(audit_context.clone()),
             )
             .await?;
         self.observe_recovery_evidence_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
-        self.remember_published_reports(&effects);
+        let visibility_complete = self
+            .project_current_outbound_visibility(&effects, None)
+            .await?;
         self.refresh_group(group_id);
+        if visibility_complete {
+            self.stage_current_account_visibility_header_batch();
+        }
         self.save_state_with_pending_local_group_deletion_frontier_clears()?;
         // Enabling lifecycle-v1 changes eligibility, not group history. It
         // intentionally emits no kind-1210 system row.
@@ -2240,15 +2899,16 @@ impl AppClient {
         );
         self.sync_runtime_groups().await?;
         let effects = self
-            .runtime
-            .send_with_audit_context(
+            .send_account_intent_with_visibility(
                 SendIntent::Disband {
                     group_id: group_id.clone(),
                 },
-                audit_context,
+                Some(audit_context),
             )
             .await?;
-        self.remember_published_reports(&effects);
+        let visibility_complete = self
+            .project_current_outbound_visibility(&effects, None)
+            .await?;
         if let Err(error) = self
             .app
             .delete_message_draft(&self.state.label, &hex::encode(group_id.as_slice()))
@@ -2263,6 +2923,9 @@ impl AppClient {
                 error_kind = error.privacy_safe_kind(),
                 "durable disband request outpaced composer draft cleanup"
             );
+        }
+        if visibility_complete {
+            self.stage_current_account_visibility_header_batch();
         }
         self.save_state_with_pending_local_group_deletion_frontier_clears()?;
         self.runtime
@@ -2285,14 +2948,27 @@ impl AppClient {
     /// restored without restoring the projection. The durable deletion frontier
     /// filters historical replay until a strictly newer app message arrives.
     pub async fn delete_group_local(&mut self, group_id: &GroupId) -> Result<bool, AppError> {
+        let mut handoff = |client: &mut Self| client.retain_direct_send_applied_visibility();
+        self.delete_group_local_with_handoff(group_id, &mut handoff)
+            .await
+    }
+
+    pub(crate) async fn delete_group_local_with_handoff(
+        &mut self,
+        group_id: &GroupId,
+        visibility_handoff: &mut impl FnMut(&mut Self),
+    ) -> Result<bool, AppError> {
         if self.runtime.disbanding_in_progress(group_id)? {
             return Err(AppError::GroupDisbanding(hex::encode(group_id.as_slice())));
         }
         // A local wipe removes this group's transport route. Any already-durable
         // removal must publish first; retaining it after the route disappears
         // would preserve bytes on disk without preserving liveness.
-        self.drain_existing_push_registration_removals_for_group(group_id)
-            .await?;
+        self.drain_existing_push_registration_removals_for_group_with_handoff(
+            group_id,
+            visibility_handoff,
+        )
+        .await?;
         let group_id_hex = hex::encode(group_id.as_slice());
         let original_groups = self.state.groups.clone();
         let original_routing = self.routing.snapshot();
@@ -2367,6 +3043,11 @@ impl AppClient {
                 }
             }
         }
+        #[cfg(test)]
+        if self.skip_epoch_backfill_prune_on_delete {
+            return Ok(was_live || result);
+        }
+        self.prune_deleted_epoch_backfill_group(group_id);
         Ok(was_live || result)
     }
 
@@ -2392,6 +3073,7 @@ impl AppClient {
         &mut self,
         group_id: &GroupId,
         audit_context: AuditEventContext,
+        visibility_handoff: &mut impl FnMut(&mut Self),
     ) -> Result<SendSummary, AppError> {
         self.ensure_group(group_id)?;
 
@@ -2399,17 +3081,19 @@ impl AppClient {
         // removal. Drain that durable intent first; if the leave later fails,
         // queue the current registration update as compensation.
         let removed_registration = self
-            .drain_push_registration_removal_before_departure(group_id)
+            .drain_push_registration_removal_before_departure_with_handoff(
+                group_id,
+                visibility_handoff,
+            )
             .await?;
         let effects = match async {
             self.sync_runtime_groups().await?;
             let effects = self
-                .runtime
-                .send_with_audit_context(
+                .send_account_intent_with_visibility(
                     SendIntent::Leave {
                         group_id: group_id.clone(),
                     },
-                    audit_context.clone(),
+                    Some(audit_context.clone()),
                 )
                 .await?;
             self.observe_recovery_evidence_then_fail_if_publish_failed(&effects)?;
@@ -2424,31 +3108,25 @@ impl AppClient {
                     removed_registration.as_ref(),
                 );
                 let _ = self
-                    .retry_pending_push_registration_shares_best_effort()
+                    .retry_pending_push_registration_shares_best_effort_with_handoff(
+                        visibility_handoff,
+                    )
                     .await;
                 return Err(err);
             }
         };
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
-        self.remember_published_reports(&effects);
+        let visibility_complete = self
+            .project_current_outbound_visibility(&effects, None)
+            .await?;
+        if visibility_complete {
+            self.stage_current_account_visibility_header_batch();
+        }
         self.save_state_with_pending_local_group_deletion_frontier_clears()?;
-        self.queue_own_group_system_projection_updates(&effects);
-        // A local leave / decline is a voluntary departure, recorded as `Left`
-        // so the chat list can distinguish it from an involuntary removal. The
-        // inbound `observe_account_device_effects` path records this for an
-        // observed self-removal, but our own relay echoes are skipped, so the
-        // locally initiated departure must record (and thereby suppress) here
-        // too. No-op if no `account_groups` row exists yet, so it never
-        // resurrects pruned projection state. This is the source-of-truth write
-        // for the account unread aggregate, so propagate its error (like the
-        // nearby projection writes) rather than swallow it: a silently failed
-        // update would leave `account_unread_total()` returning an inflated
-        // badge after a leave that otherwise reports success.
-        self.app.set_group_self_membership(
-            &self.state.label,
-            &hex::encode(group_id.as_slice()),
-            SelfMembership::Left,
-        )?;
+        // `Left` is applied from a published Leave action outcome inside
+        // outbound/drain visibility projection, before this Header save. Own
+        // relay echoes are skipped, so that typed outcome is the local
+        // authorization — including crash replay of an unacknowledged Header.
         Ok(send_summary_from_effects(&effects))
     }
 
@@ -2601,6 +3279,16 @@ impl AppClient {
         &mut self,
         group_id: &GroupId,
     ) -> Result<GroupInviteDeclineResult, AppError> {
+        let mut handoff = |client: &mut Self| client.retain_direct_send_applied_visibility();
+        self.decline_group_invite_with_handoff(group_id, &mut handoff)
+            .await
+    }
+
+    pub(crate) async fn decline_group_invite_with_handoff(
+        &mut self,
+        group_id: &GroupId,
+        visibility_handoff: &mut impl FnMut(&mut Self),
+    ) -> Result<GroupInviteDeclineResult, AppError> {
         let audit_context = Self::local_human_action_context(
             "decline_group_invite",
             vec!["membership"],
@@ -2608,7 +3296,7 @@ impl AppClient {
             Some(1),
         );
         let summary = self
-            .leave_group_with_audit_context(group_id, audit_context)
+            .leave_group_with_audit_context(group_id, audit_context, visibility_handoff)
             .await?;
         let group = self.set_group_invite_confirmation(group_id, false, true)?;
         Ok(GroupInviteDeclineResult { group, summary })
@@ -2688,21 +3376,24 @@ impl AppClient {
         self.sync_runtime_groups().await?;
         let wake_snapshot = self.snapshot_group_push_tokens_for_members(group_id, wake_targets);
         let effects = self
-            .runtime
-            .send_with_audit_context(
+            .send_account_intent_with_visibility(
                 SendIntent::UpdateAppComponents {
                     group_id: group_id.clone(),
                     updates: vec![component],
                 },
-                audit_context.clone(),
+                Some(audit_context.clone()),
             )
             .await?;
         self.observe_recovery_evidence_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
-        self.remember_published_reports(&effects);
+        let visibility_complete = self
+            .project_current_outbound_visibility(&effects, None)
+            .await?;
         self.refresh_group(group_id);
+        if visibility_complete {
+            self.stage_current_account_visibility_header_batch();
+        }
         self.save_state_with_pending_local_group_deletion_frontier_clears()?;
-        self.queue_own_group_system_projection_updates(&effects);
         self.publish_targeted_group_state_wake_best_effort(
             group_id,
             wake_snapshot,
@@ -2729,22 +3420,25 @@ impl AppClient {
 
         self.sync_runtime_groups().await?;
         let effects = self
-            .runtime
-            .send_with_audit_context(
+            .send_account_intent_with_visibility(
                 SendIntent::UpdateAppComponents {
                     group_id: group_id.clone(),
                     updates: vec![component],
                 },
-                audit_context.clone(),
+                Some(audit_context.clone()),
             )
             .await?;
         self.observe_recovery_evidence_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
-        self.remember_published_reports(&effects);
+        let visibility_complete = self
+            .project_current_outbound_visibility(&effects, None)
+            .await?;
         self.refresh_group(group_id);
         self.prune_plaintext_retention_for_group(group_id)?;
+        if visibility_complete {
+            self.stage_current_account_visibility_header_batch();
+        }
         self.save_state_with_pending_local_group_deletion_frontier_clears()?;
-        self.queue_own_group_system_projection_updates(&effects);
         Ok(send_summary_from_effects(&effects))
     }
 
@@ -2800,21 +3494,24 @@ impl AppClient {
 
         self.sync_runtime_groups().await?;
         let effects = self
-            .runtime
-            .send_with_audit_context(
+            .send_account_intent_with_visibility(
                 SendIntent::UpdateAppComponents {
                     group_id: group_id.clone(),
                     updates: vec![component],
                 },
-                audit_context.clone(),
+                Some(audit_context.clone()),
             )
             .await?;
         self.observe_recovery_evidence_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
-        self.remember_published_reports(&effects);
+        let visibility_complete = self
+            .project_current_outbound_visibility(&effects, None)
+            .await?;
         self.refresh_group(group_id);
+        if visibility_complete {
+            self.stage_current_account_visibility_header_batch();
+        }
         self.save_state_with_pending_local_group_deletion_frontier_clears()?;
-        self.queue_own_group_system_projection_updates(&effects);
         Ok(send_summary_from_effects(&effects))
     }
 
@@ -2844,21 +3541,24 @@ impl AppClient {
 
         self.sync_runtime_groups().await?;
         let effects = self
-            .runtime
-            .send_with_audit_context(
+            .send_account_intent_with_visibility(
                 SendIntent::UpdateAppComponents {
                     group_id: group_id.clone(),
                     updates: vec![component],
                 },
-                audit_context.clone(),
+                Some(audit_context.clone()),
             )
             .await?;
         self.observe_recovery_evidence_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
-        self.remember_published_reports(&effects);
+        let visibility_complete = self
+            .project_current_outbound_visibility(&effects, None)
+            .await?;
         self.refresh_group(group_id);
+        if visibility_complete {
+            self.stage_current_account_visibility_header_batch();
+        }
         self.save_state_with_pending_local_group_deletion_frontier_clears()?;
-        self.queue_own_group_system_projection_updates(&effects);
         Ok(send_summary_from_effects(&effects))
     }
 
@@ -2867,8 +3567,10 @@ impl AppClient {
         group_id: &GroupId,
         payload: &[u8],
     ) -> Result<SendSummary, AppError> {
-        self.send_with_local_projection(group_id, payload, |_| {})
-            .await
+        let result = self
+            .send_with_local_projection(group_id, payload, |_| {})
+            .await;
+        self.finish_direct_send_visibility(result).await
     }
 
     pub(crate) async fn send_with_local_projection<F>(
@@ -2906,6 +3608,145 @@ impl AppClient {
     ) -> Result<(MarmotInnerEvent, SendSummary), AppError> {
         self.send_app_event_with_local_projection(group_id, intent, |_| {})
             .await
+    }
+
+    /// Complete a send owned directly by an [`AppClient`], rather than by the
+    /// managed account worker. The worker has an outer publication chokepoint;
+    /// a direct client does not, so move any send-applied visibility into V2
+    /// before notification I/O and perform the deferred notification here.
+    async fn finish_direct_send_visibility<T>(
+        &mut self,
+        result: Result<T, AppError>,
+    ) -> Result<T, AppError> {
+        self.retain_direct_send_applied_visibility();
+        // A send can fold a peer commit after its initial subscription sync.
+        // The completed publish must not be reported as failed merely because
+        // this best-effort route rebuild fails; keep the retry intent armed for
+        // the next direct/managed seam instead.
+        if self.has_pending_runtime_group_subscription_refresh()
+            && let Err(error) = self
+                .retry_pending_runtime_group_subscription_refresh()
+                .await
+        {
+            tracing::warn!(
+                target: "marmot_app::messages",
+                method = "finish_direct_send_visibility",
+                error_kind = error.privacy_safe_kind(),
+                "direct send completed but its runtime group subscription refresh failed",
+            );
+        }
+        self.publish_pending_new_message_notifications_best_effort()
+            .await;
+        result
+    }
+
+    fn retain_direct_send_applied_visibility(&mut self) {
+        let applied = self.take_pending_applied_sync_summary();
+        if applied != crate::SyncSummary::default() {
+            self.retain_checkpointed_sync_summary(applied);
+        }
+    }
+
+    /// Project every source-independent effect carried by the current
+    /// outbound visibility operation, then observe its event stream through
+    /// the same pipeline as inbound work. `false` means an event suffix remains
+    /// durable; callers may still checkpoint the completed prefix, but must not
+    /// stage the operation Header.
+    async fn project_current_outbound_visibility(
+        &mut self,
+        effects: &marmot_account::AccountDeviceEffects,
+        deferred_app_event_id: Option<&str>,
+    ) -> Result<bool, AppError> {
+        self.project_current_account_non_session_visibility(effects, deferred_app_event_id)?;
+        Ok(self.observe_send_applied_effects_best_effort(effects).await)
+    }
+
+    /// Exercise the exact generic-outbound visibility checkpoint from app
+    /// integration tests without exposing the internal staging protocol to
+    /// production callers.
+    #[cfg(test)]
+    pub(crate) async fn checkpoint_current_outbound_visibility_for_test(
+        &mut self,
+        effects: &marmot_account::AccountDeviceEffects,
+    ) -> Result<bool, AppError> {
+        let complete = self
+            .project_current_outbound_visibility(effects, None)
+            .await?;
+        if complete {
+            self.stage_current_account_visibility_header_batch();
+        }
+        self.save_state_with_pending_local_group_deletion_frontier_clears()?;
+        Ok(complete)
+    }
+
+    async fn send_account_intent_with_visibility(
+        &mut self,
+        intent: SendIntent,
+        context: Option<AuditEventContext>,
+    ) -> Result<marmot_account::AccountDeviceEffects, AppError> {
+        self.replay_pending_account_visibility().await?;
+        let leased = match context {
+            Some(context) => {
+                self.runtime
+                    .send_with_audit_context_leased(intent, context)
+                    .await?
+            }
+            None => self.runtime.send_leased(intent).await?,
+        };
+        self.install_account_visibility_lease(
+            leased.lease,
+            leased.batches,
+            leased.current_operation_id,
+        );
+        Ok(leased.effects)
+    }
+
+    async fn queue_app_message_with_visibility(
+        &mut self,
+        group_id: GroupId,
+        payload: Vec<u8>,
+        context: AuditEventContext,
+    ) -> Result<marmot_account::AccountDeviceEffects, AppError> {
+        self.replay_pending_account_visibility().await?;
+        let leased = self
+            .runtime
+            .queue_app_message_with_audit_context_leased(group_id, payload, context)
+            .await?;
+        self.install_account_visibility_lease(
+            leased.lease,
+            leased.batches,
+            leased.current_operation_id,
+        );
+        Ok(leased.effects)
+    }
+
+    async fn publish_prepared_session_effects_with_visibility(
+        &mut self,
+        effects: SessionEffects,
+        context: AuditEventContext,
+    ) -> Result<marmot_account::AccountDeviceEffects, AppError> {
+        self.replay_pending_account_visibility().await?;
+        let leased = self
+            .runtime
+            .publish_prepared_session_effects_with_audit_context_leased(effects, context)
+            .await?;
+        self.install_account_visibility_lease(
+            leased.lease,
+            leased.batches,
+            leased.current_operation_id,
+        );
+        Ok(leased.effects)
+    }
+
+    async fn send_app_event_direct(
+        &mut self,
+        group_id: &GroupId,
+        intent: AppMessageIntent,
+    ) -> Result<(MarmotInnerEvent, SendSummary), AppError> {
+        let result = self
+            .send_app_event_with_local_projection(group_id, intent, |_| {})
+            .await;
+        self.finish_direct_send_visibility(result).await
     }
 
     pub(crate) async fn send_app_event_with_local_projection<F>(
@@ -2971,22 +3812,13 @@ impl AppClient {
                 // Thread the human-action context through the engine so the
                 // send's audit rows carry `human_action`, matching
                 // create_group/invite/etc.
-                match &audit_context {
-                    Some(context) => {
-                        self.runtime
-                            .send_with_audit_context(send_intent, context.clone())
-                            .await
-                    }
-                    None => self.runtime.send(send_intent).await,
-                }
-                .map_err(AppError::from)
+                self.send_account_intent_with_visibility(send_intent, audit_context.clone())
+                    .await
             }
             Err(error) if error.is_account_not_active() => {
                 let context = audit_context.clone().unwrap_or_default();
-                self.runtime
-                    .queue_app_message_with_audit_context(group_id.clone(), payload, context)
+                self.queue_app_message_with_visibility(group_id.clone(), payload, context)
                     .await
-                    .map_err(AppError::from)
             }
             Err(error) => Err(error),
         };
@@ -3022,7 +3854,7 @@ impl AppClient {
         if let Some(context) = &audit_context {
             self.record_human_action_succeeded(group_id, context, &effects);
         }
-        self.remember_published_reports(&effects);
+        self.project_current_account_non_session_visibility(&effects, Some(app_event_id.as_str()))?;
         // Discarded deliberately, unlike on the convergence-retry path: the
         // re-record below reprojects the same row with its new source id and
         // hands that update to `on_local_projection`, so forwarding these too
@@ -3059,15 +3891,20 @@ impl AppClient {
         // for the account worker to broadcast; dropping the events here leaves
         // storage renamed while chat-list/group-state subscribers never wake.
         // Best-effort: a projection failure must not fail a completed publish.
-        self.observe_send_applied_effects_best_effort(&effects)
+        let visibility_complete = self
+            .observe_send_applied_effects_best_effort(&effects)
             .await;
+        // The common NonSession projector intentionally deferred this send's
+        // own app-event finalization so the caller callback could receive its
+        // exact update. That finalization and local re-record are now complete.
+        self.stage_current_account_visibility_non_session_batch();
+        if visibility_complete {
+            self.stage_current_account_visibility_header_batch();
+        }
         self.save_state_with_pending_local_group_deletion_frontier_clears()?;
         if published.is_some() && notification_trigger_for_intent(&intent).is_some() {
-            self.publish_notification_trigger_best_effort(
-                group_id,
-                notifications::NotificationTrigger::NewMessage,
-            )
-            .await;
+            self.pending_new_message_notification_groups
+                .insert(group_id.clone());
         }
         Ok((
             event,
@@ -3199,8 +4036,10 @@ impl AppClient {
         target_message_id: &str,
         emoji: &str,
     ) -> Result<SendSummary, AppError> {
-        self.react_to_message_with_local_projection(group_id, target_message_id, emoji, |_| {})
-            .await
+        let result = self
+            .react_to_message_with_local_projection(group_id, target_message_id, emoji, |_| {})
+            .await;
+        self.finish_direct_send_visibility(result).await
     }
 
     pub(crate) async fn react_to_message_with_local_projection<F>(
@@ -3281,7 +4120,7 @@ impl AppClient {
             crate::messages::validate_reaction_content(emoji)?;
         }
         let (_event, summary) = self
-            .send_app_event(
+            .send_app_event_direct(
                 group_id,
                 AppMessageIntent::Unreact {
                     target_message_id: target_message_id.to_owned(),
@@ -3298,7 +4137,7 @@ impl AppClient {
         target_message_id: &str,
     ) -> Result<SendSummary, AppError> {
         let (_event, summary) = self
-            .send_app_event(
+            .send_app_event_direct(
                 group_id,
                 AppMessageIntent::Delete {
                     target_message_id: target_message_id.to_owned(),
@@ -3315,7 +4154,7 @@ impl AppClient {
         text: &str,
     ) -> Result<SendSummary, AppError> {
         let (_event, summary) = self
-            .send_app_event(
+            .send_app_event_direct(
                 group_id,
                 AppMessageIntent::Reply {
                     target_message_id: target_message_id.to_owned(),
@@ -3345,7 +4184,7 @@ impl AppClient {
             )?;
         }
         let (_event, summary) = self
-            .send_app_event(
+            .send_app_event_direct(
                 group_id,
                 AppMessageIntent::Media {
                     attachments,
@@ -3571,8 +4410,7 @@ impl AppClient {
         };
         let data = hex::decode(AppGroupImageComponent::new(input).data_hex)?;
         let effects = self
-            .runtime
-            .send_with_audit_context(
+            .send_account_intent_with_visibility(
                 SendIntent::UpdateAppComponents {
                     group_id: group_id.clone(),
                     updates: vec![AppComponentData {
@@ -3580,16 +4418,20 @@ impl AppClient {
                         data,
                     }],
                 },
-                audit_context.clone(),
+                Some(audit_context.clone()),
             )
             .await?;
         self.observe_recovery_evidence_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
-        self.remember_published_reports(&effects);
+        let visibility_complete = self
+            .project_current_outbound_visibility(&effects, None)
+            .await?;
         let summary = send_summary_from_effects(&effects);
         self.refresh_group(group_id);
+        if visibility_complete {
+            self.stage_current_account_visibility_header_batch();
+        }
         self.save_state_with_pending_local_group_deletion_frontier_clears()?;
-        self.queue_own_group_system_projection_updates(&effects);
         Ok(summary)
     }
 
@@ -3641,14 +4483,16 @@ impl AppClient {
         parent_message_id: Option<String>,
         quic_candidates: Vec<String>,
     ) -> Result<(MarmotInnerEvent, SendSummary), AppError> {
-        self.start_agent_text_stream_with_local_projection(
-            group_id,
-            stream_id,
-            parent_message_id,
-            quic_candidates,
-            |_| {},
-        )
-        .await
+        let result = self
+            .start_agent_text_stream_with_local_projection(
+                group_id,
+                stream_id,
+                parent_message_id,
+                quic_candidates,
+                |_| {},
+            )
+            .await;
+        self.finish_direct_send_visibility(result).await
     }
 
     pub(crate) async fn start_agent_text_stream_with_local_projection<F>(
@@ -3679,8 +4523,10 @@ impl AppClient {
         group_id: &GroupId,
         request: AgentTextStreamFinishRequest,
     ) -> Result<(MarmotInnerEvent, SendSummary), AppError> {
-        self.finish_agent_text_stream_with_local_projection(group_id, request, |_| {})
-            .await
+        let result = self
+            .finish_agent_text_stream_with_local_projection(group_id, request, |_| {})
+            .await;
+        self.finish_direct_send_visibility(result).await
     }
 
     pub(crate) async fn finish_agent_text_stream_with_local_projection<F>(
@@ -3709,7 +4555,7 @@ impl AppClient {
         extra: Option<serde_json::Value>,
     ) -> Result<SendSummary, AppError> {
         let (_event, summary) = self
-            .send_app_event(
+            .send_app_event_direct(
                 group_id,
                 AppMessageIntent::AgentActivity {
                     status,
@@ -3743,7 +4589,7 @@ impl AppClient {
             reply_to_message_id,
         } = request;
         let (_event, summary) = self
-            .send_app_event(
+            .send_app_event_direct(
                 group_id,
                 AppMessageIntent::AgentOperation {
                     event_type,
@@ -3773,7 +4619,7 @@ impl AppClient {
         data: Option<serde_json::Value>,
     ) -> Result<SendSummary, AppError> {
         let (_event, summary) = self
-            .send_app_event(
+            .send_app_event_direct(
                 group_id,
                 AppMessageIntent::GroupSystem {
                     system_type,
@@ -3813,39 +4659,112 @@ impl AppClient {
         &mut self,
         group_id: &GroupId,
     ) -> Result<SendSummary, AppError> {
+        let result = self
+            .retry_group_convergence_with_deferred_notification(group_id)
+            .await;
+        self.finish_direct_convergence_notification(result).await
+    }
+
+    pub(crate) async fn finish_direct_convergence_notification<T>(
+        &mut self,
+        result: Result<T, AppError>,
+    ) -> Result<T, AppError> {
+        // Explicit convergence now observes applied events through the same
+        // durable pipeline as scheduled convergence. Direct callers have no
+        // worker publication chokepoint, so preserve that summary in the
+        // client-owned V2 slot before crossing notification network I/O.
+        if let Err(error) = self.checkpoint_pending_sync_visibility() {
+            tracing::warn!(
+                target: "marmot_app::messages",
+                method = "finish_direct_convergence_notification",
+                error_kind = error.privacy_safe_kind(),
+                "direct convergence left visibility pending after its checkpoint failed",
+            );
+        }
+        self.retain_pending_explicit_convergence_visibility();
+        self.retain_direct_send_applied_visibility();
+        // Direct AppClient callers have no worker completion chokepoint. Own
+        // and finish notification fanout here even when a later projection
+        // tail failed after finalizing an earlier released message.
+        self.publish_pending_new_message_notifications_best_effort()
+            .await;
+        result
+    }
+
+    /// Worker-owned convergence keeps notification I/O deferred until its
+    /// one-shot projection updates have been published to runtime subscribers.
+    pub(crate) async fn retry_group_convergence_with_deferred_notification(
+        &mut self,
+        group_id: &GroupId,
+    ) -> Result<SendSummary, AppError> {
         self.ensure_group(group_id)?;
 
         self.sync_runtime_groups().await?;
-        let effects = self.runtime.advance_convergence(group_id).await?;
-        self.observe_convergence_retry_effects(group_id, &effects)
+        let effects = self.runtime.advance_convergence_leased(group_id).await?;
+        self.install_account_visibility_lease(
+            effects.lease,
+            effects.batches,
+            effects.current_operation_id,
+        );
+        self.observe_convergence_retry_effects(group_id, &effects.effects)
+            .await
     }
 
     /// Project one convergence retry's effects, split from the advance itself so
     /// the projection is exercisable against a given batch of effects.
-    pub(crate) fn observe_convergence_retry_effects(
+    pub(crate) async fn observe_convergence_retry_effects(
         &mut self,
         group_id: &GroupId,
         effects: &marmot_account::AccountDeviceEffects,
     ) -> Result<SendSummary, AppError> {
-        // Observe before the publish gate, for the reason spelled out in
-        // `observe_drained_session_events`.
-        self.observe_recovery_evidence(effects);
-        fail_if_publish_failed(effects)?;
-        self.remember_published_reports(effects);
-        // This is the path that releases sends the engine had retained, so its
-        // finalize updates carry the pending -> delivered flip for each of them.
-        // Unlike the send path — which drops the same updates because it
-        // immediately re-records the row and hands that update to the caller —
-        // there is nothing here to re-emit them, so buffer them for the account
-        // worker to broadcast. Dropping them leaves storage delivered while
-        // every timeline and chat-list subscriber still shows pending.
-        let finalize_updates = self.finalize_published_app_message_source_retention(effects)?;
-        self.pending_projection_updates.extend(finalize_updates);
-        self.refresh_group(group_id);
-        self.prune_plaintext_retention_for_group(group_id)?;
-        self.save_state_with_pending_local_group_deletion_frontier_clears()?;
-        self.queue_own_group_system_projection_updates(effects);
-        Ok(send_summary_from_effects(effects))
+        let send_summary = send_summary_from_effects(effects);
+        let checkpoint = self
+            .checkpoint_scheduled_convergence_effects(group_id, effects)
+            .await;
+        match checkpoint {
+            Ok(visibility) => {
+                self.retain_explicit_convergence_visibility(visibility.summary);
+            }
+            Err(error) => {
+                // The scheduled pipeline retains each fully projected prefix
+                // in V1/V2. Land what is safe before restoring the explicit
+                // path's legacy handoff slots; Header and an unfinished event
+                // remain unstaged and therefore replayable.
+                if let Err(checkpoint_error) = self.checkpoint_pending_sync_visibility() {
+                    tracing::warn!(
+                        target: "marmot_app::messages",
+                        method = "observe_convergence_retry_effects",
+                        error_kind = checkpoint_error.privacy_safe_kind(),
+                        "explicit convergence failed with visibility still pending",
+                    );
+                }
+                self.retain_pending_explicit_convergence_visibility();
+                return Err(error);
+            }
+        }
+        #[cfg(test)]
+        if self.fail_after_convergence_retry_finalize {
+            return Err(AppError::BlockingTask(
+                "injected failure after convergence-retry finalization".to_owned(),
+            ));
+        }
+        Ok(send_summary)
+    }
+
+    /// Preserve the explicit convergence API's established handoff shape
+    /// after borrowing the scheduled path's atomic projection checkpoint.
+    /// Projection updates remain one-shot for the command worker, while the
+    /// rest of the fully applied summary uses the common send-applied channel.
+    fn retain_explicit_convergence_visibility(&mut self, mut summary: crate::SyncSummary) {
+        self.pending_projection_updates
+            .append(&mut summary.projection_updates);
+        self.pending_applied_sync_summary.merge(summary);
+    }
+
+    fn retain_pending_explicit_convergence_visibility(&mut self) {
+        if let Some(summary) = self.take_pending_checkpointed_sync_summary() {
+            self.retain_explicit_convergence_visibility(summary);
+        }
     }
 
     pub async fn update_group_profile(
@@ -3877,19 +4796,21 @@ impl AppClient {
 
         self.sync_runtime_groups().await?;
         let effects = self
-            .runtime
-            .send_with_audit_context(
+            .send_account_intent_with_visibility(
                 SendIntent::UpdateGroupData {
                     group_id: group_id.clone(),
                     name: name.map(ToOwned::to_owned),
                     description: description.map(ToOwned::to_owned),
                 },
-                audit_context.clone(),
+                Some(audit_context.clone()),
             )
             .await?;
         self.observe_recovery_evidence_then_fail_if_publish_failed(&effects)?;
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
+        let visibility_complete = self
+            .project_current_outbound_visibility(&effects, None)
+            .await?;
         let group_metadata = self.runtime.group_record(group_id).ok();
         let nostr_routing = self.nostr_routing_for_group(group_id)?;
         let projection = EventGroupProjection {
@@ -3910,6 +4831,9 @@ impl AppClient {
             GroupConfirmationProjection::Preserve,
         );
         self.mark_group_projection_dirty(group_id);
+        if visibility_complete {
+            self.stage_current_account_visibility_header_batch();
+        }
         self.save_state_with_pending_local_group_deletion_frontier_clears()?;
         self.queue_own_group_system_projection_updates(&effects);
         Ok(send_summary_from_effects(&effects))
@@ -4346,7 +5270,7 @@ impl AppClient {
         Ok(refresh)
     }
 
-    fn refresh_routing(&mut self) -> Result<(), AppError> {
+    pub(crate) fn refresh_routing(&mut self) -> Result<(), AppError> {
         let routing = self.app.routing_for(&self.state)?;
         self.preserve_local_deleted_group_routes(&routing)?;
         self.routing.replace(routing.snapshot());
@@ -4392,29 +5316,75 @@ impl AppClient {
         group_id_hex: &str,
         effects: &marmot_account::AccountDeviceEffects,
     ) -> Result<(), AppError> {
-        if effects.welcome_failures.is_empty() {
-            return Ok(());
-        }
-        let storage = self.app.account_storage(&self.state.label)?;
-        let recorded_at = unix_now_seconds();
         for failure in &effects.welcome_failures {
-            let message_id_hex = hex::encode(failure.message_id.as_slice());
-            let recipient_hex = hex::encode(failure.recipient.as_slice());
-            storage.record_pending_welcome_delivery(
-                &message_id_hex,
-                group_id_hex,
-                &recipient_hex,
+            self.record_welcome_delivery_failure(group_id_hex, failure)?;
+        }
+        Ok(())
+    }
+
+    fn record_welcome_delivery_failures_from_effects_at(
+        &mut self,
+        effects: &marmot_account::AccountDeviceEffects,
+        recorded_at: u64,
+    ) -> Result<(), AppError> {
+        for failure in &effects.welcome_failures {
+            let group_id = failure.group_id.as_ref().ok_or_else(|| {
+                AppError::BlockingTask(
+                    "resumed Welcome failure is missing its owning group".to_owned(),
+                )
+            })?;
+            self.record_welcome_delivery_failure_at(
+                &hex::encode(group_id.as_slice()),
+                failure,
                 recorded_at,
             )?;
-            // Queue a runtime event so subscribers (UI/CLI/UniFFI) learn the
-            // member is unjoinable without polling the durable queue.
-            self.pending_welcome_delivery_events
-                .push(PendingWelcomeDelivery {
-                    group_id_hex: group_id_hex.to_owned(),
-                    message_id_hex,
-                    recipient_hex,
-                    recorded_at,
-                });
+        }
+        Ok(())
+    }
+
+    fn record_welcome_delivery_failure(
+        &mut self,
+        group_id_hex: &str,
+        failure: &marmot_account::WelcomeDeliveryFailure,
+    ) -> Result<(), AppError> {
+        self.record_welcome_delivery_failure_at(group_id_hex, failure, unix_now_seconds())
+    }
+
+    fn record_welcome_delivery_failure_at(
+        &mut self,
+        group_id_hex: &str,
+        failure: &marmot_account::WelcomeDeliveryFailure,
+        recorded_at: u64,
+    ) -> Result<(), AppError> {
+        let storage = self.app.account_storage(&self.state.label)?;
+        let message_id_hex = hex::encode(failure.message_id.as_slice());
+        let recipient_hex = hex::encode(failure.recipient.as_slice());
+        storage.record_pending_welcome_delivery(
+            &message_id_hex,
+            group_id_hex,
+            &recipient_hex,
+            recorded_at,
+        )?;
+        // Queue a runtime event so subscribers (UI/CLI/UniFFI) learn the
+        // member is unjoinable without polling the durable queue.
+        let pending = PendingWelcomeDelivery {
+            group_id_hex: group_id_hex.to_owned(),
+            message_id_hex: message_id_hex.clone(),
+            recipient_hex: recipient_hex.clone(),
+            recorded_at,
+        };
+        if let Some(existing) = self
+            .pending_welcome_delivery_events
+            .iter_mut()
+            .find(|existing| {
+                existing.group_id_hex == pending.group_id_hex
+                    && existing.message_id_hex == message_id_hex
+                    && existing.recipient_hex == recipient_hex
+            })
+        {
+            *existing = pending;
+        } else {
+            self.pending_welcome_delivery_events.push(pending);
         }
         Ok(())
     }
@@ -4571,13 +5541,11 @@ impl AppClient {
             } => {
                 let welcome_publish_started_at = Instant::now();
                 let publish_result = self
-                    .runtime
-                    .publish_prepared_session_effects_with_audit_context(
+                    .publish_prepared_session_effects_with_visibility(
                         effects,
                         work.audit_context.clone(),
                     )
-                    .await
-                    .map_err(AppError::from);
+                    .await;
                 record_app_performance(
                     telemetry,
                     AppPerformanceOperation::GroupCreateWelcomePublish,
@@ -4599,16 +5567,24 @@ impl AppClient {
                     "classify_founding_welcome_publish",
                     self.observe_recovery_evidence_then_fail_if_publish_failed(&effects),
                 );
-                recover_post_canonical_result(
-                    "record_founding_welcome_delivery_failures",
-                    self.record_welcome_delivery_failures(
-                        &hex::encode(work.group_id.as_slice()),
-                        &effects,
-                    ),
-                );
                 self.record_human_action_succeeded(&work.group_id, &work.audit_context, &effects);
-                self.remember_published_reports(&effects);
-                self.queue_own_group_system_projection_updates(&effects);
+                let visibility_complete = recover_post_canonical_result(
+                    "project_founding_visibility",
+                    self.project_current_outbound_visibility(&effects, None)
+                        .await,
+                );
+                if visibility_complete {
+                    self.stage_current_account_visibility_header_batch();
+                }
+                match self.save_state_with_pending_local_group_deletion_frontier_clears() {
+                    Ok(()) => {}
+                    Err(error) => tracing::warn!(
+                        target: "marmot_app::client",
+                        method = "drive_unpublished_welcome_delivery",
+                        error_kind = error.privacy_safe_kind(),
+                        "founding visibility remains durable after app checkpoint failure"
+                    ),
+                }
             }
             UnpublishedWelcomeKind::Invite {
                 welcomes,
@@ -5031,6 +6007,56 @@ mod post_canonical_create_tests {
         });
 
         assert_eq!(collect_bounded_ordered(work, 2).await, Err("first"));
+    }
+}
+
+#[cfg(test)]
+mod direct_visibility_completion_tests {
+    use super::*;
+    use crate::tests::ScriptedPushRelayClient;
+    use marmot_account::AccountHome;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn direct_send_route_refresh_failure_is_best_effort_and_stays_armed() {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(relay.clone());
+        let mut client = app.client("alice").await.unwrap();
+        client.prepare_transport().await.unwrap();
+        client
+            .create_group_with_options_and_telemetry(
+                "direct send retained route retry",
+                &[],
+                crate::AppCreateGroupOptions::default(),
+                &AppPerformanceTelemetry::default(),
+            )
+            .await
+            .unwrap();
+        client.pending_runtime_group_subscription_refresh = true;
+        relay.fail_next_subscribe();
+
+        client
+            .finish_direct_send_visibility::<()>(Ok(()))
+            .await
+            .expect("a completed send must not become a false failure");
+        assert!(
+            client.has_pending_runtime_group_subscription_refresh(),
+            "a failed best-effort refresh must remain retryable"
+        );
+
+        client
+            .finish_direct_send_visibility::<()>(Ok(()))
+            .await
+            .unwrap();
+        assert!(
+            !client.has_pending_runtime_group_subscription_refresh(),
+            "a later direct completion seam must drain the retained retry"
+        );
     }
 }
 

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -1326,6 +1326,23 @@ impl AppClient {
                 .unwrap_or(false)
     }
 
+    /// Forget this client's ephemeral ownership even when relay-side cleanup
+    /// fails. The adapter commits the matching local teardown before awaiting
+    /// its fallible unsubscribe, so retaining this entry on `Err` would make a
+    /// later maintenance pass mistake a dead registration for a live one.
+    async fn remove_post_join_maintenance_subscription(
+        &mut self,
+        group_id: &GroupId,
+        route: &cgka_traits::TransportGroupSubscription,
+    ) -> Result<(), cgka_traits::TransportAdapterError> {
+        let result = self
+            .adapter
+            .remove_group_maintenance_subscription(route)
+            .await;
+        self.post_join_maintenance_subscriptions.remove(group_id);
+        result
+    }
+
     /// Install, poll, and retire temporary post-join full-history
     /// subscriptions. A restart reconstructs this ephemeral map from durable
     /// CatchUp obligations; the EOSE deadline itself remains persisted.
@@ -1342,8 +1359,7 @@ impl AppClient {
                 .collect::<Vec<_>>();
             for (group_id, route) in active {
                 if let Err(_error) = self
-                    .adapter
-                    .remove_group_maintenance_subscription(&route)
+                    .remove_post_join_maintenance_subscription(&group_id, &route)
                     .await
                 {
                     tracing::warn!(
@@ -1354,11 +1370,41 @@ impl AppClient {
                     );
                     continue;
                 }
-                self.post_join_maintenance_subscriptions.remove(&group_id);
             }
             return Ok(());
         }
         let routes = self.routing.snapshot().group_routes;
+        // A post-join history REQ can return group traffic immediately. The
+        // adapter routes those deliveries through the ordinary group-route
+        // snapshot rather than through the maintenance subscription id, so
+        // installing or polling it while that snapshot is stale can consume
+        // and deduplicate an event the app cannot yet route. Quiesce every
+        // temporary subscription first and do not poll stale EOSE state; the
+        // worker-owned route retry re-enters this method after a successful
+        // rebuild and installs each waiting group on its current route.
+        let ordinary_routes_ready = !self.has_pending_runtime_group_subscription_refresh();
+        if !ordinary_routes_ready {
+            let active = self
+                .post_join_maintenance_subscriptions
+                .iter()
+                .map(|(group_id, (_, route))| (group_id.clone(), route.clone()))
+                .collect::<Vec<_>>();
+            for (group_id, route) in active {
+                if let Err(_error) = self
+                    .remove_post_join_maintenance_subscription(&group_id, &route)
+                    .await
+                {
+                    tracing::warn!(
+                        target: "marmot_app::maintenance",
+                        method = "advance_post_join_maintenance_subscriptions",
+                        error_kind = "stale_route_subscription_remove_failed",
+                        "could not quiesce post-join maintenance subscription before route refresh"
+                    );
+                    continue;
+                }
+            }
+            return Ok(());
+        }
         let mut waiting = HashSet::new();
 
         for group in self.state.groups.clone() {
@@ -1386,6 +1432,24 @@ impl AppClient {
                     continue;
                 }
             };
+
+            // Account activation replaces every relay subscription, including
+            // temporary maintenance REQs, and clears their adapter-owned EOSE
+            // state. The AppClient survives that activation, so discard a
+            // same-route entry whose adapter registration disappeared; the
+            // normal install block below then reissues it on the current route.
+            if let Some((subscription_id, _)) = self
+                .post_join_maintenance_subscriptions
+                .get(&group_id)
+                .cloned()
+                && self
+                    .adapter
+                    .group_maintenance_any_eose(&subscription_id)
+                    .await
+                    .is_none()
+            {
+                self.post_join_maintenance_subscriptions.remove(&group_id);
+            }
             let needs_subscription = status.obligations.iter().any(|obligation| {
                 obligation.trigger == cgka_traits::MaintenanceTrigger::PostJoin
                     && matches!(
@@ -1400,23 +1464,58 @@ impl AppClient {
             }
             waiting.insert(group_id.clone());
 
+            let Some(route) = routes
+                .iter()
+                .find(|route| route.group_id == group_id)
+                .cloned()
+            else {
+                if let Some((_, active_route)) = self
+                    .post_join_maintenance_subscriptions
+                    .get(&group_id)
+                    .cloned()
+                    && let Err(_error) = self
+                        .remove_post_join_maintenance_subscription(&group_id, &active_route)
+                        .await
+                {
+                    tracing::warn!(
+                        target: "marmot_app::maintenance",
+                        method = "advance_post_join_maintenance_subscriptions",
+                        error_kind = "missing_route_subscription_remove_failed",
+                        "could not remove post-join maintenance subscription whose route disappeared"
+                    );
+                    continue;
+                }
+                tracing::warn!(
+                    target: "marmot_app::maintenance",
+                    method = "advance_post_join_maintenance_subscriptions",
+                    error_kind = "missing_route",
+                    "skipping post-join maintenance group without a route"
+                );
+                continue;
+            };
+
+            if let Some((_, active_route)) = self
+                .post_join_maintenance_subscriptions
+                .get(&group_id)
+                .cloned()
+                && active_route != route
+                && let Err(_error) = self
+                    .remove_post_join_maintenance_subscription(&group_id, &active_route)
+                    .await
+            {
+                tracing::warn!(
+                    target: "marmot_app::maintenance",
+                    method = "advance_post_join_maintenance_subscriptions",
+                    error_kind = "rotated_route_subscription_remove_failed",
+                    "could not rotate post-join maintenance subscription to the current route"
+                );
+                continue;
+            }
+
             if !self
                 .post_join_maintenance_subscriptions
                 .contains_key(&group_id)
             {
-                let Some(route) = routes
-                    .iter()
-                    .find(|route| route.group_id == group_id)
-                    .cloned()
-                else {
-                    tracing::warn!(
-                        target: "marmot_app::maintenance",
-                        method = "advance_post_join_maintenance_subscriptions",
-                        error_kind = "missing_route",
-                        "skipping post-join maintenance group without a route"
-                    );
-                    continue;
-                };
                 let subscription_id = match self
                     .adapter
                     .install_group_maintenance_subscription(route.clone())
@@ -1486,8 +1585,7 @@ impl AppClient {
                 .get(&group_id)
                 .cloned()
                 && let Err(_error) = self
-                    .adapter
-                    .remove_group_maintenance_subscription(&route)
+                    .remove_post_join_maintenance_subscription(&group_id, &route)
                     .await
             {
                 tracing::warn!(
@@ -1498,7 +1596,6 @@ impl AppClient {
                 );
                 continue;
             }
-            self.post_join_maintenance_subscriptions.remove(&group_id);
         }
         Ok(())
     }

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -577,20 +577,56 @@ impl AppClient {
     ) -> Result<Vec<crate::AppProjectionUpdate>, AppError> {
         let mut updates = Vec::new();
         for published in &effects.published_app_messages {
-            let group_id_hex = hex::encode(published.group_id.as_slice());
-            let source_message_id_hex = hex::encode(published.message_id.as_slice());
-            if let Some(update) = self.app.finalize_account_app_event_source_retention(
-                &self.state.label,
-                &group_id_hex,
-                &published.app_event_id,
-                Some(source_message_id_hex.as_str()),
-                published.source_epoch.0,
-                published.retention,
-            )? {
+            if let Some(update) =
+                self.finalize_published_app_message_source_retention_one(published)?
+            {
                 updates.push(update);
             }
         }
         Ok(updates)
+    }
+
+    pub(crate) fn finalize_published_app_message_source_retention_one(
+        &mut self,
+        published: &marmot_account::PublishedApplicationMessage,
+    ) -> Result<Option<crate::AppProjectionUpdate>, AppError> {
+        let group_id_hex = hex::encode(published.group_id.as_slice());
+        let source_message_id_hex = hex::encode(published.message_id.as_slice());
+        self.app.finalize_account_app_event_source_retention(
+            &self.state.label,
+            &group_id_hex,
+            &published.app_event_id,
+            Some(source_message_id_hex.as_str()),
+            published.source_epoch.0,
+            published.retention,
+        )
+    }
+
+    /// Finalize a released outbound app message and retain its notification
+    /// obligation in one place. Maintenance, scheduled convergence, and an
+    /// explicit convergence retry can all release the same pending send; each
+    /// path must apply the same chat/deleted/invalidated eligibility rule.
+    pub(crate) fn finalize_published_app_message_and_queue_notification(
+        &mut self,
+        published: &marmot_account::PublishedApplicationMessage,
+    ) -> Result<Option<crate::AppProjectionUpdate>, AppError> {
+        let update = self.finalize_published_app_message_source_retention_one(published)?;
+        let group_id_hex = hex::encode(published.group_id.as_slice());
+        if self
+            .app
+            .reaction_target(&self.state.label, &group_id_hex, &published.app_event_id)
+            .ok()
+            .flatten()
+            .is_some_and(|message| {
+                message.kind == MARMOT_APP_EVENT_KIND_CHAT
+                    && !message.deleted
+                    && !message.invalidated
+            })
+        {
+            self.pending_new_message_notification_groups
+                .insert(published.group_id.clone());
+        }
+        Ok(update)
     }
 
     pub(crate) fn prune_plaintext_retention_for_group(

--- a/crates/marmot-app/src/client/push.rs
+++ b/crates/marmot-app/src/client/push.rs
@@ -8,12 +8,34 @@ use crate::notifications;
 use super::AppClient;
 
 impl AppClient {
-    pub(crate) async fn upsert_and_share_push_registration(
+    /// Finish notification fanout only after the account worker has handed the
+    /// corresponding send-applied summary to runtime subscribers. Each group
+    /// stays owned until its best-effort attempt returns, so ordinary
+    /// cancellation with a retained client can retry it.
+    pub(crate) async fn publish_pending_new_message_notifications_best_effort(&mut self) {
+        while let Some(group_id) = self
+            .pending_new_message_notification_groups
+            .iter()
+            .next()
+            .cloned()
+        {
+            self.publish_notification_trigger_best_effort(
+                &group_id,
+                notifications::NotificationTrigger::NewMessage,
+            )
+            .await;
+            self.pending_new_message_notification_groups
+                .remove(&group_id);
+        }
+    }
+
+    pub(crate) async fn upsert_and_share_push_registration_with_handoff(
         &mut self,
         platform: notifications::PushPlatform,
         raw_token: &str,
         server_pubkey_hex: &str,
         relay_hint: Option<String>,
+        visibility_handoff: &mut impl FnMut(&mut Self),
     ) -> Result<notifications::PushRegistrationSyncResult, AppError> {
         let registration = self.app.upsert_push_registration(
             &self.state.label,
@@ -22,15 +44,25 @@ impl AppClient {
             server_pubkey_hex,
             relay_hint,
         )?;
-        let share = self.share_push_registration().await?;
+        let share = self
+            .share_push_registration_with_handoff(visibility_handoff)
+            .await?;
         Ok(notifications::PushRegistrationSyncResult {
             registration,
             share,
         })
     }
 
+    #[cfg(test)]
     pub(crate) async fn share_push_registration(
         &mut self,
+    ) -> Result<notifications::PushRegistrationShareOutcome, AppError> {
+        self.share_push_registration_with_handoff(&mut |_| {}).await
+    }
+
+    pub(crate) async fn share_push_registration_with_handoff(
+        &mut self,
+        visibility_handoff: &mut impl FnMut(&mut Self),
     ) -> Result<notifications::PushRegistrationShareOutcome, AppError> {
         let account = self.app.account_home().account(&self.state.label)?;
         let settings = self.app.notification_settings(&account.label)?;
@@ -106,10 +138,14 @@ impl AppClient {
                     continue;
                 }
             };
-            match self
+            let send_result = self
                 .send_app_event(&group_id, AppMessageIntent::PushTokenRemoval { content })
-                .await
-            {
+                .await;
+            // `send_app_event` can checkpoint peer state-change visibility as a
+            // side effect. Give the owning worker a synchronous publication
+            // chokepoint before this loop crosses its next signing/send await.
+            visibility_handoff(self);
+            match send_result {
                 Ok((_event, summary))
                     if summary.accept_disposition
                         == cgka_traits::SendAcceptDisposition::Published =>
@@ -220,10 +256,11 @@ impl AppClient {
                         continue;
                     }
                 };
-                match self
+                let send_result = self
                     .send_app_event(&group_id, AppMessageIntent::PushTokenUpdate { content })
-                    .await
-                {
+                    .await;
+                visibility_handoff(self);
+                match send_result {
                     Ok((_event, summary))
                         if summary.accept_disposition
                             == cgka_traits::SendAcceptDisposition::Published =>
@@ -303,8 +340,14 @@ impl AppClient {
         ))
     }
 
-    pub(crate) async fn retry_pending_push_registration_shares_best_effort(&mut self) -> bool {
-        match self.share_push_registration().await {
+    pub(crate) async fn retry_pending_push_registration_shares_best_effort_with_handoff(
+        &mut self,
+        visibility_handoff: &mut impl FnMut(&mut Self),
+    ) -> bool {
+        match self
+            .share_push_registration_with_handoff(visibility_handoff)
+            .await
+        {
             Ok(outcome) if outcome.failed_groups > 0 => {
                 tracing::warn!(
                     target: "marmot_app::notifications",
@@ -364,19 +407,24 @@ impl AppClient {
         Ok(registration)
     }
 
-    pub(crate) async fn drain_push_registration_removal_before_departure(
+    pub(crate) async fn drain_push_registration_removal_before_departure_with_handoff(
         &mut self,
         group_id: &GroupId,
+        visibility_handoff: &mut impl FnMut(&mut Self),
     ) -> Result<Option<crate::PushRegistration>, AppError> {
         let registration = self.queue_current_push_registration_removal_for_group(group_id)?;
-        self.drain_existing_push_registration_removals_for_group(group_id)
-            .await?;
+        self.drain_existing_push_registration_removals_for_group_with_handoff(
+            group_id,
+            visibility_handoff,
+        )
+        .await?;
         Ok(registration)
     }
 
-    pub(crate) async fn drain_existing_push_registration_removals_for_group(
+    pub(crate) async fn drain_existing_push_registration_removals_for_group_with_handoff(
         &mut self,
         group_id: &GroupId,
+        visibility_handoff: &mut impl FnMut(&mut Self),
     ) -> Result<(), AppError> {
         let group_id_hex = hex::encode(group_id.as_slice());
         let had_pending_removal = self
@@ -387,7 +435,9 @@ impl AppClient {
         if !had_pending_removal {
             return Ok(());
         }
-        let _ = self.share_push_registration().await?;
+        let _ = self
+            .share_push_registration_with_handoff(visibility_handoff)
+            .await?;
         let remains_pending = self
             .app
             .pending_push_registration_removals(&self.state.label)?
@@ -426,20 +476,26 @@ impl AppClient {
         }
     }
 
-    pub(crate) async fn remove_push_registration(
+    pub(crate) async fn remove_push_registration_with_handoff(
         &mut self,
         registration: crate::PushRegistration,
+        visibility_handoff: &mut impl FnMut(&mut Self),
     ) -> Result<usize, AppError> {
         self.app
             .queue_push_registration_removals(&self.state.label, registration)?;
-        Ok(self.share_push_registration().await?.succeeded_groups as usize)
+        Ok(self
+            .share_push_registration_with_handoff(visibility_handoff)
+            .await?
+            .succeeded_groups as usize)
     }
 
-    pub(crate) async fn clear_and_share_push_registration(
+    pub(crate) async fn clear_and_share_push_registration_with_handoff(
         &mut self,
+        visibility_handoff: &mut impl FnMut(&mut Self),
     ) -> Result<notifications::PushRegistrationShareOutcome, AppError> {
         self.app.clear_push_registration(&self.state.label)?;
-        self.share_push_registration().await
+        self.share_push_registration_with_handoff(visibility_handoff)
+            .await
     }
 
     pub(crate) fn snapshot_group_push_tokens_for_members(

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -5,6 +5,7 @@ use cgka_traits::GroupId;
 use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MARMOT_APP_EVENT_KIND_DELETE};
 use cgka_traits::ingest::IngestOutcome;
 use cgka_traits::transport::TransportEnvelope;
+use serde::{Deserialize, Serialize};
 use storage_sqlite::{
     TransportReconciliationItem, TransportReconciliationRoute, clamp_to_max_future_skew,
 };
@@ -119,6 +120,84 @@ pub(crate) struct EpochBackfillExecution {
     pub(crate) started: Instant,
 }
 
+const EPOCH_BACKFILL_INTENT_JOURNAL_VERSION: u32 = 1;
+
+fn epoch_backfill_retry_deadline_unix_ms(not_before: Option<Instant>) -> Option<u64> {
+    let remaining = not_before?.saturating_duration_since(Instant::now());
+    if remaining.is_zero() {
+        return None;
+    }
+    Some(
+        crate::unix_now_seconds()
+            .saturating_mul(1_000)
+            .saturating_add(u64::try_from(remaining.as_millis()).unwrap_or(u64::MAX)),
+    )
+}
+
+fn restore_epoch_backfill_retry_deadline(deadline_unix_ms: Option<u64>) -> Option<Instant> {
+    let deadline_unix_ms = deadline_unix_ms?;
+    let now_unix_ms = crate::unix_now_seconds().saturating_mul(1_000);
+    let remaining_ms = deadline_unix_ms.saturating_sub(now_unix_ms);
+    if remaining_ms == 0 {
+        return None;
+    }
+    let cap_ms = u64::try_from(EPOCH_BACKFILL_RETRY_BACKOFF_CAP.as_millis()).unwrap_or(u64::MAX);
+    let remaining_ms = remaining_ms.min(cap_ms);
+    Instant::now().checked_add(Duration::from_millis(remaining_ms))
+}
+
+/// App-owned representation stored as one encrypted account-DB blob. Groups
+/// are a vector rather than a JSON map because `GroupId` is opaque bytes and
+/// JSON object keys must be strings.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PersistedEpochBackfillIntentJournal {
+    version: u32,
+    pending: Option<PersistedEpochBackfillIntent>,
+    active: Option<PersistedEpochBackfillIntent>,
+    queued: Vec<PersistedEpochBackfillIntent>,
+    /// Wall-clock deadline for the account-wide replay cooldown. Restored as
+    /// a remaining `Instant` duration so a restart cannot spin a fruitless
+    /// backfill at full speed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    retry_not_before_unix_ms: Option<u64>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PersistedEpochBackfillIntent {
+    attempt_id: String,
+    groups: Vec<PersistedEpochBackfillGroup>,
+    execution_attempts: u32,
+    #[serde(default)]
+    eose_unconfirmed_attempts: u32,
+    #[serde(default)]
+    no_progress_attempts: u32,
+    last_deferred_audit: Option<PersistedEpochBackfillDeferredSnapshot>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PersistedEpochBackfillGroup {
+    group_id: Vec<u8>,
+    stalled_epoch: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PersistedEpochBackfillDeferredSnapshot {
+    reason: EpochBackfillDeferredReason,
+    retry_ordinal: u64,
+    group_epochs: Vec<PersistedEpochBackfillDeferredGroupEpoch>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PersistedEpochBackfillDeferredGroupEpoch {
+    group_id: Vec<u8>,
+    observed_epoch: Option<u64>,
+}
+
 struct EpochBackfillReplayOutcome {
     duration_ms: u64,
     activation_outcome: EpochBackfillActivationOutcome,
@@ -126,6 +205,41 @@ struct EpochBackfillReplayOutcome {
     completion_kind: Option<EpochBackfillCompletionKind>,
     counts: DrainCounts,
     succeeded: bool,
+}
+
+struct ReplayedAccountVisibilityOperation {
+    operation_id: Vec<u8>,
+    source: marmot_account::AccountVisibilitySource,
+    effects: marmot_account::AccountDeviceEffects,
+}
+
+fn merge_account_visibility_effects(
+    target: &mut marmot_account::AccountDeviceEffects,
+    source: &marmot_account::AccountDeviceEffects,
+) {
+    target.events.extend(source.events.iter().cloned());
+    target.queued.extend(source.queued.iter().cloned());
+    target
+        .pending_convergence
+        .extend(source.pending_convergence.iter().cloned());
+    target.reports.extend(source.reports.iter().cloned());
+    target.fanout.extend(source.fanout.iter().cloned());
+    target.failures.extend(source.failures.iter().cloned());
+    target
+        .action_outcomes
+        .extend(source.action_outcomes.iter().cloned());
+    target
+        .published_app_messages
+        .extend(source.published_app_messages.iter().cloned());
+    target
+        .welcome_failures
+        .extend(source.welcome_failures.iter().cloned());
+    target.pending.extend(source.pending.iter().cloned());
+    if source.maintenance_disposition
+        == cgka_traits::SendMaintenanceDisposition::PostJoinRotationPendingRetryable
+    {
+        target.maintenance_disposition = source.maintenance_disposition;
+    }
 }
 
 /// Result of checking the pending epoch-gap replay queue at one execution seam.
@@ -136,6 +250,12 @@ struct EpochBackfillReplayOutcome {
 /// intent and its audit trail. Explicit full-history repair instead uses this
 /// distinction to try any queued runnable intent before falling back to its
 /// ordinary unfloored account-wide replay.
+#[derive(Debug)]
+enum EpochBackfillFinish {
+    Succeeded,
+    Failed { preserve_pacing: bool },
+}
+
 #[derive(Debug)]
 pub(crate) enum EpochBackfillRunOutcome {
     NotPending,
@@ -374,9 +494,12 @@ pub(crate) enum ConvergenceScheduleState {
     PendingOutbound,
 }
 
-enum SyncCheckpointError {
-    BeforePersistence(AppError),
-    AfterPersistence(AppError),
+/// A scheduled convergence pass whose durable projection/ACK checkpoint has
+/// completed and whose visibility summary has already been removed from the
+/// client-owned V2 slot. The worker must publish `summary` before performing
+/// either of the remaining best-effort network actions.
+pub(crate) struct ScheduledConvergenceVisibility {
+    pub(crate) summary: SyncSummary,
 }
 
 struct StagedSyncError {
@@ -390,7 +513,205 @@ impl StagedSyncError {
     }
 }
 
+impl From<&PendingEpochBackfill> for PersistedEpochBackfillIntent {
+    fn from(pending: &PendingEpochBackfill) -> Self {
+        let mut groups = pending
+            .groups
+            .iter()
+            .map(|(group_id, group)| PersistedEpochBackfillGroup {
+                group_id: group_id.as_slice().to_vec(),
+                stalled_epoch: group.stalled_epoch,
+            })
+            .collect::<Vec<_>>();
+        groups.sort_by(|left, right| left.group_id.cmp(&right.group_id));
+        Self {
+            attempt_id: pending.attempt_id.clone(),
+            groups,
+            execution_attempts: pending.execution_attempts,
+            eose_unconfirmed_attempts: pending.eose_unconfirmed_attempts,
+            no_progress_attempts: pending.no_progress_attempts,
+            last_deferred_audit: pending.last_deferred_audit.as_ref().map(|snapshot| {
+                PersistedEpochBackfillDeferredSnapshot {
+                    reason: snapshot.reason,
+                    retry_ordinal: snapshot.retry_ordinal,
+                    group_epochs: snapshot
+                        .group_epochs
+                        .iter()
+                        .map(|(group_id, observed_epoch)| {
+                            PersistedEpochBackfillDeferredGroupEpoch {
+                                group_id: group_id.as_slice().to_vec(),
+                                observed_epoch: *observed_epoch,
+                            }
+                        })
+                        .collect(),
+                }
+            }),
+        }
+    }
+}
+
+impl TryFrom<PersistedEpochBackfillIntent> for PendingEpochBackfill {
+    type Error = AppError;
+
+    fn try_from(persisted: PersistedEpochBackfillIntent) -> Result<Self, Self::Error> {
+        if persisted.attempt_id.is_empty() || persisted.groups.is_empty() {
+            return Err(AppError::BlockingTask(
+                "invalid durable epoch-backfill intent journal".to_owned(),
+            ));
+        }
+        let mut groups = HashMap::with_capacity(persisted.groups.len());
+        for group in persisted.groups {
+            if group.group_id.is_empty() {
+                return Err(AppError::BlockingTask(
+                    "invalid durable epoch-backfill intent group".to_owned(),
+                ));
+            }
+            if groups
+                .insert(
+                    GroupId::new(group.group_id),
+                    PendingEpochBackfillGroup {
+                        stalled_epoch: group.stalled_epoch,
+                    },
+                )
+                .is_some()
+            {
+                return Err(AppError::BlockingTask(
+                    "duplicate durable epoch-backfill intent group".to_owned(),
+                ));
+            }
+        }
+        let last_deferred_audit = persisted
+            .last_deferred_audit
+            .map(|snapshot| {
+                let mut group_epochs = Vec::with_capacity(snapshot.group_epochs.len());
+                for group in snapshot.group_epochs {
+                    if group.group_id.is_empty() {
+                        return Err(AppError::BlockingTask(
+                            "invalid durable epoch-backfill deferral group".to_owned(),
+                        ));
+                    }
+                    group_epochs.push((GroupId::new(group.group_id), group.observed_epoch));
+                }
+                Ok(EpochBackfillDeferredSnapshot {
+                    reason: snapshot.reason,
+                    retry_ordinal: snapshot.retry_ordinal,
+                    group_epochs,
+                })
+            })
+            .transpose()?;
+        Ok(Self {
+            attempt_id: persisted.attempt_id,
+            groups,
+            execution_attempts: persisted.execution_attempts,
+            eose_unconfirmed_attempts: persisted.eose_unconfirmed_attempts,
+            no_progress_attempts: persisted.no_progress_attempts,
+            last_deferred_audit,
+        })
+    }
+}
+
 impl AppClient {
+    fn persist_epoch_backfill_intent_journal(&mut self) -> Result<(), AppError> {
+        let result = (|| {
+            let storage = self.app.account_storage(&self.state.label)?;
+            if self.pending_epoch_backfill.is_none()
+                && self.active_epoch_backfill.is_none()
+                && self.queued_epoch_backfills.is_empty()
+                && epoch_backfill_retry_deadline_unix_ms(self.epoch_backfill_retry_not_before)
+                    .is_none()
+            {
+                storage.clear_epoch_backfill_intent_journal()?;
+                return Ok(());
+            }
+            let journal = PersistedEpochBackfillIntentJournal {
+                version: EPOCH_BACKFILL_INTENT_JOURNAL_VERSION,
+                pending: self
+                    .pending_epoch_backfill
+                    .as_ref()
+                    .map(PersistedEpochBackfillIntent::from),
+                active: self
+                    .active_epoch_backfill
+                    .as_ref()
+                    .map(PersistedEpochBackfillIntent::from),
+                queued: self
+                    .queued_epoch_backfills
+                    .iter()
+                    .map(PersistedEpochBackfillIntent::from)
+                    .collect(),
+                retry_not_before_unix_ms: epoch_backfill_retry_deadline_unix_ms(
+                    self.epoch_backfill_retry_not_before,
+                ),
+            };
+            storage.store_epoch_backfill_intent_journal(&serde_json::to_vec(&journal)?)?;
+            Ok(())
+        })();
+        self.epoch_backfill_intent_journal_dirty = result.is_err();
+        result
+    }
+
+    /// Retry a failed intent-journal write before any external replay or
+    /// before the worker becomes idle. The detector may not emit the same arm
+    /// twice, so this explicit obligation is the durable retry source.
+    pub(crate) fn ensure_epoch_backfill_intent_journal_persisted(
+        &mut self,
+    ) -> Result<(), AppError> {
+        if self.epoch_backfill_intent_journal_dirty {
+            self.persist_epoch_backfill_intent_journal()?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn restore_epoch_backfill_intent_journal(&mut self) -> Result<(), AppError> {
+        let Some(raw) = self
+            .app
+            .account_storage(&self.state.label)?
+            .load_epoch_backfill_intent_journal()?
+        else {
+            return Ok(());
+        };
+        let persisted: PersistedEpochBackfillIntentJournal = serde_json::from_slice(&raw)?;
+        if persisted.version != EPOCH_BACKFILL_INTENT_JOURNAL_VERSION {
+            return Err(AppError::BlockingTask(
+                "unsupported durable epoch-backfill intent journal".to_owned(),
+            ));
+        }
+        self.pending_epoch_backfill = persisted.pending.map(TryInto::try_into).transpose()?;
+        self.active_epoch_backfill = persisted.active.map(TryInto::try_into).transpose()?;
+        self.queued_epoch_backfills = persisted
+            .queued
+            .into_iter()
+            .map(TryInto::try_into)
+            .collect::<Result<_, _>>()?;
+        self.epoch_backfill_retry_not_before =
+            restore_epoch_backfill_retry_deadline(persisted.retry_not_before_unix_ms);
+
+        // A process cannot still own the replay represented by an active row.
+        // Restore it with the same ordering used by an ordinary failed attempt:
+        // a newer primary stays first, and the interrupted intent retries after
+        // the already-queued work ahead of it.
+        if let Some(interrupted) = self.active_epoch_backfill.take() {
+            if self.pending_epoch_backfill.is_none() {
+                self.pending_epoch_backfill = Some(interrupted);
+            } else {
+                self.queued_epoch_backfills.push_back(interrupted);
+            }
+            self.persist_epoch_backfill_intent_journal()?;
+        }
+        Ok(())
+    }
+
+    fn recover_active_epoch_backfill_after_cancellation(&mut self) -> Result<(), AppError> {
+        let Some(interrupted) = self.active_epoch_backfill.take() else {
+            return Ok(());
+        };
+        if self.pending_epoch_backfill.is_none() {
+            self.pending_epoch_backfill = Some(interrupted);
+        } else {
+            self.queued_epoch_backfills.push_back(interrupted);
+        }
+        self.persist_epoch_backfill_intent_journal()
+    }
+
     pub(crate) fn take_pending_convergence_groups(&mut self) -> Vec<cgka_traits::GroupId> {
         self.pending_convergence_groups.drain().collect()
     }
@@ -476,9 +797,9 @@ impl AppClient {
     pub(crate) fn observe_recovery_evidence(
         &mut self,
         effects: &marmot_account::AccountDeviceEffects,
-    ) {
+    ) -> Result<(), AppError> {
         if self.app.cursor_persistence() != CursorPersistence::Advance {
-            return;
+            return Ok(());
         }
         for event in &effects.events {
             match event {
@@ -509,11 +830,12 @@ impl AppClient {
                         record.epoch.0,
                         decision,
                         EpochStallBackfillTrigger::ResourceRefusal,
-                    );
+                    )?;
                 }
                 _ => {}
             }
         }
+        Ok(())
     }
 
     /// Apply the publish gate to `effects`, observing the same batch's
@@ -542,11 +864,12 @@ impl AppClient {
         &mut self,
         effects: &marmot_account::AccountDeviceEffects,
     ) -> Result<(), AppError> {
-        self.observe_recovery_evidence(effects);
+        self.observe_recovery_evidence(effects)?;
         fail_if_publish_failed(effects)
     }
 
     pub(crate) async fn sync_runtime_groups(&mut self) -> Result<(), AppError> {
+        self.replay_pending_account_visibility().await?;
         let rebuild_since = self.subscription_rebuild_since();
         self.sync_runtime_groups_since(rebuild_since).await
     }
@@ -742,6 +1065,561 @@ impl AppClient {
         self.pending_runtime_group_subscription_refresh
     }
 
+    fn merge_occupied_sync_summary(slot: &mut Option<SyncSummary>, summary: SyncSummary) {
+        match slot {
+            Some(pending) => pending.merge(summary),
+            None => *slot = Some(summary),
+        }
+    }
+
+    pub(crate) fn install_account_visibility_lease(
+        &mut self,
+        lease: marmot_account::AccountVisibilityLease,
+        batches: Vec<marmot_account::AccountVisibilityBatch>,
+        current_operation_id: Option<Vec<u8>>,
+    ) {
+        let mut staged_batch_ids = self
+            .pending_account_visibility_lease
+            .take()
+            .map(|pending| pending.staged_batch_ids)
+            .unwrap_or_default();
+        staged_batch_ids.retain(|batch_id| batches.iter().any(|batch| batch.batch_id == *batch_id));
+        self.pending_account_visibility_lease = Some(super::PendingAccountVisibilityLease {
+            lease,
+            batches,
+            staged_batch_ids,
+            projection_operation_id: current_operation_id,
+        });
+    }
+
+    /// Project every lower account-effects operation left by an interrupted
+    /// caller before accepting new relay or send work. Operations remain
+    /// ordered by their first durable row and are dispatched under their
+    /// original source; a later command can never lend an older batch its own
+    /// delivery metadata, group, or timestamp.
+    pub(crate) async fn replay_pending_account_visibility(&mut self) -> Result<bool, AppError> {
+        if self.has_staged_account_visibility_batches() {
+            self.save_state_with_pending_local_group_deletion_frontier_clears()?;
+        }
+        let Some(leased) = self.runtime.replay_visibility_leased()? else {
+            return Ok(false);
+        };
+        let batches = leased.batches.clone();
+        self.install_account_visibility_lease(leased.lease, leased.batches, None);
+
+        let mut operations = Vec::<ReplayedAccountVisibilityOperation>::new();
+        for batch in batches {
+            let operation_index = operations
+                .iter()
+                .position(|operation| operation.operation_id == batch.operation_id);
+            let operation = match operation_index {
+                Some(index) => &mut operations[index],
+                None => {
+                    operations.push(ReplayedAccountVisibilityOperation {
+                        operation_id: batch.operation_id.clone(),
+                        source: batch.source.clone(),
+                        effects: marmot_account::AccountDeviceEffects::default(),
+                    });
+                    operations
+                        .last_mut()
+                        .expect("just appended visibility operation")
+                }
+            };
+            if operation.source != batch.source {
+                return Err(AppError::BlockingTask(
+                    "account visibility operation changed source".to_owned(),
+                ));
+            }
+            merge_account_visibility_effects(&mut operation.effects, &batch.effects);
+        }
+
+        for operation in operations {
+            self.set_account_visibility_projection_operation(Some(operation.operation_id));
+            let replayed = match operation.source {
+                marmot_account::AccountVisibilitySource::Inbound {
+                    delivery,
+                    outcome,
+                    observed_at,
+                } => {
+                    self.replay_source_attributed_inbound_visibility(
+                        delivery,
+                        outcome,
+                        &operation.effects,
+                        observed_at.0,
+                    )
+                    .await
+                }
+                marmot_account::AccountVisibilitySource::Drain { observed_at } => self
+                    .replay_source_attributed_drain_visibility(&operation.effects, observed_at.0),
+                marmot_account::AccountVisibilitySource::Convergence {
+                    group_id,
+                    observed_at,
+                } => {
+                    self.replay_source_attributed_convergence_visibility(
+                        &group_id,
+                        &operation.effects,
+                        observed_at.0,
+                    )
+                    .await
+                }
+                marmot_account::AccountVisibilitySource::Maintenance { observed_at } => self
+                    .checkpoint_maintenance_effects_at(&operation.effects, observed_at.0)
+                    .map(|_| ()),
+                marmot_account::AccountVisibilitySource::Outbound {
+                    group_id,
+                    observed_at,
+                    ..
+                } => {
+                    self.replay_source_attributed_outbound_visibility(
+                        group_id.as_ref(),
+                        &operation.effects,
+                        observed_at.0,
+                    )
+                    .await
+                }
+            };
+            if let Err(error) = replayed {
+                // Do not let a later unrelated local save inherit this
+                // operation as its projection authority. Exact completed rows
+                // are already staged individually and remain safe to checkpoint;
+                // the Header and unfinished record stay durable for replay.
+                self.set_account_visibility_projection_operation(None);
+                return Err(error);
+            }
+            // Header is the operation-complete marker. It is intentionally the
+            // last row staged, including for an empty drain/no-op maintenance
+            // pass, so no generic save can acknowledge an operation whose
+            // source-specific tail has not completed.
+            self.stage_current_account_visibility_header_batch();
+            self.checkpoint_pending_sync_visibility()?;
+        }
+        self.set_account_visibility_projection_operation(None);
+        Ok(true)
+    }
+
+    async fn replay_source_attributed_inbound_visibility(
+        &mut self,
+        delivery: cgka_traits::TransportDelivery,
+        outcome: IngestOutcome,
+        effects: &marmot_account::AccountDeviceEffects,
+        observed_at: u64,
+    ) -> Result<(), AppError> {
+        self.project_account_non_session_visibility_at(effects, observed_at, None)?;
+        let display_names = self.app.display_names_by_id()?;
+        let mut summary = SyncSummary::default();
+        let source_message_id_hex = hex::encode(delivery.message.id.as_slice());
+        let ingested = self
+            .project_source_attributed_inbound_visibility(
+                &outcome,
+                effects,
+                &display_names,
+                &mut summary,
+                &source_message_id_hex,
+                delivery.received_at.0,
+                delivery.message.timestamp.0,
+                delivery.group_id_hint.clone(),
+                matches!(outcome, IngestOutcome::ResourceRefused { .. }),
+            )
+            .await?;
+        self.retain_uncheckpointed_sync_summary(summary);
+        self.remember_uncheckpointed_runtime_group_subscription_refresh(ingested.routes_dirty);
+        if !ingested.must_stay_fetchable {
+            self.remember_seen_event(source_message_id_hex);
+        }
+        if ingested.routes_dirty {
+            self.save_state_with_pending_local_group_deletion_frontier_clears()?;
+        }
+        let refresh = self.refresh_group_routes()?;
+        if !ingested.routes_dirty || refresh.state_pruned {
+            self.remember_uncheckpointed_runtime_group_subscription_refresh(
+                refresh.routing_changed,
+            );
+            self.save_state_with_pending_local_group_deletion_frontier_clears()?;
+        } else {
+            self.pending_runtime_group_subscription_refresh |= refresh.routing_changed;
+        }
+        Ok(())
+    }
+
+    fn replay_source_attributed_drain_visibility(
+        &mut self,
+        effects: &marmot_account::AccountDeviceEffects,
+        observed_at: u64,
+    ) -> Result<(), AppError> {
+        let affected_groups =
+            self.project_account_non_session_visibility_at(effects, observed_at, None)?;
+        let mut projectable = effects.clone();
+        if !projectable.failures.is_empty() {
+            tracing::warn!(
+                target: "marmot_app",
+                method = "replay_account_visibility",
+                failure_count = projectable.failures.len(),
+                "replaying a completed account operation that reported publish failures"
+            );
+            projectable.failures.clear();
+        }
+        self.observe_drained_session_events_staged_at(&projectable, observed_at)?;
+        for group_id in affected_groups {
+            self.refresh_group(&group_id);
+            self.prune_plaintext_retention_for_group(&group_id)?;
+        }
+        self.checkpoint_pending_sync_visibility()?;
+        Ok(())
+    }
+
+    async fn replay_source_attributed_convergence_visibility(
+        &mut self,
+        group_id: &cgka_traits::GroupId,
+        effects: &marmot_account::AccountDeviceEffects,
+        observed_at: u64,
+    ) -> Result<(), AppError> {
+        let mut projectable = effects.clone();
+        if !projectable.failures.is_empty() {
+            tracing::warn!(
+                target: "marmot_app",
+                method = "replay_account_visibility",
+                failure_count = projectable.failures.len(),
+                "replaying convergence effects that reported publish failures"
+            );
+            projectable.failures.clear();
+        }
+        let visibility = self
+            .checkpoint_scheduled_convergence_effects_at(group_id, &projectable, observed_at)
+            .await?;
+        self.retain_checkpointed_sync_summary(visibility.summary);
+        Ok(())
+    }
+
+    async fn replay_source_attributed_outbound_visibility(
+        &mut self,
+        source_group_id: Option<&cgka_traits::GroupId>,
+        effects: &marmot_account::AccountDeviceEffects,
+        observed_at: u64,
+    ) -> Result<(), AppError> {
+        let primary_group = source_group_id.cloned().or_else(|| {
+            effects
+                .events
+                .iter()
+                .find_map(event_group_id)
+                .cloned()
+                .or_else(|| {
+                    effects
+                        .published_app_messages
+                        .first()
+                        .map(|published| published.group_id.clone())
+                })
+        });
+        let mut projectable = effects.clone();
+        if !projectable.failures.is_empty() {
+            tracing::warn!(
+                target: "marmot_app",
+                method = "replay_account_visibility",
+                failure_count = projectable.failures.len(),
+                "replaying outbound effects that reported publish failures"
+            );
+            projectable.failures.clear();
+        }
+        if let Some(group_id) = primary_group {
+            let visibility = self
+                .checkpoint_scheduled_convergence_effects_at(&group_id, &projectable, observed_at)
+                .await?;
+            self.retain_checkpointed_sync_summary(visibility.summary);
+        } else {
+            let affected_groups =
+                self.project_account_non_session_visibility_at(effects, observed_at, None)?;
+            self.observe_drained_session_events_staged_at(&projectable, observed_at)?;
+            for group_id in affected_groups {
+                self.refresh_group(&group_id);
+                self.prune_plaintext_retention_for_group(&group_id)?;
+            }
+            self.checkpoint_pending_sync_visibility()?;
+        }
+        Ok(())
+    }
+
+    /// Apply terminal outbound-action tails before any Header acknowledgement.
+    ///
+    /// Local Leave has no inbound echo of our own SelfRemove, so `Left` is
+    /// authorized only by a durable `published: true` action outcome. A failed
+    /// or still-attempting fanout must not move membership; restart replay uses
+    /// this same projector so crash recovery cannot ACK the Header first.
+    fn apply_published_outbound_action_outcomes(
+        &self,
+        effects: &marmot_account::AccountDeviceEffects,
+    ) -> Result<(), AppError> {
+        for outcome in &effects.action_outcomes {
+            match outcome.action {
+                marmot_account::AccountVisibilityOutboundAction::Leave => {
+                    if !outcome.published {
+                        continue;
+                    }
+                    self.app.set_group_self_membership(
+                        &self.state.label,
+                        &hex::encode(outcome.group_id.as_slice()),
+                        SelfMembership::Left,
+                    )?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn project_account_non_session_visibility_at(
+        &mut self,
+        effects: &marmot_account::AccountDeviceEffects,
+        recorded_at: u64,
+        deferred_app_event_id: Option<&str>,
+    ) -> Result<HashSet<cgka_traits::GroupId>, AppError> {
+        self.apply_published_outbound_action_outcomes(effects)?;
+        self.remember_published_reports(effects);
+        self.record_welcome_delivery_failures_from_effects_at(effects, recorded_at)?;
+        let mut affected_groups = effects
+            .events
+            .iter()
+            .filter_map(event_group_id)
+            .cloned()
+            .collect::<HashSet<_>>();
+        for published in &effects.published_app_messages {
+            affected_groups.insert(published.group_id.clone());
+            if deferred_app_event_id == Some(published.app_event_id.as_str()) {
+                continue;
+            }
+            if let Some(update) =
+                self.finalize_published_app_message_and_queue_notification(published)?
+            {
+                let mut finalized = SyncSummary::default();
+                finalized.projection_updates.push(update);
+                self.retain_uncheckpointed_sync_summary(finalized);
+            }
+        }
+        // NonSession is one cumulative row: acknowledge none of it until the
+        // complete vector has projected. SessionControl is safe at the same
+        // point because `remember_published_reports` retained every convergence
+        // wake before this boundary. Header remains the source-handler tail.
+        if deferred_app_event_id.is_none() {
+            self.stage_current_account_visibility_non_session_batch();
+        }
+        self.stage_current_account_visibility_record_kind(
+            marmot_account::AccountVisibilityRecordKind::SessionControl,
+        );
+        Ok(affected_groups)
+    }
+
+    pub(super) fn project_current_account_non_session_visibility(
+        &mut self,
+        effects: &marmot_account::AccountDeviceEffects,
+        deferred_app_event_id: Option<&str>,
+    ) -> Result<HashSet<cgka_traits::GroupId>, AppError> {
+        let recorded_at = self.current_account_visibility_observed_at();
+        self.project_account_non_session_visibility_at(effects, recorded_at, deferred_app_event_id)
+    }
+
+    pub(super) fn current_account_visibility_observed_at(&self) -> u64 {
+        let Some(pending) = self.pending_account_visibility_lease.as_ref() else {
+            return unix_now_seconds();
+        };
+        let Some(operation_id) = pending.projection_operation_id.as_ref() else {
+            return unix_now_seconds();
+        };
+        pending
+            .batches
+            .iter()
+            .find(|batch| &batch.operation_id == operation_id)
+            .map(|batch| match &batch.source {
+                marmot_account::AccountVisibilitySource::Inbound { observed_at, .. }
+                | marmot_account::AccountVisibilitySource::Drain { observed_at }
+                | marmot_account::AccountVisibilitySource::Convergence { observed_at, .. }
+                | marmot_account::AccountVisibilitySource::Maintenance { observed_at }
+                | marmot_account::AccountVisibilitySource::Outbound { observed_at, .. } => {
+                    observed_at.0
+                }
+            })
+            .unwrap_or_else(unix_now_seconds)
+    }
+
+    fn set_account_visibility_projection_operation(&mut self, operation_id: Option<Vec<u8>>) {
+        if let Some(pending) = self.pending_account_visibility_lease.as_mut() {
+            pending.projection_operation_id = operation_id;
+        }
+    }
+
+    fn stage_current_account_visibility_record_kind(
+        &mut self,
+        kind: marmot_account::AccountVisibilityRecordKind,
+    ) {
+        let Some(pending) = self.pending_account_visibility_lease.as_ref() else {
+            return;
+        };
+        let Some(operation_id) = pending.projection_operation_id.as_ref() else {
+            return;
+        };
+        let batch_ids = pending
+            .batches
+            .iter()
+            .filter(|batch| &batch.operation_id == operation_id)
+            .filter(|batch| batch.kind == kind)
+            .map(|batch| batch.batch_id.clone())
+            .collect::<Vec<_>>();
+        let pending = self
+            .pending_account_visibility_lease
+            .as_mut()
+            .expect("visibility lease remains installed");
+        for batch_id in batch_ids {
+            if !pending.staged_batch_ids.contains(&batch_id) {
+                pending.staged_batch_ids.push(batch_id);
+            }
+        }
+    }
+
+    pub(super) fn stage_current_account_visibility_header_batch(&mut self) {
+        self.stage_current_account_visibility_record_kind(
+            marmot_account::AccountVisibilityRecordKind::Header,
+        );
+    }
+
+    pub(super) fn stage_current_account_visibility_non_session_batch(&mut self) {
+        self.stage_current_account_visibility_record_kind(
+            marmot_account::AccountVisibilityRecordKind::NonSession,
+        );
+    }
+
+    pub(super) fn stage_current_account_visibility_event(
+        &mut self,
+        event: &cgka_traits::engine::GroupEvent,
+    ) {
+        let Some(pending) = self.pending_account_visibility_lease.as_ref() else {
+            return;
+        };
+        let Some(operation_id) = pending.projection_operation_id.as_ref() else {
+            return;
+        };
+        let Some(batch_id) = pending
+            .batches
+            .iter()
+            .filter(|batch| &batch.operation_id == operation_id)
+            .filter(|batch| {
+                matches!(
+                    batch.kind,
+                    marmot_account::AccountVisibilityRecordKind::Event { .. }
+                )
+            })
+            .filter(|batch| !pending.staged_batch_ids.contains(&batch.batch_id))
+            .find(|batch| batch.effects.events.as_slice() == std::slice::from_ref(event))
+            .map(|batch| batch.batch_id.clone())
+        else {
+            return;
+        };
+        self.pending_account_visibility_lease
+            .as_mut()
+            .expect("visibility lease remains installed")
+            .staged_batch_ids
+            .push(batch_id);
+    }
+
+    fn has_staged_account_visibility_batches(&self) -> bool {
+        self.pending_account_visibility_lease
+            .as_ref()
+            .is_some_and(|pending| !pending.staged_batch_ids.is_empty())
+    }
+
+    /// Retain successfully projected output before its next await or fallible
+    /// boundary. Occupancy is explicit so an empty batch that wakes convergence
+    /// or epoch backfill is not confused with no pending visibility work.
+    pub(super) fn retain_uncheckpointed_sync_summary(&mut self, summary: SyncSummary) {
+        Self::merge_occupied_sync_summary(&mut self.pending_uncheckpointed_sync_summary, summary);
+    }
+
+    pub(super) fn retain_checkpointed_sync_summary(&mut self, summary: SyncSummary) {
+        Self::merge_occupied_sync_summary(&mut self.pending_checkpointed_sync_summary, summary);
+    }
+
+    fn remember_uncheckpointed_runtime_group_subscription_refresh(&mut self, dirty: bool) {
+        self.pending_uncheckpointed_runtime_group_subscription_refresh |= dirty;
+    }
+
+    /// Complete the visibility checkpoint synchronously after the common state
+    /// transaction commits. There must be no await between that commit and this
+    /// promotion: V1 is protected by engine replay, while V2 is bounded
+    /// process-local ownership until an outer caller/worker consumes it.
+    fn promote_uncheckpointed_sync_visibility(&mut self) {
+        if let Some(summary) = self.pending_uncheckpointed_sync_summary.take() {
+            self.retain_checkpointed_sync_summary(summary);
+        }
+        self.pending_runtime_group_subscription_refresh |=
+            std::mem::take(&mut self.pending_uncheckpointed_runtime_group_subscription_refresh);
+    }
+
+    /// Take the one bounded, durably checkpointed aggregate. `Some(default)` is
+    /// meaningful occupancy for direct `next_event`; callers deciding whether
+    /// an empty result is publishable must inspect the summary, not collapse the
+    /// option. Epoch-stall escalations join only at this final ownership handoff.
+    pub(crate) fn take_pending_checkpointed_sync_summary(&mut self) -> Option<SyncSummary> {
+        if self.pending_checkpointed_sync_summary.is_none()
+            && self.pending_epoch_stall_escalations.is_empty()
+        {
+            return None;
+        }
+        let mut summary = self
+            .pending_checkpointed_sync_summary
+            .take()
+            .unwrap_or_default();
+        self.drain_epoch_stall_escalations(&mut summary);
+        Some(summary)
+    }
+
+    /// Finish a cancellation-retained V1 batch without awaiting relay I/O.
+    ///
+    /// The engine application-event outbox remains unacknowledged while V1 is
+    /// occupied. A managed timeout therefore calls this before its fallback
+    /// publication: the common save commits projection + ACK state and promotes
+    /// the aggregate to V2 synchronously, while the ordinary subscription
+    /// rebuild stays armed for the worker's bounded retry task.
+    pub(crate) fn checkpoint_pending_sync_visibility(&mut self) -> Result<bool, AppError> {
+        if self.pending_uncheckpointed_sync_summary.is_none()
+            && !self.has_staged_account_visibility_batches()
+        {
+            return Ok(false);
+        }
+        let refresh = self.refresh_group_routes()?;
+        self.remember_uncheckpointed_runtime_group_subscription_refresh(refresh.routing_changed);
+        self.save_state_with_pending_local_group_deletion_frontier_clears()?;
+        Ok(true)
+    }
+
+    fn take_checkpointed_sync_summary_or_default(&mut self) -> SyncSummary {
+        let mut summary = self
+            .pending_checkpointed_sync_summary
+            .take()
+            .unwrap_or_default();
+        self.drain_epoch_stall_escalations(&mut summary);
+        summary
+    }
+
+    /// Consume only output an error's plain `partial_summary` can represent.
+    /// An occupied empty V2 is a wake edge, not reportable partial progress, so
+    /// it stays owned for the next successful/direct/worker seam.
+    fn take_reportable_checkpointed_sync_summary_for_failure(&mut self) -> SyncSummary {
+        let mut summary = if self
+            .pending_checkpointed_sync_summary
+            .as_ref()
+            .is_some_and(|summary| summary != &SyncSummary::default())
+        {
+            self.pending_checkpointed_sync_summary
+                .take()
+                .expect("checked nonempty checkpointed summary")
+        } else {
+            SyncSummary::default()
+        };
+        self.drain_epoch_stall_escalations(&mut summary);
+        summary
+    }
+
+    fn merge_checkpointed_visibility_into_failure(&mut self, failure: &mut ClassifiedSyncFailure) {
+        let mut retained = self.take_reportable_checkpointed_sync_summary_for_failure();
+        retained.merge(std::mem::take(&mut failure.partial_summary));
+        failure.partial_summary = retained;
+    }
+
     /// Retry an ordinary group-subscription rebuild that was deliberately
     /// moved behind live-ingest visibility. A successful rebuild disarms the
     /// intent; an error leaves it armed so the worker's bounded backoff can
@@ -751,6 +1629,14 @@ impl AppClient {
     ) -> Result<bool, AppError> {
         if !self.pending_runtime_group_subscription_refresh {
             return Ok(false);
+        }
+        // A routes-dirty delivery can checkpoint before its first route-table
+        // reconciliation. Rebuild the in-memory snapshot here on every retry;
+        // otherwise a cancelled/failed refresh could later subscribe the stale
+        // snapshot and incorrectly clear the durable retry intent.
+        let refresh = self.refresh_group_routes()?;
+        if refresh.state_pruned {
+            self.save_state_with_pending_local_group_deletion_frontier_clears()?;
         }
         if let Err(error) = self.sync_runtime_groups().await {
             if error.is_account_not_active() {
@@ -768,6 +1654,18 @@ impl AppClient {
         Ok(false)
     }
 
+    /// Preserve a direct caller's durable sync output while restoring the
+    /// historical ready-on-return subscription guarantee. The summary moves to
+    /// client-owned storage before the first retry await, so cancellation cannot
+    /// discard output whose engine-outbox acknowledgement already committed.
+    async fn finalize_direct_sync_summary(&mut self) -> Result<SyncSummary, AppError> {
+        if self.has_pending_runtime_group_subscription_refresh() {
+            self.retry_pending_runtime_group_subscription_refresh()
+                .await?;
+        }
+        Ok(self.take_checkpointed_sync_summary_or_default())
+    }
+
     pub(crate) async fn prepare_transport(&mut self) -> Result<(), AppError> {
         self.prepare_transport_with_telemetry(None).await
     }
@@ -776,12 +1674,30 @@ impl AppClient {
         &mut self,
         telemetry: Option<&AppPerformanceTelemetry>,
     ) -> Result<(), AppError> {
+        self.replay_pending_account_visibility().await?;
         self.prepare_transport_for_sync(telemetry)
             .await
             .map_err(|(_, error)| error)
     }
 
     async fn prepare_transport_for_sync(
+        &mut self,
+        telemetry: Option<&AppPerformanceTelemetry>,
+    ) -> Result<(), (SyncFailureStage, AppError)> {
+        self.ensure_active_signing_account()
+            .map_err(|error| (SyncFailureStage::TransportActivation, error))?;
+        self.prepare_transport_for_admitted_session(telemetry).await
+    }
+
+    pub(crate) async fn prepare_teardown_transport(&mut self) -> Result<(), AppError> {
+        self.ensure_teardown_cleanup_account()?;
+        self.prepare_transport_for_admitted_session(None)
+            .await
+            .map_err(|(_, error)| error)?;
+        self.ensure_teardown_cleanup_account()
+    }
+
+    async fn prepare_transport_for_admitted_session(
         &mut self,
         telemetry: Option<&AppPerformanceTelemetry>,
     ) -> Result<(), (SyncFailureStage, AppError)> {
@@ -823,13 +1739,16 @@ impl AppClient {
     /// report the durably applied prefix of a failed catch-up pass.
     pub async fn sync(&mut self) -> Result<SyncSummary, AppError> {
         match self.sync_inner(None).await {
-            Ok(summary) => Ok(summary),
-            Err(failure) => {
+            Ok(()) => self.finalize_direct_sync_summary().await,
+            Err(mut failure) => {
                 // Compatibility callers cannot observe a failure summary.
                 // Retain any already-checkpointed prefix for their next
                 // successful sync instead of consuming it with the error.
-                self.pending_failed_sync_summary
-                    .merge(failure.partial_summary);
+                if failure.partial_summary != SyncSummary::default() {
+                    self.retain_checkpointed_sync_summary(std::mem::take(
+                        &mut failure.partial_summary,
+                    ));
+                }
                 Err(failure.source)
             }
         }
@@ -837,18 +1756,29 @@ impl AppClient {
 
     /// Synchronize while retaining the durably applied prefix on failure.
     pub async fn sync_with_partial_progress(&mut self) -> Result<SyncSummary, SyncFailure> {
-        self.sync_with_classified_partial_progress()
-            .await
-            .map_err(SyncFailure::from)
+        match self.sync_inner(None).await {
+            Ok(()) => match self.finalize_direct_sync_summary().await {
+                Ok(summary) => Ok(summary),
+                Err(source) => {
+                    let partial_summary =
+                        self.take_reportable_checkpointed_sync_summary_for_failure();
+                    Err(SyncFailure::new(partial_summary, source))
+                }
+            },
+            Err(mut failure) => {
+                self.merge_checkpointed_visibility_into_failure(&mut failure);
+                Err(SyncFailure::from(failure))
+            }
+        }
     }
 
     pub(crate) async fn sync_with_classified_partial_progress(
         &mut self,
     ) -> Result<SyncSummary, ClassifiedSyncFailure> {
         match self.sync_inner(None).await {
-            Ok(summary) => Ok(summary),
+            Ok(()) => Ok(self.take_checkpointed_sync_summary_or_default()),
             Err(mut failure) => {
-                self.drain_epoch_stall_escalations(&mut failure.partial_summary);
+                self.merge_checkpointed_visibility_into_failure(&mut failure);
                 Err(failure)
             }
         }
@@ -859,9 +1789,9 @@ impl AppClient {
         telemetry: &AppPerformanceTelemetry,
     ) -> Result<SyncSummary, ClassifiedSyncFailure> {
         match self.sync_inner(Some(telemetry)).await {
-            Ok(summary) => Ok(summary),
+            Ok(()) => Ok(self.take_checkpointed_sync_summary_or_default()),
             Err(mut failure) => {
-                self.drain_epoch_stall_escalations(&mut failure.partial_summary);
+                self.merge_checkpointed_visibility_into_failure(&mut failure);
                 Err(failure)
             }
         }
@@ -870,7 +1800,16 @@ impl AppClient {
     async fn sync_inner(
         &mut self,
         telemetry: Option<&AppPerformanceTelemetry>,
-    ) -> Result<SyncSummary, ClassifiedSyncFailure> {
+    ) -> Result<(), ClassifiedSyncFailure> {
+        self.replay_pending_account_visibility()
+            .await
+            .map_err(|error| {
+                ClassifiedSyncFailure::at_stage(
+                    SyncSummary::default(),
+                    error,
+                    SyncFailureStage::StatePersist,
+                )
+            })?;
         // Reconcile epoch-bounded prior routes before issuing the first relay
         // subscriptions. This makes retirement deterministic even for a quiet
         // group that has no new inbound events after restart.
@@ -930,38 +1869,40 @@ impl AppClient {
         // A complete startup/catch-up rebuild satisfies any older deferred
         // refresh intent before this pass starts ingesting new deliveries.
         self.pending_runtime_group_subscription_refresh = false;
+        self.pending_uncheckpointed_runtime_group_subscription_refresh = false;
         // Both the inbox/group activation and the group-subscription refresh
         // have now registered on relays; emit the rebuild audit row from the
         // drained registration log before draining inbound deliveries.
         self.record_subscription_rebuild(rebuild_since_secs).await;
-        let mut counts = DrainCounts::default();
-        let (mut summary, drain_verdict) = self.sync_sdk_relay(&mut counts).await?;
-        if drain_verdict == DrainVerdict::Overflow || self.delivery_overflow_recovery_pending {
-            self.recover_delivery_overflow_and_merge(&mut summary)
-                .await?;
+        // Drain effects that existed before this relay pass into V1 first. The
+        // relay checkpoint below then commits them in the same transaction as
+        // any newly received prefix. This deliberately leaves no network await
+        // after V1 has been promoted to process-local V2.
+        //
+        // Session `open()` hydration queues `GroupHydrationQuarantined` without
+        // an inbound delivery (mdk#426). Folding those events here keeps them
+        // visible even when the later relay drain is quiet.
+        if let Err(error) = self.drain_pending_session_events_staged().await {
+            return Err(ClassifiedSyncFailure::at_stage(
+                SyncSummary::default(),
+                error,
+                SyncFailureStage::Unknown,
+            ));
         }
-        // Surface engine events queued without an inbound delivery — most
-        // importantly `GroupHydrationQuarantined`, queued during session
-        // `open()` hydration (mdk#426). If no relay delivery arrived
-        // above, `sync_sdk_relay` never drained the engine, so these would stay
-        // buffered and invisible to runtime subscribers until some later
-        // unrelated send/ingest. Fold any pending events into this summary.
-        let drained = match self.drain_pending_session_events().await {
-            Ok(drained) => drained,
-            Err(error) => {
-                // This composite drain spans engine drain, app-state reads,
-                // publish checks, and projection. Its AppError does not retain
-                // the inner boundary, so do not infer a stage from the cause.
-                return Err(ClassifiedSyncFailure::at_stage(
-                    summary,
-                    error,
-                    SyncFailureStage::Unknown,
-                ));
-            }
-        };
-        summary.merge(drained);
-        self.drain_epoch_stall_escalations(&mut summary);
-        Ok(summary)
+        let mut counts = DrainCounts::default();
+        let drain_verdict = self.sync_sdk_relay(&mut counts).await?;
+        if drain_verdict == DrainVerdict::Overflow || self.delivery_overflow_recovery_pending {
+            let mut recovered = SyncSummary::default();
+            self.recover_delivery_overflow_and_merge(&mut recovered)
+                .await?;
+            self.retain_checkpointed_sync_summary(recovered);
+        }
+        #[cfg(test)]
+        if let Some((entered, release)) = self.block_after_sync_prefix_checkpoint.take() {
+            entered.notify_one();
+            release.notified().await;
+        }
+        Ok(())
     }
 
     /// Drain engine events that were queued without an inbound transport
@@ -977,16 +1918,81 @@ impl AppClient {
     /// reference a not-yet-live (quarantined) group must not abort the drain —
     /// projection lookups are best-effort.
     pub(crate) async fn drain_pending_session_events(&mut self) -> Result<SyncSummary, AppError> {
-        let effects = self.runtime.drain().await?;
-        self.observe_drained_session_events(&effects).await
+        self.drain_pending_session_events_staged().await?;
+        self.checkpoint_pending_sync_visibility()?;
+        Ok(self.take_checkpointed_sync_summary_or_default())
+    }
+
+    /// Nested drain used by sync/backfill/repair. It stages visibility V1 but
+    /// does not save or take V2: the following relay-prefix checkpoint owns the
+    /// one durable commit, so no acknowledged output crosses another await.
+    async fn drain_pending_session_events_staged(&mut self) -> Result<(), AppError> {
+        // A lower drain creates a new durable source operation before it
+        // returns. Finish any older source-attributed suffix first so a replay
+        // projection error cannot be hidden behind (or rebound to) that new
+        // Drain operation. Replay handlers only project/checkpoint supplied
+        // effects; none calls this lower drain entry again.
+        self.replay_pending_account_visibility().await?;
+        let leased = self.runtime.drain_leased().await?;
+        self.install_account_visibility_lease(
+            leased.lease,
+            leased.batches,
+            leased.current_operation_id,
+        );
+        let effects = leased.effects;
+        self.project_current_account_non_session_visibility(&effects, None)?;
+        match self.observe_drained_session_events_staged(&effects) {
+            Ok(()) => {
+                self.stage_current_account_visibility_header_batch();
+                Ok(())
+            }
+            Err(error) => {
+                // The observer retains every fully projected event in V1 as it
+                // goes. Promote that exact prefix before returning an error so
+                // classified sync failure publication cannot overtake it.
+                self.checkpoint_pending_sync_visibility()?;
+                Err(error)
+            }
+        }
     }
 
     /// Project one drained batch of engine events, split from the drain itself
     /// so the projection is exercisable against a given batch of effects.
+    #[cfg(test)]
     pub(crate) async fn observe_drained_session_events(
         &mut self,
         effects: &marmot_account::AccountDeviceEffects,
     ) -> Result<SyncSummary, AppError> {
+        // Mirror `drain_pending_session_events_staged`: NonSession owns
+        // report/fanout/app-message projection, then events project in order,
+        // and Header is staged only after the complete source handler.
+        self.project_current_account_non_session_visibility(effects, None)?;
+        match self.observe_drained_session_events_staged(effects) {
+            Ok(()) => self.stage_current_account_visibility_header_batch(),
+            Err(error) => {
+                self.checkpoint_pending_sync_visibility()?;
+                return Err(error);
+            }
+        }
+        self.checkpoint_pending_sync_visibility()?;
+        Ok(self.take_checkpointed_sync_summary_or_default())
+    }
+
+    pub(super) fn observe_drained_session_events_staged(
+        &mut self,
+        effects: &marmot_account::AccountDeviceEffects,
+    ) -> Result<(), AppError> {
+        self.observe_drained_session_events_staged_at(
+            effects,
+            self.current_account_visibility_observed_at(),
+        )
+    }
+
+    pub(super) fn observe_drained_session_events_staged_at(
+        &mut self,
+        effects: &marmot_account::AccountDeviceEffects,
+        source_received_at: u64,
+    ) -> Result<(), AppError> {
         // Session open seeds this list from durable queued/convergence input.
         // Preserve that scheduling edge even when hydration emitted no app
         // events; the worker drains this set immediately after startup sync.
@@ -999,15 +2005,15 @@ impl AppClient {
         // because it is a field mutation plus a durable audit row, not summary
         // state. The two conditions are correlated rather than independent: this
         // drain publishes, so the failure and the refusal ride the same effects.
-        self.observe_recovery_evidence(effects);
-        fail_if_publish_failed(effects)?;
-        let mut summary = SyncSummary::default();
+        self.observe_recovery_evidence(effects)?;
+        let publish_error = fail_if_publish_failed(effects).err();
         if effects.events.is_empty() {
-            self.drain_epoch_stall_escalations(&mut summary);
-            return Ok(summary);
+            return match publish_error {
+                Some(error) => Err(error),
+                None => Ok(()),
+            };
         }
         let display_names = self.app.display_names_by_id()?;
-        let source_received_at = unix_now_seconds();
         // Hydration re-emits a stored group's `GroupDisbanded` on every open
         // (`restore_disband_tombstone`), and that replay is the only reconciler
         // left for a disband whose live-session projection never completed — a
@@ -1023,8 +2029,8 @@ impl AppClient {
         let local_group_deletion_frontiers =
             self.local_group_deletion_frontiers_at_batch_start(effects)?;
         let mut routes_dirty = false;
-        let mut gossip_message_ids = HashSet::new();
         for event in &effects.events {
+            let mut event_summary = SyncSummary::default();
             // A replayed application event has no outer relay envelope, but its
             // durable engine outbox key is stable and unique. Use that key as
             // the synthetic source so a crash can replay several pending
@@ -1058,6 +2064,9 @@ impl AppClient {
             {
                 routes_dirty |= changed;
                 self.prepare_pending_application_event_ack(event);
+                self.remember_uncheckpointed_runtime_group_subscription_refresh(changed);
+                self.retain_uncheckpointed_sync_summary(event_summary);
+                self.stage_current_account_visibility_event(event);
                 continue;
             }
             let before = self.state.groups.len();
@@ -1074,7 +2083,7 @@ impl AppClient {
             if let Some(message) = observe_event(
                 &mut self.state,
                 &display_names,
-                &mut summary,
+                &mut event_summary,
                 event,
                 group_projection.as_ref(),
                 &source_message_id_hex,
@@ -1082,9 +2091,11 @@ impl AppClient {
                 None,
                 self.app.allow_loopback_blob_endpoints(),
             ) && let Some(gossip_message_id) =
-                self.project_received_message(message, group_metadata.as_ref(), &mut summary)?
+                self.project_received_message(message, group_metadata.as_ref(), &mut event_summary)?
             {
-                gossip_message_ids.insert(gossip_message_id);
+                event_summary
+                    .messages
+                    .retain(|message| message.message_id_hex != gossip_message_id);
             }
             let updated_group =
                 event_group_id(event).and_then(|group_id| self.state_group_record(group_id));
@@ -1099,8 +2110,12 @@ impl AppClient {
                 updated_group.as_ref(),
                 &source_message_id_hex,
             );
-            routes_dirty |=
-                self.observe_event_projection_effects(event, &local_account_id_hex, &mut summary)?;
+            let event_routes_dirty = self.observe_event_projection_effects(
+                event,
+                &local_account_id_hex,
+                &mut event_summary,
+            )?;
+            routes_dirty |= event_routes_dirty;
             let can_ack_application_event = if crosses_frontier {
                 self.prepare_local_group_deletion_frontier_clear(
                     event,
@@ -1111,37 +2126,27 @@ impl AppClient {
             };
             if can_ack_application_event {
                 self.prepare_pending_application_event_ack(event);
+                self.stage_current_account_visibility_event(event);
             }
             if self.state.groups.len() != before {
                 routes_dirty = true;
             }
-        }
-        if !gossip_message_ids.is_empty() {
-            summary
-                .messages
-                .retain(|message| !gossip_message_ids.contains(&message.message_id_hex));
+            self.remember_uncheckpointed_runtime_group_subscription_refresh(
+                event_routes_dirty || self.state.groups.len() != before,
+            );
+            // The event is now fully projected. Move its only summary copy to
+            // V1 before the next loop iteration can hit another fallible seam.
+            self.retain_uncheckpointed_sync_summary(event_summary);
         }
         self.clear_terminal_local_group_deletion_frontiers(effects)?;
-        // Reconcile transport routes once after the batch drains instead of per
-        // membership-changing event. This installs a join's current route and
-        // retains any still-live address displaced by a routing rotation.
-        let routes_changed = self.refresh_group_routes()?.routing_changed;
-        if (routes_dirty || routes_changed)
-            && let Err(error) = self.sync_runtime_groups().await
-        {
-            self.pending_failed_sync_summary.merge(summary);
-            return Err(error);
+        // Record the routing obligation once after the batch drains instead of
+        // reconciling per membership-changing event. The outer checkpoint does
+        // the one route refresh and state save for this staged batch.
+        self.remember_uncheckpointed_runtime_group_subscription_refresh(routes_dirty);
+        match publish_error {
+            Some(error) => Err(error),
+            None => Ok(()),
         }
-        if let Err(error) = self.save_state_with_pending_local_group_deletion_frontier_clears() {
-            // The engine outbox remains unacknowledged. A reopened client will
-            // replay it; a retained client instead checkpoints the projected
-            // state on its next sync and returns this deferred summary once.
-            self.pending_failed_sync_summary.merge(summary);
-            return Err(error);
-        }
-        summary.merge(std::mem::take(&mut self.pending_failed_sync_summary));
-        self.drain_epoch_stall_escalations(&mut summary);
-        Ok(summary)
     }
 
     /// Observe group events the engine applied as a side effect of an outbound
@@ -1169,8 +2174,8 @@ impl AppClient {
         // Synthetic source identity: these events have no single inbound
         // transport message (see `drain_pending_session_events`).
         let source_message_id_hex = String::new();
-        let source_received_at = unix_now_seconds();
-        let routes_dirty = self
+        let source_received_at = self.current_account_visibility_observed_at();
+        let routes_dirty = match self
             .observe_account_device_effects(
                 effects,
                 &display_names,
@@ -1179,12 +2184,21 @@ impl AppClient {
                 source_received_at,
                 None,
             )
-            .await?;
-        let routes_changed = self.refresh_group_routes()?.routing_changed;
-        if routes_dirty || routes_changed {
-            self.sync_runtime_groups().await?;
-        }
+            .await
+        {
+            Ok(routes_dirty) => routes_dirty,
+            Err(error) => {
+                self.pending_applied_sync_summary.merge(summary);
+                return Err(error);
+            }
+        };
+        // Own every fully projected event before route reconciliation or relay
+        // I/O can fail/cancel. The worker drains this aggregate after the send,
+        // while its ordinary state save commits any staged app-event ACKs.
         self.pending_applied_sync_summary.merge(summary);
+        self.pending_runtime_group_subscription_refresh |= routes_dirty;
+        let routes_changed = self.refresh_group_routes()?.routing_changed;
+        self.pending_runtime_group_subscription_refresh |= routes_changed;
         Ok(())
     }
 
@@ -1195,14 +2209,18 @@ impl AppClient {
     pub(crate) async fn observe_send_applied_effects_best_effort(
         &mut self,
         effects: &marmot_account::AccountDeviceEffects,
-    ) {
-        if let Err(_err) = self.observe_send_applied_effects(effects).await {
-            tracing::warn!(
-                target: "marmot_app::messages",
-                method = "observe_send_applied_effects",
-                error_code = "send_applied_observe_failed",
-                "failed to observe group events applied during a send"
-            );
+    ) -> bool {
+        match self.observe_send_applied_effects(effects).await {
+            Ok(()) => true,
+            Err(_err) => {
+                tracing::warn!(
+                    target: "marmot_app::messages",
+                    method = "observe_send_applied_effects",
+                    error_code = "send_applied_observe_failed",
+                    "failed to observe group events applied during a send"
+                );
+                false
+            }
         }
     }
 
@@ -1244,8 +2262,95 @@ impl AppClient {
         })
     }
 
+    /// Finish one direct receive batch after its projection has committed.
+    ///
+    /// Only batches the historical `next_event` return predicate would expose
+    /// occupy the retention slot. That includes an empty summary when pending
+    /// convergence or epoch backfill needs to wake the caller. Occupancy is set
+    /// before the relay await, so cancellation cannot collapse that meaningful
+    /// empty batch back into "nothing pending".
+    async fn finalize_direct_next_event_summary(
+        &mut self,
+        summary: SyncSummary,
+    ) -> Result<Option<SyncSummary>, AppError> {
+        let should_return = summary != SyncSummary::default()
+            || !self.pending_convergence_groups.is_empty()
+            || self.has_pending_epoch_backfill();
+        if should_return {
+            self.retain_checkpointed_sync_summary(summary);
+        }
+
+        // A directly-owned AppClient has no account-worker scheduler to perform
+        // the post-visibility retry. Preserve its historical readiness contract
+        // when possible, but never hide an already-durable returnable batch
+        // behind a later relay failure.
+        if let Err(error) = self
+            .retry_pending_runtime_group_subscription_refresh()
+            .await
+        {
+            return self.direct_next_event_summary_after_refresh_error(error);
+        }
+        Ok(self.take_pending_checkpointed_sync_summary())
+    }
+
+    /// A nonempty committed batch remains more useful than a later route error,
+    /// so hand it to the caller and leave the retry armed. An empty batch is only
+    /// an internal wake edge; retain its occupied slot and surface the route
+    /// error until readiness succeeds, then return that wake exactly once.
+    fn direct_next_event_summary_after_refresh_error(
+        &mut self,
+        error: AppError,
+    ) -> Result<Option<SyncSummary>, AppError> {
+        if self
+            .pending_checkpointed_sync_summary
+            .as_ref()
+            .is_some_and(|summary| summary != &SyncSummary::default())
+        {
+            let summary = self
+                .take_pending_checkpointed_sync_summary()
+                .expect("checked occupied direct next-event summary");
+            tracing::warn!(
+                target: "marmot_app",
+                method = "next_event",
+                error_kind = error.privacy_safe_kind(),
+                "returning durable receive output while group-subscription refresh remains pending"
+            );
+            return Ok(Some(summary));
+        }
+        Err(error)
+    }
+
     pub async fn next_event(&mut self) -> Result<SyncSummary, AppError> {
         loop {
+            self.replay_pending_account_visibility().await?;
+            // A prior direct ingest can be cancelled (or fail route
+            // reconciliation) after projection but before its first save. Do
+            // not wait for another delivery: finish that staged checkpoint and
+            // promote V1 before any receive await.
+            if self.pending_uncheckpointed_sync_summary.is_some() {
+                let refresh = self.refresh_group_routes()?;
+                self.remember_uncheckpointed_runtime_group_subscription_refresh(
+                    refresh.routing_changed,
+                );
+                self.save_state_with_pending_local_group_deletion_frontier_clears()?;
+            }
+            // Finish an older durable refresh before accepting another
+            // delivery. A retained batch is returned immediately afterward, so
+            // relay readiness and app-visible output stay in commit order.
+            if self.has_pending_runtime_group_subscription_refresh()
+                && let Err(error) = self
+                    .retry_pending_runtime_group_subscription_refresh()
+                    .await
+            {
+                match self.direct_next_event_summary_after_refresh_error(error) {
+                    Ok(Some(summary)) => return Ok(summary),
+                    Ok(None) => unreachable!("refresh failure cannot synthesize no summary"),
+                    Err(error) => return Err(error),
+                }
+            }
+            if let Some(summary) = self.take_pending_checkpointed_sync_summary() {
+                return Ok(summary);
+            }
             let summary = match self.receive_next_delivery().await? {
                 crate::relay_plane::AccountDeliveryReceive::Delivery(delivery) => {
                     self.ingest_received_delivery(*delivery).await?
@@ -1254,31 +2359,21 @@ impl AppClient {
                     let mut summary = SyncSummary::default();
                     match self.recover_delivery_overflow_and_merge(&mut summary).await {
                         Ok(()) => summary,
-                        Err(failure) => {
-                            self.pending_failed_sync_summary
-                                .merge(failure.partial_summary);
+                        Err(mut failure) => {
+                            self.merge_checkpointed_visibility_into_failure(&mut failure);
+                            self.retain_checkpointed_sync_summary(failure.partial_summary);
                             return Err(failure.source);
                         }
                     }
                 }
             };
-            // A directly-owned AppClient has no account-worker scheduler to
-            // perform the post-visibility retry. Preserve its historical
-            // contract by completing the pending rebuild before handing the
-            // summary to its caller; the managed worker uses the lower-level
-            // ingest method and owns the background retry instead.
-            self.retry_pending_runtime_group_subscription_refresh()
-                .await?;
-            if summary.joined_groups.is_empty()
-                && summary.messages.is_empty()
-                && summary.events.is_empty()
-                && summary.epoch_stall_escalations.is_empty()
-                && self.pending_convergence_groups.is_empty()
-                && !self.has_pending_epoch_backfill()
-            {
-                continue;
+            // The ingest checkpoint and engine-outbox acknowledgements are
+            // already durable. Finalization retains a returnable batch before
+            // its first relay await so cancellation cannot strand it on this
+            // stack.
+            if let Some(summary) = self.finalize_direct_next_event_summary(summary).await? {
+                return Ok(summary);
             }
-            return Ok(summary);
         }
     }
 
@@ -1347,6 +2442,11 @@ impl AppClient {
             // of the marker that represents the omitted older delivery.
             self.state.last_transport_timestamp = cursor_before_secs;
         }
+        // `ingest_delivery` has fully projected this delivery. Transfer its
+        // only app-visible copy to V1 before the first save/route-refresh
+        // boundary, including an occupied empty wake batch.
+        self.retain_uncheckpointed_sync_summary(summary);
+        self.remember_uncheckpointed_runtime_group_subscription_refresh(ingested.routes_dirty);
         // Mark the delivery seen only after durable ingest succeeds, matching
         // the catch-up drain below. Marking at receive time would let a failed
         // ingest poison the index, so a reused client would silently skip the
@@ -1369,27 +2469,17 @@ impl AppClient {
         // routing-table delta lives in memory and obligates a subscription
         // refresh, not a second identical state write.
         if !routes_dirty || refresh.state_pruned {
+            self.remember_uncheckpointed_runtime_group_subscription_refresh(
+                refresh.routing_changed,
+            );
             self.save_state_with_pending_local_group_deletion_frontier_clears()?;
+        } else {
+            // The first save already checkpointed this batch. A routing-only
+            // refresh needs no second state write, so arm its runtime intent
+            // directly on the checkpointed side.
+            self.pending_runtime_group_subscription_refresh |= refresh.routing_changed;
         }
-        self.pending_runtime_group_subscription_refresh |= routes_dirty || refresh.routing_changed;
-        self.drain_epoch_stall_escalations(&mut summary);
-        Ok(summary)
-    }
-
-    fn checkpoint_error_stage_and_cursor(
-        &self,
-        error: &SyncCheckpointError,
-        cursor_before_secs: Option<u64>,
-    ) -> (SyncFailureStage, Option<u64>) {
-        match error {
-            SyncCheckpointError::BeforePersistence(_) => {
-                (SyncFailureStage::StatePersist, cursor_before_secs)
-            }
-            SyncCheckpointError::AfterPersistence(_) => (
-                SyncFailureStage::GroupSubscriptionSync,
-                self.state.last_transport_timestamp,
-            ),
-        }
+        Ok(self.take_checkpointed_sync_summary_or_default())
     }
 
     /// Drain the transport for an ordinary floored sync: ingest what is waiting
@@ -1397,7 +2487,7 @@ impl AppClient {
     async fn sync_sdk_relay(
         &mut self,
         counts: &mut DrainCounts,
-    ) -> Result<(SyncSummary, DrainVerdict), ClassifiedSyncFailure> {
+    ) -> Result<DrainVerdict, ClassifiedSyncFailure> {
         self.drain_sdk_relay(counts, DrainCompletion::Quiescence)
             .await
     }
@@ -1409,7 +2499,7 @@ impl AppClient {
     async fn backfill_sdk_relay(
         &mut self,
         counts: &mut DrainCounts,
-    ) -> Result<(SyncSummary, DrainVerdict), ClassifiedSyncFailure> {
+    ) -> Result<DrainVerdict, ClassifiedSyncFailure> {
         let execution_quantum = self.epoch_backfill_execution_quantum();
         let completion = DrainCompletion::EndOfStoredEvents {
             silence_budget: self.epoch_backfill_eose_wait(),
@@ -1463,9 +2553,10 @@ impl AppClient {
             ));
         }
         self.pending_runtime_group_subscription_refresh = false;
+        self.pending_uncheckpointed_runtime_group_subscription_refresh = false;
         self.record_subscription_rebuild(None).await;
         let mut counts = DrainCounts::default();
-        let (summary, verdict) = match self
+        let verdict = match self
             .drain_sdk_relay(
                 &mut counts,
                 DrainCompletion::EndOfStoredEvents {
@@ -1481,6 +2572,7 @@ impl AppClient {
                 return Err(error);
             }
         };
+        let summary = self.take_checkpointed_sync_summary_or_default();
         if verdict == DrainVerdict::Complete
             && let Some(recovery_elapsed_ms) =
                 self.adapter.finish_delivery_overflow_recovery(attempt)
@@ -1518,8 +2610,6 @@ impl AppClient {
                 elapsed_ms = started.elapsed().as_millis() as u64,
                 "account delivery overflow recovery completed",
             );
-            let mut summary = summary;
-            self.drain_epoch_stall_escalations(&mut summary);
             return Ok(DeliveryOverflowRecoveryOutcome::Completed(summary));
         }
 
@@ -1662,7 +2752,7 @@ impl AppClient {
         &mut self,
         counts: &mut DrainCounts,
         completion: DrainCompletion,
-    ) -> Result<(SyncSummary, DrainVerdict), ClassifiedSyncFailure> {
+    ) -> Result<DrainVerdict, ClassifiedSyncFailure> {
         // These are local app-state reads before the relay receive loop. They
         // are not failures of the account-worker command boundary.
         let display_names = self.app.display_names_by_id().map_err(|error| {
@@ -1684,7 +2774,6 @@ impl AppClient {
                 )
             })?
             .account_id_hex;
-        let mut summary = SyncSummary::default();
         let mut first_wait = true;
         // Forensic drain accounting: wall-clock span, deliveries actually
         // ingested and receives skipped as echo or duplicate (counted apart, so
@@ -1739,7 +2828,6 @@ impl AppClient {
                         self.state.last_transport_timestamp = cursor_before_secs;
                         return Err(self
                             .finish_failed_sync_drain(
-                                summary,
                                 routes_dirty,
                                 counts.clone(),
                                 StagedSyncError::new(error, SyncFailureStage::StatePersist),
@@ -1761,7 +2849,6 @@ impl AppClient {
                 Ok(Err(error)) => {
                     return Err(self
                         .finish_failed_sync_drain(
-                            summary,
                             routes_dirty,
                             counts.clone(),
                             StagedSyncError::new(error.into(), SyncFailureStage::RelayReceive),
@@ -1818,7 +2905,6 @@ impl AppClient {
             {
                 return Err(self
                     .finish_failed_sync_drain(
-                        summary,
                         routes_dirty,
                         counts.clone(),
                         StagedSyncError::new(
@@ -1839,7 +2925,6 @@ impl AppClient {
                 Err(error) => {
                     return Err(self
                         .finish_failed_sync_drain(
-                            summary,
                             routes_dirty,
                             counts.clone(),
                             StagedSyncError::new(error, SyncFailureStage::CgkaIngest),
@@ -1866,9 +2951,17 @@ impl AppClient {
             if !ingested.must_stay_fetchable {
                 self.remember_seen_event(event_id);
             }
+            // `ingest_delivery` has fully projected this delivery. Make V1 its
+            // sole summary owner before any later receive/checkpoint await.
+            self.retain_uncheckpointed_sync_summary(delivery_summary);
+            self.remember_uncheckpointed_runtime_group_subscription_refresh(ingested.routes_dirty);
             counts.deliveries = counts.deliveries.saturating_add(1);
-            summary.merge(delivery_summary);
             routes_dirty |= ingested.routes_dirty;
+            #[cfg(test)]
+            if let Some((entered, release)) = self.block_after_sync_delivery_projection.take() {
+                entered.notify_one();
+                release.notified().await;
+            }
         };
 
         if verdict != DrainVerdict::Overflow
@@ -1881,7 +2974,6 @@ impl AppClient {
             if let Err(error) = self.observe_delivery_overflow(overflow) {
                 return Err(self
                     .finish_failed_sync_drain(
-                        summary,
                         routes_dirty,
                         counts.clone(),
                         StagedSyncError::new(error, SyncFailureStage::StatePersist),
@@ -1893,20 +2985,18 @@ impl AppClient {
             verdict = DrainVerdict::Overflow;
         }
 
-        if let Err(error) = self
-            .checkpoint_sync_prefix(&mut summary, routes_dirty, counts.deliveries)
-            .await
-        {
-            let (stage, cursor_after_secs) =
-                self.checkpoint_error_stage_and_cursor(&error, cursor_before_secs);
-            let (summary, source) = self.checkpoint_failure_summary(summary, error);
+        if let Err(source) = self.checkpoint_sync_prefix(routes_dirty, counts.deliveries) {
             self.record_sync_drain(
                 drain_started.elapsed().as_millis() as u64,
                 counts.clone(),
                 cursor_before_secs,
-                cursor_after_secs,
+                cursor_before_secs,
             );
-            return Err(ClassifiedSyncFailure::at_stage(summary, source, stage));
+            return Err(ClassifiedSyncFailure::at_stage(
+                SyncSummary::default(),
+                source,
+                SyncFailureStage::StatePersist,
+            ));
         }
         self.record_sync_drain(
             drain_started.elapsed().as_millis() as u64,
@@ -1914,51 +3004,41 @@ impl AppClient {
             cursor_before_secs,
             self.state.last_transport_timestamp,
         );
-        Ok((summary, verdict))
+        Ok(verdict)
     }
 
     async fn finish_failed_sync_drain(
         &mut self,
-        mut summary: SyncSummary,
         routes_dirty: bool,
         counts: DrainCounts,
         original: StagedSyncError,
         drain_started: std::time::Instant,
         cursor_before_secs: Option<u64>,
     ) -> ClassifiedSyncFailure {
-        let (source, stage, cursor_after_secs) = match self
-            .checkpoint_sync_prefix(&mut summary, routes_dirty, counts.deliveries)
-            .await
-        {
-            Ok(()) => (
-                original.source,
-                original.stage,
-                self.state.last_transport_timestamp,
-            ),
-            Err(error) => {
-                let (stage, cursor_after_secs) =
-                    self.checkpoint_error_stage_and_cursor(&error, cursor_before_secs);
-                let (retained_summary, checkpoint_error) =
-                    self.checkpoint_failure_summary(summary, error);
-                summary = retained_summary;
-                (checkpoint_error, stage, cursor_after_secs)
-            }
-        };
+        let (source, stage, cursor_after_secs) =
+            match self.checkpoint_sync_prefix(routes_dirty, counts.deliveries) {
+                Ok(()) => (
+                    original.source,
+                    original.stage,
+                    self.state.last_transport_timestamp,
+                ),
+                Err(error) => (error, SyncFailureStage::StatePersist, cursor_before_secs),
+            };
         self.record_sync_drain(
             drain_started.elapsed().as_millis() as u64,
             counts,
             cursor_before_secs,
             cursor_after_secs,
         );
-        ClassifiedSyncFailure::at_stage(summary, source, stage)
+        ClassifiedSyncFailure::at_stage(SyncSummary::default(), source, stage)
     }
 
-    async fn checkpoint_sync_prefix(
+    fn checkpoint_sync_prefix(
         &mut self,
-        summary: &mut SyncSummary,
         routes_dirty: bool,
         deliveries: u64,
-    ) -> Result<(), SyncCheckpointError> {
+    ) -> Result<(), AppError> {
+        self.remember_uncheckpointed_runtime_group_subscription_refresh(routes_dirty);
         // The checkpoint re-runs `refresh_group_routes` only when the drained
         // prefix could have changed routing: deliveries advance epochs (which
         // gate prior-route pruning) and can mark groups disbanded. With zero
@@ -1966,15 +3046,17 @@ impl AppClient {
         // byte-identical to what the sync-start refresh already read, so the
         // recomputation here would rescan every group only to install the same
         // routing snapshot (mdk#1380).
-        let routes_changed = if deliveries > 0 || routes_dirty {
+        let routes_changed = if deliveries > 0
+            || routes_dirty
+            || self.pending_uncheckpointed_runtime_group_subscription_refresh
+        {
             self.checkpoint_route_refresh_recomputes =
                 self.checkpoint_route_refresh_recomputes.saturating_add(1);
-            self.refresh_group_routes()
-                .map_err(SyncCheckpointError::BeforePersistence)?
-                .routing_changed
+            self.refresh_group_routes()?.routing_changed
         } else {
             false
         };
+        self.remember_uncheckpointed_runtime_group_subscription_refresh(routes_changed);
         let checkpointed_before = self.checkpointed_transport_timestamp;
         if self.adapter.pending_delivery_overflow().is_none() {
             self.checkpointed_transport_timestamp = self.state.last_transport_timestamp;
@@ -1994,44 +3076,13 @@ impl AppClient {
         };
         if let Err(error) = checkpoint {
             self.checkpointed_transport_timestamp = checkpointed_before;
-            return Err(SyncCheckpointError::BeforePersistence(error));
+            return Err(error);
         }
 
-        summary.merge(std::mem::take(&mut self.pending_failed_sync_summary));
-
-        if routes_dirty || routes_changed {
-            match self.sync_runtime_groups().await {
-                Ok(()) => self.pending_runtime_group_subscription_refresh = false,
-                Err(error) => {
-                    // The projection and route checkpoint above are durable.
-                    // Retain an explicit retry edge so the worker repairs the
-                    // ordinary subscriptions without replaying this prefix or
-                    // waiting for another catch-up trigger.
-                    self.pending_runtime_group_subscription_refresh = true;
-                    return Err(SyncCheckpointError::AfterPersistence(error));
-                }
-            }
-        }
+        // Projection, cursor, and application-event acknowledgements are now
+        // durable, and the common save moved their bounded aggregate to V2.
+        // Relay I/O belongs to the direct wrapper or managed scheduler.
         Ok(())
-    }
-
-    fn checkpoint_failure_summary(
-        &mut self,
-        summary: SyncSummary,
-        error: SyncCheckpointError,
-    ) -> (SyncSummary, AppError) {
-        match error {
-            SyncCheckpointError::BeforePersistence(source) => {
-                // Message/join projections from this drain are not reportable
-                // until their checkpoint commits. Keep one-shot epoch-stall
-                // escalations pending here: partial-progress entry points drain
-                // them into the failure, while compatibility `sync()` leaves
-                // them available for the retained client's next success.
-                self.pending_failed_sync_summary.merge(summary);
-                (SyncSummary::default(), source)
-            }
-            SyncCheckpointError::AfterPersistence(source) => (summary, source),
-        }
     }
 
     fn record_transport_reconciliation_item(
@@ -2086,19 +3137,51 @@ impl AppClient {
         let group_id_hint = delivery.group_id_hint.clone();
         let reconciliation_record =
             transport_reconciliation_record(self.adapter.account_id(), &delivery);
-        let effects = self.runtime.ingest_delivery(delivery).await?;
-        let publish_error = fail_if_publish_failed(&effects.effects).err();
+        let effects = self.runtime.ingest_delivery_leased(delivery).await?;
+        self.install_account_visibility_lease(
+            effects.lease,
+            effects.batches,
+            effects.current_operation_id,
+        );
         let must_stay_fetchable = effects.left_object_unpersisted;
         if !must_stay_fetchable && let Some((route, item)) = &reconciliation_record {
             self.record_transport_reconciliation_item(route, item);
         }
-        let refused_group = match &effects.outcome {
+        self.project_source_attributed_inbound_visibility(
+            &effects.outcome,
+            &effects.effects,
+            display_names,
+            summary,
+            &source_message_id_hex,
+            source_received_at,
+            outer_transport_at,
+            group_id_hint,
+            must_stay_fetchable,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn project_source_attributed_inbound_visibility(
+        &mut self,
+        outcome: &IngestOutcome,
+        effects: &marmot_account::AccountDeviceEffects,
+        display_names: &HashMap<String, String>,
+        summary: &mut SyncSummary,
+        source_message_id_hex: &str,
+        source_received_at: u64,
+        outer_transport_at: u64,
+        group_id_hint: Option<cgka_traits::GroupId>,
+        must_stay_fetchable: bool,
+    ) -> Result<DeliveryIngest, AppError> {
+        let publish_error = fail_if_publish_failed(effects).err();
+        let refused_group = match outcome {
             IngestOutcome::ResourceRefused { group_id, .. } => Some(group_id.clone()),
             _ => None,
         };
-        self.remember_buffered_convergence_outcome(&effects.outcome);
-        self.remember_pending_convergence_groups(&effects.effects);
-        self.observe_recovery_evidence(&effects.effects);
+        self.remember_buffered_convergence_outcome(outcome);
+        self.remember_pending_convergence_groups(effects);
+        self.observe_recovery_evidence(effects)?;
         // The cursor is held back only by a resource refusal, which is
         // narrower than `must_stay_fetchable` on purpose.
         //
@@ -2120,34 +3203,14 @@ impl AppClient {
         if refused_group.is_none() {
             self.remember_transport_cursor(outer_transport_at);
         }
-        self.detect_epoch_stall(group_id_hint, &source_message_id_hex, &effects.outcome);
-        // A delivery can contain several application events. If projection
-        // fails after an earlier event staged its acknowledgement, keep that
-        // event in the durable engine outbox so a retained or reopened client
-        // can replay its live summary. Recording only candidates absent before
-        // this delivery avoids cloning the whole accumulated acknowledgement
-        // set on every catch-up step.
-        let new_application_event_ack_candidates = effects
-            .effects
-            .events
-            .iter()
-            .filter_map(|event| match event {
-                cgka_traits::engine::GroupEvent::MessageReceived { message_id, .. } => {
-                    Some(message_id.clone())
-                }
-                cgka_traits::engine::GroupEvent::GroupJoined { via_welcome, .. } => {
-                    Some(via_welcome.clone())
-                }
-                _ => None,
-            })
-            .filter(|event_id| !self.pending_application_event_acks.contains(event_id))
-            .collect::<Vec<_>>();
+        self.detect_epoch_stall(group_id_hint, source_message_id_hex, outcome)?;
+        self.project_current_account_non_session_visibility(effects, None)?;
         let routes_dirty = match self
             .observe_account_device_effects(
-                &effects.effects,
+                effects,
                 display_names,
                 summary,
-                &source_message_id_hex,
+                source_message_id_hex,
                 source_received_at,
                 Some(outer_transport_at),
             )
@@ -2155,9 +3218,13 @@ impl AppClient {
         {
             Ok(routes_dirty) => routes_dirty,
             Err(error) => {
-                for event_id in new_application_event_ack_candidates {
-                    self.pending_application_event_acks.remove(&event_id);
-                }
+                // `observe_account_device_effects` merges only events whose
+                // projection and ACK staging fully completed. Move that exact
+                // prefix into V1 before the failed delivery unwinds; the sync
+                // failure checkpoint will commit it and return it before the
+                // AccountError. The incomplete current event keeps no ACK and
+                // remains replayable from the engine outbox.
+                self.retain_uncheckpointed_sync_summary(std::mem::take(summary));
                 return Err(error);
             }
         };
@@ -2176,6 +3243,7 @@ impl AppClient {
                 "incidental auto-publish failed after inbound effects were projected"
             );
         }
+        self.stage_current_account_visibility_header_batch();
         Ok(DeliveryIngest {
             routes_dirty,
             must_stay_fetchable,
@@ -2197,17 +3265,17 @@ impl AppClient {
         group_id_hint: Option<cgka_traits::GroupId>,
         message_id_hex: &str,
         outcome: &IngestOutcome,
-    ) {
+    ) -> Result<(), AppError> {
         if self.app.cursor_persistence() != CursorPersistence::Advance {
-            return;
+            return Ok(());
         }
         let Some(group_id) = group_id_hint else {
-            return;
+            return Ok(());
         };
         // A group we cannot resolve (unknown or quarantined) has its own recovery
         // surface; do not track it here.
         let Ok(record) = self.runtime.group_record(&group_id) else {
-            return;
+            return Ok(());
         };
         let now_ms = epoch_stall_now_ms();
         let decision = match outcome {
@@ -2248,7 +3316,7 @@ impl AppClient {
                 IngestOutcome::ResourceRefused { .. } => EpochStallBackfillTrigger::ResourceRefusal,
                 _ => EpochStallBackfillTrigger::UndecryptableThreshold,
             },
-        );
+        )
     }
 
     /// Apply an epoch-stall backfill decision: arm the replay, and record an
@@ -2269,7 +3337,7 @@ impl AppClient {
         stalled_epoch: u64,
         decision: BackfillDecision,
         trigger: EpochStallBackfillTrigger,
-    ) {
+    ) -> Result<(), AppError> {
         if decision.arms_backfill() {
             let durable_intent = storage_sqlite::StoredEpochBackfillIntent {
                 group_id_hex: hex::encode(group_id.as_slice()),
@@ -2310,11 +3378,10 @@ impl AppClient {
                 operation_id: Some(attempt_id),
                 ..AuditEventContext::default()
             };
-            // Record the arm decision before the replay side effect runs (the
-            // worker seam calls run_pending_epoch_backfill after this returns).
-            // Best-effort, fire-and-forget: recording can never block or fail
-            // the backfill.
+            // The executable intent, not only its audit evidence, must be
+            // durable before the worker can start its external replay.
             if record_arm {
+                self.persist_epoch_backfill_intent_journal()?;
                 self.record_epoch_stall_backfill_armed(group_id, stalled_epoch, trigger, &context);
             }
             // The arm mark is what paces the next one, so it has to outlive the
@@ -2335,6 +3402,7 @@ impl AppClient {
                 "apply_backfill_decision",
             );
         }
+        Ok(())
     }
 
     /// Report that repeated full-history replay is not recovering a group.
@@ -2377,15 +3445,15 @@ impl AppClient {
     pub(crate) fn restore_persisted_epoch_backfill_intents(
         &mut self,
         intents: Vec<storage_sqlite::StoredEpochBackfillIntent>,
-    ) {
-        let mut pending = PendingEpochBackfill::new();
+    ) -> Result<(), AppError> {
+        let mut table_groups = std::collections::HashMap::new();
         let mut malformed = 0_u64;
         for intent in intents {
             let Ok(group_id) = hex::decode(&intent.group_id_hex) else {
                 malformed = malformed.saturating_add(1);
                 continue;
             };
-            pending.groups.insert(
+            table_groups.insert(
                 cgka_traits::GroupId::new(group_id),
                 PendingEpochBackfillGroup {
                     stalled_epoch: intent.stalled_epoch,
@@ -2400,8 +3468,135 @@ impl AppClient {
                 "ignored malformed durable epoch-gap recovery markers"
             );
         }
-        if !pending.groups.is_empty() {
-            self.pending_epoch_backfill = Some(pending);
+        // Live engine groups keep their backfill intent even when the app
+        // projection is still torn. Locally deleted groups keep a durable
+        // frontier and must not re-arm the journal off the protocol record.
+        // Snapshot engine/projected IDs once; any storage uncertainty leaves
+        // both durable representations unchanged.
+        let (live_engine_ids, projected_ids) = self.epoch_backfill_liveness_snapshot()?;
+        let journal_restored = self.pending_epoch_backfill.is_some()
+            || self.active_epoch_backfill.is_some()
+            || !self.queued_epoch_backfills.is_empty();
+        let journal_ids = self
+            .pending_epoch_backfill
+            .iter()
+            .chain(self.active_epoch_backfill.iter())
+            .chain(self.queued_epoch_backfills.iter())
+            .flat_map(|intent| intent.groups.keys().cloned())
+            .collect::<Vec<_>>();
+        let mut candidates = table_groups.keys().cloned().collect::<HashSet<_>>();
+        candidates.extend(journal_ids);
+        let mut live = HashSet::new();
+        for group_id in &candidates {
+            if self.epoch_backfill_group_is_live(group_id, &live_engine_ids, &projected_ids)? {
+                live.insert(group_id.clone());
+            }
+        }
+        table_groups.retain(|group_id, _| live.contains(group_id));
+        if journal_restored {
+            let mut pruned = self.retain_live_epoch_backfill_groups(&live);
+            let known = self
+                .pending_epoch_backfill
+                .iter()
+                .chain(self.active_epoch_backfill.iter())
+                .chain(self.queued_epoch_backfills.iter())
+                .flat_map(|intent| intent.groups.keys().cloned())
+                .collect::<HashSet<_>>();
+            for (group_id, group) in table_groups {
+                if !known.contains(&group_id) {
+                    let pending = self
+                        .pending_epoch_backfill
+                        .get_or_insert_with(PendingEpochBackfill::new);
+                    pending.groups.entry(group_id).or_insert(group);
+                    pruned = true;
+                }
+            }
+            if pruned {
+                self.persist_epoch_backfill_intent_journal()?;
+            }
+            return Ok(());
+        }
+        if table_groups.is_empty() {
+            return Ok(());
+        }
+        let mut pending = PendingEpochBackfill::new();
+        pending.groups = table_groups;
+        self.pending_epoch_backfill = Some(pending);
+        Ok(())
+    }
+
+    fn retain_live_epoch_backfill_groups(&mut self, live: &HashSet<cgka_traits::GroupId>) -> bool {
+        let mut pruned = false;
+        let retain = |intent: &mut PendingEpochBackfill| {
+            let before = intent.groups.len();
+            intent.groups.retain(|group_id, _| live.contains(group_id));
+            intent.groups.len() != before
+        };
+        if let Some(pending) = self.pending_epoch_backfill.as_mut() {
+            pruned |= retain(pending);
+        }
+        if let Some(active) = self.active_epoch_backfill.as_mut() {
+            pruned |= retain(active);
+        }
+        for queued in &mut self.queued_epoch_backfills {
+            pruned |= retain(queued);
+        }
+        if self
+            .pending_epoch_backfill
+            .as_ref()
+            .is_some_and(|intent| intent.groups.is_empty())
+        {
+            self.pending_epoch_backfill = None;
+            pruned = true;
+        }
+        if self
+            .active_epoch_backfill
+            .as_ref()
+            .is_some_and(|intent| intent.groups.is_empty())
+        {
+            self.active_epoch_backfill = None;
+            pruned = true;
+        }
+        let queued_before = self.queued_epoch_backfills.len();
+        self.queued_epoch_backfills
+            .retain(|intent| !intent.groups.is_empty());
+        if self.queued_epoch_backfills.len() != queued_before {
+            pruned = true;
+        }
+        if self.pending_epoch_backfill.is_none()
+            && let Some(next) = self.queued_epoch_backfills.pop_front()
+        {
+            self.pending_epoch_backfill = Some(next);
+            pruned = true;
+        }
+        pruned
+    }
+
+    pub(crate) fn prune_deleted_epoch_backfill_group(&mut self, group_id: &cgka_traits::GroupId) {
+        let group_id_hex = hex::encode(group_id.as_slice());
+        if let Ok(intents) = self.app.pending_epoch_backfill_intents(&self.state.label) {
+            let stale = intents
+                .into_iter()
+                .filter(|intent| intent.group_id_hex == group_id_hex)
+                .collect::<Vec<_>>();
+            if !stale.is_empty() {
+                let _ = self
+                    .app
+                    .clear_epoch_backfill_intents(&self.state.label, &stale);
+            }
+        }
+        let mut live = HashSet::new();
+        for intent in self
+            .pending_epoch_backfill
+            .iter()
+            .chain(self.active_epoch_backfill.iter())
+            .chain(self.queued_epoch_backfills.iter())
+        {
+            live.extend(intent.groups.keys().cloned());
+        }
+        live.remove(group_id);
+        if self.retain_live_epoch_backfill_groups(&live) {
+            let _ = self.persist_epoch_backfill_intent_journal();
         }
     }
 
@@ -2542,7 +3737,9 @@ impl AppClient {
     /// the account worker to schedule a forensic audit-tracker upload for the
     /// just-recorded `epoch_stall_backfill_armed` row without poking the field.
     pub(crate) fn has_pending_epoch_backfill(&self) -> bool {
-        self.pending_epoch_backfill.is_some() || !self.queued_epoch_backfills.is_empty()
+        self.pending_epoch_backfill.is_some()
+            || self.active_epoch_backfill.is_some()
+            || !self.queued_epoch_backfills.is_empty()
     }
 
     fn take_next_pending_epoch_backfill(&mut self) -> Option<PendingEpochBackfill> {
@@ -2594,7 +3791,7 @@ impl AppClient {
         &mut self,
         execution: EpochBackfillExecution,
         succeeded: bool,
-    ) {
+    ) -> Result<(), AppError> {
         self.finish_epoch_backfill_execution(
             execution,
             EpochBackfillActivationOutcome::Succeeded,
@@ -2605,8 +3802,15 @@ impl AppClient {
             },
             succeeded.then_some(EpochBackfillCompletionKind::EndOfStoredEvents),
             DrainCounts::default(),
-            succeeded,
-        );
+            if succeeded {
+                EpochBackfillFinish::Succeeded
+            } else {
+                EpochBackfillFinish::Failed {
+                    preserve_pacing: false,
+                }
+            },
+        )
+        .map(|_| ())
     }
 
     /// Complete an execution the way a served end-of-stored-events drain does,
@@ -2629,8 +3833,9 @@ impl AppClient {
                 refused,
                 ..DrainCounts::default()
             },
-            true,
-        );
+            EpochBackfillFinish::Succeeded,
+        )
+        .expect("test epoch-backfill completion must persist its intent journal");
     }
 
     fn local_epoch_for_group(&self, group_id: &cgka_traits::GroupId) -> Option<u64> {
@@ -2638,6 +3843,60 @@ impl AppClient {
             .group_record(group_id)
             .ok()
             .map(|record| record.epoch.0)
+    }
+
+    fn epoch_backfill_liveness_snapshot(
+        &self,
+    ) -> Result<(HashSet<cgka_traits::GroupId>, HashSet<cgka_traits::GroupId>), AppError> {
+        #[cfg(test)]
+        if self
+            .app
+            .fail_epoch_backfill_live_group_ids
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            return Err(std::io::Error::other(
+                "injected epoch-backfill live-group listing failure",
+            )
+            .into());
+        }
+        let live_engine_ids = self
+            .runtime
+            .live_group_ids()?
+            .into_iter()
+            .collect::<HashSet<_>>();
+        let projected_ids = self
+            .state
+            .groups
+            .iter()
+            .filter_map(|group| {
+                hex::decode(&group.group_id_hex)
+                    .ok()
+                    .map(cgka_traits::GroupId::new)
+            })
+            .collect::<HashSet<_>>();
+        Ok((live_engine_ids, projected_ids))
+    }
+
+    fn epoch_backfill_group_is_live(
+        &self,
+        group_id: &cgka_traits::GroupId,
+        live_engine_ids: &HashSet<cgka_traits::GroupId>,
+        projected_ids: &HashSet<cgka_traits::GroupId>,
+    ) -> Result<bool, AppError> {
+        #[cfg(test)]
+        if self
+            .app
+            .fail_epoch_backfill_deletion_frontier
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            return Err(
+                std::io::Error::other("injected epoch-backfill deletion-frontier failure").into(),
+            );
+        }
+        if self.has_local_group_deletion_frontier(group_id)? {
+            return Ok(false);
+        }
+        Ok(live_engine_ids.contains(group_id) || projected_ids.contains(group_id))
     }
 
     fn capture_pending_group_epochs(
@@ -2664,8 +3923,11 @@ impl AppClient {
     pub(crate) fn begin_epoch_backfill_execution(
         &mut self,
         seam: EpochBackfillExecutionSeam,
-    ) -> Option<EpochBackfillExecution> {
-        let mut pending = self.take_next_pending_epoch_backfill()?;
+    ) -> Result<Option<EpochBackfillExecution>, AppError> {
+        self.recover_active_epoch_backfill_after_cancellation()?;
+        let Some(mut pending) = self.take_next_pending_epoch_backfill() else {
+            return Ok(None);
+        };
         let retry_ordinal = u64::from(pending.execution_attempts);
         let eose_unconfirmed_ordinal = u64::from(pending.eose_unconfirmed_attempts);
         let no_progress_ordinal = u64::from(pending.no_progress_attempts);
@@ -2687,19 +3949,30 @@ impl AppClient {
                 pending.last_deferred_audit = Some(defer_state);
             }
             self.restore_deferred_epoch_backfill(pending);
-            return None;
+            self.persist_epoch_backfill_intent_journal()?;
+            return Ok(None);
         }
         pending.last_deferred_audit = None;
         pending.execution_attempts = pending.execution_attempts.saturating_add(1);
+        self.active_epoch_backfill = Some(pending.clone());
+        if let Err(error) = self.persist_epoch_backfill_intent_journal() {
+            self.active_epoch_backfill = None;
+            if self.pending_epoch_backfill.is_none() {
+                self.pending_epoch_backfill = Some(pending);
+            } else {
+                self.queued_epoch_backfills.push_front(pending);
+            }
+            return Err(error);
+        }
         self.record_epoch_stall_backfill_started(seam, retry_ordinal, &context);
-        Some(EpochBackfillExecution {
+        Ok(Some(EpochBackfillExecution {
             pending,
             epochs_before,
             retry_ordinal,
             eose_unconfirmed_ordinal,
             no_progress_ordinal,
             started: Instant::now(),
-        })
+        }))
     }
 
     fn finish_epoch_backfill_execution(
@@ -2709,8 +3982,21 @@ impl AppClient {
         error_kind: Option<String>,
         completion_kind: Option<EpochBackfillCompletionKind>,
         counts: DrainCounts,
-        succeeded: bool,
-    ) -> bool {
+        finish: EpochBackfillFinish,
+    ) -> Result<bool, AppError> {
+        let (succeeded, preserve_pacing) = match finish {
+            EpochBackfillFinish::Succeeded => (true, false),
+            EpochBackfillFinish::Failed { preserve_pacing } => (false, preserve_pacing),
+        };
+        if self
+            .active_epoch_backfill
+            .as_ref()
+            .is_none_or(|active| active.attempt_id != execution.pending.attempt_id)
+        {
+            return Err(AppError::BlockingTask(
+                "epoch-backfill terminal state does not match active intent".to_owned(),
+            ));
+        }
         let duration_ms = execution.started.elapsed().as_millis() as u64;
         let epochs_after = self.capture_pending_group_epochs(&execution.pending);
         let observed_all_groups = epochs_after.len() == execution.pending.groups.len();
@@ -2734,7 +4020,12 @@ impl AppClient {
                 succeeded,
             },
         );
-        if !succeeded {
+        let previous_pending = self.pending_epoch_backfill.clone();
+        let previous_active = self.active_epoch_backfill.clone();
+        let previous_queued = self.queued_epoch_backfills.clone();
+        let previous_retry_not_before = self.epoch_backfill_retry_not_before;
+        self.active_epoch_backfill = None;
+        let recovered = if !succeeded {
             // Every error exit of `run_pending_epoch_backfill` lands here
             // without ever producing a drain verdict, so none of the
             // verdict-derived pacing rules in that function runs for it. Pace
@@ -2761,47 +4052,66 @@ impl AppClient {
             // beyond a longer wait: no attempt limit degrades or abandons an
             // intent, and a caller-directed repair stays exempt from the
             // cooldown entirely.
-            let backoff = self.epoch_backfill_retry_backoff(execution.retry_ordinal);
-            self.epoch_backfill_retry_not_before = Some(Instant::now() + backoff);
+            if !preserve_pacing {
+                let backoff = self.epoch_backfill_retry_backoff(execution.retry_ordinal);
+                self.epoch_backfill_retry_not_before = Some(Instant::now() + backoff);
+            }
             self.requeue_failed_epoch_backfill_intent(execution.pending);
-            return false;
-        }
-        if Self::replay_recovered_something(&execution.epochs_before, &epochs_after, &counts) {
+            false
+        } else if Self::replay_recovered_something(&execution.epochs_before, &epochs_after, &counts)
+        {
             self.epoch_stall.mark_replayed();
-            return true;
-        }
-        // Fruitless. An end-of-stored-events completion is the relays saying
-        // they served this account's stored history in full and it held nothing
-        // that moves these groups — the one piece of evidence a device wedged
-        // at an epoch nobody can advance is able to accumulate, and the only
-        // completion shape strong enough to count. A drain that gave up
-        // unconfirmed proves only that the drain gave up.
-        if matches!(
-            completion_kind,
-            Some(EpochBackfillCompletionKind::EndOfStoredEvents)
-        ) {
-            let fruitless_threshold = self.epoch_stall.fruitless_completion_threshold();
-            let escalations = self
-                .epoch_stall
-                .observe_fruitless_completion(execution.pending.groups.keys());
-            for escalation in escalations {
-                self.report_epoch_stall_escalation(
-                    &escalation.group_id,
-                    escalation.stalled_epoch,
-                    escalation.completions,
-                    fruitless_threshold,
-                    "finish_epoch_backfill_execution",
+            if !preserve_pacing {
+                self.epoch_backfill_retry_not_before = None;
+            }
+            true
+        } else {
+            // Fruitless. An end-of-stored-events completion is the relays saying
+            // they served this account's stored history in full and it held nothing
+            // that moves these groups — the one piece of evidence a device wedged
+            // at an epoch nobody can advance is able to accumulate, and the only
+            // completion shape strong enough to count. A drain that gave up
+            // unconfirmed proves only that the drain gave up.
+            if matches!(
+                completion_kind,
+                Some(EpochBackfillCompletionKind::EndOfStoredEvents)
+            ) {
+                let fruitless_threshold = self.epoch_stall.fruitless_completion_threshold();
+                let escalations = self
+                    .epoch_stall
+                    .observe_fruitless_completion(execution.pending.groups.keys());
+                for escalation in escalations {
+                    self.report_epoch_stall_escalation(
+                        &escalation.group_id,
+                        escalation.stalled_epoch,
+                        escalation.completions,
+                        fruitless_threshold,
+                        "finish_epoch_backfill_execution",
+                    );
+                }
+                self.persist_epoch_stall_evidence(execution.pending.groups.keys());
+            }
+            // Withholding `mark_replayed` re-arms bystanders only; the groups this
+            // drain actually refused history for latched themselves when they armed,
+            // so they need an explicit clear or they can never arm again at this
+            // epoch.
+            self.epoch_stall
+                .rearm_refused_groups(&counts.refused_groups);
+            if !preserve_pacing {
+                self.epoch_backfill_retry_not_before = Some(
+                    Instant::now() + self.epoch_backfill_retry_backoff(execution.retry_ordinal),
                 );
             }
-            self.persist_epoch_stall_evidence(execution.pending.groups.keys());
+            false
+        };
+        if let Err(error) = self.persist_epoch_backfill_intent_journal() {
+            self.pending_epoch_backfill = previous_pending;
+            self.active_epoch_backfill = previous_active;
+            self.queued_epoch_backfills = previous_queued;
+            self.epoch_backfill_retry_not_before = previous_retry_not_before;
+            return Err(error);
         }
-        // Withholding `mark_replayed` re-arms bystanders only; the groups this
-        // drain actually refused history for latched themselves when they armed,
-        // so they need an explicit clear or they can never arm again at this
-        // epoch.
-        self.epoch_stall
-            .rearm_refused_groups(&counts.refused_groups);
-        false
+        Ok(recovered)
     }
 
     /// Whether a completed replay recovered anything, and has therefore earned
@@ -2894,6 +4204,8 @@ impl AppClient {
         &mut self,
         seam: EpochBackfillExecutionSeam,
     ) -> Result<EpochBackfillRunOutcome, AppError> {
+        self.ensure_epoch_backfill_intent_journal_persisted()?;
+        self.recover_active_epoch_backfill_after_cancellation()?;
         if !self.has_pending_epoch_backfill() {
             return Ok(EpochBackfillRunOutcome::NotPending);
         }
@@ -2908,7 +4220,7 @@ impl AppClient {
         if self.epoch_backfill_retry_is_paced(seam) {
             return Ok(EpochBackfillRunOutcome::Deferred);
         }
-        let Some(mut execution) = self.begin_epoch_backfill_execution(seam) else {
+        let Some(mut execution) = self.begin_epoch_backfill_execution(seam)? else {
             return Ok(EpochBackfillRunOutcome::Deferred);
         };
         if let Err(error) = self.persist_epoch_backfill_intent(&execution.pending) {
@@ -2919,8 +4231,10 @@ impl AppClient {
                 Some(terminal_error),
                 None,
                 DrainCounts::default(),
-                false,
-            );
+                EpochBackfillFinish::Failed {
+                    preserve_pacing: false,
+                },
+            )?;
             return Err(error);
         }
 
@@ -2936,48 +4250,59 @@ impl AppClient {
                         Some(terminal_error),
                         None,
                         DrainCounts::default(),
-                        false,
-                    );
+                        EpochBackfillFinish::Failed {
+                            preserve_pacing: false,
+                        },
+                    )?;
                     return Err(err);
                 }
                 self.warm_encrypted_media_epoch_secrets("post_subscription_sync");
+                // This is a complete activation + group-subscription rebuild,
+                // so it satisfies both older deferred refresh ownership slots
+                // before the replay starts ingesting new history.
+                self.pending_runtime_group_subscription_refresh = false;
+                self.pending_uncheckpointed_runtime_group_subscription_refresh = false;
                 self.record_subscription_rebuild(None).await;
+                if let Err(err) = self.drain_pending_session_events_staged().await {
+                    let terminal_error = err.privacy_safe_kind().to_string();
+                    self.finish_epoch_backfill_execution(
+                        execution,
+                        EpochBackfillActivationOutcome::Succeeded,
+                        Some(terminal_error),
+                        None,
+                        DrainCounts::default(),
+                        EpochBackfillFinish::Failed {
+                            preserve_pacing: false,
+                        },
+                    )?;
+                    return Err(err);
+                }
                 let mut counts = DrainCounts::default();
                 let retry_ordinal = execution.retry_ordinal;
                 let eose_unconfirmed_ordinal = execution.eose_unconfirmed_ordinal;
                 let no_progress_ordinal = execution.no_progress_ordinal;
-                let (mut summary, verdict) = match self.backfill_sdk_relay(&mut counts).await {
+                let verdict = match self.backfill_sdk_relay(&mut counts).await {
                     Ok(drained) => drained,
-                    Err(err) => {
+                    Err(mut err) => {
                         let terminal_error = err.source.privacy_safe_kind().to_string();
+                        if err.partial_summary != SyncSummary::default() {
+                            self.retain_checkpointed_sync_summary(std::mem::take(
+                                &mut err.partial_summary,
+                            ));
+                        }
                         self.finish_epoch_backfill_execution(
                             execution,
                             EpochBackfillActivationOutcome::Succeeded,
                             Some(terminal_error),
                             None,
                             counts,
-                            false,
-                        );
-                        self.pending_failed_sync_summary.merge(err.partial_summary);
+                            EpochBackfillFinish::Failed {
+                                preserve_pacing: false,
+                            },
+                        )?;
                         return Err(err.source);
                     }
                 };
-                let drained = match self.drain_pending_session_events().await {
-                    Ok(drained) => drained,
-                    Err(err) => {
-                        let terminal_error = err.privacy_safe_kind().to_string();
-                        self.finish_epoch_backfill_execution(
-                            execution,
-                            EpochBackfillActivationOutcome::Succeeded,
-                            Some(terminal_error),
-                            None,
-                            counts,
-                            false,
-                        );
-                        return Err(err);
-                    }
-                };
-                summary.merge(drained);
                 // Activation itself succeeded either way; what the verdict
                 // decides is whether the replay it opened actually served this
                 // account's stored history. An unconfirmed drain must not
@@ -3006,19 +4331,12 @@ impl AppClient {
                         Some(terminal_error),
                         None,
                         counts,
-                        false,
-                    );
-                    self.pending_failed_sync_summary.merge(summary);
+                        EpochBackfillFinish::Failed {
+                            preserve_pacing: false,
+                        },
+                    )?;
                     return Err(error);
                 }
-                let recovered = self.finish_epoch_backfill_execution(
-                    execution,
-                    EpochBackfillActivationOutcome::Succeeded,
-                    error_kind.map(str::to_owned),
-                    verdict.completion_kind(),
-                    counts.clone(),
-                    error_kind.is_none(),
-                );
                 if let Some(error_kind) = error_kind {
                     tracing::warn!(
                         target: "marmot_app::epoch_stall",
@@ -3040,26 +4358,33 @@ impl AppClient {
                         };
                         Some(Instant::now() + self.epoch_backfill_retry_backoff(pacing_ordinal))
                     };
-                    return Ok(EpochBackfillRunOutcome::Incomplete(summary));
+                    self.finish_epoch_backfill_execution(
+                        execution,
+                        EpochBackfillActivationOutcome::Succeeded,
+                        Some(error_kind.to_owned()),
+                        verdict.completion_kind(),
+                        counts.clone(),
+                        EpochBackfillFinish::Failed {
+                            preserve_pacing: true,
+                        },
+                    )?;
+                    return Ok(EpochBackfillRunOutcome::Incomplete(
+                        self.take_checkpointed_sync_summary_or_default(),
+                    ));
                 }
-                if recovered {
-                    self.epoch_backfill_retry_not_before = None;
-                } else {
-                    // A completed-but-fruitless replay just re-armed the groups
-                    // whose history it could not retain. Clearing the cooldown
-                    // here would let that re-arm drain the whole account again
-                    // immediately, against a cap that is still full — an
-                    // unpaced arm -> drain -> clear -> re-arm loop, because a
-                    // fresh intent starts at `execution_attempts == 0`. A
-                    // fruitless success pays the same backoff an unconfirmed
-                    // drain does, which bounds the loop to one account-wide
-                    // replay per window. `epoch_backfill_retry_is_paced`
-                    // exempts caller-directed catch-up, so a person asking for
-                    // a repair still never waits on it.
-                    self.epoch_backfill_retry_not_before =
-                        Some(Instant::now() + self.epoch_backfill_retry_backoff(retry_ordinal));
-                }
-                Ok(EpochBackfillRunOutcome::Completed(summary))
+                // Terminal intent and earned cooldown persist together so a
+                // crash cannot re-arm an unpaced retry.
+                let _recovered = self.finish_epoch_backfill_execution(
+                    execution,
+                    EpochBackfillActivationOutcome::Succeeded,
+                    None,
+                    verdict.completion_kind(),
+                    counts.clone(),
+                    EpochBackfillFinish::Succeeded,
+                )?;
+                Ok(EpochBackfillRunOutcome::Completed(
+                    self.take_checkpointed_sync_summary_or_default(),
+                ))
             }
             Err(err) => {
                 let app_err: AppError = err.into();
@@ -3070,8 +4395,10 @@ impl AppClient {
                     Some(terminal_error),
                     None,
                     DrainCounts::default(),
-                    false,
-                );
+                    EpochBackfillFinish::Failed {
+                        preserve_pacing: false,
+                    },
+                )?;
                 Err(app_err)
             }
         }
@@ -3082,9 +4409,41 @@ impl AppClient {
     /// participant that has no new traffic capable of arming epoch-stall
     /// detection). Unlike the automatic detector path, this is a caller-owned
     /// operation and therefore does not mutate the detector's debounce state.
+    #[cfg(test)]
     pub(crate) async fn repair_full_history(
         &mut self,
     ) -> Result<SyncSummary, ClassifiedSyncFailure> {
+        self.repair_full_history_with_intermediate_handoff(|client, summary| {
+            // A directly-owned client can keep V2 on itself while the explicit
+            // unfloored fallback runs. Cancellation returns the client to its
+            // caller with that visibility still owned; the account worker uses
+            // the sibling API below to publish the prefix synchronously instead.
+            client.retain_checkpointed_sync_summary(summary);
+        })
+        .await
+    }
+
+    /// Run explicit repair while handing any unconfirmed detector-backfill
+    /// prefix to the caller before the unfloored fallback crosses another
+    /// relay await. The managed worker uses this chokepoint to broadcast V2;
+    /// direct callers retain it on the client through [`Self::repair_full_history`].
+    pub(crate) async fn repair_full_history_with_intermediate_handoff(
+        &mut self,
+        mut handoff: impl FnMut(&mut Self, SyncSummary),
+    ) -> Result<SyncSummary, ClassifiedSyncFailure> {
+        match self.repair_full_history_inner(&mut handoff).await {
+            Ok(()) => Ok(self.take_checkpointed_sync_summary_or_default()),
+            Err(mut failure) => {
+                self.merge_checkpointed_visibility_into_failure(&mut failure);
+                Err(failure)
+            }
+        }
+    }
+
+    async fn repair_full_history_inner(
+        &mut self,
+        handoff: &mut impl FnMut(&mut Self, SyncSummary),
+    ) -> Result<(), ClassifiedSyncFailure> {
         let refresh = self.refresh_group_routes().map_err(|error| {
             ClassifiedSyncFailure::at_stage(
                 SyncSummary::default(),
@@ -3132,25 +4491,30 @@ impl AppClient {
                             SyncFailureStage::Unknown,
                         )
                     })? {
-                    EpochBackfillRunOutcome::Completed(mut summary) => {
+                    EpochBackfillRunOutcome::Completed(summary) => {
+                        self.retain_checkpointed_sync_summary(summary);
                         if self.delivery_overflow_recovery_pending {
-                            self.recover_delivery_overflow_and_merge(&mut summary)
+                            let mut recovered = self.take_checkpointed_sync_summary_or_default();
+                            self.recover_delivery_overflow_and_merge(&mut recovered)
                                 .await?;
+                            self.retain_checkpointed_sync_summary(recovered);
                             if self.delivery_overflow_recovery_pending {
+                                let summary = self.take_checkpointed_sync_summary_or_default();
                                 return Err(incomplete_full_history_repair(
                                     summary,
                                     DrainVerdict::Overflow,
                                 ));
                             }
                         }
-                        return Ok(summary);
+                        return Ok(());
                     }
-                    // The intent's own replay could not confirm it served this
-                    // account's history. Retain what it did ingest and fall
-                    // through to the caller-directed unfloored repair below
-                    // rather than re-running the same intent in a tight loop.
+                    // The detector replay did not confirm it served this
+                    // account's history, so its intent remains queued and the
+                    // caller-directed unfloored repair still has work to do.
+                    // Hand off its already-ACKed prefix *before* that second
+                    // relay pass: no V2 may remain future-local across it.
                     EpochBackfillRunOutcome::Incomplete(summary) => {
-                        self.pending_failed_sync_summary.merge(summary);
+                        handoff(self, summary);
                         break;
                     }
                     EpochBackfillRunOutcome::Deferred => continue,
@@ -3186,84 +4550,117 @@ impl AppClient {
             })?;
         self.warm_encrypted_media_epoch_secrets("post_subscription_sync");
         self.pending_runtime_group_subscription_refresh = false;
+        self.pending_uncheckpointed_runtime_group_subscription_refresh = false;
         self.record_subscription_rebuild(None).await;
+        self.drain_pending_session_events_staged()
+            .await
+            .map_err(|error| {
+                ClassifiedSyncFailure::at_stage(
+                    SyncSummary::default(),
+                    error,
+                    SyncFailureStage::Unknown,
+                )
+            })?;
         let mut counts = DrainCounts::default();
-        let (mut summary, mut verdict) = self.backfill_sdk_relay(&mut counts).await?;
+        let mut verdict = self.backfill_sdk_relay(&mut counts).await?;
         if verdict == DrainVerdict::Overflow || self.delivery_overflow_recovery_pending {
-            self.recover_delivery_overflow_and_merge(&mut summary)
+            let mut recovered = self.take_checkpointed_sync_summary_or_default();
+            self.recover_delivery_overflow_and_merge(&mut recovered)
                 .await?;
+            self.retain_checkpointed_sync_summary(recovered);
             verdict = if self.delivery_overflow_recovery_pending {
                 DrainVerdict::Overflow
             } else {
                 DrainVerdict::Complete
             };
         }
-        let drained = match self.drain_pending_session_events().await {
-            Ok(drained) => drained,
-            Err(error) => {
-                // As above, this composite drain has lost its inner boundary.
-                return Err(ClassifiedSyncFailure::at_stage(
-                    summary,
-                    error,
-                    SyncFailureStage::Unknown,
-                ));
-            }
-        };
-        summary.merge(drained);
         if verdict == DrainVerdict::Complete {
-            Ok(summary)
+            Ok(())
         } else {
-            Err(incomplete_full_history_repair(summary, verdict))
+            Err(incomplete_full_history_repair(
+                self.take_checkpointed_sync_summary_or_default(),
+                verdict,
+            ))
         }
     }
 
     pub(crate) async fn advance_convergence_after_runtime_sync(
         &mut self,
         group_id: &cgka_traits::GroupId,
-    ) -> Result<SyncSummary, AppError> {
+    ) -> Result<ScheduledConvergenceVisibility, AppError> {
         // The account worker refreshes transport groups once for the scheduled
         // convergence batch before calling this per-group path.
-        let effects = self.runtime.advance_convergence(group_id).await?;
-        self.observe_scheduled_convergence_effects(group_id, &effects)
+        let effects = self.runtime.advance_convergence_leased(group_id).await?;
+        self.install_account_visibility_lease(
+            effects.lease,
+            effects.batches,
+            effects.current_operation_id,
+        );
+        self.checkpoint_scheduled_convergence_effects(group_id, &effects.effects)
             .await
     }
 
     /// Project one scheduled convergence batch's effects, split from the
     /// advance itself so the projection is exercisable against a given batch of
     /// effects.
+    #[cfg(test)]
     pub(crate) async fn observe_scheduled_convergence_effects(
         &mut self,
         group_id: &cgka_traits::GroupId,
         effects: &marmot_account::AccountDeviceEffects,
     ) -> Result<SyncSummary, AppError> {
+        let visibility = self
+            .checkpoint_scheduled_convergence_effects(group_id, effects)
+            .await?;
+        if self.has_pending_runtime_group_subscription_refresh() {
+            self.retry_pending_runtime_group_subscription_refresh()
+                .await?;
+        }
+        self.publish_pending_new_message_notifications_best_effort()
+            .await;
+        Ok(visibility.summary)
+    }
+
+    /// Project and durably checkpoint one scheduled convergence batch without
+    /// awaiting after V1 is promoted. This is the worker-facing half of the
+    /// operation: it returns the only V2 copy immediately so the worker can
+    /// publish it before subscription or notification network work.
+    pub(super) async fn checkpoint_scheduled_convergence_effects(
+        &mut self,
+        group_id: &cgka_traits::GroupId,
+        effects: &marmot_account::AccountDeviceEffects,
+    ) -> Result<ScheduledConvergenceVisibility, AppError> {
+        self.checkpoint_scheduled_convergence_effects_at(
+            group_id,
+            effects,
+            self.current_account_visibility_observed_at(),
+        )
+        .await
+    }
+
+    async fn checkpoint_scheduled_convergence_effects_at(
+        &mut self,
+        group_id: &cgka_traits::GroupId,
+        effects: &marmot_account::AccountDeviceEffects,
+        source_received_at: u64,
+    ) -> Result<ScheduledConvergenceVisibility, AppError> {
         self.remember_pending_convergence_groups(effects);
         // Observe before the publish gate, for the reason spelled out in
         // `observe_drained_session_events`.
-        self.observe_recovery_evidence(effects);
-        fail_if_publish_failed(effects)?;
-        self.remember_published_reports(effects);
-        let finalize_updates = self.finalize_published_app_message_source_retention(effects)?;
-        let publish_new_message_notification =
-            effects.published_app_messages.iter().any(|published| {
-                let group_id_hex = hex::encode(published.group_id.as_slice());
-                self.app
-                    .reaction_target(&self.state.label, &group_id_hex, &published.app_event_id)
-                    .ok()
-                    .flatten()
-                    .is_some_and(|message| {
-                        message.kind == MARMOT_APP_EVENT_KIND_CHAT
-                            && !message.deleted
-                            && !message.invalidated
-                    })
-            });
-        self.refresh_group(group_id);
+        self.observe_recovery_evidence(effects)?;
+        let publish_error = fail_if_publish_failed(effects).err();
+        let mut affected_groups =
+            self.project_account_non_session_visibility_at(effects, source_received_at, None)?;
+        affected_groups.insert(group_id.clone());
+        affected_groups.extend(effects.events.iter().filter_map(event_group_id).cloned());
+        for affected_group in &affected_groups {
+            self.refresh_group(affected_group);
+        }
 
         let display_names = self.app.display_names_by_id()?;
         let mut summary = SyncSummary::default();
-        summary.projection_updates.extend(finalize_updates);
         let source_message_id_hex = String::new();
-        let source_received_at = unix_now_seconds();
-        let routes_dirty = self
+        let observe_result = self
             .observe_account_device_effects(
                 effects,
                 &display_names,
@@ -3272,22 +4669,29 @@ impl AppClient {
                 source_received_at,
                 None,
             )
-            .await?;
-        let routes_changed = self.refresh_group_routes()?.routing_changed;
-        if routes_dirty || routes_changed {
-            self.sync_runtime_groups().await?;
-        }
-        self.prune_plaintext_retention_for_group(group_id)?;
-        self.save_state_with_pending_local_group_deletion_frontier_clears()?;
-        if publish_new_message_notification {
-            self.publish_notification_trigger_best_effort(
-                group_id,
-                notifications::NotificationTrigger::NewMessage,
-            )
             .await;
+        self.retain_uncheckpointed_sync_summary(summary);
+        let routes_dirty = match observe_result {
+            Ok(routes_dirty) => routes_dirty,
+            Err(error) => {
+                self.checkpoint_pending_sync_visibility()?;
+                return Err(error);
+            }
+        };
+        self.remember_uncheckpointed_runtime_group_subscription_refresh(routes_dirty);
+        let routes_changed = self.refresh_group_routes()?.routing_changed;
+        self.remember_uncheckpointed_runtime_group_subscription_refresh(routes_changed);
+        for affected_group in &affected_groups {
+            self.prune_plaintext_retention_for_group(affected_group)?;
         }
-        self.drain_epoch_stall_escalations(&mut summary);
-        Ok(summary)
+        self.stage_current_account_visibility_header_batch();
+        self.save_state_with_pending_local_group_deletion_frontier_clears()?;
+        if let Some(error) = publish_error {
+            return Err(error);
+        }
+        Ok(ScheduledConvergenceVisibility {
+            summary: self.take_checkpointed_sync_summary_or_default(),
+        })
     }
 
     /// Snapshot each affected group's durable local-delete frontier before any
@@ -3488,6 +4892,15 @@ impl AppClient {
         self.pending_application_event_acks.insert(event_id.clone());
     }
 
+    fn discard_pending_application_event_ack(&mut self, event: &cgka_traits::engine::GroupEvent) {
+        let event_id = match event {
+            cgka_traits::engine::GroupEvent::MessageReceived { message_id, .. } => message_id,
+            cgka_traits::engine::GroupEvent::GroupJoined { via_welcome, .. } => via_welcome,
+            _ => return,
+        };
+        self.pending_application_event_acks.remove(event_id);
+    }
+
     pub(crate) fn save_state_with_pending_local_group_deletion_frontier_clears(
         &mut self,
     ) -> Result<(), AppError> {
@@ -3518,6 +4931,11 @@ impl AppClient {
             .iter()
             .cloned()
             .collect::<Vec<_>>();
+        let visibility_batch_ids_to_ack = self
+            .pending_account_visibility_lease
+            .as_ref()
+            .map(|pending| pending.staged_batch_ids.clone())
+            .unwrap_or_default();
         let seen_start = self
             .state
             .seen_events
@@ -3545,23 +4963,62 @@ impl AppClient {
                         &delta,
                         &frontiers_to_clear,
                         &application_event_ids_to_ack,
+                        &visibility_batch_ids_to_ack,
                         group_id_hex,
                     )?,
             )
         } else {
             self.app
-                .save_state_delta_clearing_local_group_deletion_frontiers_and_acking_application_events(
+                .save_state_delta_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
                     &delta,
                     &frontiers_to_clear,
                     &application_event_ids_to_ack,
+                    &visibility_batch_ids_to_ack,
                 )?;
             None
         };
+        self.finish_durably_acknowledged_account_visibility_batches(&visibility_batch_ids_to_ack)?;
         self.pending_seen_event_count = 0;
         self.pending_group_projection_updates.clear();
         self.pending_local_group_deletion_frontier_clears.clear();
         self.pending_application_event_acks.clear();
+        // This save is the single visibility checkpoint for every caller that
+        // staged projection/ACK state. Promote synchronously after commit and
+        // before returning; an intervening unrelated save therefore completes,
+        // rather than loses, an older cancelled operation's V1 batch.
+        self.promote_uncheckpointed_sync_visibility();
         Ok(created_chat_list_row)
+    }
+
+    fn finish_durably_acknowledged_account_visibility_batches(
+        &mut self,
+        acknowledged_batch_ids: &[Vec<u8>],
+    ) -> Result<(), AppError> {
+        if acknowledged_batch_ids.is_empty() {
+            return Ok(());
+        }
+        let Some(lease) = self
+            .pending_account_visibility_lease
+            .as_ref()
+            .map(|pending| pending.lease)
+        else {
+            return Ok(());
+        };
+        self.runtime
+            .forget_durably_acknowledged_visibility_batches(lease, acknowledged_batch_ids)?;
+        let Some(pending) = self.pending_account_visibility_lease.as_mut() else {
+            return Ok(());
+        };
+        pending
+            .batches
+            .retain(|batch| !acknowledged_batch_ids.contains(&batch.batch_id));
+        pending
+            .staged_batch_ids
+            .retain(|batch_id| !acknowledged_batch_ids.contains(batch_id));
+        if pending.batches.is_empty() {
+            self.pending_account_visibility_lease = None;
+        }
+        Ok(())
     }
 
     /// Terminal disposition for accepted-but-unpublished sends (#1177).
@@ -3720,13 +5177,16 @@ impl AppClient {
             .account(&self.state.label)?
             .account_id_hex;
         let mut routes_dirty = false;
-        // #760: collect push-gossip ids and strip them from `summary.messages` in
-        // ONE pass after the loop. The previous per-message `retain` was O(n) per
-        // gossip event → O(n²) over a batch a relay could flood with kind-448s.
-        let mut gossip_message_ids: HashSet<String> = HashSet::new();
         let local_group_deletion_frontiers =
             self.local_group_deletion_frontiers_at_batch_start(effects)?;
         for event in &effects.events {
+            // An event may mutate in-memory projection state before a later
+            // projection/frontier operation fails. Keep its live summary local
+            // until every fallible boundary and its durable engine-outbox ACK
+            // have succeeded. On error, callers can checkpoint `summary` as the
+            // exact fully-completed prefix without broadcasting the current
+            // half-projected event (or replaying it twice after reopen).
+            let mut event_summary = SyncSummary::default();
             let batch_start_frontier = event_group_id(event)
                 .and_then(|group_id| {
                     local_group_deletion_frontiers.get(&hex::encode(group_id.as_slice()))
@@ -3747,6 +5207,11 @@ impl AppClient {
             {
                 routes_dirty |= changed;
                 self.prepare_pending_application_event_ack(event);
+                self.remember_uncheckpointed_runtime_group_subscription_refresh(changed);
+                // An intentionally suppressed event still owns an ACK
+                // checkpoint, represented by an empty completed-prefix batch.
+                summary.merge(event_summary);
+                self.stage_current_account_visibility_event(event);
                 continue;
             }
             let before = self.state.groups.len();
@@ -3776,7 +5241,7 @@ impl AppClient {
             if let Some(message) = observe_event(
                 &mut self.state,
                 display_names,
-                summary,
+                &mut event_summary,
                 event,
                 group_projection.as_ref(),
                 source_message_id_hex,
@@ -3784,9 +5249,11 @@ impl AppClient {
                 outer_transport_at,
                 self.app.allow_loopback_blob_endpoints(),
             ) && let Some(gossip_message_id) =
-                self.project_received_message(message, group_metadata.as_ref(), summary)?
+                self.project_received_message(message, group_metadata.as_ref(), &mut event_summary)?
             {
-                gossip_message_ids.insert(gossip_message_id);
+                event_summary
+                    .messages
+                    .retain(|candidate| candidate.message_id_hex != gossip_message_id);
             }
             let updated_group =
                 event_group_id(event).and_then(|group_id| self.state_group_record(group_id));
@@ -3801,8 +5268,12 @@ impl AppClient {
                 updated_group.as_ref(),
                 source_message_id_hex,
             );
-            routes_dirty |=
-                self.observe_event_projection_effects(event, &local_account_id_hex, summary)?;
+            let event_routes_dirty = self.observe_event_projection_effects(
+                event,
+                &local_account_id_hex,
+                &mut event_summary,
+            )?;
+            routes_dirty |= event_routes_dirty;
             if self.state.groups.len() != before {
                 routes_dirty = true;
             }
@@ -3819,23 +5290,25 @@ impl AppClient {
                 if cfg!(feature = "test-policy-overrides")
                     && self.app.config.dev_fail_ingest_after_application_event_ack
                 {
+                    // This injected seam represents an incomplete current event:
+                    // leave both its summary and engine ACK out of the completed
+                    // prefix so durable replay owns it exactly once.
+                    self.discard_pending_application_event_ack(event);
                     return Err(AppError::BlockingTask(
                         "injected failure after application-event acknowledgement".to_owned(),
                     ));
                 }
+                self.stage_current_account_visibility_event(event);
             }
+            self.remember_uncheckpointed_runtime_group_subscription_refresh(
+                event_routes_dirty || self.state.groups.len() != before,
+            );
+            event_summary.projection_updates.extend(
+                self.project_group_system_rows(std::slice::from_ref(event), source_received_at),
+            );
+            summary.merge(event_summary);
         }
         self.clear_terminal_local_group_deletion_frontiers(effects)?;
-        // #760: strip all collected push-gossip messages in one pass.
-        if !gossip_message_ids.is_empty() {
-            summary
-                .messages
-                .retain(|candidate| !gossip_message_ids.contains(&candidate.message_id_hex));
-        }
-        // Synthesize durable kind-1210 system rows from authenticated state
-        // changes (peer commits, auto-commits, and scheduled convergence).
-        let system_updates = self.project_group_system_rows(&effects.events, source_received_at);
-        summary.projection_updates.extend(system_updates);
         Ok(routes_dirty)
     }
 
@@ -4106,14 +5579,70 @@ mod membership_change_tests {
 #[cfg(test)]
 mod runtime_group_subscription_refresh_tests {
     use std::sync::Arc;
+    use std::time::Duration;
 
-    use super::{SyncCheckpointError, SyncSummary};
+    use super::SyncSummary;
+    use crate::client::epoch_stall::BackfillDecision;
     use crate::tests::ScriptedPushRelayClient;
-    use crate::{AppPerformanceTelemetry, MarmotApp};
+    use crate::{AppPerformanceTelemetry, MarmotApp, MarmotRelayPlane};
     use marmot_account::AccountHome;
+    use marmot_forensics::EpochStallBackfillTrigger;
+    use tokio::sync::Notify;
+
+    async fn pending_welcome_fixture(
+        group_name: &str,
+    ) -> (
+        tempfile::TempDir,
+        Arc<ScriptedPushRelayClient>,
+        crate::AppClient,
+        crate::AppClient,
+        cgka_traits::GroupId,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let home = AccountHome::open(dir.path());
+        home.create_account("alice").unwrap();
+        let bob = home.create_account("bob").unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(relay.clone());
+        let endpoint = crate::TransportEndpoint("wss://relay.example".to_owned());
+        let mut relay_lists = crate::AccountRelayListStatus::empty();
+        relay_lists.nip65.relays = vec![endpoint.0.clone()];
+        relay_lists.nip65.read_relays = vec![endpoint.0.clone()];
+        relay_lists.nip65.write_relays = vec![endpoint.0.clone()];
+        relay_lists.refresh();
+        app.write_nip65_route_generation(
+            "bob",
+            &crate::Nip65RouteGeneration {
+                created_at: crate::unix_now_seconds(),
+                event_id: "44".repeat(32),
+                nip65: relay_lists.nip65.clone(),
+            },
+        )
+        .unwrap();
+        app.remember_directory_relay_lists(&bob.account_id_hex, &relay_lists)
+            .unwrap();
+        app.mark_key_package_cutover_scan_complete("bob").unwrap();
+        let plane = MarmotRelayPlane::new(None, relay.clone());
+        let mut alice = app
+            .client_with_relay_plane("alice", &plane, None)
+            .await
+            .unwrap();
+        let mut bob_client = app
+            .client_with_relay_plane("bob", &plane, None)
+            .await
+            .unwrap();
+        bob_client.publish_key_package().await.unwrap();
+        bob_client.sync().await.unwrap();
+        let group_id = alice
+            .create_group(group_name, &[bob.account_id_hex.as_str()])
+            .await
+            .unwrap();
+        (dir, relay, alice, bob_client, group_id)
+    }
 
     #[tokio::test]
-    async fn catch_up_checkpoint_arms_refresh_after_durable_subscription_failure() {
+    async fn catch_up_checkpoint_defers_subscription_refresh_after_durable_save() {
         let dir = tempfile::tempdir().unwrap();
         AccountHome::open(dir.path())
             .create_account("alice")
@@ -4135,12 +5664,15 @@ mod runtime_group_subscription_refresh_tests {
             .unwrap();
 
         relay.fail_next_subscribe();
-        let mut summary = SyncSummary::default();
-        let error = client
-            .checkpoint_sync_prefix(&mut summary, true, 0)
+        client
+            .checkpoint_sync_prefix(true, 0)
+            .expect("a durable checkpoint must not await relay I/O");
+        assert!(client.has_pending_runtime_group_subscription_refresh());
+
+        client
+            .retry_pending_runtime_group_subscription_refresh()
             .await
-            .expect_err("the injected post-checkpoint subscription rebuild must fail");
-        assert!(matches!(error, SyncCheckpointError::AfterPersistence(_)));
+            .expect_err("the deferred injected subscription failure must reach the retry");
         assert!(client.has_pending_runtime_group_subscription_refresh());
 
         assert!(
@@ -4149,6 +5681,403 @@ mod runtime_group_subscription_refresh_tests {
                 .await
                 .unwrap()
         );
+        assert!(!client.has_pending_runtime_group_subscription_refresh());
+    }
+
+    #[tokio::test]
+    async fn cancelled_next_event_is_returned_by_following_sync() {
+        let (_dir, relay, _alice, mut bob_client, group_id) =
+            pending_welcome_fixture("cancelled next-event output").await;
+
+        relay.block_next_subscribe();
+        let mut next = Box::pin(bob_client.next_event());
+        tokio::time::timeout(Duration::from_secs(5), async {
+            tokio::select! {
+                result = &mut next => {
+                    panic!("next_event returned before its injected refresh block: {result:?}")
+                }
+                () = relay.wait_for_blocked_subscribe() => {}
+            }
+        })
+        .await
+        .expect("next_event must reach the post-ingest subscription refresh");
+        drop(next);
+        relay.release_subscribe();
+
+        assert!(bob_client.has_pending_runtime_group_subscription_refresh());
+        assert_eq!(
+            bob_client
+                .pending_checkpointed_sync_summary
+                .as_ref()
+                .map(|summary| summary.joined_groups.as_slice()),
+            Some(std::slice::from_ref(&group_id)),
+            "cancellation must retain the already-durable join summary",
+        );
+
+        let recovered = tokio::time::timeout(Duration::from_secs(5), bob_client.sync())
+            .await
+            .expect("the following sync must recover the cancelled next-event output")
+            .unwrap();
+        assert_eq!(recovered.joined_groups, vec![group_id.clone()]);
+        assert!(bob_client.pending_checkpointed_sync_summary.is_none());
+        assert!(!bob_client.has_pending_runtime_group_subscription_refresh());
+        let next = bob_client.sync().await.unwrap();
+        assert!(
+            !next.joined_groups.contains(&group_id),
+            "the retained summary must be returned exactly once",
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_sync_v1_is_checkpointed_by_the_managed_fallback() {
+        let (_dir, _relay, _alice, mut bob_client, group_id) =
+            pending_welcome_fixture("pre-checkpoint cancellation").await;
+        let entered = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        bob_client.block_after_sync_delivery_projection = Some((entered.clone(), release.clone()));
+
+        let mut sync = Box::pin(bob_client.sync_with_classified_partial_progress());
+        tokio::time::timeout(Duration::from_secs(5), async {
+            tokio::select! {
+                result = &mut sync => {
+                    panic!("sync returned before its pre-checkpoint block: {result:?}")
+                }
+                () = entered.notified() => {}
+            }
+        })
+        .await
+        .expect("sync must retain the projected delivery before checkpointing");
+        drop(sync);
+        release.notify_one();
+
+        assert_eq!(
+            bob_client
+                .pending_uncheckpointed_sync_summary
+                .as_ref()
+                .map(|summary| summary.joined_groups.as_slice()),
+            Some(std::slice::from_ref(&group_id)),
+        );
+        assert!(bob_client.pending_checkpointed_sync_summary.is_none());
+        assert!(
+            !bob_client.pending_application_event_acks.is_empty(),
+            "V1 must retain the matching engine-outbox acknowledgement set",
+        );
+
+        // The managed worker's timeout/error fallback synchronously lands the
+        // still-staged projection and ACKs before it tries to publish V2.
+        assert!(bob_client.checkpoint_pending_sync_visibility().unwrap());
+        assert!(bob_client.pending_uncheckpointed_sync_summary.is_none());
+        assert_eq!(
+            bob_client
+                .pending_checkpointed_sync_summary
+                .as_ref()
+                .map(|summary| summary.joined_groups.as_slice()),
+            Some(std::slice::from_ref(&group_id)),
+        );
+        assert!(bob_client.pending_application_event_acks.is_empty());
+
+        let recovered = bob_client
+            .take_pending_checkpointed_sync_summary()
+            .expect("the fallback must receive the promoted V2 batch");
+        assert_eq!(recovered.joined_groups, vec![group_id]);
+        assert!(bob_client.pending_checkpointed_sync_summary.is_none());
+        assert!(!bob_client.checkpoint_pending_sync_visibility().unwrap());
+        assert!(
+            bob_client.sync().await.unwrap().joined_groups.is_empty(),
+            "the checkpointed batch must be handed off exactly once",
+        );
+    }
+
+    #[tokio::test]
+    async fn an_escalation_without_a_summary_still_occupies_the_v2_handoff() {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+        let mut client = app.client("alice").await.unwrap();
+        let escalation = crate::EpochStallEscalation {
+            group_id: cgka_traits::GroupId::new(vec![0x5a; 32]),
+            stalled_epoch: 9,
+            arms: 3,
+        };
+        client
+            .pending_epoch_stall_escalations
+            .push(escalation.clone());
+
+        let summary = client
+            .take_pending_checkpointed_sync_summary()
+            .expect("an escalation-only handoff must not collapse to None");
+        assert_eq!(summary.epoch_stall_escalations, vec![escalation]);
+        assert!(client.take_pending_checkpointed_sync_summary().is_none());
+    }
+
+    #[tokio::test]
+    async fn cancelled_sync_after_prefix_checkpoint_leaves_summary_owned_by_client() {
+        let (_dir, _relay, _alice, mut bob_client, group_id) =
+            pending_welcome_fixture("post-checkpoint cancellation").await;
+        let entered = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        bob_client.block_after_sync_prefix_checkpoint = Some((entered.clone(), release.clone()));
+
+        let mut sync = Box::pin(bob_client.sync_with_classified_partial_progress());
+        tokio::time::timeout(Duration::from_secs(5), async {
+            tokio::select! {
+                result = &mut sync => {
+                    panic!("sync returned before its post-checkpoint test block: {result:?}")
+                }
+                () = entered.notified() => {}
+            }
+        })
+        .await
+        .expect("sync must checkpoint the relay prefix before returning it");
+        drop(sync);
+        release.notify_one();
+
+        assert!(bob_client.pending_uncheckpointed_sync_summary.is_none());
+        assert_eq!(
+            bob_client
+                .pending_checkpointed_sync_summary
+                .as_ref()
+                .map(|summary| summary.joined_groups.as_slice()),
+            Some(std::slice::from_ref(&group_id)),
+            "V2 must remain client-owned while the post-checkpoint future is cancellable",
+        );
+        assert!(bob_client.pending_application_event_acks.is_empty());
+
+        let recovered = bob_client.sync().await.unwrap();
+        assert_eq!(recovered.joined_groups, vec![group_id]);
+        assert!(bob_client.pending_checkpointed_sync_summary.is_none());
+    }
+
+    #[tokio::test]
+    async fn scheduled_convergence_returns_v2_before_subscription_network_work() {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(relay.clone());
+        let mut client = app.client("alice").await.unwrap();
+        client.prepare_transport().await.unwrap();
+        let group_id = client
+            .create_group("convergence visibility handoff", &[])
+            .await
+            .unwrap();
+        client
+            .checkpoint_sync_prefix(true, 0)
+            .expect("the route change must be checkpointed without relay I/O");
+        assert!(client.has_pending_runtime_group_subscription_refresh());
+
+        let visibility = tokio::time::timeout(
+            Duration::from_secs(5),
+            client.checkpoint_scheduled_convergence_effects(
+                &group_id,
+                &marmot_account::AccountDeviceEffects::default(),
+            ),
+        )
+        .await
+        .expect("the V2 handoff must not await a subscription refresh")
+        .unwrap();
+        assert_eq!(visibility.summary, SyncSummary::default());
+        assert!(client.pending_checkpointed_sync_summary.is_none());
+        assert!(
+            client.has_pending_runtime_group_subscription_refresh(),
+            "the V2 handoff must leave subscription network work for the worker scheduler",
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_next_event_retains_an_empty_epoch_backfill_wake_batch() {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(relay.clone());
+        let mut client = app.client("alice").await.unwrap();
+        client.prepare_transport().await.unwrap();
+        let telemetry = AppPerformanceTelemetry::default();
+        let group_id = client
+            .create_group_with_options_and_telemetry(
+                "empty next-event backfill wake",
+                &[],
+                crate::AppCreateGroupOptions::default(),
+                &telemetry,
+            )
+            .await
+            .unwrap()
+            .group_id;
+        let stalled_epoch = client.group_mls_state(&group_id).unwrap().epoch;
+        client
+            .apply_backfill_decision(
+                &group_id,
+                stalled_epoch,
+                BackfillDecision::Arm,
+                EpochStallBackfillTrigger::UndecryptableThreshold,
+            )
+            .unwrap();
+        assert!(client.has_pending_epoch_backfill());
+
+        client.pending_runtime_group_subscription_refresh = true;
+        relay.block_next_subscribe();
+        let mut finalize =
+            Box::pin(client.finalize_direct_next_event_summary(SyncSummary::default()));
+        tokio::time::timeout(Duration::from_secs(5), async {
+            tokio::select! {
+                result = &mut finalize => {
+                    panic!("empty wake batch finalized before its injected refresh block: {result:?}")
+                }
+                () = relay.wait_for_blocked_subscribe() => {}
+            }
+        })
+        .await
+        .expect("empty wake batch must reach the post-ingest subscription refresh");
+        drop(finalize);
+        relay.release_subscribe();
+
+        assert_eq!(
+            client.pending_checkpointed_sync_summary,
+            Some(SyncSummary::default()),
+            "occupied retention must distinguish an empty wake batch from no batch",
+        );
+        assert!(client.has_pending_runtime_group_subscription_refresh());
+
+        relay.fail_next_subscribe();
+        tokio::time::timeout(Duration::from_secs(5), client.next_event())
+            .await
+            .expect("the injected retry failure must return promptly")
+            .expect_err("an empty wake batch must not hide a refresh error");
+        assert_eq!(
+            client.pending_checkpointed_sync_summary,
+            Some(SyncSummary::default()),
+            "an empty wake batch must remain occupied across retry failure",
+        );
+        assert!(client.has_pending_runtime_group_subscription_refresh());
+
+        let recovered = tokio::time::timeout(Duration::from_secs(5), client.next_event())
+            .await
+            .expect("a successful retry must return the retained empty wake batch")
+            .unwrap();
+        assert_eq!(recovered, SyncSummary::default());
+        assert!(client.pending_checkpointed_sync_summary.is_none());
+        assert!(!client.has_pending_runtime_group_subscription_refresh());
+        assert!(client.has_pending_epoch_backfill());
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), client.next_event())
+                .await
+                .is_err(),
+            "the empty wake batch must be returned exactly once",
+        );
+    }
+
+    #[tokio::test]
+    async fn drained_event_returns_summary_and_defers_subscription_retry() {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(relay.clone());
+        let mut client = app.client("alice").await.unwrap();
+        client.prepare_transport().await.unwrap();
+        let telemetry = AppPerformanceTelemetry::default();
+        let created = client
+            .create_group_with_options_and_telemetry(
+                "drained-event retry intent",
+                &[],
+                crate::AppCreateGroupOptions::default(),
+                &telemetry,
+            )
+            .await
+            .unwrap();
+        // Model a durable engine event replay whose app projection did not
+        // survive the prior process. Re-observation restores the group and
+        // therefore owes an ordinary subscription rebuild.
+        client.state.groups.clear();
+        let group_id = created.group_id;
+        let joined = cgka_traits::engine::GroupEvent::GroupJoined {
+            group_id: group_id.clone(),
+            via_welcome: cgka_traits::MessageId::new(vec![0x42; 32]),
+            welcomer: None,
+        };
+        let effects = marmot_account::AccountDeviceEffects {
+            events: vec![joined.clone()],
+            ..Default::default()
+        };
+
+        // A drained projection is visibility-first: the injected relay failure
+        // must remain untouched until the explicit background retry.
+        relay.fail_next_subscribe();
+        let summary = client
+            .observe_drained_session_events(&effects)
+            .await
+            .expect("the durable drained projection must not await relay I/O");
+        assert_eq!(summary.joined_groups, vec![group_id]);
+        assert_eq!(summary.events, vec![joined]);
+        assert!(client.has_pending_runtime_group_subscription_refresh());
+
+        client
+            .retry_pending_runtime_group_subscription_refresh()
+            .await
+            .expect_err("the deferred injected subscription failure must reach the retry");
+        assert!(client.has_pending_runtime_group_subscription_refresh());
+
+        assert!(
+            !client
+                .retry_pending_runtime_group_subscription_refresh()
+                .await
+                .unwrap()
+        );
+        assert!(!client.has_pending_runtime_group_subscription_refresh());
+    }
+
+    #[tokio::test]
+    async fn direct_sync_finalizer_retains_summary_across_refresh_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(relay.clone());
+        let mut client = app.client("alice").await.unwrap();
+        client.prepare_transport().await.unwrap();
+        let telemetry = AppPerformanceTelemetry::default();
+        let created = client
+            .create_group_with_options_and_telemetry(
+                "direct sync retained output",
+                &[],
+                crate::AppCreateGroupOptions::default(),
+                &telemetry,
+            )
+            .await
+            .unwrap();
+        client.pending_runtime_group_subscription_refresh = true;
+        let durable_summary = SyncSummary {
+            joined_groups: vec![created.group_id],
+            ..Default::default()
+        };
+        client.retain_checkpointed_sync_summary(durable_summary.clone());
+
+        relay.fail_next_subscribe();
+        client
+            .finalize_direct_sync_summary()
+            .await
+            .expect_err("the injected direct subscription finalizer must fail");
+        assert_eq!(
+            client.pending_checkpointed_sync_summary,
+            Some(durable_summary.clone())
+        );
+        assert!(client.has_pending_runtime_group_subscription_refresh());
+
+        let recovered = client.finalize_direct_sync_summary().await.unwrap();
+        assert_eq!(recovered, durable_summary);
+        assert!(client.pending_checkpointed_sync_summary.is_none());
         assert!(!client.has_pending_runtime_group_subscription_refresh());
     }
 }
@@ -4322,8 +6251,8 @@ pub(crate) fn epoch_stall_now_ms() -> u64 {
 mod tests {
     use super::{
         DrainVerdict, backfill_drain_verdict, incomplete_full_history_repair,
-        reconciliation_start_after_cursor, retry_backoff_for_ordinal,
-        transport_reconciliation_record,
+        reconciliation_start_after_cursor, restore_epoch_backfill_retry_deadline,
+        retry_backoff_for_ordinal, transport_reconciliation_record,
     };
     use crate::tests::{
         ScriptedPushRelayClient, bounded_epoch_backfill_config, client_on_app_relay_plane,
@@ -4425,6 +6354,20 @@ mod tests {
     }
 
     #[test]
+    fn restored_epoch_backfill_deadlines_are_capped_and_checked() {
+        assert!(restore_epoch_backfill_retry_deadline(None).is_none());
+        let now_ms = crate::unix_now_seconds().saturating_mul(1_000);
+        assert!(restore_epoch_backfill_retry_deadline(Some(now_ms)).is_none());
+        let restored = restore_epoch_backfill_retry_deadline(Some(now_ms.saturating_add(u64::MAX)))
+            .expect("a far-future deadline must restore as a capped delay");
+        let cap = EPOCH_BACKFILL_RETRY_BACKOFF_CAP + Duration::from_secs(1);
+        assert!(
+            restored.saturating_duration_since(std::time::Instant::now()) <= cap,
+            "restored wall-clock delay must not exceed the retry cap"
+        );
+    }
+
+    #[test]
     fn drain_verdict_reads_end_of_stored_events_progress() {
         let progress =
             |subscriptions,
@@ -4503,7 +6446,7 @@ mod tests {
             joined_groups: vec![cgka_traits::GroupId::new(vec![0x42])],
             ..SyncSummary::default()
         };
-        client.pending_failed_sync_summary.merge(ingested.clone());
+        client.retain_checkpointed_sync_summary(ingested.clone());
 
         let failure = client
             .repair_full_history()

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -5642,6 +5642,208 @@ mod runtime_group_subscription_refresh_tests {
     }
 
     #[tokio::test]
+    async fn pending_route_refresh_quiesces_and_rotates_post_join_maintenance_subscription() {
+        let (_dir, relay, _alice, mut bob_client, group_id) =
+            pending_welcome_fixture("post-join maintenance route rotation").await;
+
+        let joined = bob_client.sync().await.unwrap();
+        assert_eq!(joined.joined_groups, vec![group_id.clone()]);
+        assert!(!bob_client.has_pending_runtime_group_subscription_refresh());
+
+        let route_a = bob_client
+            .routing
+            .snapshot()
+            .group_routes
+            .into_iter()
+            .find(|route| route.group_id == group_id)
+            .expect("the joined group must have an ordinary route");
+        bob_client
+            .advance_post_join_maintenance_subscriptions()
+            .await
+            .unwrap();
+        let (subscription_a, active_route_a) = bob_client
+            .post_join_maintenance_subscriptions
+            .get(&group_id)
+            .cloned()
+            .expect("the CatchUp obligation must install route A maintenance");
+        assert_eq!(active_route_a, route_a);
+
+        for endpoint in &route_a.endpoints {
+            bob_client
+                .relay_plane
+                .handle_relay_eose_for_test(endpoint.clone(), subscription_a.clone())
+                .await;
+        }
+        assert_eq!(
+            bob_client
+                .adapter
+                .group_maintenance_any_eose(&subscription_a)
+                .await,
+            Some(true),
+            "route A must hold stale EOSE evidence before the refresh starts",
+        );
+
+        // Adapter teardown is local-first. Even if relay-side unsubscribe
+        // fails, the client must forget route A so the successful refresh can
+        // install route B instead of retaining a dead ownership record.
+        relay.fail_next_unsubscribe();
+        bob_client.pending_runtime_group_subscription_refresh = true;
+        bob_client
+            .advance_post_join_maintenance_subscriptions()
+            .await
+            .unwrap();
+        assert!(
+            !bob_client
+                .post_join_maintenance_subscriptions
+                .contains_key(&group_id),
+            "a pending ordinary-route refresh must quiesce route A maintenance",
+        );
+        assert_eq!(
+            bob_client
+                .adapter
+                .group_maintenance_any_eose(&subscription_a)
+                .await,
+            None,
+            "quiescing route A must forget its stale EOSE evidence",
+        );
+        let status = bob_client.runtime.maintenance_status(&group_id).unwrap();
+        let post_join = status
+            .obligations
+            .iter()
+            .find(|obligation| obligation.trigger == cgka_traits::MaintenanceTrigger::PostJoin)
+            .expect("the post-join obligation must remain durable while routes refresh");
+        assert_eq!(
+            post_join.phase,
+            cgka_traits::MaintenancePhase::CatchUp,
+            "stale route A EOSE must not advance the obligation",
+        );
+
+        let mut route_b = route_a;
+        route_b.endpoints = vec![crate::TransportEndpoint("wss://relay-b.example".to_owned())];
+        assert!(
+            bob_client
+                .routing
+                .replace_group_routes(&group_id, vec![route_b.clone()]),
+            "route B must differ from the installed ordinary route",
+        );
+        bob_client.pending_runtime_group_subscription_refresh = false;
+        bob_client
+            .advance_post_join_maintenance_subscriptions()
+            .await
+            .unwrap();
+
+        let (subscription_b, active_route_b) = bob_client
+            .post_join_maintenance_subscriptions
+            .get(&group_id)
+            .cloned()
+            .expect("the refreshed route must reinstall post-join maintenance");
+        assert_eq!(active_route_b, route_b);
+        assert_ne!(
+            subscription_b, subscription_a,
+            "the endpoint change must produce a fresh maintenance subscription id",
+        );
+        assert_eq!(
+            bob_client
+                .adapter
+                .group_maintenance_any_eose(&subscription_b)
+                .await,
+            Some(false),
+            "route B must start with fresh EOSE state",
+        );
+    }
+
+    #[tokio::test]
+    async fn account_reactivation_reinstalls_same_route_post_join_maintenance_subscription() {
+        let (_dir, relay, _alice, mut bob_client, group_id) =
+            pending_welcome_fixture("post-join maintenance account reactivation").await;
+
+        let joined = bob_client.sync().await.unwrap();
+        assert_eq!(joined.joined_groups, vec![group_id.clone()]);
+        bob_client
+            .advance_post_join_maintenance_subscriptions()
+            .await
+            .unwrap();
+        let (subscription_before, route_before) = bob_client
+            .post_join_maintenance_subscriptions
+            .get(&group_id)
+            .cloned()
+            .expect("the CatchUp obligation must install maintenance");
+        let accepted_before = relay
+            .accepted_subscriptions()
+            .into_iter()
+            .filter(|subscription| {
+                matches!(
+                    subscription,
+                    transport_nostr_adapter::NostrSubscription::GroupMaintenance {
+                        group_id: subscribed_group,
+                        ..
+                    } if subscribed_group == &group_id
+                )
+            })
+            .count();
+
+        // Account activation replaces every SDK subscription and clears the
+        // adapter's maintenance ownership/EOSE state, while this AppClient and
+        // its same-route ephemeral entry survive.
+        bob_client.runtime.activate_transport(None).await.unwrap();
+        assert_eq!(
+            bob_client
+                .adapter
+                .group_maintenance_any_eose(&subscription_before)
+                .await,
+            None,
+            "reactivation must retire the old adapter registration",
+        );
+        assert!(
+            bob_client
+                .post_join_maintenance_subscriptions
+                .contains_key(&group_id),
+            "the regression requires a surviving same-route client entry",
+        );
+
+        bob_client
+            .advance_post_join_maintenance_subscriptions()
+            .await
+            .unwrap();
+        let (subscription_after, route_after) = bob_client
+            .post_join_maintenance_subscriptions
+            .get(&group_id)
+            .cloned()
+            .expect("maintenance must reinstall after account activation");
+        assert_eq!(route_after, route_before);
+        assert_eq!(
+            subscription_after, subscription_before,
+            "same account/group/route intentionally reuses its deterministic id",
+        );
+        assert_eq!(
+            bob_client
+                .adapter
+                .group_maintenance_any_eose(&subscription_after)
+                .await,
+            Some(false),
+            "the reused id must own a fresh adapter registration",
+        );
+        let accepted_after = relay
+            .accepted_subscriptions()
+            .into_iter()
+            .filter(|subscription| {
+                matches!(
+                    subscription,
+                    transport_nostr_adapter::NostrSubscription::GroupMaintenance {
+                        group_id: subscribed_group,
+                        ..
+                    } if subscribed_group == &group_id
+                )
+            })
+            .count();
+        assert_eq!(
+            accepted_after,
+            accepted_before + 1,
+            "maintenance must be reissued instead of polling a forgotten id",
+        );
+    }
+
+    #[tokio::test]
     async fn catch_up_checkpoint_defers_subscription_refresh_after_durable_save() {
         let dir = tempfile::tempdir().unwrap();
         AccountHome::open(dir.path())

--- a/crates/marmot-app/src/directory/cache.rs
+++ b/crates/marmot-app/src/directory/cache.rs
@@ -12,7 +12,9 @@ use storage_sqlite::{
     CloseableConnection, ConnectionGuard, SqlCipherHardening, SqlCipherKey, open_hardened_sqlcipher,
 };
 
-use crate::{AccountRelayListStatus, AppError, UserDirectoryRecord, UserProfileMetadata};
+use crate::{
+    AccountRelayListStatus, AppError, DirectoryKeyPackage, UserDirectoryRecord, UserProfileMetadata,
+};
 
 /// How long a `kind:0` profile resolved by web-of-trust search stays usable
 /// before search re-fetches it.
@@ -160,6 +162,52 @@ impl DirectoryCache {
         Self::put_with_reason_locked(&tx, entry, reason)?;
         tx.commit()?;
         Ok(())
+    }
+
+    /// Remove only the cached KeyPackage in `stable_slot_id`, preserving every
+    /// other directory field and any sibling-device slot that won a race.
+    pub(crate) fn clear_key_package_if_slot(
+        &self,
+        account_id_hex: &str,
+        stable_slot_id: Option<&str>,
+    ) -> Result<bool, AppError> {
+        let mut conn = self.lock()?;
+        let tx = conn.transaction()?;
+        let Some(key_package_json) = tx
+            .query_row(
+                "SELECT key_package_json
+                 FROM directory_users
+                 WHERE account_id_hex = ?1",
+                [account_id_hex],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .optional()?
+            .flatten()
+        else {
+            tx.commit()?;
+            return Ok(false);
+        };
+        let should_clear = match stable_slot_id {
+            Some(stable_slot_id) => {
+                serde_json::from_str::<DirectoryKeyPackage>(&key_package_json)?.key_package_id
+                    == stable_slot_id
+            }
+            None => true,
+        };
+        if !should_clear {
+            tx.commit()?;
+            return Ok(false);
+        }
+        let changed = tx.execute(
+            "UPDATE directory_users
+             SET key_package_json = NULL,
+                 updated_at = ?3
+             WHERE account_id_hex = ?1
+               AND key_package_json = ?2",
+            params![account_id_hex, key_package_json, unix_now_seconds() as i64],
+        )?;
+        tx.commit()?;
+        Ok(changed != 0)
     }
 
     fn put_with_reason_locked(
@@ -896,6 +944,41 @@ mod tests {
 
         assert_eq!(user_count, 1);
         assert_eq!(follows, vec![bob]);
+    }
+
+    #[test]
+    fn conditional_key_package_clear_preserves_identity_and_sibling_slot() {
+        let (_dir, cache) = test_cache();
+        let alice = account_id(1);
+        let bob = account_id(2);
+        let mut record = directory_record(alice.clone(), vec![bob.clone()]);
+        record.key_package = Some(DirectoryKeyPackage {
+            key_package_id: "removed-slot".to_owned(),
+            key_package_ref_hex: "11".repeat(32),
+            key_package_event_id: "22".repeat(32),
+            key_package_hex: "33".repeat(32),
+            created_at: 1_700_000_002,
+            source_relays: vec!["wss://relay.example".to_owned()],
+        });
+        cache.put(&record).unwrap();
+
+        assert!(
+            !cache
+                .clear_key_package_if_slot(&alice, Some("sibling-slot"))
+                .unwrap()
+        );
+        assert_eq!(cache.entry(&alice).unwrap().unwrap(), record);
+
+        assert!(
+            cache
+                .clear_key_package_if_slot(&alice, Some("removed-slot"))
+                .unwrap()
+        );
+        let scrubbed = cache.entry(&alice).unwrap().unwrap();
+        assert_eq!(scrubbed.profile, record.profile);
+        assert_eq!(scrubbed.relay_lists, record.relay_lists);
+        assert_eq!(scrubbed.follows, vec![bob]);
+        assert!(scrubbed.key_package.is_none());
     }
 
     #[test]

--- a/crates/marmot-app/src/directory/member_key_packages.rs
+++ b/crates/marmot-app/src/directory/member_key_packages.rs
@@ -21,8 +21,7 @@ use transport_nostr_adapter::{
 };
 
 use crate::key_package_records::{
-    fresh_or_cached_key_package, fresh_relay_list_status_from_records,
-    latest_fresh_key_package_from_records, validated_cached_key_package,
+    fresh_or_cached_key_package, fresh_relay_list_status_from_records, validated_cached_key_package,
 };
 use crate::relay_plane::DirectoryEventQuery;
 use crate::{AccountRelayListStatus, AppError, FetchedKeyPackage, MarmotApp, push_unique_strings};
@@ -77,6 +76,12 @@ mod tests {
             Instant::now() - MEMBER_PREWARM_CACHE_TTL - Duration::from_secs(1);
         assert!(cache.get(&newest).is_none());
         assert!(!cache.order.contains(&newest));
+
+        let retained = format!("{:064x}", MEMBER_PREWARM_CACHE_LIMIT - 1);
+        assert!(cache.get(&retained).is_some());
+        cache.remove(&retained);
+        assert!(cache.get(&retained).is_none());
+        assert!(!cache.order.contains(&retained));
     }
 }
 
@@ -112,6 +117,14 @@ impl MemberKeyPackagePrewarmCache {
             };
             self.entries.remove(&oldest);
         }
+    }
+
+    /// Evict all process-local composition material for one identity.
+    /// Sign-out/removal calls this while the canonical account record is still
+    /// available, before the same pubkey can be re-added as a tracked account.
+    pub(crate) fn remove(&mut self, account_id_hex: &str) {
+        self.entries.remove(account_id_hex);
+        self.order.retain(|existing| existing != account_id_hex);
     }
 
     fn remove_expired(&mut self) {
@@ -166,6 +179,7 @@ impl From<MemberKeyPackageResolutionStats> for MemberKeyPackagePrewarmSummary {
 struct MemberTarget {
     account_id_hex: String,
     local_label: Option<String>,
+    local_signing_unavailable: bool,
     relay_lists: AccountRelayListStatus,
 }
 
@@ -252,23 +266,64 @@ impl MarmotApp {
         let mut seen = HashSet::new();
         let mut targets = Vec::new();
         for member_ref in member_refs {
-            let local = self.account_home().account(member_ref).ok();
-            let account_id_hex = match &local {
+            let local_by_ref = self.account_home().account(member_ref).ok();
+            let account_id_hex = match &local_by_ref {
                 Some(account) => account.account_id_hex.clone(),
                 None => PublicKey::parse(member_ref)
                     .map_err(|_| AppError::InvalidPublicKey)?
                     .to_hex(),
             };
+            // `AccountHome::account(hex)` can resolve only an account whose
+            // canonical label is that hex value. Test/dev aliases and legacy
+            // named local accounts still need to be classified by their
+            // stored account id; otherwise a signed-out local identity passed
+            // by npub/hex is accidentally treated as remote.
+            let local = match local_by_ref {
+                Some(account) => Some(account),
+                None => self
+                    .account_home()
+                    .accounts()?
+                    .into_iter()
+                    .find(|account| account.account_id_hex == account_id_hex),
+            };
             if !seen.insert(account_id_hex.clone()) {
                 continue;
             }
-            let relay_lists = self
-                .directory_entry_for_account_id(&account_id_hex)?
-                .map(|entry| entry.relay_lists)
-                .unwrap_or_else(AccountRelayListStatus::empty);
+            let local_signing = local.as_ref().is_some_and(|account| account.can_sign());
+            let (local_signing_unavailable, relay_lists) = if local_signing {
+                match self.with_local_key_package_admission(
+                    &account_id_hex,
+                    |local_signing_account| {
+                        Ok(self
+                            .directory_entry_for_account_id_with_admitted_account(
+                                &account_id_hex,
+                                local_signing_account,
+                            )?
+                            .map(|entry| entry.relay_lists)
+                            .unwrap_or_else(AccountRelayListStatus::empty))
+                    },
+                )? {
+                    Some(relay_lists) => (false, relay_lists),
+                    // A signed-out or teardown-fenced local identity is a
+                    // terminal missing outcome for this pass. Do not consult
+                    // durable directory state outside the admission gate:
+                    // doing so can reopen its private cache after eviction.
+                    None => (true, AccountRelayListStatus::empty()),
+                }
+            } else {
+                (
+                    false,
+                    self.directory_entry_for_account_id(&account_id_hex)?
+                        .map(|entry| entry.relay_lists)
+                        .unwrap_or_else(AccountRelayListStatus::empty),
+                )
+            };
             targets.push(MemberTarget {
                 account_id_hex,
-                local_label: local.map(|account| account.label),
+                local_label: local
+                    .filter(|account| account.can_sign() && !account.signed_out)
+                    .map(|account| account.label),
+                local_signing_unavailable,
                 relay_lists,
             });
         }
@@ -279,19 +334,32 @@ impl MarmotApp {
         let mut unresolved = Vec::new();
         let mut reused_members = 0usize;
         for (index, target) in targets.iter().enumerate() {
+            if target.local_signing_unavailable {
+                outcomes[index] = Some(Err(AppError::MissingKeyPackage(
+                    target.account_id_hex.clone(),
+                )));
+                continue;
+            }
             if let Some(label) = &target.local_label
                 && let Some(key_package) = self.validated_current_local_key_package(label)
-                && let Ok(key_package) =
-                    self.validate_member_key_package_current(&target.account_id_hex, key_package)
+                && let Ok(key_package) = self
+                    .validate_current_local_member_key_package(&target.account_id_hex, key_package)
             {
                 outcomes[index] = Some(Ok(key_package));
                 reused_members += 1;
                 continue;
             }
-            let cached = self.directory_entry_for_account_id(&target.account_id_hex)?;
-            if let Some(key_package) = cached.and_then(|entry| entry.key_package)
+            let cached = self.directory_entry_for_member_target(target)?;
+            if let Some(cached_key_package) = cached.and_then(|entry| entry.key_package)
+                && self
+                    .local_key_package_revision_is_live(
+                        &target.account_id_hex,
+                        &cached_key_package.key_package_ref_hex,
+                        &cached_key_package.key_package_event_id,
+                    )
+                    .unwrap_or(false)
                 && let Ok(key_package) =
-                    validated_cached_key_package(&target.account_id_hex, &key_package)
+                    validated_cached_key_package(&target.account_id_hex, &cached_key_package)
                 && let Ok(key_package) =
                     self.validate_member_key_package_current(&target.account_id_hex, key_package)
             {
@@ -357,22 +425,94 @@ impl MarmotApp {
         })
     }
 
+    /// Read a locally signing target's directory projection only while its
+    /// teardown admission remains open. Remote/tracked targets need no local
+    /// serialization and retain the ordinary directory behavior.
+    fn directory_entry_for_member_target(
+        &self,
+        target: &MemberTarget,
+    ) -> Result<Option<crate::UserDirectoryRecord>, AppError> {
+        if target.local_label.is_none() {
+            return self.directory_entry_for_account_id(&target.account_id_hex);
+        }
+        Ok(self
+            .with_local_key_package_admission(&target.account_id_hex, |local_signing_account| {
+                self.directory_entry_for_account_id_with_admitted_account(
+                    &target.account_id_hex,
+                    local_signing_account,
+                )
+            })?
+            .flatten())
+    }
+
     fn accept_prefetched_key_package(
         &self,
         purpose: MemberResolutionPurpose,
         fetched: FetchedKeyPackage,
     ) -> Result<KeyPackage, AppError> {
+        if self.removed_local_key_package_slot_is_retired(
+            &fetched.account_id_hex,
+            &fetched.key_package_id,
+        )? {
+            return Err(AppError::MissingKeyPackage(fetched.account_id_hex));
+        }
+        if !self.local_key_package_revision_is_live(
+            &fetched.account_id_hex,
+            &fetched.key_package_ref_hex,
+            &fetched.key_package_event_id,
+        )? {
+            return Err(AppError::MissingKeyPackage(fetched.account_id_hex));
+        }
         let key_package = self.validate_member_key_package_current(
             &fetched.account_id_hex,
             fetched.key_package.clone(),
         )?;
         match purpose {
-            MemberResolutionPurpose::Commit => self.remember_directory_key_package(&fetched)?,
-            MemberResolutionPurpose::Prewarm => self
-                .member_key_package_prewarm_cache
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .insert(fetched),
+            MemberResolutionPurpose::Commit => {
+                if !self.remember_directory_key_package_if_live(&fetched)? {
+                    return Err(AppError::MissingKeyPackage(fetched.account_id_hex));
+                }
+            }
+            MemberResolutionPurpose::Prewarm => {
+                let account_id_hex = fetched.account_id_hex.clone();
+                let admitted = self
+                    .with_local_key_package_admission(&account_id_hex, |local_signing_account| {
+                        if let Some(account) = local_signing_account
+                            && !self.local_key_package_revision_is_live_for_account(
+                                account,
+                                &fetched.key_package_ref_hex,
+                                &fetched.key_package_event_id,
+                            )?
+                        {
+                            return Ok(false);
+                        }
+                        self.member_key_package_prewarm_cache
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner())
+                            .insert(fetched);
+                        Ok(true)
+                    })?
+                    .unwrap_or(false);
+                if !admitted {
+                    return Err(AppError::MissingKeyPackage(account_id_hex));
+                }
+            }
+        }
+        Ok(key_package)
+    }
+
+    fn validate_current_local_member_key_package(
+        &self,
+        account_id_hex: &str,
+        key_package: KeyPackage,
+    ) -> Result<KeyPackage, AppError> {
+        let key_package = self.validate_member_key_package_current(account_id_hex, key_package)?;
+        let metadata = key_package_metadata(&key_package)
+            .map_err(|error| AppError::InvalidKeyPackageEvent(error.to_string()))?;
+        if !self
+            .local_current_key_package_ref_is_live(account_id_hex, &metadata.key_package_ref_hex)?
+        {
+            return Err(AppError::MissingKeyPackage(account_id_hex.to_owned()));
         }
         Ok(key_package)
     }
@@ -662,15 +802,14 @@ impl MarmotApp {
                     .cloned()
                     .collect::<Vec<_>>();
                 let cached = self
-                    .directory_entry_for_account_id(account_id)
+                    .directory_entry_for_member_target(&targets[index])
                     .ok()
                     .flatten();
-                let selected = latest_fresh_key_package_from_records(
-                    account_id,
-                    account_records,
-                    self.directory_freshness(),
-                )
-                .and_then(|selection| fresh_or_cached_key_package(account_id, selection, cached));
+                let selected = self
+                    .latest_fresh_non_retired_key_package_from_records(account_id, account_records)
+                    .and_then(|selection| {
+                        fresh_or_cached_key_package(account_id, selection, cached)
+                    });
                 match selected {
                     Ok(mut fetched) => {
                         fetched.relay_lists = targets[index].relay_lists.clone();
@@ -724,13 +863,12 @@ impl MarmotApp {
                             .map_err(|error| {
                                 AppError::RelayDirectory(format!("fetch key packages: {error}"))
                             })?;
-                        let cached = app.directory_entry_for_account_id(&target.account_id_hex)?;
+                        let cached = app.directory_entry_for_member_target(&target)?;
                         let mut fetched = fresh_or_cached_key_package(
                             &target.account_id_hex,
-                            latest_fresh_key_package_from_records(
+                            app.latest_fresh_non_retired_key_package_from_records(
                                 &target.account_id_hex,
                                 records,
-                                app.directory_freshness(),
                             )?,
                             cached,
                         )?;

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -10,7 +10,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::fs;
 use std::path::PathBuf;
 
-use cgka_traits::TransportEndpoint;
+use cgka_traits::{MaintenanceStorage, TransportEndpoint};
 use marmot_account::AccountSummary;
 use nostr_sdk::prelude::PublicKey;
 use storage_sqlite::{PublicDirectoryUserRecord, SqliteSharedStorage};
@@ -47,6 +47,37 @@ use crate::{
     blocking_app_task, push_unique_strings, relay_list_state_from_event, remove_sqlite_file_set,
 };
 
+/// Per-relay bound for setup-time kind-10002 history. A conforming relay has
+/// one replaceable winner; reaching this bound is therefore ambiguous and must
+/// not establish local route authority.
+const SETUP_NIP65_STRICT_HISTORY_LIMIT: usize = 12;
+
+#[derive(Clone, Copy)]
+enum RemovedSlotAdmission<'a> {
+    InspectSessionGate,
+    AlreadyAdmitted(Option<&'a AccountSummary>),
+}
+
+fn merge_newer_live_key_package(
+    current: &mut Option<DirectoryKeyPackage>,
+    candidate: Option<&DirectoryKeyPackage>,
+) {
+    let Some(candidate) = candidate else {
+        return;
+    };
+    let replace = current.as_ref().is_none_or(|current| {
+        crate::nostr_replaceable_coordinate_is_newer(
+            candidate.created_at,
+            &candidate.key_package_event_id,
+            current.created_at,
+            &current.key_package_event_id,
+        )
+    });
+    if replace {
+        *current = Some(candidate.clone());
+    }
+}
+
 impl MarmotApp {
     pub fn warm_directory_storage(&self) -> Result<(), AppError> {
         let _span = tracing::debug_span!(
@@ -55,8 +86,60 @@ impl MarmotApp {
             method = "warm_directory_storage"
         )
         .entered();
-        let _shared = self.shared_storage()?;
-        let _caches = self.directory_caches()?;
+        let shared = self.shared_storage()?;
+        let caches = self.directory_caches()?;
+        self.reconcile_removed_local_key_package_projections(&caches, &shared)?;
+        Ok(())
+    }
+
+    /// Retry the non-authoritative projection scrub after a crash between the
+    /// immutable tombstone commit and cache cleanup. Only active account
+    /// caches are opened here; a signed-out cache is reconciled when an
+    /// explicit sign-in makes it active and warms directory storage again.
+    fn reconcile_removed_local_key_package_projections(
+        &self,
+        caches: &[DirectoryCache],
+        shared: &SqliteSharedStorage,
+    ) -> Result<(), AppError> {
+        // Tombstones are immutable and both projection clears are CAS-style.
+        // Do not hold the projection-mutation mutex while the marker check
+        // consults account-session admission: live ingestion orders those
+        // locks admission -> mutation, so the inverse order would deadlock.
+        let mut changed = false;
+        for record in shared.public_directory_users()? {
+            let Some(key_package_json) = record.key_package_json.as_deref() else {
+                continue;
+            };
+            let key_package: DirectoryKeyPackage = serde_json::from_str(key_package_json)?;
+            if self.removed_local_key_package_slot_is_retired(
+                &record.account_id_hex,
+                &key_package.key_package_id,
+            )? {
+                changed |= shared.clear_public_directory_key_package_if_matches(
+                    &record.account_id_hex,
+                    key_package_json,
+                )?;
+            }
+        }
+        for cache in caches {
+            for entry in cache.entries()? {
+                let Some(key_package) = entry.key_package else {
+                    continue;
+                };
+                if self.removed_local_key_package_slot_is_retired(
+                    &entry.account_id_hex,
+                    &key_package.key_package_id,
+                )? {
+                    changed |= cache.clear_key_package_if_slot(
+                        &entry.account_id_hex,
+                        Some(&key_package.key_package_id),
+                    )?;
+                }
+            }
+        }
+        if changed {
+            self.request_directory_sync_rebuild();
+        }
         Ok(())
     }
 
@@ -136,8 +219,10 @@ impl MarmotApp {
             let app = self.clone();
             let account_id = account_id_hex.clone();
             let remembered = status.clone();
-            blocking_app_task(move || app.remember_directory_relay_lists(&account_id, &remembered))
-                .await?;
+            blocking_app_task(move || {
+                app.remember_observed_directory_relay_lists(&account_id, &remembered)
+            })
+            .await?;
         }
         Ok(status)
     }
@@ -216,10 +301,136 @@ impl MarmotApp {
             let app = self.clone();
             let account_id = account_id_hex.clone();
             let remembered = status.clone();
-            blocking_app_task(move || app.remember_directory_relay_lists(&account_id, &remembered))
-                .await?;
+            blocking_app_task(move || {
+                app.remember_observed_directory_relay_lists(&account_id, &remembered)
+            })
+            .await?;
         }
         Ok(Some(status))
+    }
+
+    /// Fetch the exact signed kind-10002 winner used to establish a local
+    /// signing account's durable route authority during import/login.
+    ///
+    /// Unlike ordinary directory projection reads, every requested relay must
+    /// explicitly complete its stored-event page. A future-dated event or a
+    /// page that fills the bounded history capacity is inconclusive rather
+    /// than permission to adopt an older visible revision.
+    pub(crate) async fn fetch_exact_self_nip65_event_strict(
+        &self,
+        account_id_hex: &str,
+        discovery_relays: &[TransportEndpoint],
+    ) -> Result<Option<RelayEventRecord>, AppError> {
+        let public_key =
+            PublicKey::parse(account_id_hex).map_err(|_| AppError::InvalidPublicKey)?;
+        let account_id_hex = public_key.to_hex();
+        let source_relays = self.directory_source_relays(discovery_relays);
+        let records = self
+            .relay_plane
+            .fetch_directory_events_strict(
+                source_relays,
+                vec![DirectoryEventQuery::new(
+                    KIND_NIP65_RELAY_LIST,
+                    vec![account_id_hex.clone()],
+                    SETUP_NIP65_STRICT_HISTORY_LIMIT,
+                )],
+            )
+            .await
+            .map_err(|error| {
+                AppError::RelayDirectory(format!(
+                    "strict setup NIP-65 discovery did not complete: {error}"
+                ))
+            })?;
+
+        let freshness = self.directory_freshness();
+        let mut endpoint_event_ids = BTreeMap::<String, HashSet<String>>::new();
+        let mut candidates = Vec::new();
+        for record in records {
+            if record.event.pubkey != account_id_hex || record.event.kind != KIND_NIP65_RELAY_LIST {
+                return Err(AppError::RelayDirectory(
+                    "strict setup NIP-65 discovery returned an unrelated event".into(),
+                ));
+            }
+            record.event.to_verified_nostr_event().map_err(|_| {
+                AppError::RelayDirectory(
+                    "strict setup NIP-65 discovery returned an invalid signature".into(),
+                )
+            })?;
+            if !freshness.accepts(&record) {
+                return Err(AppError::RelayDirectory(
+                    "strict setup NIP-65 discovery observed a future-dated event".into(),
+                ));
+            }
+            if record.endpoints.is_empty() {
+                return Err(AppError::RelayDirectory(
+                    "strict setup NIP-65 discovery returned an unscoped event".into(),
+                ));
+            }
+            if relay_list_state_from_event(&record.event).is_none() {
+                return Err(AppError::RelayDirectory(
+                    "strict setup NIP-65 discovery returned a malformed relay list".into(),
+                ));
+            }
+            for endpoint in &record.endpoints {
+                endpoint_event_ids
+                    .entry(endpoint.0.clone())
+                    .or_default()
+                    .insert(record.event.id.clone());
+            }
+            candidates.push(record);
+        }
+        if endpoint_event_ids
+            .values()
+            .any(|event_ids| event_ids.len() >= SETUP_NIP65_STRICT_HISTORY_LIMIT)
+        {
+            return Err(AppError::RelayDirectory(
+                "strict setup NIP-65 discovery reached its bounded history capacity".into(),
+            ));
+        }
+
+        let Some(mut winner_index) = (!candidates.is_empty()).then_some(0usize) else {
+            return Ok(None);
+        };
+        for candidate_index in 1..candidates.len() {
+            let candidate = &candidates[candidate_index].event;
+            let winner = &candidates[winner_index].event;
+            if crate::nostr_replaceable_coordinate_is_newer(
+                candidate.created_at,
+                &candidate.id,
+                winner.created_at,
+                &winner.id,
+            ) {
+                winner_index = candidate_index;
+            }
+        }
+        let winner_event = candidates[winner_index].event.clone();
+        let winner_state = relay_list_state_from_event(&winner_event).ok_or_else(|| {
+            AppError::RelayDirectory("strict setup NIP-65 winner has no relay-list state".into())
+        })?;
+        let safe_write_relays = self.sanitize_key_package_deletion_endpoints(
+            winner_state
+                .relays
+                .iter()
+                .cloned()
+                .map(TransportEndpoint)
+                .collect(),
+        )?;
+        if safe_write_relays.is_empty() {
+            return Err(AppError::MissingRelayLists(vec![
+                MissingRelayListKind::Nip65,
+            ]));
+        }
+        let mut endpoints = candidates
+            .iter()
+            .filter(|candidate| candidate.event.id == winner_event.id)
+            .flat_map(|candidate| candidate.endpoints.iter().cloned())
+            .collect::<Vec<_>>();
+        endpoints.sort();
+        endpoints.dedup();
+        Ok(Some(RelayEventRecord {
+            endpoints,
+            event: winner_event,
+        }))
     }
 
     /// Fetch the account's own current published kind:0 profile metadata from
@@ -305,8 +516,10 @@ impl MarmotApp {
             let app = self.clone();
             let account_id = account_id_hex.to_owned();
             let remembered = relay_lists.clone();
-            blocking_app_task(move || app.remember_directory_relay_lists(&account_id, &remembered))
-                .await?;
+            blocking_app_task(move || {
+                app.remember_observed_directory_relay_lists(&account_id, &remembered)
+            })
+            .await?;
         }
         let mut source_relays = self.retain_safe_discovered_endpoints(
             relay_lists
@@ -336,20 +549,43 @@ impl MarmotApp {
         };
         let mut fetched = fresh_or_cached_key_package(
             account_id_hex,
-            latest_fresh_key_package_from_records(
-                account_id_hex,
-                records,
-                self.directory_freshness(),
-            )?,
+            self.latest_fresh_non_retired_key_package_from_records(account_id_hex, records)?,
             cached_entry,
         )?;
         fetched.relay_lists = relay_lists;
-        {
+        let remembered = {
             let app = self.clone();
             let remembered = fetched.clone();
-            blocking_app_task(move || app.remember_directory_key_package(&remembered)).await?;
+            blocking_app_task(move || app.remember_directory_key_package_if_live(&remembered))
+                .await?
+        };
+        if !remembered {
+            return Err(AppError::MissingKeyPackage(account_id_hex.to_owned()));
         }
         Ok(fetched)
+    }
+
+    /// Filter immutable removed-local slots before selecting the newest NIP-33
+    /// coordinate. This preserves a valid sibling-device slot even when a
+    /// newer relay echo exists for the removed device's retired `d` tag.
+    pub(crate) fn latest_fresh_non_retired_key_package_from_records(
+        &self,
+        account_id_hex: &str,
+        records: Vec<RelayEventRecord>,
+    ) -> Result<crate::DirectorySelection<Option<FetchedKeyPackage>>, AppError> {
+        let mut admitted = Vec::with_capacity(records.len());
+        for record in records {
+            let retired = record.event.kind == KIND_MARMOT_KEY_PACKAGE
+                && record.event.pubkey == account_id_hex
+                && self.removed_local_key_package_slot_is_retired(
+                    account_id_hex,
+                    record.event.tag_value("d").unwrap_or_default(),
+                )?;
+            if !retired {
+                admitted.push(record);
+            }
+        }
+        latest_fresh_key_package_from_records(account_id_hex, admitted, self.directory_freshness())
     }
 
     pub async fn refresh_directory_entry_for_account_id(
@@ -370,8 +606,10 @@ impl MarmotApp {
             let app = self.clone();
             let account_id = account_id_hex.to_owned();
             let remembered = status.clone();
-            blocking_app_task(move || app.remember_directory_relay_lists(&account_id, &remembered))
-                .await?;
+            blocking_app_task(move || {
+                app.remember_observed_directory_relay_lists(&account_id, &remembered)
+            })
+            .await?;
         }
         let app = self.clone();
         let account_id = account_id_hex.to_owned();
@@ -390,6 +628,26 @@ impl MarmotApp {
         let caches = self.directory_caches()?;
         let shared_storage = self.shared_storage()?;
         self.directory_entry_for_account_id_with_handles(&account_id_hex, &caches, &shared_storage)
+    }
+
+    /// Admission-aware cache read for a caller already holding
+    /// `account_session_admissions`. The ordinary hydration path may inspect
+    /// that same non-reentrant mutex when an account-wide legacy tombstone is
+    /// present, so admitted callers must carry their proof through instead.
+    pub(crate) fn directory_entry_for_account_id_with_admitted_account(
+        &self,
+        account_id_hex: &str,
+        local_signing_account: Option<&AccountSummary>,
+    ) -> Result<Option<UserDirectoryRecord>, AppError> {
+        let account_id_hex = parse_account_id_hex(account_id_hex)?;
+        let caches = self.directory_caches()?;
+        let shared_storage = self.shared_storage()?;
+        self.directory_entry_for_account_id_with_handles_and_admission(
+            &account_id_hex,
+            &caches,
+            &shared_storage,
+            RemovedSlotAdmission::AlreadyAdmitted(local_signing_account),
+        )
     }
 
     /// Bounded local cached-identity page for many account IDs.
@@ -703,6 +961,28 @@ impl MarmotApp {
             .map_err(|e| AppError::RelayDirectory(format!("fetch key packages: {e}")))
     }
 
+    pub(crate) async fn fetch_key_package_events_for_account_id_with_limit_strict(
+        &self,
+        account_id_hex: &str,
+        source_relays: &[TransportEndpoint],
+        limit: usize,
+    ) -> Result<Vec<RelayEventRecord>, AppError> {
+        let public_key =
+            PublicKey::parse(account_id_hex).map_err(|_| AppError::InvalidPublicKey)?;
+        let source_relays = self.directory_source_relays(source_relays);
+        self.relay_plane
+            .fetch_directory_events_strict(
+                source_relays,
+                vec![DirectoryEventQuery::new(
+                    KIND_MARMOT_KEY_PACKAGE,
+                    vec![public_key.to_hex()],
+                    limit,
+                )],
+            )
+            .await
+            .map_err(|e| AppError::RelayDirectory(format!("strict key package fetch: {e}")))
+    }
+
     pub(crate) async fn fetch_follow_list_for_account_id(
         &self,
         account_id_hex: &str,
@@ -967,12 +1247,32 @@ impl MarmotApp {
         caches: &[DirectoryCache],
         shared_storage: &SqliteSharedStorage,
     ) -> Result<Option<UserDirectoryRecord>, AppError> {
+        self.directory_entry_for_account_id_with_handles_and_admission(
+            account_id_hex,
+            caches,
+            shared_storage,
+            RemovedSlotAdmission::InspectSessionGate,
+        )
+    }
+
+    fn directory_entry_for_account_id_with_handles_and_admission(
+        &self,
+        account_id_hex: &str,
+        caches: &[DirectoryCache],
+        shared_storage: &SqliteSharedStorage,
+        admission: RemovedSlotAdmission<'_>,
+    ) -> Result<Option<UserDirectoryRecord>, AppError> {
         let cached_entry = Self::directory_entry_from_caches(caches, account_id_hex)?
-            .map(|entry| self.hydrate_directory_record(entry))
+            .map(|entry| self.hydrate_directory_record_with_admission(entry, admission))
             .transpose()?;
         let shared_entry = shared_storage
             .public_directory_user(account_id_hex)?
-            .map(|record| self.hydrate_public_directory_record(record))
+            .map(|record| {
+                self.hydrate_directory_record_with_admission(
+                    user_directory_record_from_public(record)?,
+                    admission,
+                )
+            })
             .transpose()?;
         Ok(select_newer_directory_entry(cached_entry, shared_entry))
     }
@@ -1015,15 +1315,147 @@ impl MarmotApp {
         self.save_directory_entry(&entry)
     }
 
+    /// Cache relay-list observations without allowing a generic directory read
+    /// to replace the locally managed NIP-65 route. The account-manager path is
+    /// the sole authority for a local identity's kind-10002 projection; inbox
+    /// and bootstrap observations remain safe to refresh here.
+    fn remember_observed_directory_relay_lists(
+        &self,
+        account_id_hex: &str,
+        relay_lists: &AccountRelayListStatus,
+    ) -> Result<(), AppError> {
+        let account_id_hex = parse_account_id_hex(account_id_hex)?;
+        if self.local_account_label_for_id(&account_id_hex).is_none() {
+            return self.remember_directory_relay_lists(&account_id_hex, relay_lists);
+        }
+        let mut entry = self
+            .directory_entry_for_account_id(&account_id_hex)?
+            .unwrap_or_else(|| self.empty_directory_record(&account_id_hex));
+        let local_nip65 = entry.relay_lists.nip65.clone();
+        entry.account_id_hex = account_id_hex;
+        entry.relay_lists = relay_lists.clone();
+        entry.relay_lists.nip65 = local_nip65;
+        entry.relay_lists.refresh();
+        self.save_directory_entry(&entry)
+    }
+
     pub(crate) fn remember_directory_key_package(
         &self,
         fetched: &FetchedKeyPackage,
     ) -> Result<(), AppError> {
+        let _ = self.remember_directory_key_package_if_live(fetched)?;
+        Ok(())
+    }
+
+    /// Admit one exact KeyPackage observation into the durable directory.
+    ///
+    /// For identities this app can sign as, the account-private lifecycle is
+    /// authoritative. Signed-out accounts are rejected before their SQLCipher
+    /// storage is opened, and active accounts accept only the exact current or
+    /// pending signed revision. Public/tracked account records intentionally
+    /// remain ordinary remote identities and do not acquire local lifecycle
+    /// semantics merely because they are present in `AccountHome`.
+    pub(crate) fn remember_directory_key_package_if_live(
+        &self,
+        fetched: &FetchedKeyPackage,
+    ) -> Result<bool, AppError> {
+        Ok(self
+            .with_local_key_package_admission(&fetched.account_id_hex, |local_signing_account| {
+                self.remember_directory_key_package_if_live_admitted(fetched, local_signing_account)
+            })?
+            .unwrap_or(false))
+    }
+
+    /// Run one bounded local KeyPackage cache operation under the same
+    /// admission mutex teardown closes synchronously before its first await.
+    /// An operation admitted first finishes before teardown can proceed to its
+    /// final eviction; an operation arriving second observes the closed gate
+    /// and returns before opening any account-private directory/session store.
+    pub(crate) fn with_local_key_package_admission<T>(
+        &self,
+        account_id_hex: &str,
+        operation: impl FnOnce(Option<&AccountSummary>) -> Result<T, AppError>,
+    ) -> Result<Option<T>, AppError> {
+        let local_signing_account = self.local_signing_account_for_id(account_id_hex)?;
+        let _session_admission = if let Some(account) = local_signing_account.as_ref() {
+            let admission = self
+                .account_session_admissions
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let admission_open = admission
+                .get(&account.label)
+                .is_none_or(|state| state.account_id_hex != account.account_id_hex || state.open);
+            if account.signed_out || !admission_open {
+                return Ok(None);
+            }
+            Some(admission)
+        } else {
+            None
+        };
+        operation(local_signing_account.as_ref()).map(Some)
+    }
+
+    /// Cache an exact revision after the caller has serialized local signing
+    /// state with teardown's session-admission gate.
+    fn remember_directory_key_package_if_live_admitted(
+        &self,
+        fetched: &FetchedKeyPackage,
+        local_signing_account: Option<&AccountSummary>,
+    ) -> Result<bool, AppError> {
+        if self.removed_local_key_package_slot_is_retired_for_admitted_account(
+            &fetched.account_id_hex,
+            &fetched.key_package_id,
+            local_signing_account,
+        )? {
+            return Ok(false);
+        }
+        if let Some(account) = local_signing_account
+            && !self.local_key_package_revision_is_live_for_account(
+                account,
+                &fetched.key_package_ref_hex,
+                &fetched.key_package_event_id,
+            )?
+        {
+            // The account lifecycle is the private-material authority for our
+            // own identity. A delayed relay echo must never make a consumed,
+            // deleted, signed-out, or otherwise non-live revision available
+            // to local invite resolution again.
+            return Ok(false);
+        }
         let mut entry = self
-            .directory_entry_for_account_id(&fetched.account_id_hex)?
+            .directory_entry_for_account_id_with_admitted_account(
+                &fetched.account_id_hex,
+                local_signing_account,
+            )?
             .unwrap_or_else(|| self.empty_directory_record(&fetched.account_id_hex));
+        if entry.key_package.as_ref().is_some_and(|cached| {
+            !crate::nostr_replaceable_coordinate_is_newer(
+                fetched.created_at,
+                &fetched.key_package_event_id,
+                cached.created_at,
+                &cached.key_package_event_id,
+            )
+        }) {
+            let already_remembered = entry.key_package.as_ref().is_some_and(|cached| {
+                cached.key_package_id == fetched.key_package_id
+                    && cached.key_package_ref_hex == fetched.key_package_ref_hex
+                    && cached.key_package_event_id == fetched.key_package_event_id
+                    && cached.key_package_hex == hex::encode(fetched.key_package.bytes())
+                    && cached.created_at == fetched.created_at
+            });
+            // Live subscriptions deliver one relay record at a time and may
+            // echo an older parameterized-replaceable revision after a newer
+            // one was already projected. Keep the NIP-33 coordinate winner so
+            // arrival order cannot resurrect a consumed/stale KeyPackage.
+            return Ok(already_remembered);
+        }
+        let local_nip65 = local_signing_account.map(|_| entry.relay_lists.nip65.clone());
         entry.account_id_hex = fetched.account_id_hex.clone();
         entry.relay_lists = fetched.relay_lists.clone();
+        if let Some(local_nip65) = local_nip65 {
+            entry.relay_lists.nip65 = local_nip65;
+            entry.relay_lists.refresh();
+        }
         entry.key_package = Some(DirectoryKeyPackage {
             key_package_id: fetched.key_package_id.clone(),
             key_package_ref_hex: fetched.key_package_ref_hex.clone(),
@@ -1032,7 +1464,158 @@ impl MarmotApp {
             created_at: fetched.created_at,
             source_relays: fetched.source_relays.clone(),
         });
-        self.save_directory_entry(&entry)
+        self.save_directory_entry_with_reason_under_admission(
+            &entry,
+            "directory",
+            local_signing_account,
+        )?;
+
+        // `save_directory_entry` reconciles the account-private and shared
+        // projections. Re-read the winner so a concurrent newer coordinate is
+        // a rejection at a composition commit boundary rather than permission
+        // to return the older prefetched bytes.
+        Ok(self
+            .directory_entry_for_account_id_with_admitted_account(
+                &fetched.account_id_hex,
+                local_signing_account,
+            )?
+            .and_then(|entry| entry.key_package)
+            .is_some_and(|cached| {
+                cached.key_package_id == fetched.key_package_id
+                    && cached.key_package_ref_hex == fetched.key_package_ref_hex
+                    && cached.key_package_event_id == fetched.key_package_event_id
+                    && cached.key_package_hex == hex::encode(fetched.key_package.bytes())
+                    && cached.created_at == fetched.created_at
+            }))
+    }
+
+    pub(crate) fn local_signing_account_for_id(
+        &self,
+        account_id_hex: &str,
+    ) -> Result<Option<AccountSummary>, AppError> {
+        Ok(self
+            .account_home()
+            .accounts()?
+            .into_iter()
+            .find(|account| account.account_id_hex == account_id_hex && account.can_sign()))
+    }
+
+    /// Whether an observed exact revision is still authorized by local
+    /// private-material state. Remote and tracked-only identities return true;
+    /// signed-out signing identities return false before account storage is
+    /// consulted.
+    pub(crate) fn local_key_package_revision_is_live(
+        &self,
+        account_id_hex: &str,
+        key_package_ref_hex: &str,
+        key_package_event_id: &str,
+    ) -> Result<bool, AppError> {
+        let Some(account) = self.local_signing_account_for_id(account_id_hex)? else {
+            return Ok(true);
+        };
+        let admission = self
+            .account_session_admissions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let admission_open = admission
+            .get(&account.label)
+            .is_none_or(|state| state.account_id_hex != account.account_id_hex || state.open);
+        if account.signed_out || !admission_open {
+            return Ok(false);
+        }
+        self.local_key_package_revision_is_live_for_account(
+            &account,
+            key_package_ref_hex,
+            key_package_event_id,
+        )
+    }
+
+    /// Inner lifecycle authority check for callers already holding the account
+    /// session-admission mutex.
+    pub(crate) fn local_key_package_revision_is_live_for_account(
+        &self,
+        account: &AccountSummary,
+        key_package_ref_hex: &str,
+        key_package_event_id: &str,
+    ) -> Result<bool, AppError> {
+        let key_package_ref = hex::decode(key_package_ref_hex)?;
+        let event_id_bytes = hex::decode(key_package_event_id)?;
+        if event_id_bytes.len() != 32 {
+            return Ok(false);
+        }
+        let event_id = cgka_traits::MessageId::new(event_id_bytes);
+        let Some(lifecycle) = self
+            .account_storage(&account.label)?
+            .key_package_lifecycle()?
+        else {
+            return Ok(false);
+        };
+        if lifecycle.key_package_ref_is_consumed(&key_package_ref)
+            || lifecycle
+                .deleted_live_revision_event_ids
+                .contains(&event_id)
+        {
+            return Ok(false);
+        }
+        let live_current = lifecycle.current_key_package_ref.as_ref() == Some(&key_package_ref)
+            && lifecycle.authored_event_id.as_ref() == Some(&event_id)
+            && lifecycle
+                .authored_signed_event
+                .as_ref()
+                .is_none_or(|artifact| artifact.id == event_id);
+        let live_pending = lifecycle
+            .pending_replacement
+            .as_ref()
+            .is_some_and(|pending| {
+                pending.key_package_ref == key_package_ref
+                    && pending
+                        .signed_event
+                        .as_ref()
+                        .is_some_and(|artifact| artifact.id == event_id)
+            });
+        Ok(live_current || live_pending)
+    }
+
+    /// Validate locally stored current private material against the exact live
+    /// lifecycle revision. The event id is lifecycle-owned, so callers only
+    /// supply the KeyPackageRef derived from the candidate bytes.
+    pub(crate) fn local_current_key_package_ref_is_live(
+        &self,
+        account_id_hex: &str,
+        key_package_ref_hex: &str,
+    ) -> Result<bool, AppError> {
+        let Some(account) = self.local_signing_account_for_id(account_id_hex)? else {
+            return Ok(true);
+        };
+        let admission = self
+            .account_session_admissions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let admission_open = admission
+            .get(&account.label)
+            .is_none_or(|state| state.account_id_hex != account.account_id_hex || state.open);
+        if account.signed_out || !admission_open {
+            return Ok(false);
+        }
+        let key_package_ref = hex::decode(key_package_ref_hex)?;
+        let Some(lifecycle) = self
+            .account_storage(&account.label)?
+            .key_package_lifecycle()?
+        else {
+            return Ok(false);
+        };
+        let Some(event_id) = lifecycle.authored_event_id.as_ref() else {
+            return Ok(false);
+        };
+        Ok(
+            lifecycle.current_key_package_ref.as_ref() == Some(&key_package_ref)
+                && !lifecycle.key_package_ref_is_consumed(&key_package_ref)
+                && !lifecycle.deleted_live_revision_event_ids.contains(event_id)
+                && lifecycle
+                    .authored_signed_event
+                    .as_ref()
+                    .is_none_or(|artifact| &artifact.id == event_id),
+        )
     }
 
     fn remember_directory_user(&self, account_id_hex: &str) -> Result<(), AppError> {
@@ -1156,6 +1739,11 @@ impl MarmotApp {
         account_id_hex: &str,
         record: &RelayEventRecord,
     ) -> Result<(), AppError> {
+        if record.event.kind == KIND_NIP65_RELAY_LIST
+            && self.local_account_label_for_id(account_id_hex).is_some()
+        {
+            return Ok(());
+        }
         let Some(state) = relay_list_state_from_event(&record.event) else {
             return Ok(());
         };
@@ -1183,6 +1771,11 @@ impl MarmotApp {
             return Ok(());
         }
         let account_id_hex = parse_account_id_hex(&record.event.pubkey)?;
+        if record.event.kind == KIND_NIP65_RELAY_LIST
+            && self.local_account_label_for_id(&account_id_hex).is_some()
+        {
+            return Ok(());
+        }
         match record.event.kind {
             KIND_NOSTR_METADATA => {
                 if let Some((profile_account_id, profile)) = profile_from_record(record) {
@@ -1198,10 +1791,26 @@ impl MarmotApp {
             }
             KIND_MARMOT_KEY_PACKAGE => {
                 let mut fetched = key_package_from_record(record)?;
-                fetched.relay_lists = self
-                    .account_relay_list_status_for_account_id(&account_id_hex)
-                    .unwrap_or_else(|_| AccountRelayListStatus::empty());
-                self.remember_directory_key_package(&fetched)?;
+                let _ = self.with_local_key_package_admission(
+                    &account_id_hex,
+                    |local_signing_account| {
+                        fetched.relay_lists = self
+                            .directory_entry_for_account_id_with_admitted_account(
+                                &account_id_hex,
+                                local_signing_account,
+                            )
+                            .map(|entry| {
+                                entry
+                                    .map(|entry| entry.relay_lists)
+                                    .unwrap_or_else(AccountRelayListStatus::empty)
+                            })
+                            .unwrap_or_else(|_| AccountRelayListStatus::empty());
+                        self.remember_directory_key_package_if_live_admitted(
+                            &fetched,
+                            local_signing_account,
+                        )
+                    },
+                )?;
             }
             _ => {}
         }
@@ -1217,24 +1826,92 @@ impl MarmotApp {
         entry: &UserDirectoryRecord,
         reason: &str,
     ) -> Result<(), AppError> {
-        let proposed_entry = self.hydrate_directory_record(entry.clone())?;
+        let local_signing_account = self.local_signing_account_for_id(&entry.account_id_hex)?;
+        let session_admission = local_signing_account.as_ref().map(|_| {
+            self.account_session_admissions
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+        });
+        let admitted_local_signing_account = local_signing_account.as_ref().filter(|account| {
+            account.is_active_signing()
+                && session_admission.as_ref().is_some_and(|admissions| {
+                    admissions.get(&account.label).is_none_or(|state| {
+                        state.account_id_hex != account.account_id_hex || state.open
+                    })
+                })
+        });
+        self.save_directory_entry_with_reason_under_admission(
+            entry,
+            reason,
+            admitted_local_signing_account,
+        )
+    }
+
+    /// Persist a projection while carrying the caller's already-held session
+    /// admission proof. Lock ordering is always session admission -> removed
+    /// slot mutation; hydration must use that proof rather than recursively
+    /// inspecting the non-reentrant admission mutex.
+    fn save_directory_entry_with_reason_under_admission(
+        &self,
+        entry: &UserDirectoryRecord,
+        reason: &str,
+        local_signing_account: Option<&AccountSummary>,
+    ) -> Result<(), AppError> {
+        // Acquire handles first: one-time legacy migration takes the mutation
+        // mutex internally and must finish before this write transaction takes
+        // the same mutex.
+        let caches = self.directory_caches()?;
         let shared_storage = self.shared_storage()?;
+        let _removed_local_key_package_mutation = self
+            .removed_local_key_package_mutation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let admission = RemovedSlotAdmission::AlreadyAdmitted(local_signing_account);
+        let proposed_entry =
+            self.hydrate_directory_record_with_admission(entry.clone(), admission)?;
         let shared_record = shared_storage.public_directory_user(&proposed_entry.account_id_hex)?;
         let shared_entry = shared_record
             .clone()
-            .map(|record| self.hydrate_public_directory_record(record))
+            .map(|record| {
+                self.hydrate_directory_record_with_admission(
+                    user_directory_record_from_public(record)?,
+                    admission,
+                )
+            })
             .transpose()?;
-        let entry = select_newer_directory_entry(Some(proposed_entry), shared_entry.clone())
+        // Profile/follow changes and KeyPackage revisions have independent
+        // Nostr coordinates. In particular, filtering a retired local slot
+        // turns one stale whole-record candidate into `key_package = None`;
+        // that must not let a newer profile timestamp erase a live sibling
+        // device's KeyPackage from another projection.
+        let mut live_key_package = proposed_entry.key_package.clone();
+        merge_newer_live_key_package(
+            &mut live_key_package,
+            shared_entry
+                .as_ref()
+                .and_then(|entry| entry.key_package.as_ref()),
+        );
+        let mut cached_entries = Vec::with_capacity(caches.len());
+        for cache in &caches {
+            let cached_entry = cache
+                .entry(&proposed_entry.account_id_hex)?
+                .map(|record| self.hydrate_directory_record_with_admission(record, admission))
+                .transpose()?;
+            merge_newer_live_key_package(
+                &mut live_key_package,
+                cached_entry
+                    .as_ref()
+                    .and_then(|entry| entry.key_package.as_ref()),
+            );
+            cached_entries.push(cached_entry);
+        }
+        let mut entry = select_newer_directory_entry(Some(proposed_entry), shared_entry.clone())
             .expect("proposed directory entry should be present");
-        let caches = self.directory_caches()?;
+        entry.key_package = live_key_package;
         let public_entry = public_directory_user_record(&entry)?;
         let shared_entry_matches = shared_record.as_ref() == Some(&public_entry);
         let mut caches_match = true;
-        for cache in &caches {
-            let cached_entry = cache
-                .entry(&entry.account_id_hex)?
-                .map(|record| self.hydrate_directory_record(record))
-                .transpose()?;
+        for cached_entry in cached_entries {
             if cached_entry.as_ref() != Some(&entry) {
                 caches_match = false;
                 break;
@@ -1264,7 +1941,7 @@ impl MarmotApp {
             .unwrap_or_else(|poisoned| poisoned.into_inner()) = handle;
     }
 
-    fn request_directory_sync_rebuild(&self) {
+    pub(crate) fn request_directory_sync_rebuild(&self) {
         let handle = self
             .directory_sync
             .read()
@@ -1363,6 +2040,10 @@ impl MarmotApp {
         &self,
         caches: &[DirectoryCache],
     ) -> Result<(), AppError> {
+        let _removed_local_key_package_mutation = self
+            .removed_local_key_package_mutation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let mut checked = self
             .legacy_directory_cache_checked
             .lock()
@@ -1382,7 +2063,17 @@ impl MarmotApp {
 
         let entries = entries
             .into_iter()
-            .map(|entry| self.hydrate_directory_record(entry))
+            // A plaintext legacy cache can contain only pre-migration state,
+            // so an account-wide removal marker rejects every slot it carries.
+            // Do not consult account-session admission while holding the
+            // marker mutation mutex; that would invert live ingestion's
+            // admission -> mutation lock order.
+            .map(|entry| {
+                self.hydrate_directory_record_with_admission(
+                    entry,
+                    RemovedSlotAdmission::AlreadyAdmitted(None),
+                )
+            })
             .collect::<Result<Vec<_>, _>>()?;
         let shared_storage = self.shared_storage()?;
         for entry in &entries {
@@ -1457,11 +2148,54 @@ impl MarmotApp {
 
     fn hydrate_directory_record(
         &self,
+        entry: UserDirectoryRecord,
+    ) -> Result<UserDirectoryRecord, AppError> {
+        self.hydrate_directory_record_with_admission(
+            entry,
+            RemovedSlotAdmission::InspectSessionGate,
+        )
+    }
+
+    fn hydrate_directory_record_with_admission(
+        &self,
         mut entry: UserDirectoryRecord,
+        admission: RemovedSlotAdmission<'_>,
     ) -> Result<UserDirectoryRecord, AppError> {
         entry.account_id_hex = parse_account_id_hex(&entry.account_id_hex)?;
         entry.npub = npub_for_account_id(&entry.account_id_hex)?;
+        let key_package_is_retired = entry
+            .key_package
+            .as_ref()
+            .map(|key_package| match admission {
+                RemovedSlotAdmission::InspectSessionGate => self
+                    .removed_local_key_package_slot_is_retired(
+                        &entry.account_id_hex,
+                        &key_package.key_package_id,
+                    ),
+                RemovedSlotAdmission::AlreadyAdmitted(local_signing_account) => self
+                    .removed_local_key_package_slot_is_retired_for_admitted_account(
+                        &entry.account_id_hex,
+                        &key_package.key_package_id,
+                        local_signing_account,
+                    ),
+            })
+            .transpose()?
+            .unwrap_or(false);
+        if key_package_is_retired {
+            entry.key_package = None;
+        }
         entry.local_account = self.local_account_for_id(&entry.account_id_hex);
+        if let Some(local) = entry.local_account.as_ref()
+            && let Some(generation) =
+                self.read_nip65_route_generation_for_authoring(&local.label)?
+        {
+            // Profiles and KeyPackages may make a shared/cache record newer as
+            // a whole, but they do not carry route authority. Overlay the exact
+            // state bound to the verified local kind-10002 generation so cache
+            // selection can never roll the account back to stale relays.
+            entry.relay_lists.nip65 = generation.nip65;
+            entry.relay_lists.refresh();
+        }
         entry.follows = normalize_account_ids(entry.follows)?;
         entry.follow_source_relays.sort();
         entry.follow_source_relays.dedup();

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -407,14 +407,7 @@ impl MarmotApp {
         let winner_state = relay_list_state_from_event(&winner_event).ok_or_else(|| {
             AppError::RelayDirectory("strict setup NIP-65 winner has no relay-list state".into())
         })?;
-        let safe_write_relays = self.sanitize_key_package_deletion_endpoints(
-            winner_state
-                .relays
-                .iter()
-                .cloned()
-                .map(TransportEndpoint)
-                .collect(),
-        )?;
+        let safe_write_relays = self.effective_nip65_key_package_endpoints(&winner_state)?;
         if safe_write_relays.is_empty() {
             return Err(AppError::MissingRelayLists(vec![
                 MissingRelayListKind::Nip65,

--- a/crates/marmot-app/src/directory/search.rs
+++ b/crates/marmot-app/src/directory/search.rs
@@ -1850,7 +1850,7 @@ mod tests {
             .expect("create the stranger's identity")
             .account;
         wait_for_network_ready(&stranger_runtime, &stranger.account_id_hex).await;
-        stranger_app
+        stranger_runtime
             .publish_account_relay_lists(
                 &stranger.account_id_hex,
                 crate::AccountRelayListBootstrap::new(
@@ -2121,7 +2121,7 @@ mod tests {
             .expect("create the stranger's identity")
             .account;
         wait_for_network_ready(&stranger_runtime, &stranger.account_id_hex).await;
-        stranger_app
+        stranger_runtime
             .publish_account_relay_lists(
                 &stranger.account_id_hex,
                 crate::AccountRelayListBootstrap::new(

--- a/crates/marmot-app/src/directory/sync.rs
+++ b/crates/marmot-app/src/directory/sync.rs
@@ -213,7 +213,11 @@ impl DirectorySyncPlan {
 }
 
 impl DirectorySyncHandle {
-    pub(crate) fn spawn(app: MarmotApp, relay_plane: MarmotRelayPlane) -> Self {
+    pub(crate) fn spawn(
+        app: MarmotApp,
+        relay_plane: MarmotRelayPlane,
+        account_manager: Option<crate::AccountManager>,
+    ) -> Self {
         let (commands, command_rx) = mpsc::channel(32);
         let directory_events = relay_plane.subscribe_directory_events();
         let rebuild_queued = Arc::new(AtomicBool::new(false));
@@ -223,6 +227,7 @@ impl DirectorySyncHandle {
             command_rx,
             directory_events,
             rebuild_queued.clone(),
+            account_manager,
         ));
         let abort = task.abort_handle();
         Self {
@@ -277,6 +282,7 @@ async fn run_directory_sync_worker(
         crate::relay_plane::DirectoryRelayPlaneEvent,
     >,
     rebuild_queued: Arc<AtomicBool>,
+    account_manager: Option<crate::AccountManager>,
 ) {
     let mut recovery_rebuilds = DirectoryRecoveryRebuildQueue::default();
     let mut recovery_task: Option<DirectoryRecoveryRebuildTask> = None;
@@ -322,8 +328,12 @@ async fn run_directory_sync_worker(
             event = directory_events.recv() => {
                 match event {
                     Ok(crate::relay_plane::DirectoryRelayPlaneEvent::Record(record)) => {
-                        let app = app.clone();
-                        let _ = blocking_app_task(move || app.ingest_directory_relay_event(record)).await;
+                        if let Some(account_manager) = account_manager.as_ref() {
+                            let _ = account_manager.ingest_directory_relay_event(record).await;
+                        } else {
+                            let app = app.clone();
+                            let _ = blocking_app_task(move || app.ingest_directory_relay_event(record)).await;
+                        }
                     }
                     Ok(crate::relay_plane::DirectoryRelayPlaneEvent::RecoveryRequired)
                     | Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
@@ -543,7 +553,7 @@ mod tests {
         let relay_plane = MarmotRelayPlane::with_subscription_rebuild_lookback(
             std::time::Duration::from_secs(30),
         );
-        let handle = DirectorySyncHandle::spawn(app, relay_plane);
+        let handle = DirectorySyncHandle::spawn(app, relay_plane, None);
 
         handle.request_rebuild();
         wait_for_background_rebuild_flag_to_clear(&handle).await;

--- a/crates/marmot-app/src/key_package_records.rs
+++ b/crates/marmot-app/src/key_package_records.rs
@@ -471,7 +471,7 @@ pub(crate) fn parse_key_package_event_id_hex(value: &str) -> Result<String, AppE
             bytes.len()
         )));
     }
-    Ok(trimmed.to_owned())
+    Ok(hex::encode(bytes))
 }
 
 /// Per spec/transports/nostr.md, each KeyPackage id-list tag is exactly one

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -54,7 +54,8 @@ use marmot_account::{
     TransportRoutingPolicy,
 };
 use nostr_sdk::prelude::{
-    Client as NostrSdkClient, EventBuilder, Kind, PublicKey, Tag, Timestamp as NostrTimestamp,
+    Client as NostrSdkClient, EventBuilder, Kind, PublicKey, RelayUrl, Tag,
+    Timestamp as NostrTimestamp,
 };
 use rand::RngCore;
 use rand::rngs::OsRng;
@@ -1523,11 +1524,10 @@ struct RemovedLocalKeyPackageTombstone {
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 struct RemovedLocalKeyPackageTombstoneJournal {
     account_id_hex: String,
-    #[serde(default)]
     retired_stable_slot_ids: Vec<String>,
-    #[serde(default)]
     account_wide: bool,
 }
 
@@ -6141,14 +6141,7 @@ impl MarmotApp {
                     return false;
                 }
             };
-        let source_relays = relay_lists
-            .nip65
-            .relays
-            .iter()
-            .cloned()
-            .map(TransportEndpoint)
-            .collect::<Vec<_>>();
-        let source_relays = match self.sanitize_key_package_deletion_endpoints(source_relays) {
+        let source_relays = match self.effective_nip65_key_package_endpoints(&relay_lists.nip65) {
             Ok(source_relays) if !source_relays.is_empty() => source_relays,
             Ok(_) | Err(_) => return false,
         };
@@ -7265,8 +7258,10 @@ impl MarmotApp {
 
     /// Canonicalize each NIP-65 compatibility/directional endpoint vector for
     /// semantic authority comparisons. Persisted event order and URL aliases
-    /// must not make the same relay declaration look different, while a
-    /// malformed or unsafe alias still fails closed.
+    /// must not make the same relay declaration look different. This is
+    /// deliberately structural rather than a dial-policy check: a signed
+    /// declaration remains the same authority when the local denylist,
+    /// loopback policy, or configured fallback changes.
     fn canonical_nip65_route_state(
         &self,
         state: &AccountRelayListState,
@@ -7276,14 +7271,17 @@ impl MarmotApp {
                 "NIP-65 authority comparison received the wrong event kind".into(),
             ));
         }
-        let canonicalize = |relays: &[String]| {
-            self.sanitize_key_package_deletion_endpoints(
-                relays
-                    .iter()
-                    .cloned()
-                    .map(TransportEndpoint)
-                    .collect::<Vec<_>>(),
-            )
+        let canonicalize = |relays: &[String]| -> Result<Vec<TransportEndpoint>, AppError> {
+            let mut canonical = Vec::with_capacity(relays.len());
+            for relay in relays {
+                let relay_url = RelayUrl::parse(relay.trim()).map_err(|_| {
+                    AppError::Publish("NIP-65 authority contains an invalid relay endpoint".into())
+                })?;
+                canonical.push(TransportEndpoint(relay_url.to_string()));
+            }
+            canonical.sort();
+            canonical.dedup();
+            Ok(canonical)
         };
         Ok((
             canonicalize(&state.relays)?,
@@ -7307,20 +7305,24 @@ impl MarmotApp {
                 "durable NIP-65 route generation has an invalid event id".into(),
             ));
         }
-        let endpoints = generation
-            .nip65
-            .relays
-            .iter()
-            .cloned()
-            .map(TransportEndpoint)
-            .collect::<Vec<_>>();
-        let endpoints = self.sanitize_key_package_deletion_endpoints(endpoints)?;
+        let endpoints = self.canonical_nip65_route_state(&generation.nip65)?.0;
         if endpoints.is_empty() {
             return Err(AppError::MissingRelayLists(vec![
                 MissingRelayListKind::Nip65,
             ]));
         }
         Ok(endpoints)
+    }
+
+    /// Select the safe endpoints this device may use for one exact durable
+    /// generation. Generation validation remains configuration-independent;
+    /// only this operational step may filter or fall back.
+    fn effective_nip65_route_generation_endpoints(
+        &self,
+        generation: &Nip65RouteGeneration,
+    ) -> Result<Vec<TransportEndpoint>, AppError> {
+        self.validate_nip65_route_generation(generation)?;
+        self.effective_nip65_key_package_endpoints(&generation.nip65)
     }
 
     fn next_locally_authored_nip65_created_at(&self, label: &str) -> Result<u64, AppError> {
@@ -7394,7 +7396,7 @@ impl MarmotApp {
                 "local NIP-65 route authority is unavailable".into(),
             ));
         };
-        self.validate_nip65_route_generation(&generation)
+        self.effective_nip65_route_generation_endpoints(&generation)
     }
 
     async fn sign_account_transport_event(
@@ -7458,19 +7460,7 @@ impl MarmotApp {
                 "pending NIP-65 route generation has an invalid event id".into(),
             ));
         }
-        let proposed = pending
-            .nip65
-            .relays
-            .iter()
-            .cloned()
-            .map(TransportEndpoint)
-            .collect::<Vec<_>>();
-        let proposed = self.sanitize_key_package_deletion_endpoints(proposed)?;
-        if proposed.is_empty() {
-            return Err(AppError::MissingRelayLists(vec![
-                MissingRelayListKind::Nip65,
-            ]));
-        }
+        let proposed = self.validate_nip65_route_generation(&pending.generation)?;
         if let Some(event) = pending.signed_event.as_ref() {
             event
                 .to_verified_nostr_event()
@@ -7651,7 +7641,15 @@ impl MarmotApp {
                     .into(),
             ));
         }
-        let proposed = self.validate_pending_nip65_route_mutation(label, &pending)?;
+        let declared = self.validate_pending_nip65_route_mutation(label, &pending)?;
+        let proposed = if pending.source == Nip65RouteMutationSource::GeneratedAccountBootstrap {
+            // A generated identity's prepared KeyPackage is bound to the
+            // caller-requested exact authority. A later local policy change
+            // must fail recovery rather than silently substitute defaults.
+            self.sanitize_key_package_deletion_endpoints(declared)?
+        } else {
+            self.effective_nip65_key_package_endpoints(&pending.nip65)?
+        };
         // Always re-evaluate the marker before recovery I/O. Only the exact
         // generated-account bootstrap intent may retain a fresh-identity
         // proof; every legacy or ordinary intent re-arms the SQL gate. This
@@ -7752,19 +7750,8 @@ impl MarmotApp {
         {
             return self.account_relay_list_status(label);
         }
-        let proposed = self.sanitize_key_package_deletion_endpoints(
-            nip65
-                .relays
-                .iter()
-                .cloned()
-                .map(TransportEndpoint)
-                .collect(),
-        )?;
-        if proposed.is_empty() {
-            return Err(AppError::MissingRelayLists(vec![
-                MissingRelayListKind::Nip65,
-            ]));
-        }
+        self.validate_nip65_route_generation(&generation)?;
+        let proposed = self.effective_nip65_key_package_endpoints(&generation.nip65)?;
         let pending = PendingNip65RouteMutation {
             account_id_hex: account.account_id_hex,
             nip65,
@@ -7872,7 +7859,7 @@ impl MarmotApp {
             return Ok(BTreeSet::new());
         };
         Ok(self
-            .validate_nip65_route_generation(&generation)?
+            .effective_nip65_route_generation_endpoints(&generation)?
             .into_iter()
             .collect())
     }
@@ -8584,7 +8571,8 @@ impl MarmotApp {
         else {
             return false;
         };
-        let Ok(authoritative_endpoints) = self.validate_nip65_route_generation(&current_generation)
+        let Ok(authoritative_endpoints) =
+            self.effective_nip65_route_generation_endpoints(&current_generation)
         else {
             return false;
         };
@@ -8630,7 +8618,7 @@ impl MarmotApp {
                 )
             })?;
         let mut generation_relays = self
-            .validate_nip65_route_generation(&generation)?
+            .effective_nip65_route_generation_endpoints(&generation)?
             .into_iter()
             .map(|endpoint| endpoint.0)
             .collect::<Vec<_>>();
@@ -10750,10 +10738,16 @@ impl MarmotApp {
         // list. Fall back to the configured default relays when the account has
         // no usable NIP-65 relay. This runtime fallback is not published as a
         // replacement for the account's relay list.
-        let offered = relay_lists.nip65.relays.len();
+        self.select_nip65_key_package_endpoints(&relay_lists.nip65)
+    }
+
+    fn select_nip65_key_package_endpoints(
+        &self,
+        nip65: &AccountRelayListState,
+    ) -> Vec<TransportEndpoint> {
+        let offered = nip65.relays.len();
         let safe = self.retain_safe_discovered_endpoints(
-            relay_lists
-                .nip65
+            nip65
                 .relays
                 .iter()
                 .cloned()
@@ -10775,6 +10769,22 @@ impl MarmotApp {
             );
         }
         fallback
+    }
+
+    /// Resolve an untrusted signed NIP-65 declaration to the endpoints this
+    /// device may actually use without rewriting the signed declaration.
+    /// Unsafe discovered routes are filtered; when none remain, configured
+    /// defaults retain the existing key-package routing fallback contract.
+    pub(crate) fn effective_nip65_key_package_endpoints(
+        &self,
+        nip65: &AccountRelayListState,
+    ) -> Result<Vec<TransportEndpoint>, AppError> {
+        // Reject a structurally malformed signed declaration even when a
+        // configured fallback exists. Retired or otherwise policy-prohibited
+        // but well-formed URLs remain durable and are filtered below.
+        self.canonical_nip65_route_state(nip65)?;
+        let endpoints = self.select_nip65_key_package_endpoints(nip65);
+        self.sanitize_key_package_deletion_endpoints(endpoints)
     }
 
     fn transport_label(&self) -> &'static str {

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -4,10 +4,10 @@
 //! early app surfaces: encrypted session storage, Nostr MLS peeling, Nostr
 //! transport publishing, and relay-backed app projections.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -42,13 +42,14 @@ use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MARMOT_APP_EVENT_KIND_G
 use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
 use cgka_traits::engine::{GroupEvent, KeyPackage};
 use cgka_traits::storage::{DisbandTombstoneStorage, KeyPackageBundleStorage, MaintenanceStorage};
-use cgka_traits::transport::{TransportEnvelope, TransportMessage};
+use cgka_traits::transport::{Timestamp, TransportEnvelope, TransportMessage};
 use cgka_traits::{
     GroupId, MemberId, MessageId, TransportEndpoint, TransportGroupSubscription,
     TransportPublishTarget,
 };
 use marmot_account::{
-    AccountDeviceRuntime, AccountHome, AccountHomeError, AccountSummary, KeyPackagePublication,
+    AccountDeviceRuntime, AccountHome, AccountHomeError, AccountSetupKind, AccountSetupPhase,
+    AccountSummary, DetailedKeyPackagePublishReceipt, KeyPackagePublication,
     KeyPackagePublishError, KeyPackagePublishReceipt, KeyPackagePublisher, TransportRoutingError,
     TransportRoutingPolicy,
 };
@@ -95,6 +96,8 @@ mod projection;
 mod publisher_sequences;
 mod relay_plane;
 mod relay_telemetry_export;
+#[cfg(test)]
+mod removed_local_key_package_tests;
 mod root_runtime_lease;
 mod runtime;
 mod sqlcipher;
@@ -277,10 +280,7 @@ use key_package_records::{
     publish_endpoints_from_bootstrap,
 };
 #[cfg(test)]
-use key_package_records::{
-    fresh_or_cached_key_package, latest_fresh_key_package_from_records,
-    validated_cached_key_package,
-};
+use key_package_records::{fresh_or_cached_key_package, validated_cached_key_package};
 use projection::LegacyAccountProjectionDb;
 use relay_plane::DirectoryRelayEventRecord as RelayEventRecord;
 
@@ -302,8 +302,25 @@ pub(crate) const LOCAL_PUBLISH_FAILED_REASON: &str = "local_publish_failed";
 const APP_CACHE_DB_FILE: &str = "app-cache.sqlite3";
 const SHARED_DB_FILE: &str = "shared.sqlite3";
 const KEY_PACKAGE_CUTOVER_RELAY_SCAN_LIMIT: usize = 1_024;
+// Each reported account-runtime pass can perform at most one relay deletion.
+// Keep one app cutover invocation bounded even if a relay exposes a long
+// parameterized-replaceable history one winner at a time. The durable frontier
+// makes the next open/retry resume without losing the post-delete scan proof.
+const KEY_PACKAGE_CUTOVER_MAX_DELETION_PASSES: usize = 16;
+// A durable history endpoint is retained across route generations so a crash
+// cannot forget it after SQL liability pruning. Bound that monotonic set; a
+// 257th unique relay is rejected before exact deletion I/O rather than turning
+// a privacy journal into unbounded state.
+const KEY_PACKAGE_CUTOVER_RELAY_HISTORY_CAPACITY: usize = 256;
+const KEY_PACKAGE_REAUTHOR_AT_AGE_SECS: u64 = 10 * 60;
 const SESSION_DB_FILE: &str = "session.sqlite";
 const KEY_PACKAGE_DIR: &str = "key-packages";
+const REMOVED_LOCAL_KEY_PACKAGE_TOMBSTONE_DIR: &str = "removed-local-slots-v1";
+const REMOVED_LOCAL_KEY_PACKAGE_TOMBSTONE_JOURNAL: &str = "slots.json";
+/// Exact retired-slot identities kept in the per-account tombstone journal.
+/// A further distinct locally-removed slot fails closed rather than evicting
+/// anti-resurrection proof.
+const MAX_REMOVED_LOCAL_KEY_PACKAGE_TOMBSTONE_SLOTS: usize = 256;
 const SDK_FIRST_SYNC_WAIT: Duration = Duration::from_millis(750);
 const SDK_DRAIN_WAIT: Duration = Duration::from_millis(250);
 /// Maximum wall-clock quantum one epoch-gap backfill drain owns the serial
@@ -551,6 +568,15 @@ type AppRuntime = AccountDeviceRuntime<
     AppTransportRouting,
     AppKeyPackagePublisher,
 >;
+type CanonicalNip65RouteState = (
+    Vec<TransportEndpoint>,
+    Vec<TransportEndpoint>,
+    Vec<TransportEndpoint>,
+);
+type KeyPackageDeletionEndpointAliases = (
+    Vec<TransportEndpoint>,
+    Vec<(TransportEndpoint, TransportEndpoint)>,
+);
 
 #[cfg(test)]
 type LegacyProjectionOpenHook = Arc<dyn Fn() + Send + Sync>;
@@ -579,13 +605,34 @@ pub struct MarmotApp {
     /// [`Self::close_storage`] holds the write side across its whole teardown.
     /// See [`Self::begin_storage_open`].
     storage_lifecycle: Arc<RwLock<()>>,
+    /// Admission for synchronous mutations of AccountHome and other files in
+    /// the Marmot root. Terminal close holds the writer through root-lease
+    /// release, so detached old-runtime work either commits before ownership
+    /// transfers or wakes afterward and observes the closed latch.
+    root_mutation_lifecycle: Arc<RwLock<()>>,
     relay_urls: Vec<String>,
     account_home: AccountHome,
     relay_plane: MarmotRelayPlane,
     config: MarmotAppConfig,
     directory_sync: Arc<RwLock<Option<DirectorySyncHandle>>>,
     account_storages: Arc<Mutex<HashMap<String, SqliteAccountStorage>>>,
+    /// Session-owned connections are opened independently from
+    /// `account_storages`. Retain one close handle per live account session so
+    /// terminal close and per-account eviction can make every engine/OpenMLS
+    /// clone inert without waiting for an unabortable blocking open to drop.
+    account_session_storages: Arc<Mutex<HashMap<String, SqliteAccountStorage>>>,
     account_session_owners: Arc<Mutex<HashSet<String>>>,
+    /// Process-local monotonic admission for account sessions. The durable
+    /// signed-out bit says whether a new session may be opened; this
+    /// generation additionally makes every capability captured before a
+    /// sign-out permanently stale, even after an explicit sign-in clears that
+    /// reversible bit again.
+    account_session_admissions: Arc<Mutex<HashMap<String, AccountSessionAdmissionState>>>,
+    next_account_session_admission_generation: Arc<AtomicU64>,
+    /// Revocable transport capability for the one live session per account.
+    /// Runtime teardown uses this registry to reach standalone public-client
+    /// relay planes, not only the managed runtime's shared plane.
+    account_session_adapters: Arc<Mutex<HashMap<String, MarmotRelayPlaneAccountAdapter>>>,
     directory_caches: Arc<Mutex<HashMap<String, DirectoryCache>>>,
     /// Bounded, process-local composition prewarm. Entries are never durable
     /// directory admission and never reserve or consume a KeyPackage.
@@ -601,6 +648,10 @@ pub struct MarmotApp {
     legacy_projection_open_hook: Arc<Mutex<Option<LegacyProjectionOpenHook>>>,
     #[cfg(test)]
     test_relay_client: Option<Arc<dyn NostrRelayClient>>,
+    #[cfg(test)]
+    fail_epoch_backfill_live_group_ids: Arc<AtomicBool>,
+    #[cfg(test)]
+    fail_epoch_backfill_deletion_frontier: Arc<AtomicBool>,
     shared_storage: Arc<Mutex<Option<SqliteSharedStorage>>>,
     account_state_ready: Arc<Mutex<HashSet<String>>>,
     chat_list_projection_warmed: Arc<Mutex<HashSet<String>>>,
@@ -611,6 +662,26 @@ pub struct MarmotApp {
     /// account worker share this client so the worker can reuse the same relay
     /// pool instead of constructing another TCP/TLS/WebSocket stack.
     account_publish_clients: Arc<Mutex<HashMap<String, Arc<dyn NostrRelayClient>>>>,
+    /// Serialize the authoritative NIP-65 mutation boundary with the final
+    /// kind-30443 check and relay send for each account. This closes the gap in
+    /// which a route-list event could commit after validation but before the
+    /// old-route KeyPackage attempt reached the transport.
+    key_package_route_locks: Arc<Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
+    /// Serialize an exact KeyPackage deletion, its pre-I/O relay-history
+    /// frontier, and the strict replay that discharges that frontier with the
+    /// final kind-30443 publication boundary. This is deliberately distinct
+    /// from `key_package_route_locks`: cutover holds the route lock while it
+    /// invokes deletion and would deadlock on recursive acquisition.
+    key_package_history_locks: Arc<Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
+    /// The root-mutation lifecycle is a close-admission read lock, not an
+    /// exclusive file-operation lock. Serialize frontier read/modify/write
+    /// sequences across app clones so a concurrent endpoint arm cannot be
+    /// lost by another clone's completion update.
+    key_package_frontier_mutation_lock: Arc<Mutex<()>>,
+    /// Serialize immutable removed-local-slot publication with directory
+    /// projection writes. A concurrent relay echo therefore either commits
+    /// before the tombstone scrub or observes the tombstone and is rejected.
+    removed_local_key_package_mutation_lock: Arc<Mutex<()>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1161,9 +1232,190 @@ pub(crate) struct KeyPackageDeletionTarget {
 }
 
 #[derive(Debug)]
+pub(crate) struct KeyPackageDeletionAdmission {
+    pub admitted: Vec<KeyPackageDeletionTarget>,
+    pub deferred: Vec<KeyPackageDeletionTarget>,
+    /// Safety-rejected exact keys that were journaled but must not reach I/O.
+    pub unsafe_targets: Vec<KeyPackageDeletionTarget>,
+    /// Malformed target rows that cannot be journaled or sent. They remain
+    /// isolated from valid siblings in the same teardown batch.
+    pub invalid_targets: Vec<KeyPackageDeletionInvalidTarget>,
+}
+
+#[derive(Debug)]
+pub(crate) struct KeyPackageDeletionInvalidTarget {
+    pub target: KeyPackageDeletionTarget,
+    pub reason: String,
+}
+
+#[derive(Debug)]
+struct CachedKeyPackageRetirementAdmission {
+    complete: bool,
+    event_id: Option<MessageId>,
+}
+
+#[derive(Debug)]
 pub(crate) struct KeyPackageDeletionResult {
     pub event_id_hex: String,
+    pub accepted_endpoints: Vec<TransportEndpoint>,
+    pub confirmed_absent_endpoints: Vec<TransportEndpoint>,
+    pub failed_endpoints: Vec<TransportEndpoint>,
     pub result: Result<usize, AppError>,
+}
+
+fn canonicalize_key_package_fanout_targets<F>(
+    targets: &mut Vec<cgka_traits::TransportFanoutTarget>,
+    mut canonicalize: F,
+) -> bool
+where
+    F: FnMut(&TransportEndpoint) -> Option<TransportEndpoint>,
+{
+    let before = targets.clone();
+    for target in targets.iter_mut() {
+        if let Some(canonical) = canonicalize(&target.endpoint) {
+            target.endpoint = canonical;
+        }
+    }
+    targets.sort_by(|left, right| left.endpoint.cmp(&right.endpoint));
+    let mut merged = Vec::<cgka_traits::TransportFanoutTarget>::with_capacity(targets.len());
+    for candidate in std::mem::take(targets) {
+        if let Some(existing) = merged
+            .last_mut()
+            .filter(|existing| existing.endpoint == candidate.endpoint)
+        {
+            merge_key_package_fanout_target_evidence(existing, candidate);
+        } else {
+            merged.push(candidate);
+        }
+    }
+    *targets = merged;
+    *targets != before
+}
+
+fn key_package_lifecycle_endpoint_liability_count(
+    lifecycle: &cgka_traits::KeyPackageLifecycleState,
+) -> usize {
+    let mut liabilities = HashSet::<(Vec<u8>, TransportEndpoint)>::new();
+    let mut include = |event_id: &MessageId, targets: &[cgka_traits::TransportFanoutTarget]| {
+        for target in targets {
+            if target.failure_code.as_deref() != Some("confirmed_absent") {
+                liabilities.insert((event_id.as_slice().to_vec(), target.endpoint.clone()));
+            }
+        }
+    };
+    if let Some(event_id) = lifecycle
+        .authored_signed_event
+        .as_ref()
+        .map(|artifact| &artifact.id)
+        .or(lifecycle.authored_event_id.as_ref())
+    {
+        include(event_id, &lifecycle.publication_targets);
+    }
+    if let Some(pending) = lifecycle.pending_replacement.as_ref()
+        && let Some(artifact) = pending.signed_event.as_ref()
+    {
+        include(&artifact.id, &pending.targets);
+    }
+    for retired in &lifecycle.retired_publications_pending_deletion {
+        include(&retired.event_id, &retired.deletion_targets);
+    }
+    liabilities.len()
+}
+
+fn retain_imported_legacy_key_package_publication(
+    lifecycle: &mut cgka_traits::KeyPackageLifecycleState,
+    imported: cgka_traits::RetiredKeyPackagePublication,
+) {
+    if let Some(existing) = lifecycle
+        .retired_publications_pending_deletion
+        .iter_mut()
+        .find(|existing| existing.event_id == imported.event_id)
+    {
+        existing.authored_created_at = existing
+            .authored_created_at
+            .max(imported.authored_created_at);
+        if existing.key_package_ref.is_none() {
+            existing.key_package_ref = imported.key_package_ref;
+        }
+        if existing.package_not_after.is_none() {
+            existing.package_not_after = imported.package_not_after;
+        }
+        existing.delete_without_successor |= imported.delete_without_successor;
+        for target in imported.deletion_targets {
+            if !existing
+                .deletion_targets
+                .iter()
+                .any(|candidate| candidate.endpoint == target.endpoint)
+            {
+                existing.deletion_targets.push(target);
+            }
+        }
+        existing
+            .deletion_targets
+            .sort_by(|left, right| left.endpoint.cmp(&right.endpoint));
+        return;
+    }
+
+    lifecycle
+        .retired_publications_pending_deletion
+        .push(imported);
+    lifecycle
+        .retired_publications_pending_deletion
+        .sort_by(|left, right| {
+            left.authored_created_at
+                .cmp(&right.authored_created_at)
+                .then_with(|| left.event_id.as_slice().cmp(right.event_id.as_slice()))
+        });
+}
+
+fn merge_key_package_fanout_target_evidence(
+    existing: &mut cgka_traits::TransportFanoutTarget,
+    candidate: cgka_traits::TransportFanoutTarget,
+) {
+    use cgka_traits::TransportFanoutAttemptState;
+
+    let confirmed_absent = existing.failure_code.as_deref() == Some("confirmed_absent")
+        || candidate.failure_code.as_deref() == Some("confirmed_absent");
+    let accepted = existing.state == TransportFanoutAttemptState::Accepted
+        || candidate.state == TransportFanoutAttemptState::Accepted;
+    let existing_policy_prohibited =
+        existing.state == TransportFanoutAttemptState::PolicyProhibited;
+    let candidate_policy_prohibited =
+        candidate.state == TransportFanoutAttemptState::PolicyProhibited;
+    let all_policy_prohibited = existing_policy_prohibited && candidate_policy_prohibited;
+    let attempted = existing.attempt_count > 0
+        || candidate.attempt_count > 0
+        || existing.last_attempt_at.is_some()
+        || candidate.last_attempt_at.is_some()
+        || existing.state == TransportFanoutAttemptState::AttemptedFailed
+        || candidate.state == TransportFanoutAttemptState::AttemptedFailed;
+    let policy_failure = existing
+        .failure_code
+        .clone()
+        .or(candidate.failure_code.clone());
+
+    existing.attempt_count = existing.attempt_count.max(candidate.attempt_count);
+    existing.last_attempt_at = match (existing.last_attempt_at, candidate.last_attempt_at) {
+        (Some(left), Some(right)) => Some(left.max(right)),
+        (left, right) => left.or(right),
+    };
+    if confirmed_absent {
+        existing.state = TransportFanoutAttemptState::AttemptedFailed;
+        existing.failure_code = Some("confirmed_absent".into());
+    } else if accepted {
+        existing.state = TransportFanoutAttemptState::Accepted;
+        existing.failure_code = None;
+    } else if all_policy_prohibited {
+        existing.state = TransportFanoutAttemptState::PolicyProhibited;
+        existing.failure_code =
+            policy_failure.or_else(|| Some("endpoint_removed_from_policy".into()));
+    } else if attempted {
+        existing.state = TransportFanoutAttemptState::AttemptedFailed;
+        existing.failure_code = Some("possible_exposure".into());
+    } else {
+        existing.state = TransportFanoutAttemptState::Unattempted;
+        existing.failure_code = None;
+    }
 }
 
 /// Per-account unread aggregate, suitable for an account-switcher and
@@ -1262,9 +1514,136 @@ struct KeyPackageRecord {
     key_package_hex: String,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct RemovedLocalKeyPackageTombstone {
+    account_id_hex: String,
+    /// `None` is the explicit legacy fail-closed fallback used only when the
+    /// removed account's durable NIP-33 slot can no longer be proven.
+    stable_slot_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+struct RemovedLocalKeyPackageTombstoneJournal {
+    account_id_hex: String,
+    #[serde(default)]
+    retired_stable_slot_ids: Vec<String>,
+    #[serde(default)]
+    account_wide: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum RemovedLocalKeyPackageScope {
+    StableSlot(String),
+    AccountWideLegacy,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct KeyPackageCutoverScanMarker {
+    /// `false` for markers authored by the pre-peeling implementation. Those
+    /// markers proved only one visible NIP-33 winner per relay and must never
+    /// authorize publication after this upgrade.
+    #[serde(default)]
+    strict_history_peeling: bool,
+    #[serde(default)]
+    fresh_account_proof: bool,
+    #[serde(default)]
+    authoritative_relays: Vec<String>,
+    /// Every durable current/pending/retired publication endpoint covered by
+    /// the strict scan, including relays no longer present in NIP-65.
+    #[serde(default)]
+    history_relays: Vec<String>,
+    /// NIP-33 ordering coordinate of the self-authored kind-10002 projection
+    /// whose write-relay set was scanned. URL equality alone is insufficient:
+    /// a B -> A -> B route cycle may expose a new same-slot KeyPackage on B.
+    #[serde(default)]
+    route_created_at: Option<u64>,
+    #[serde(default)]
+    route_event_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct KeyPackageCutoverRelayFrontier {
+    #[serde(default)]
+    relays: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct KeyPackageRelayAdmissionSummary {
+    non_current_event_count: usize,
+    discovered_current_revision_count: usize,
+    deferred_endpoint_count: usize,
+    admission_failure_count: usize,
+}
+
+impl KeyPackageRelayAdmissionSummary {
+    fn absorb(&mut self, other: Self) {
+        self.non_current_event_count = self
+            .non_current_event_count
+            .saturating_add(other.non_current_event_count);
+        self.discovered_current_revision_count = self
+            .discovered_current_revision_count
+            .saturating_add(other.discovered_current_revision_count);
+        self.deferred_endpoint_count = self
+            .deferred_endpoint_count
+            .saturating_add(other.deferred_endpoint_count);
+        self.admission_failure_count = self
+            .admission_failure_count
+            .saturating_add(other.admission_failure_count);
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct Nip65RouteGeneration {
+    created_at: u64,
+    event_id: String,
+    /// Exact parsed write-relay authority from the same verified kind-10002
+    /// event. Directory cache rows remain projections and must never select a
+    /// different route merely because they carry a newer profile or
+    /// KeyPackage timestamp.
+    nip65: AccountRelayListState,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct GeneratedNip65RouteAuthorityProof {
+    generation: Nip65RouteGeneration,
+    endpoints: Vec<TransportEndpoint>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum Nip65RouteMutationSource {
+    /// Includes every pre-field journal and every ordinary route edit. Keeping
+    /// this as the serde default makes old intents retain the strict gate.
+    #[default]
+    AccountMutation,
+    /// The first route declaration authored by a durably journaled generated
+    /// identity before any KeyPackage publication could have completed.
+    GeneratedAccountBootstrap,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct PendingNip65RouteMutation {
+    account_id_hex: String,
+    nip65: AccountRelayListState,
+    #[serde(default)]
+    bootstrap_relays: Vec<String>,
+    #[serde(default)]
+    publish_endpoints: Vec<String>,
+    /// Exact signed local event. Relay-observed mutations are already accepted
+    /// and can recover from their proposed state plus ordering coordinate.
+    #[serde(default)]
+    signed_event: Option<NostrTransportEvent>,
+    generation: Nip65RouteGeneration,
+    #[serde(default)]
+    network_accepted: bool,
+    #[serde(default)]
+    source: Nip65RouteMutationSource,
+}
+
 struct OpenAppAccount {
     runtime: AppRuntime,
     session_guard: AppAccountSessionGuard,
+    session_admission: AccountSessionAdmission,
     adapter: MarmotRelayPlaneAccountAdapter,
     routing: AppTransportRouting,
     state: AccountState,
@@ -1273,17 +1652,94 @@ struct OpenAppAccount {
     signer: Arc<dyn nostr::NostrSigner>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct AccountSessionAdmissionToken {
+    account_id_hex: String,
+    generation: u64,
+}
+
+/// Exact capability required by the lowest account relay-list signing and
+/// publication boundary. Ordinary edits carry the live account-session
+/// generation; setup publication carries its separately revocable setup
+/// generation. There is deliberately no capability-free variant.
+#[derive(Clone, Copy)]
+enum AccountRelayListMutationAdmission<'a> {
+    Active(&'a AccountSessionAdmissionToken),
+    Setup(&'a runtime::AccountSetupPublicationAdmission),
+}
+
+/// Exact, process-local capability for the cleanup phase of one account
+/// teardown. It is valid only while ordinary admission remains closed at the
+/// generation against which it was minted, and the teardown barrier revokes
+/// it on every exit.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct AccountTeardownSessionAdmissionToken {
+    account_id_hex: String,
+    closed_generation: u64,
+    generation: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum AccountSessionAdmission {
+    Active(AccountSessionAdmissionToken),
+    Teardown(AccountTeardownSessionAdmissionToken),
+}
+
+#[derive(Clone, Debug)]
+struct AccountSessionAdmissionState {
+    account_id_hex: String,
+    generation: u64,
+    open: bool,
+    teardown_generation: Option<u64>,
+}
+
+/// Keeps runtime account-open admission live while a completed blocking open
+/// is waiting to be consumed by its async caller. A cancelled `spawn_blocking`
+/// waiter cannot cancel the blocking work, so dropping the permit inside the
+/// closure would let shutdown report the open drained while `OpenAppAccount`
+/// was still retained in the task's result slot.
+struct OpenAppAccountResult {
+    open: OpenAppAccount,
+    _permit: Option<runtime::RuntimeAccountOpenPermit>,
+}
+
 struct AppAccountSessionGuard {
     label: String,
     owners: Arc<Mutex<HashSet<String>>>,
+    storages: Arc<Mutex<HashMap<String, SqliteAccountStorage>>>,
+    adapters: Arc<Mutex<HashMap<String, MarmotRelayPlaneAccountAdapter>>>,
 }
 
 impl Drop for AppAccountSessionGuard {
     fn drop(&mut self) {
-        self.owners
+        // Keep ownership admission closed until this session's registered
+        // connection is removed and closed. Releasing `owners` first would let
+        // a replacement session register under the same label, which this
+        // guard could then accidentally remove as if it were the old handle.
+        let mut owners = self
+            .owners
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut storages = self
+            .storages
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(storage) = storages.remove(&self.label)
+            && let Err(error) = storage.close()
+        {
+            tracing::warn!(
+                target: "marmot_app::storage",
+                method = "drop_account_session_guard",
+                error_kind = AppError::from(error).privacy_safe_kind(),
+                "failed to close released account session storage",
+            );
+        }
+        drop(storages);
+        self.adapters
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .remove(&self.label);
+        owners.remove(&self.label);
     }
 }
 
@@ -1417,12 +1873,17 @@ impl MarmotApp {
             storage_closed: Arc::new(AtomicBool::new(false)),
             storage_close_completed: Arc::new(AtomicBool::new(false)),
             storage_lifecycle: Arc::new(RwLock::new(())),
+            root_mutation_lifecycle: Arc::new(RwLock::new(())),
             relay_urls,
             relay_plane,
             config,
             directory_sync: Arc::new(RwLock::new(None)),
             account_storages: Arc::new(Mutex::new(HashMap::new())),
+            account_session_storages: Arc::new(Mutex::new(HashMap::new())),
             account_session_owners: Arc::new(Mutex::new(HashSet::new())),
+            account_session_admissions: Arc::new(Mutex::new(HashMap::new())),
+            next_account_session_admission_generation: Arc::new(AtomicU64::new(0)),
+            account_session_adapters: Arc::new(Mutex::new(HashMap::new())),
             directory_caches: Arc::new(Mutex::new(HashMap::new())),
             member_key_package_prewarm_cache: Arc::new(Mutex::new(
                 directory::MemberKeyPackagePrewarmCache::default(),
@@ -1438,6 +1899,10 @@ impl MarmotApp {
             legacy_projection_open_hook: Arc::new(Mutex::new(None)),
             #[cfg(test)]
             test_relay_client: None,
+            #[cfg(test)]
+            fail_epoch_backfill_live_group_ids: Arc::new(AtomicBool::new(false)),
+            #[cfg(test)]
+            fail_epoch_backfill_deletion_frontier: Arc::new(AtomicBool::new(false)),
             shared_storage: Arc::new(Mutex::new(None)),
             account_state_ready: Arc::new(Mutex::new(HashSet::new())),
             chat_list_projection_warmed: Arc::new(Mutex::new(HashSet::new())),
@@ -1445,6 +1910,10 @@ impl MarmotApp {
             audit_log_tracker_config: Arc::new(Mutex::new(AuditLogTrackerConfig::default())),
             external_signers: Arc::new(Mutex::new(HashMap::new())),
             account_publish_clients: Arc::new(Mutex::new(HashMap::new())),
+            key_package_route_locks: Arc::new(Mutex::new(HashMap::new())),
+            key_package_history_locks: Arc::new(Mutex::new(HashMap::new())),
+            key_package_frontier_mutation_lock: Arc::new(Mutex::new(())),
+            removed_local_key_package_mutation_lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -1490,13 +1959,18 @@ impl MarmotApp {
             storage_closed: Arc::new(AtomicBool::new(false)),
             storage_close_completed: Arc::new(AtomicBool::new(false)),
             storage_lifecycle: Arc::new(RwLock::new(())),
+            root_mutation_lifecycle: Arc::new(RwLock::new(())),
             relay_urls,
             account_home,
             relay_plane,
             config,
             directory_sync: Arc::new(RwLock::new(None)),
             account_storages: Arc::new(Mutex::new(HashMap::new())),
+            account_session_storages: Arc::new(Mutex::new(HashMap::new())),
             account_session_owners: Arc::new(Mutex::new(HashSet::new())),
+            account_session_admissions: Arc::new(Mutex::new(HashMap::new())),
+            next_account_session_admission_generation: Arc::new(AtomicU64::new(0)),
+            account_session_adapters: Arc::new(Mutex::new(HashMap::new())),
             directory_caches: Arc::new(Mutex::new(HashMap::new())),
             member_key_package_prewarm_cache: Arc::new(Mutex::new(
                 directory::MemberKeyPackagePrewarmCache::default(),
@@ -1512,6 +1986,10 @@ impl MarmotApp {
             legacy_projection_open_hook: Arc::new(Mutex::new(None)),
             #[cfg(test)]
             test_relay_client: None,
+            #[cfg(test)]
+            fail_epoch_backfill_live_group_ids: Arc::new(AtomicBool::new(false)),
+            #[cfg(test)]
+            fail_epoch_backfill_deletion_frontier: Arc::new(AtomicBool::new(false)),
             shared_storage: Arc::new(Mutex::new(None)),
             account_state_ready: Arc::new(Mutex::new(HashSet::new())),
             chat_list_projection_warmed: Arc::new(Mutex::new(HashSet::new())),
@@ -1519,6 +1997,10 @@ impl MarmotApp {
             audit_log_tracker_config: Arc::new(Mutex::new(AuditLogTrackerConfig::default())),
             external_signers: Arc::new(Mutex::new(HashMap::new())),
             account_publish_clients: Arc::new(Mutex::new(HashMap::new())),
+            key_package_route_locks: Arc::new(Mutex::new(HashMap::new())),
+            key_package_history_locks: Arc::new(Mutex::new(HashMap::new())),
+            key_package_frontier_mutation_lock: Arc::new(Mutex::new(())),
+            removed_local_key_package_mutation_lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -1569,6 +2051,239 @@ impl MarmotApp {
         Ok(())
     }
 
+    #[cfg(test)]
+    pub(crate) fn inject_epoch_backfill_liveness_failures(
+        &self,
+        live_group_ids: bool,
+        deletion_frontier: bool,
+    ) {
+        self.fail_epoch_backfill_live_group_ids
+            .store(live_group_ids, Ordering::SeqCst);
+        self.fail_epoch_backfill_deletion_frontier
+            .store(deletion_frontier, Ordering::SeqCst);
+    }
+
+    fn next_account_session_admission_generation(&self) -> Result<u64, AppError> {
+        self.next_account_session_admission_generation
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |generation| {
+                generation.checked_add(1)
+            })
+            .map(|generation| generation + 1)
+            .map_err(|_| {
+                AppError::BlockingTask("account session admission generation exhausted".into())
+            })
+    }
+
+    /// Capture the exact process-local account-session generation before any
+    /// unabortable database open begins. A teardown closes and advances this
+    /// state synchronously, so an open that completes late can never become
+    /// valid again merely because a later sign-in clears the durable marker.
+    fn capture_account_session_admission(
+        &self,
+        label: &str,
+        account_id_hex: &str,
+    ) -> Result<AccountSessionAdmissionToken, AppError> {
+        let mut admissions = self
+            .account_session_admissions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(admission) = admissions.get(label)
+            && admission.account_id_hex == account_id_hex
+        {
+            if !admission.open {
+                return Err(AppError::AccountWorkerBusy);
+            }
+            return Ok(AccountSessionAdmissionToken {
+                account_id_hex: account_id_hex.to_owned(),
+                generation: admission.generation,
+            });
+        }
+
+        // A missing entry is the first open in this process. A changed account
+        // id is a same-label replacement: allocate a fresh generation so a
+        // capability from the removed identity cannot follow the label.
+        let generation = self.next_account_session_admission_generation()?;
+        admissions.insert(
+            label.to_owned(),
+            AccountSessionAdmissionState {
+                account_id_hex: account_id_hex.to_owned(),
+                generation,
+                open: true,
+                teardown_generation: None,
+            },
+        );
+        Ok(AccountSessionAdmissionToken {
+            account_id_hex: account_id_hex.to_owned(),
+            generation,
+        })
+    }
+
+    /// Explicitly open a new generation after an authorized signed-out to
+    /// active transition. This always advances, even when the previous state
+    /// was already closed, so no pre-sign-out token can suffer an ABA.
+    pub(crate) fn open_account_session_admission(
+        &self,
+        label: &str,
+        account_id_hex: &str,
+    ) -> Result<AccountSessionAdmissionToken, AppError> {
+        let mut admissions = self
+            .account_session_admissions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let generation = self.next_account_session_admission_generation()?;
+        admissions.insert(
+            label.to_owned(),
+            AccountSessionAdmissionState {
+                account_id_hex: account_id_hex.to_owned(),
+                generation,
+                open: true,
+                teardown_generation: None,
+            },
+        );
+        Ok(AccountSessionAdmissionToken {
+            account_id_hex: account_id_hex.to_owned(),
+            generation,
+        })
+    }
+
+    /// Revoke every capability captured for this label before returning. At
+    /// generation exhaustion the gate still becomes permanently closed: the
+    /// `open` bit is part of validation, while no later open can allocate a
+    /// generation that aliases the revoked token.
+    pub(crate) fn close_account_session_admission(&self, label: &str, account_id_hex: &str) {
+        let mut admissions = self
+            .account_session_admissions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let generation = self
+            .next_account_session_admission_generation()
+            .unwrap_or(u64::MAX);
+        admissions.insert(
+            label.to_owned(),
+            AccountSessionAdmissionState {
+                account_id_hex: account_id_hex.to_owned(),
+                generation,
+                open: false,
+                teardown_generation: None,
+            },
+        );
+    }
+
+    /// Mint the only session capability accepted while ordinary account
+    /// admission is closed. The caller must already own the account teardown
+    /// barrier; validation ties the capability to the exact closed generation
+    /// so sign-in, another teardown, or same-label replacement revokes it.
+    pub(crate) fn open_account_teardown_session_admission(
+        &self,
+        label: &str,
+        account_id_hex: &str,
+    ) -> Result<AccountTeardownSessionAdmissionToken, AppError> {
+        let mut admissions = self
+            .account_session_admissions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let admission = admissions
+            .get_mut(label)
+            .filter(|admission| admission.account_id_hex == account_id_hex && !admission.open)
+            .ok_or(AppError::AccountWorkerBusy)?;
+        let generation = self.next_account_session_admission_generation()?;
+        admission.teardown_generation = Some(generation);
+        Ok(AccountTeardownSessionAdmissionToken {
+            account_id_hex: account_id_hex.to_owned(),
+            closed_generation: admission.generation,
+            generation,
+        })
+    }
+
+    pub(crate) fn close_account_teardown_session_admission(
+        &self,
+        label: &str,
+        token: &AccountTeardownSessionAdmissionToken,
+    ) {
+        let mut admissions = self
+            .account_session_admissions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(admission) = admissions.get_mut(label)
+            && !admission.open
+            && admission.account_id_hex == token.account_id_hex
+            && admission.generation == token.closed_generation
+            && admission.teardown_generation == Some(token.generation)
+        {
+            admission.teardown_generation = None;
+        }
+    }
+
+    pub(crate) fn account_teardown_session_admission_is_current(
+        &self,
+        label: &str,
+        token: &AccountTeardownSessionAdmissionToken,
+    ) -> bool {
+        self.account_session_admissions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(label)
+            .is_some_and(|admission| {
+                !admission.open
+                    && admission.account_id_hex == token.account_id_hex
+                    && admission.generation == token.closed_generation
+                    && admission.teardown_generation == Some(token.generation)
+            })
+    }
+
+    pub(crate) fn account_session_admission_is_current(
+        &self,
+        label: &str,
+        token: &AccountSessionAdmissionToken,
+    ) -> bool {
+        self.account_session_admissions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(label)
+            .is_some_and(|admission| {
+                admission.open
+                    && admission.account_id_hex == token.account_id_hex
+                    && admission.generation == token.generation
+            })
+    }
+
+    pub(crate) fn active_account_session_admission_is_current(
+        &self,
+        label: &str,
+        token: &AccountSessionAdmissionToken,
+    ) -> bool {
+        self.account_home().account(label).is_ok_and(|account| {
+            account.is_active_signing() && account.account_id_hex == token.account_id_hex
+        }) && self.account_session_admission_is_current(label, token)
+    }
+
+    pub(crate) fn account_session_admission_is_open(
+        &self,
+        label: &str,
+        account_id_hex: &str,
+    ) -> bool {
+        self.account_session_admissions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(label)
+            .is_none_or(|admission| admission.account_id_hex != account_id_hex || admission.open)
+    }
+
+    fn account_open_admission_is_current(
+        &self,
+        label: &str,
+        admission: &AccountSessionAdmission,
+    ) -> bool {
+        match admission {
+            AccountSessionAdmission::Active(token) => {
+                self.account_session_admission_is_current(label, token)
+            }
+            AccountSessionAdmission::Teardown(token) => {
+                self.account_teardown_session_admission_is_current(label, token)
+            }
+        }
+    }
+
     /// Open the account's exclusive in-memory engine session.
     ///
     /// Only one [`AppClient`] for an account may exist within a [`MarmotApp`]
@@ -1576,6 +2291,12 @@ impl MarmotApp {
     /// returns [`AppError::AccountSessionBusy`]. Drop the owning client before
     /// retrying.
     pub async fn client(&self, label: &str) -> Result<AppClient, AppError> {
+        let account = self.account_home().account(label)?;
+        if !account.is_active_signing() {
+            return Err(AppError::Publish(
+                "cannot open a direct client for a signed-out or non-signing account".into(),
+            ));
+        }
         #[cfg(test)]
         let relay_plane = self
             .test_relay_client
@@ -1590,8 +2311,20 @@ impl MarmotApp {
         let relay_plane = MarmotRelayPlane::full_history_with_loopback(
             self.config.allow_loopback_relay_endpoints,
         );
-        self.client_with_relay_plane(label, &relay_plane, None)
-            .await
+        let mut client = self
+            .local_client_with_relay_plane(label, &relay_plane, None)
+            .await?;
+        // An unabortable blocking open may finish after concurrent sign-out.
+        // Re-prove the exact record before transport activation; if teardown
+        // already found this session in the registry, its revoked adapter also
+        // makes activation fail closed.
+        client.ensure_active_signing_account()?;
+        client.prepare_transport().await?;
+        client.ensure_active_signing_account()?;
+        self.finish_client_open_network_maintenance(&mut client)
+            .await;
+        client.ensure_active_signing_account()?;
+        Ok(client)
     }
 
     async fn runtime_local_client(
@@ -1607,6 +2340,7 @@ impl MarmotApp {
             .await
     }
 
+    #[cfg(test)]
     async fn client_with_relay_plane(
         &self,
         label: &str,
@@ -1623,6 +2357,16 @@ impl MarmotApp {
         self.finish_client_open_network_maintenance(&mut client)
             .await;
         Ok(client)
+    }
+
+    #[cfg(test)]
+    async fn local_client_with_deferred_hydration_for_test(
+        &self,
+        label: &str,
+        relay_plane: &MarmotRelayPlane,
+    ) -> Result<AppClient, AppError> {
+        self.local_client_with_relay_plane_and_hydration(label, relay_plane, None, true)
+            .await
     }
 
     async fn local_client_with_relay_plane(
@@ -1642,26 +2386,102 @@ impl MarmotApp {
         lifecycle: Option<runtime::RuntimeLifecycle>,
         defer_group_hydration: bool,
     ) -> Result<AppClient, AppError> {
-        let app = self.clone();
         // Resolve every supported account ref before touching label-keyed
         // caches or the session-owner registry.
-        let label = self.account_home().account(label)?.label;
+        let account = self.account_home().account(label)?;
+        if !account.is_active_signing() {
+            return Err(AppError::Publish(
+                "cannot open a client for a signed-out or non-signing account".into(),
+            ));
+        }
+        let label = account.label;
+        let account_id_hex = account.account_id_hex.clone();
+        let session_admission = AccountSessionAdmission::Active(
+            self.capture_account_session_admission(&label, &account_id_hex)?,
+        );
+        self.local_client_with_admission(
+            label,
+            account_id_hex,
+            relay_plane,
+            lifecycle,
+            defer_group_hydration,
+            session_admission,
+        )
+        .await
+    }
+
+    /// Open one exact teardown-owned session without reopening ordinary
+    /// account admission. This path is crate-private, consumes a capability
+    /// owned by the live teardown barrier, and constructs a publisher that is
+    /// categorically unable to emit a KeyPackage.
+    pub(crate) async fn local_teardown_cleanup_client_with_relay_plane(
+        &self,
+        label: &str,
+        account_id_hex: &str,
+        relay_plane: &MarmotRelayPlane,
+        admission: &AccountTeardownSessionAdmissionToken,
+    ) -> Result<AppClient, AppError> {
+        let account = self.account_home().account(label)?;
+        if !account.signed_out
+            || !account.can_sign()
+            || account.account_id_hex != account_id_hex
+            || admission.account_id_hex != account_id_hex
+            || !self.account_teardown_session_admission_is_current(&account.label, admission)
+        {
+            return Err(AppError::AccountWorkerBusy);
+        }
+        self.local_client_with_admission(
+            account.label,
+            account.account_id_hex,
+            relay_plane,
+            None,
+            false,
+            AccountSessionAdmission::Teardown(admission.clone()),
+        )
+        .await
+    }
+
+    async fn local_client_with_admission(
+        &self,
+        label: String,
+        account_id_hex: String,
+        relay_plane: &MarmotRelayPlane,
+        lifecycle: Option<runtime::RuntimeLifecycle>,
+        defer_group_hydration: bool,
+        session_admission: AccountSessionAdmission,
+    ) -> Result<AppClient, AppError> {
+        let app = self.clone();
+        let label_for_open = label.clone();
         let relay_plane_for_open = relay_plane.clone();
         let permit = lifecycle
             .as_ref()
             .map(runtime::RuntimeLifecycle::begin_account_open)
             .transpose()?;
-        let open = blocking_app_task(move || {
-            let _permit = permit;
-            app.ensure_account_state(&label)?;
-            let open = app.open_account(&label, &relay_plane_for_open, defer_group_hydration);
+        let open_result = blocking_app_task(move || {
+            app.ensure_account_state(&label_for_open)?;
+            let open = app.open_account_with_admission(
+                &label_for_open,
+                &relay_plane_for_open,
+                defer_group_hydration,
+                session_admission,
+            );
             #[cfg(test)]
-            app.local_open_gates.wait(&label);
-            open
+            app.local_open_gates.wait(&label_for_open);
+            open.map(|open| OpenAppAccountResult {
+                open,
+                _permit: permit,
+            })
         })
         .await?;
         if let Some(lifecycle) = &lifecycle {
             lifecycle.ensure_running()?;
+        }
+        let OpenAppAccountResult {
+            open,
+            _permit: open_permit,
+        } = open_result;
+        if !self.account_open_admission_is_current(&label, &open.session_admission) {
+            return Err(AppError::AccountWorkerBusy);
         }
         let seen_events_index = open
             .state
@@ -1684,6 +2504,8 @@ impl MarmotApp {
         let mut client = AppClient {
             app: self.clone(),
             runtime: open.runtime,
+            account_id_hex,
+            session_admission: open.session_admission,
             _session_guard: open.session_guard,
             adapter: open.adapter,
             routing: open.routing,
@@ -1695,69 +2517,322 @@ impl MarmotApp {
             pending_group_projection_updates: std::collections::HashSet::new(),
             pending_projection_updates: Vec::new(),
             pending_applied_sync_summary: SyncSummary::default(),
-            pending_failed_sync_summary: SyncSummary::default(),
+            pending_uncheckpointed_sync_summary: None,
+            pending_checkpointed_sync_summary: None,
             pending_epoch_stall_escalations: Vec::new(),
             pending_convergence_groups: std::collections::HashSet::new(),
             pending_local_group_deletion_frontier_clears: std::collections::HashMap::new(),
             pending_application_event_acks: std::collections::HashSet::new(),
+            pending_account_visibility_lease: None,
+            pending_uncheckpointed_runtime_group_subscription_refresh: false,
             pending_runtime_group_subscription_refresh: false,
             checkpointed_transport_timestamp,
             delivery_overflow_recovery_pending: open.delivery_overflow_recovery_pending,
             delivery_overflow_recovery_marker_token: open.delivery_overflow_recovery_marker_token,
+            pending_new_message_notification_groups: std::collections::HashSet::new(),
             #[cfg(test)]
             force_event_group_projection_unavailable: false,
+            #[cfg(test)]
+            block_after_sync_delivery_projection: None,
+            #[cfg(test)]
+            block_after_sync_prefix_checkpoint: None,
+            #[cfg(test)]
+            fail_after_convergence_retry_finalize: false,
+            #[cfg(test)]
+            skip_epoch_backfill_prune_on_delete: false,
             pending_welcome_delivery_events: Vec::new(),
             unpublished_welcome_delivery: None,
             epoch_stall: crate::client::epoch_stall::EpochStallDetector::default()
                 .with_wedge_rearm_interval_ms(wedge_rearm_interval_ms),
             epoch_backfill_retry_not_before: None,
             pending_epoch_backfill: None,
+            active_epoch_backfill: None,
+            epoch_backfill_intent_journal_dirty: false,
             queued_epoch_backfills: std::collections::VecDeque::new(),
             post_join_maintenance_subscriptions: HashMap::new(),
             encrypted_media_not_required_epochs: HashMap::new(),
             checkpoint_route_refresh_recomputes: 0,
         };
+        client.ensure_session_account()?;
+        client.restore_epoch_backfill_intent_journal()?;
         let persisted_backfills = self.pending_epoch_backfill_intents(&client.state.label)?;
-        client.restore_persisted_epoch_backfill_intents(persisted_backfills);
+        client.restore_persisted_epoch_backfill_intents(persisted_backfills)?;
         let persisted_evidence = self.epoch_stall_evidence(&client.state.label)?;
         client.restore_persisted_epoch_stall_evidence(persisted_evidence);
         if !defer_group_hydration {
             // These repairs read live group state. Deferred runtime opens run
             // them after the account worker's hydration pipeline instead.
             client.reconcile_hydrated_account_state()?;
+            client.replay_pending_account_visibility().await?;
         }
+        // The open is now fully represented by `client`; shutdown may stop
+        // counting the blocking handoff without waiting for the client's whole
+        // lifetime.
+        drop(open_permit);
         Ok(client)
     }
 
     async fn finish_client_open_network_maintenance(&self, client: &mut AppClient) {
-        client
-            .app
-            .retire_cached_non_current_key_package(&client.state.label)
-            .await;
-        client
-            .app
-            .retire_relay_non_current_key_packages(&client.state.label)
-            .await;
-        if client
-            .app
-            .key_package_cutover_replacement_pending(&client.state.label)
+        let cutover_app = client.app.clone();
+        let cutover_label = client.state.label.clone();
+        match cutover_app.generated_initial_key_package_publication_held(&cutover_label) {
+            Ok(true) => {
+                let _ = client
+                    .runtime
+                    .set_key_package_cutover_publication_blocked(true);
+                return;
+            }
+            Err(error) => {
+                let _ = client
+                    .runtime
+                    .set_key_package_cutover_publication_blocked(true);
+                tracing::warn!(
+                    target: "marmot_app::key_packages",
+                    method = "finish_client_open_network_maintenance",
+                    error_kind = error.privacy_safe_kind(),
+                    "could not validate the generated initial KeyPackage publication hold"
+                );
+                return;
+            }
+            Ok(false) => {}
+        }
+        let cutover_route_lock = cutover_app.key_package_route_lock(&cutover_label);
+        let cutover_route_guard = cutover_route_lock.lock().await;
+        if let Err(error) = cutover_app
+            .recover_pending_nip65_route_mutation(&cutover_label, client.transport_signer.clone())
+            .await
         {
-            let lifecycle_current = client
+            let _ = client
+                .runtime
+                .set_key_package_cutover_publication_blocked(true);
+            tracing::warn!(
+                target: "marmot_app::key_packages",
+                method = "finish_client_open_network_maintenance",
+                error_kind = error.privacy_safe_kind(),
+                "could not recover a pending authoritative NIP-65 route mutation"
+            );
+            return;
+        }
+        if let Err(error) = client.refresh_routing() {
+            let _ = client
+                .runtime
+                .set_key_package_cutover_publication_blocked(true);
+            tracing::warn!(
+                target: "marmot_app::key_packages",
+                method = "finish_client_open_network_maintenance",
+                error_kind = error.privacy_safe_kind(),
+                "could not refresh routing after NIP-65 cutover recovery"
+            );
+            return;
+        }
+        // A generated identity's exact first KeyPackage is prepared under a
+        // durable no-predecessor proof before its initial NIP-65 route exists.
+        // Once pending route recovery has completed, that narrow proof is
+        // sufficient for the setup-priority publisher's final lifecycle,
+        // route, and marker checks. Running the ordinary retirement path here
+        // would invalidate the one-time proof merely because the replacement
+        // intent is still pending, permanently wedging setup.
+        if client
+            .runtime
+            .key_package_maintenance_status()
+            .ok()
+            .flatten()
+            .is_some_and(|lifecycle| {
+                cutover_app
+                    .generated_account_fresh_replacement_can_open_cutover_gate(
+                        &cutover_label,
+                        &lifecycle,
+                    )
+                    .unwrap_or(false)
+            })
+        {
+            return;
+        }
+        if (!cutover_app.key_package_cutover_publication_allowed(&cutover_label)
+            || cutover_app.key_package_cutover_replacement_pending(&cutover_label))
+            && let Err(error) = client
+                .runtime
+                .set_key_package_cutover_publication_blocked(true)
+        {
+            tracing::warn!(
+                target: "marmot_app::key_packages",
+                method = "finish_client_open_network_maintenance",
+                error_kind = AppError::from(error).privacy_safe_kind(),
+                "could not arm key package cutover publication interlock"
+            );
+            return;
+        }
+        let cached_admission =
+            cutover_app.retire_cached_non_current_key_package(&cutover_label, &mut client.runtime);
+        // Exact deletion now owns the active-session route lock at its lowest
+        // signer/network boundary. Release the wider cutover guard before the
+        // retirement runtime invokes that publisher, then reacquire it for the
+        // marker/gate decisions below. Every such decision is re-read after the
+        // unlocked scan, so a route mutation that wins here remains fail-closed.
+        drop(cutover_route_guard);
+        let relay_scan_complete = cutover_app
+            .retire_relay_non_current_key_packages(&cutover_label, &mut client.runtime)
+            .await;
+        let cutover_route_guard = cutover_route_lock.lock().await;
+        if cached_admission.complete
+            && let Some(event_id) = cached_admission.event_id.as_ref()
+            && let Ok(_root_mutation) =
+                cutover_app.begin_root_mutation("remove terminal cached KeyPackage revision")
+        {
+            cutover_app.remove_terminal_cached_key_package_record(&cutover_label, event_id);
+        }
+        if !cached_admission.complete || !relay_scan_complete {
+            if let Err(error) = client
+                .runtime
+                .set_key_package_cutover_publication_blocked(true)
+            {
+                tracing::warn!(
+                    target: "marmot_app::key_packages",
+                    method = "finish_client_open_network_maintenance",
+                    error_kind = AppError::from(error).privacy_safe_kind(),
+                    "could not retain key package cutover publication interlock"
+                );
+            }
+            tracing::warn!(
+                target: "marmot_app::key_packages",
+                method = "finish_client_open_network_maintenance",
+                cached_admission_complete = cached_admission.complete,
+                relay_scan_complete,
+                "deferred key package replacement until every discovered historical publication is durably admitted"
+            );
+            return;
+        }
+        // Re-read the endpoint-bound marker after the scan. A live NIP-65
+        // mutation can complete while per-relay discovery is in flight; its
+        // new route set must not inherit the proof for the old set.
+        if !cutover_app.key_package_cutover_publication_allowed(&cutover_label) {
+            tracing::warn!(
+                target: "marmot_app::key_packages",
+                method = "finish_client_open_network_maintenance",
+                "authoritative key package relays changed during cutover; retaining publication interlock"
+            );
+            return;
+        }
+        let replacement_pending =
+            cutover_app.key_package_cutover_replacement_pending(&cutover_label);
+        let lifecycle_current = client
+            .runtime
+            .key_package_maintenance_status()
+            .ok()
+            .flatten()
+            .is_some_and(|lifecycle| {
+                cutover_app
+                    .key_package_lifecycle_has_current_cutover_revision(&cutover_label, &lifecycle)
+            });
+        if replacement_pending && !lifecycle_current {
+            let replacement_endpoints = match cutover_app
+                .authoritative_key_package_relays(&cutover_label)
+            {
+                Ok(endpoints) if !endpoints.is_empty() => endpoints,
+                Ok(_) | Err(_) => {
+                    tracing::warn!(
+                        target: "marmot_app::key_packages",
+                        method = "finish_client_open_network_maintenance",
+                        "could not prepare a cutover replacement without safe authoritative relays"
+                    );
+                    return;
+                }
+            };
+            if let Err(error) = client
+                .runtime
+                .prepare_fresh_key_package(replacement_endpoints.clone())
+                .await
+            {
+                tracing::warn!(
+                    target: "marmot_app::key_packages",
+                    method = "finish_client_open_network_maintenance",
+                    error_kind = AppError::from(error).privacy_safe_kind(),
+                    "could not durably prepare the strict-newer cutover replacement"
+                );
+                return;
+            }
+            let prepared = client
                 .runtime
                 .key_package_maintenance_status()
                 .ok()
                 .flatten()
-                .and_then(|lifecycle| lifecycle.current_key_package)
-                .and_then(|key_package| key_package_metadata(&key_package).ok())
-                .is_some_and(|metadata| {
-                    client
-                        .app
-                        .key_package_metadata_matches_current_support(&metadata)
+                .is_some_and(|lifecycle| {
+                    cutover_app.key_package_lifecycle_has_prepared_cutover_replacement(
+                        &cutover_label,
+                        &lifecycle,
+                        &replacement_endpoints,
+                    )
                 });
+            if !prepared {
+                tracing::warn!(
+                    target: "marmot_app::key_packages",
+                    method = "finish_client_open_network_maintenance",
+                    "prepared cutover replacement failed durable strict-newer validation"
+                );
+                return;
+            }
+        }
+        // Signing a pending replacement may await an external signer. Re-read
+        // the generation-bound marker immediately before clearing the SQL
+        // gate; a self NIP-65 update admitted through any route during that
+        // wait must retain the interlock.
+        if !cutover_app.key_package_cutover_publication_allowed(&cutover_label) {
+            tracing::warn!(
+                target: "marmot_app::key_packages",
+                method = "finish_client_open_network_maintenance",
+                "authoritative key package route changed while preparing the cutover replacement"
+            );
+            return;
+        }
+        // Preparing can run the conservative legacy private-material sweep and
+        // create additional cutover-only consumption tombstones after the
+        // relay scan's first finalization pass. Transfer/reclaim those refs in
+        // this same serialized cutover before opening publication admission.
+        if let Err(error) = client
+            .runtime
+            .finalize_key_package_cutover_consumption_evidence()
+        {
+            tracing::warn!(
+                target: "marmot_app::key_packages",
+                method = "finish_client_open_network_maintenance",
+                error_kind = AppError::from(error).privacy_safe_kind(),
+                "could not finalize key package cutover consumption evidence"
+            );
+            return;
+        }
+        if let Err(error) = client
+            .runtime
+            .set_key_package_cutover_publication_blocked(false)
+        {
+            tracing::warn!(
+                target: "marmot_app::key_packages",
+                method = "finish_client_open_network_maintenance",
+                error_kind = AppError::from(error).privacy_safe_kind(),
+                "could not clear completed key package cutover publication interlock"
+            );
+            return;
+        }
+        // The final publisher takes this same lock around its marker/gate/route
+        // validation and relay I/O. Release before calling it to avoid
+        // recursive acquisition; a route mutation that wins next re-arms the
+        // gate and invalidates the marker, so the final check will fail closed.
+        drop(cutover_route_guard);
+        if replacement_pending {
             if lifecycle_current {
-                client
+                if let Ok(_root_mutation) = client
                     .app
-                    .clear_key_package_cutover_replacement_pending(&client.state.label);
+                    .begin_root_mutation("clear completed KeyPackage cutover replacement")
+                    && let Err(error) = client
+                        .app
+                        .clear_key_package_cutover_replacement_pending(&client.state.label)
+                {
+                    tracing::warn!(
+                        target: "marmot_app::key_packages",
+                        method = "finish_client_open_network_maintenance",
+                        error_kind = error.privacy_safe_kind(),
+                        "could not durably clear completed KeyPackage cutover replacement"
+                    );
+                }
             } else {
                 match client.runtime.publish_fresh_key_package().await {
                     Ok(_) => tracing::info!(
@@ -1777,20 +2852,127 @@ impl MarmotApp {
                     .key_package_maintenance_status()
                     .ok()
                     .flatten()
-                    .and_then(|lifecycle| lifecycle.current_key_package)
-                    .and_then(|key_package| key_package_metadata(&key_package).ok())
-                    .is_some_and(|metadata| {
+                    .is_some_and(|lifecycle| {
                         client
                             .app
-                            .key_package_metadata_matches_current_support(&metadata)
+                            .key_package_lifecycle_has_current_cutover_revision(
+                                &client.state.label,
+                                &lifecycle,
+                            )
                     })
-                {
-                    client
+                    && let Ok(_root_mutation) = client
                         .app
-                        .clear_key_package_cutover_replacement_pending(&client.state.label);
+                        .begin_root_mutation("clear published KeyPackage cutover replacement")
+                    && let Err(error) = client
+                        .app
+                        .clear_key_package_cutover_replacement_pending(&client.state.label)
+                {
+                    tracing::warn!(
+                        target: "marmot_app::key_packages",
+                        method = "finish_client_open_network_maintenance",
+                        error_kind = error.privacy_safe_kind(),
+                        "could not durably clear published KeyPackage cutover replacement"
+                    );
                 }
             }
         }
+    }
+
+    fn key_package_lifecycle_has_current_cutover_revision(
+        &self,
+        label: &str,
+        lifecycle: &cgka_traits::KeyPackageLifecycleState,
+    ) -> bool {
+        let Some(artifact) = lifecycle.authored_signed_event.as_ref() else {
+            return false;
+        };
+        let Some(key_package_ref) = lifecycle.current_key_package_ref.as_ref() else {
+            return false;
+        };
+        let Some(metadata) = lifecycle
+            .current_key_package
+            .as_ref()
+            .and_then(|key_package| key_package_metadata(key_package).ok())
+        else {
+            return false;
+        };
+        let Ok(metadata_ref) = hex::decode(&metadata.key_package_ref_hex) else {
+            return false;
+        };
+        let Ok(account) = self.account_home().account(label) else {
+            return false;
+        };
+        self.key_package_metadata_matches_current_support(&metadata)
+            && metadata.credential_identity_hex == account.account_id_hex
+            && metadata_ref == *key_package_ref
+            && !lifecycle.key_package_ref_is_consumed(key_package_ref)
+            && lifecycle.authored_event_id.as_ref() == Some(&artifact.id)
+            && lifecycle.authored_event_created_at == Some(artifact.created_at)
+            && !lifecycle
+                .deleted_live_revision_event_ids
+                .contains(&artifact.id)
+            && lifecycle
+                .retired_publications_pending_deletion
+                .iter()
+                .all(|retired| retired.authored_created_at < artifact.created_at)
+    }
+
+    fn key_package_lifecycle_has_prepared_cutover_replacement(
+        &self,
+        label: &str,
+        lifecycle: &cgka_traits::KeyPackageLifecycleState,
+        authoritative_endpoints: &[TransportEndpoint],
+    ) -> bool {
+        let Some(pending) = lifecycle.pending_replacement.as_ref() else {
+            return false;
+        };
+        let Some(artifact) = pending.signed_event.as_ref() else {
+            return false;
+        };
+        let Some(metadata) = key_package_metadata(&pending.key_package).ok() else {
+            return false;
+        };
+        let Ok(account) = self.account_home().account(label) else {
+            return false;
+        };
+        let Ok(metadata_ref) = hex::decode(&metadata.key_package_ref_hex) else {
+            return false;
+        };
+        let Ok(expected) =
+            self.sanitize_key_package_deletion_endpoints(authoritative_endpoints.to_vec())
+        else {
+            return false;
+        };
+        let Ok(actual) = self.sanitize_key_package_deletion_endpoints(
+            pending
+                .targets
+                .iter()
+                .filter(|target| {
+                    target.state != cgka_traits::TransportFanoutAttemptState::PolicyProhibited
+                })
+                .map(|target| target.endpoint.clone())
+                .collect::<Vec<_>>(),
+        ) else {
+            return false;
+        };
+
+        !expected.is_empty()
+            && actual == expected
+            && self.key_package_metadata_matches_current_support(&metadata)
+            && metadata.credential_identity_hex == account.account_id_hex
+            && metadata_ref == pending.key_package_ref
+            && !lifecycle.key_package_ref_is_consumed(&pending.key_package_ref)
+            && artifact.created_at == pending.authored_created_at
+            && !lifecycle
+                .deleted_live_revision_event_ids
+                .contains(&artifact.id)
+            && lifecycle
+                .authored_event_created_at
+                .is_none_or(|high_water| artifact.created_at > high_water)
+            && lifecycle
+                .retired_publications_pending_deletion
+                .iter()
+                .all(|retired| retired.authored_created_at < artifact.created_at)
     }
 
     pub fn status(&self, label: &str) -> Result<AppStatus, AppError> {
@@ -1811,38 +2993,432 @@ impl MarmotApp {
         })
     }
 
+    /// Legacy direct-app seam retained for API compatibility.
+    ///
+    /// Relay-list mutations require account-worker or setup admission, neither
+    /// of which a bare [`MarmotApp`] owns. Use the matching
+    /// [`MarmotAppRuntime`] operation; this method always fails before reading
+    /// account caches, signing, or relay I/O.
     pub async fn publish_account_relay_lists(
+        &self,
+        _label: &str,
+        _bootstrap: AccountRelayListBootstrap,
+    ) -> Result<AccountRelayListStatus, AppError> {
+        Err(AppError::AccountWorkerBusy)
+    }
+
+    pub(crate) async fn publish_account_relay_lists_for_setup(
         &self,
         label: &str,
         bootstrap: AccountRelayListBootstrap,
+        setup_admission: &runtime::AccountSetupPublicationAdmission,
     ) -> Result<AccountRelayListStatus, AppError> {
-        self.publish_selected_account_relay_lists(
+        self.publish_selected_account_relay_lists_with_nip65(
             label,
             bootstrap,
             &[
                 NostrAccountRelayListKind::Nip65,
                 NostrAccountRelayListKind::Inbox,
             ],
+            None,
+            AccountRelayListMutationAdmission::Setup(setup_admission),
         )
         .await
+    }
+
+    /// Durably stage and sign the generated identity's exact initial NIP-65
+    /// authority without contacting a relay. The pending route file is both the
+    /// crash-recovery source for the exact signed event and the final-boundary
+    /// fence that prevents a KeyPackage from escaping before that authority is
+    /// committed.
+    pub(crate) async fn stage_generated_account_nip65_route_mutation(
+        &self,
+        label: &str,
+        bootstrap: &AccountRelayListBootstrap,
+    ) -> Result<(), AppError> {
+        if bootstrap.default_relays.is_empty() {
+            return Err(AppError::MissingDefaultRelays);
+        }
+        self.validate_account_relay_list_declarations(bootstrap, None)?;
+        let route_lock = self.key_package_route_lock(label);
+        let _route_guard = route_lock.lock().await;
+        let account = self.account_home().account(label)?;
+        let signer = self.account_signer_for_summary(&account)?;
+        self.stage_generated_account_nip65_route_mutation_unlocked(
+            label,
+            bootstrap,
+            signer.as_nostr_signer(),
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Validate the generated setup's desired authority, stage it when absent,
+    /// then exact-replay/commit it under the same account route lock. Callers
+    /// pass the relay options recovered from the durable generated-setup
+    /// context; an older pending intent for any other authority fails before
+    /// network I/O instead of being reinterpreted as this setup attempt.
+    pub(crate) async fn recover_generated_account_nip65_route_authority_for_session(
+        &self,
+        label: &str,
+        bootstrap: &AccountRelayListBootstrap,
+        signer: Arc<dyn nostr::NostrSigner>,
+        session_admission: &AccountSessionAdmissionToken,
+    ) -> Result<GeneratedNip65RouteAuthorityProof, AppError> {
+        if bootstrap.default_relays.is_empty() {
+            return Err(AppError::MissingDefaultRelays);
+        }
+        self.validate_account_relay_list_declarations(bootstrap, None)?;
+        let route_lock = self.key_package_route_lock(label);
+        let _route_guard = route_lock.lock().await;
+        if !self.active_account_session_admission_is_current(label, session_admission) {
+            return Err(AppError::AccountWorkerBusy);
+        }
+        let desired = self
+            .stage_generated_account_nip65_route_mutation_unlocked(label, bootstrap, signer.clone())
+            .await?;
+        if !self.active_account_session_admission_is_current(label, session_admission) {
+            return Err(AppError::AccountWorkerBusy);
+        }
+        self.recover_validated_generated_nip65_route_mutation(label, signer)
+            .await?;
+        let generation = self
+            .read_nip65_route_generation_for_authoring(label)?
+            .ok_or_else(|| {
+                AppError::Publish(
+                    "generated account NIP-65 authority was not durably committed".into(),
+                )
+            })?;
+        if self.canonical_nip65_route_state(&generation.nip65)?
+            != self.canonical_nip65_route_state(&desired)?
+        {
+            return Err(AppError::Publish(
+                "generated account NIP-65 authority does not match its durable setup context"
+                    .into(),
+            ));
+        }
+        let endpoints = self.validate_nip65_route_generation(&generation)?;
+        Ok(GeneratedNip65RouteAuthorityProof {
+            generation,
+            endpoints,
+        })
+    }
+
+    #[cfg(test)]
+    async fn recover_generated_account_nip65_route_authority(
+        &self,
+        label: &str,
+        bootstrap: &AccountRelayListBootstrap,
+        signer: Arc<dyn nostr::NostrSigner>,
+    ) -> Result<GeneratedNip65RouteAuthorityProof, AppError> {
+        let account = self.account_home().account(label)?;
+        let admission =
+            self.capture_account_session_admission(&account.label, &account.account_id_hex)?;
+        self.recover_generated_account_nip65_route_authority_for_session(
+            label, bootstrap, signer, &admission,
+        )
+        .await
+    }
+
+    /// Reopen the generated setup's SQL publication interlock only after the
+    /// caller has refreshed routing from the recovered authority. This second
+    /// route-locked proof prevents a refresh failure or an intervening route
+    /// mutation from inheriting the recovery capability.
+    pub(crate) async fn open_generated_account_key_package_publication_gate(
+        &self,
+        label: &str,
+        bootstrap: &AccountRelayListBootstrap,
+        proof: &GeneratedNip65RouteAuthorityProof,
+        session_admission: &AccountSessionAdmissionToken,
+    ) -> Result<(), AppError> {
+        if bootstrap.default_relays.is_empty() {
+            return Err(AppError::MissingDefaultRelays);
+        }
+        self.validate_account_relay_list_declarations(bootstrap, None)?;
+        let route_lock = self.key_package_route_lock(label);
+        let _route_guard = route_lock.lock().await;
+        if !self.active_account_session_admission_is_current(label, session_admission) {
+            return Err(AppError::AccountWorkerBusy);
+        }
+        let account = self.account_home().account(label)?;
+        let publish_endpoints = self.publish_route_including_requested(
+            &account.account_id_hex,
+            publish_endpoints_from_bootstrap(bootstrap),
+        );
+        let (_, desired) =
+            self.generated_account_nip65_event_and_state(&account, bootstrap, publish_endpoints)?;
+        let desired_authority = self.canonical_nip65_route_state(&desired)?;
+        let current = self
+            .read_nip65_route_generation_for_authoring(label)?
+            .ok_or_else(|| {
+                AppError::Publish(
+                    "generated account NIP-65 authority disappeared before gate admission".into(),
+                )
+            })?;
+        let current_endpoints = self.validate_nip65_route_generation(&current)?;
+        if current != proof.generation
+            || self.canonical_nip65_route_state(&current.nip65)? != desired_authority
+            || current_endpoints != proof.endpoints
+            || desired_authority.0 != proof.endpoints
+        {
+            return Err(AppError::Publish(
+                "generated account NIP-65 authority changed before KeyPackage gate admission"
+                    .into(),
+            ));
+        }
+        let storage = self.account_storage(label)?;
+        let Some(mut lifecycle) = storage.key_package_lifecycle()? else {
+            return Err(AppError::Publish(
+                "generated account route recovery has no durable KeyPackage lifecycle".into(),
+            ));
+        };
+        if !self.generated_account_fresh_replacement_can_open_cutover_gate(label, &lifecycle)? {
+            return Err(AppError::Publish(
+                "generated account route recovery cannot prove its exact fresh KeyPackage replacement"
+                    .into(),
+            ));
+        }
+        if !self.active_account_session_admission_is_current(label, session_admission) {
+            return Err(AppError::AccountWorkerBusy);
+        }
+        self.clear_generated_initial_key_package_publication_hold(label)?;
+        if lifecycle.cutover_publication_blocked {
+            lifecycle.cutover_publication_blocked = false;
+            storage.put_key_package_lifecycle(&lifecycle)?;
+        }
+        Ok(())
+    }
+
+    /// The caller owns `key_package_route_lock(label)`. This method performs no
+    /// relay I/O: it only validates existing durable authority or signs and
+    /// persists one exact pending generated-bootstrap event.
+    async fn stage_generated_account_nip65_route_mutation_unlocked(
+        &self,
+        label: &str,
+        bootstrap: &AccountRelayListBootstrap,
+        signer: Arc<dyn nostr::NostrSigner>,
+    ) -> Result<AccountRelayListState, AppError> {
+        let account = self.account_home().account(label)?;
+        let publish_endpoints = self.publish_route_including_requested(
+            &account.account_id_hex,
+            publish_endpoints_from_bootstrap(bootstrap),
+        );
+        let (generated_event, desired) = self.generated_account_nip65_event_and_state(
+            &account,
+            bootstrap,
+            publish_endpoints.clone(),
+        )?;
+        let desired_authority = self.canonical_nip65_route_state(&desired)?;
+        let desired_endpoints = desired_authority.0.clone();
+        let desired_publish_endpoints = self.canonical_nip65_publication_endpoints(
+            publish_endpoints.clone(),
+            "generated-account NIP-65 setup publication",
+        )?;
+
+        if self.pending_nip65_route_mutation(label) {
+            let pending = self.read_pending_nip65_route_mutation(label)?;
+            let pending_endpoints = self.validate_pending_nip65_route_mutation(label, &pending)?;
+            let pending_publish_endpoints = self.canonical_nip65_publication_endpoints(
+                pending
+                    .publish_endpoints
+                    .iter()
+                    .cloned()
+                    .map(TransportEndpoint)
+                    .collect(),
+                "pending generated-account NIP-65 publication",
+            )?;
+            let pending_bootstrap_endpoints = self.canonical_nip65_publication_endpoints(
+                pending
+                    .bootstrap_relays
+                    .iter()
+                    .cloned()
+                    .map(TransportEndpoint)
+                    .collect(),
+                "pending generated-account bootstrap projection",
+            )?;
+            if pending.source != Nip65RouteMutationSource::GeneratedAccountBootstrap
+                || pending.signed_event.is_none()
+                || self.canonical_nip65_route_state(&pending.nip65)? != desired_authority
+                || pending_endpoints != desired_endpoints
+                || pending_publish_endpoints != desired_publish_endpoints
+                || pending_bootstrap_endpoints != desired_publish_endpoints
+            {
+                return Err(AppError::Publish(
+                    "pending generated-account NIP-65 route does not match its durable setup context"
+                        .into(),
+                ));
+            }
+            return Ok(pending.nip65);
+        }
+
+        if let Some(generation) = self.read_nip65_route_generation_for_authoring(label)? {
+            let generation_endpoints = self.validate_nip65_route_generation(&generation)?;
+            if self.canonical_nip65_route_state(&generation.nip65)? != desired_authority
+                || generation_endpoints != desired_endpoints
+            {
+                return Err(AppError::Publish(
+                    "generated account NIP-65 authority does not match its durable setup context"
+                        .into(),
+                ));
+            }
+            // The declared authority is unchanged, but a reconstructed setup
+            // context may name a different bootstrap publication route. The
+            // generation journal does not prove that route saw the event, so
+            // deterministically re-sign the exact committed coordinate and
+            // stage an id-equal replay to the context-authorized endpoints.
+            // This never authors a newer route revision and never silently
+            // reuses stale bootstrap endpoints.
+            let mut signed_event = generated_event;
+            signed_event.created_at = generation.created_at;
+            signed_event = self
+                .sign_account_transport_event(signer, signed_event)
+                .await?;
+            if signed_event.id != generation.event_id
+                || relay_list_state_from_event(&signed_event).as_ref() != Some(&generation.nip65)
+            {
+                return Err(AppError::Publish(
+                    "generated account NIP-65 generation cannot be exactly replayed to its durable setup route"
+                        .into(),
+                ));
+            }
+            let pending = PendingNip65RouteMutation {
+                account_id_hex: account.account_id_hex,
+                nip65: generation.nip65.clone(),
+                bootstrap_relays: publish_endpoints
+                    .iter()
+                    .map(|endpoint| endpoint.0.clone())
+                    .collect(),
+                publish_endpoints: publish_endpoints
+                    .iter()
+                    .map(|endpoint| endpoint.0.clone())
+                    .collect(),
+                signed_event: Some(signed_event),
+                generation: generation.clone(),
+                network_accepted: false,
+                source: Nip65RouteMutationSource::GeneratedAccountBootstrap,
+            };
+            let _root_mutation =
+                self.begin_root_mutation("stage exact generated-account NIP-65 route replay")?;
+            self.write_pending_nip65_route_mutation(label, &pending)?;
+            return Ok(generation.nip65);
+        }
+
+        let mut signed_event = generated_event;
+        signed_event.created_at = self.next_locally_authored_nip65_created_at(label)?;
+        signed_event = self
+            .sign_account_transport_event(signer, signed_event)
+            .await?;
+        let nip65 = relay_list_state_from_event(&signed_event).ok_or_else(|| {
+            AppError::Publish("signed NIP-65 event has no relay-list state".into())
+        })?;
+        if nip65 != desired {
+            return Err(AppError::Publish(
+                "signed generated-account NIP-65 event changed its declared authority".into(),
+            ));
+        }
+        let pending = PendingNip65RouteMutation {
+            account_id_hex: account.account_id_hex,
+            nip65: nip65.clone(),
+            bootstrap_relays: publish_endpoints
+                .iter()
+                .map(|endpoint| endpoint.0.clone())
+                .collect(),
+            publish_endpoints: publish_endpoints
+                .iter()
+                .map(|endpoint| endpoint.0.clone())
+                .collect(),
+            signed_event: Some(signed_event.clone()),
+            generation: Nip65RouteGeneration {
+                created_at: signed_event.created_at,
+                event_id: signed_event.id.clone(),
+                nip65: nip65.clone(),
+            },
+            network_accepted: false,
+            source: Nip65RouteMutationSource::GeneratedAccountBootstrap,
+        };
+        {
+            let _root_mutation =
+                self.begin_root_mutation("stage generated-account NIP-65 route mutation")?;
+            self.write_pending_nip65_route_mutation(label, &pending)?;
+            let fresh_account_proof_preserved =
+                self.invalidate_key_package_cutover_scan_for_route_mutation(label)?;
+            if !fresh_account_proof_preserved {
+                self.arm_key_package_cutover_publication_gate_for_relays(
+                    label,
+                    &desired_endpoints,
+                )?;
+            }
+        }
+        Ok(nip65)
+    }
+
+    fn generated_account_nip65_event_and_state(
+        &self,
+        account: &AccountSummary,
+        bootstrap: &AccountRelayListBootstrap,
+        publish_endpoints: Vec<TransportEndpoint>,
+    ) -> Result<(NostrTransportEvent, AccountRelayListState), AppError> {
+        let generated_event = NostrAccountRelayListPublication {
+            account_id: MemberId::new(hex::decode(&account.account_id_hex)?),
+            list_kind: NostrAccountRelayListKind::Nip65,
+            relays: bootstrap.default_relays.clone(),
+            publish_endpoints,
+        }
+        .to_event()?;
+        let desired = relay_list_state_from_event(&generated_event).ok_or_else(|| {
+            AppError::Publish("generated NIP-65 event has no relay-list state".into())
+        })?;
+        Ok((generated_event, desired))
     }
 
     /// Publish every generated-identity bootstrap record through one scoped
     /// relay batch. The SDK connects the endpoint union once for the two relay
     /// lists, empty follow list, and default profile, then returns one ordered
     /// acknowledgement result per replaceable event.
-    pub(crate) async fn publish_generated_account_bootstrap(
+    pub(crate) async fn publish_generated_account_bootstrap_admitted(
         &self,
         label: &str,
         bootstrap: AccountRelayListBootstrap,
         profile: &UserProfileMetadata,
+        setup_admission: &runtime::AccountSetupPublicationAdmission,
     ) -> Result<GeneratedAccountBootstrapPublication, AppError> {
         if bootstrap.default_relays.is_empty() {
             return Err(AppError::MissingDefaultRelays);
         }
         self.validate_account_relay_list_declarations(&bootstrap, None)?;
+        let key_package_route_lock = self.key_package_route_lock(label);
+        let _key_package_route_guard = key_package_route_lock.lock().await;
         let account = self.account_home().account(label)?;
+        let setup_is_current = || {
+            self.account_home().account(label).is_ok_and(|current| {
+                current.is_active_signing()
+                    && current.account_id_hex == setup_admission.account_id_hex()
+                    && current.signed_out == setup_admission.started_signed_out()
+            }) && setup_admission.is_current()
+                && self.account_session_admission_is_open(&account.label, &account.account_id_hex)
+        };
+        if !setup_is_current() {
+            return Err(AppError::AccountWorkerBusy);
+        }
         let signer = self.account_signer_for_summary(&account)?;
+        // Validate an older exact intent against this durable setup request
+        // before replaying it. A mismatched but otherwise valid pending route
+        // must not be committed merely because it carries the generated source.
+        let pending_preexisted = self.pending_nip65_route_mutation(label);
+        let desired_nip65 = self
+            .stage_generated_account_nip65_route_mutation_unlocked(
+                label,
+                &bootstrap,
+                signer.as_nostr_signer(),
+            )
+            .await?;
+        if pending_preexisted {
+            if !setup_is_current() {
+                return Err(AppError::AccountWorkerBusy);
+            }
+            self.recover_validated_generated_nip65_route_mutation(label, signer.as_nostr_signer())
+                .await?;
+        }
         let account_id = MemberId::new(hex::decode(&account.account_id_hex)?);
         // Relay-list records are discoverability maps and therefore go to the
         // bootstrap route. Profiles and contact lists are outbox content: keep
@@ -1855,23 +3431,43 @@ impl MarmotApp {
             publish_endpoints_from_bootstrap(&bootstrap),
         );
 
+        let relays = bootstrap
+            .default_relays
+            .iter()
+            .map(|endpoint| endpoint.0.clone())
+            .collect::<Vec<_>>();
         let mut requests = Vec::with_capacity(4);
-        for list_kind in [
-            NostrAccountRelayListKind::Nip65,
-            NostrAccountRelayListKind::Inbox,
-        ] {
+        let mut record_kinds = Vec::with_capacity(4);
+        let mut pending_nip65 = if self.pending_nip65_route_mutation(label) {
+            Some(self.read_pending_nip65_route_mutation(label)?)
+        } else {
+            None
+        };
+        if let Some(pending) = pending_nip65.as_ref() {
+            let event = pending.signed_event.clone().ok_or_else(|| {
+                AppError::Publish(
+                    "unacknowledged generated NIP-65 route intent has no exact signed event".into(),
+                )
+            })?;
             requests.push(NostrEventPublishRequest {
                 endpoints: endpoints.clone(),
-                event: NostrAccountRelayListPublication {
-                    account_id: account_id.clone(),
-                    list_kind,
-                    relays: bootstrap.default_relays.clone(),
-                    publish_endpoints: endpoints.clone(),
-                }
-                .to_event()?,
+                event,
                 required_acks: 1,
             });
+            record_kinds.push("NIP-65 relay list");
         }
+        requests.push(NostrEventPublishRequest {
+            endpoints: endpoints.clone(),
+            event: NostrAccountRelayListPublication {
+                account_id: account_id.clone(),
+                list_kind: NostrAccountRelayListKind::Inbox,
+                relays: bootstrap.default_relays.clone(),
+                publish_endpoints: endpoints.clone(),
+            }
+            .to_event()?,
+            required_acks: 1,
+        });
+        record_kinds.push("inbox relay list");
         requests.push(NostrEventPublishRequest {
             endpoints: content_endpoints.clone(),
             event: NostrTransportEvent::new_unsigned(
@@ -1882,6 +3478,7 @@ impl MarmotApp {
             ),
             required_acks: 1,
         });
+        record_kinds.push("contact list");
         requests.push(NostrEventPublishRequest {
             endpoints: content_endpoints.clone(),
             event: NostrTransportEvent::new_unsigned(
@@ -1892,15 +3489,13 @@ impl MarmotApp {
             ),
             required_acks: 1,
         });
+        record_kinds.push("profile metadata");
 
         let relay_client =
             self.relay_client_for_account_id(&account.account_id_hex, signer.as_nostr_signer());
-        let record_kinds = [
-            "NIP-65 relay list",
-            "inbox relay list",
-            "contact list",
-            "profile metadata",
-        ];
+        if !setup_is_current() {
+            return Err(AppError::AccountWorkerBusy);
+        }
         let batch = relay_client.publish_events_with_timings(&requests).await;
         let outcomes = batch.outcomes;
         if outcomes.len() != record_kinds.len() {
@@ -1917,39 +3512,44 @@ impl MarmotApp {
                 record_kinds.len()
             )));
         }
-        let relay_and_follow_duration = batch.request_durations[..3]
+        let non_profile_request_count = batch.request_durations.len().saturating_sub(1);
+        let relay_and_follow_duration = batch.request_durations[..non_profile_request_count]
             .iter()
             .copied()
             .max()
             .unwrap_or_default();
-        let default_profile_duration = batch.request_durations[3];
-        for (record_kind, outcome) in record_kinds.into_iter().zip(outcomes) {
+        let default_profile_duration = batch.request_durations.last().copied().unwrap_or_default();
+        for (index, (record_kind, outcome)) in record_kinds.into_iter().zip(outcomes).enumerate() {
             if outcome?.accepted.is_empty() {
                 return Err(AppError::Publish(format!(
                     "relay acknowledged zero events for bootstrap record {record_kind}"
                 )));
             }
+            if index == 0
+                && let Some(pending) = pending_nip65.as_mut()
+            {
+                debug_assert_eq!(record_kind, "NIP-65 relay list");
+                pending.network_accepted = true;
+                {
+                    let _root_mutation = self.begin_root_mutation(
+                        "record generated-account NIP-65 route acknowledgement",
+                    )?;
+                    self.write_pending_nip65_route_mutation(label, pending)?;
+                }
+                self.commit_pending_nip65_route_mutation(label, pending)?;
+            }
         }
 
-        let relays = bootstrap
-            .default_relays
-            .iter()
-            .map(|endpoint| endpoint.0.clone())
-            .collect::<Vec<_>>();
         let mut status = AccountRelayListStatus {
             complete: false,
             missing: Vec::new(),
             default_relays: Vec::new(),
-            bootstrap_relays: endpoints
+            bootstrap_relays: bootstrap
+                .bootstrap_relays
                 .iter()
                 .map(|endpoint| endpoint.0.clone())
                 .collect(),
-            nip65: AccountRelayListState {
-                kind: KIND_NIP65_RELAY_LIST,
-                relays: relays.clone(),
-                read_relays: relays.clone(),
-                write_relays: relays.clone(),
-            },
+            nip65: desired_nip65,
             inbox: AccountRelayListState {
                 kind: KIND_MARMOT_INBOX_RELAY_LIST,
                 relays,
@@ -1977,21 +3577,65 @@ impl MarmotApp {
         })
     }
 
-    pub async fn publish_missing_account_relay_lists(
+    #[cfg(test)]
+    async fn publish_generated_account_bootstrap(
         &self,
         label: &str,
         bootstrap: AccountRelayListBootstrap,
-    ) -> Result<AccountRelayListStatus, AppError> {
-        let current = self.account_relay_list_status(label)?;
-        self.publish_missing_account_relay_lists_from_status(label, bootstrap, current)
+        profile: &UserProfileMetadata,
+    ) -> Result<GeneratedAccountBootstrapPublication, AppError> {
+        let account = self.account_home().account(label)?;
+        let admission =
+            runtime::AccountSetupPublicationAdmission::for_test(&account.account_id_hex);
+        self.publish_generated_account_bootstrap_admitted(label, bootstrap, profile, &admission)
             .await
     }
 
+    /// Legacy direct-app seam retained for API compatibility; use
+    /// [`MarmotAppRuntime`] so the active account worker supplies admission.
+    /// This method always fails before reading account caches or publishing.
+    pub async fn publish_missing_account_relay_lists(
+        &self,
+        _label: &str,
+        _bootstrap: AccountRelayListBootstrap,
+    ) -> Result<AccountRelayListStatus, AppError> {
+        Err(AppError::AccountWorkerBusy)
+    }
+
+    /// Legacy direct-app seam retained for API compatibility; use
+    /// [`MarmotAppRuntime`] so the active account worker supplies admission.
+    /// This method always fails before reading account caches or publishing.
     pub async fn publish_missing_account_relay_lists_from_status(
+        &self,
+        _label: &str,
+        _bootstrap: AccountRelayListBootstrap,
+        _current: AccountRelayListStatus,
+    ) -> Result<AccountRelayListStatus, AppError> {
+        Err(AppError::AccountWorkerBusy)
+    }
+
+    pub(crate) async fn publish_missing_account_relay_lists_from_status_for_setup(
         &self,
         label: &str,
         bootstrap: AccountRelayListBootstrap,
         current: AccountRelayListStatus,
+        setup_admission: &runtime::AccountSetupPublicationAdmission,
+    ) -> Result<AccountRelayListStatus, AppError> {
+        self.publish_missing_account_relay_lists_from_status_unlocked(
+            label,
+            bootstrap,
+            current,
+            AccountRelayListMutationAdmission::Setup(setup_admission),
+        )
+        .await
+    }
+
+    async fn publish_missing_account_relay_lists_from_status_unlocked(
+        &self,
+        label: &str,
+        bootstrap: AccountRelayListBootstrap,
+        current: AccountRelayListStatus,
+        admission: AccountRelayListMutationAdmission<'_>,
     ) -> Result<AccountRelayListStatus, AppError> {
         let missing = current
             .missing
@@ -2004,13 +3648,16 @@ impl MarmotApp {
         if missing.is_empty() {
             return Ok(current);
         }
-        self.publish_selected_account_relay_lists(label, bootstrap, &missing)
-            .await
+        self.publish_selected_account_relay_lists_with_nip65(
+            label, bootstrap, &missing, None, admission,
+        )
+        .await
     }
 
-    async fn ensure_local_account_relay_lists(
+    pub(crate) async fn ensure_local_account_relay_lists_for_session(
         &self,
         label: &str,
+        session_admission: &AccountSessionAdmissionToken,
     ) -> Result<AccountRelayListStatus, AppError> {
         let account = self.account_home().account(label)?;
         let status = self.account_relay_list_status_for_account_id(&account.account_id_hex)?;
@@ -2021,20 +3668,35 @@ impl MarmotApp {
         if default_relays.is_empty() {
             return Err(AppError::MissingRelayLists(status.missing));
         }
-        self.publish_missing_account_relay_lists_from_status(
+        let missing = status
+            .missing
+            .iter()
+            .map(|kind| match kind {
+                MissingRelayListKind::Nip65 => NostrAccountRelayListKind::Nip65,
+                MissingRelayListKind::Inbox => NostrAccountRelayListKind::Inbox,
+            })
+            .collect::<Vec<_>>();
+        self.publish_selected_account_relay_lists_with_nip65(
             label,
             AccountRelayListBootstrap::new(default_relays.clone(), default_relays),
-            status,
+            &missing,
+            None,
+            AccountRelayListMutationAdmission::Active(session_admission),
         )
         .await
     }
 
+    /// Legacy direct-app seam retained for API compatibility.
+    ///
+    /// Supported relay-list kinds fail closed without runtime admission;
+    /// unknown kinds retain their input-validation error. Use
+    /// [`MarmotAppRuntime::publish_account_relay_list_kind`] for mutations.
     pub async fn publish_account_relay_list_kind(
         &self,
-        label: &str,
+        _label: &str,
         list_kind: &str,
-        relays: Vec<TransportEndpoint>,
-        bootstrap_relays: Vec<TransportEndpoint>,
+        _relays: Vec<TransportEndpoint>,
+        _bootstrap_relays: Vec<TransportEndpoint>,
     ) -> Result<AccountRelayListStatus, AppError> {
         let list_kind = match list_kind {
             "nip65" => NostrAccountRelayListKind::Nip65,
@@ -2045,12 +3707,8 @@ impl MarmotApp {
                 )));
             }
         };
-        self.publish_selected_account_relay_lists(
-            label,
-            AccountRelayListBootstrap::new(relays, bootstrap_relays),
-            &[list_kind],
-        )
-        .await
+        let _ = list_kind;
+        Err(AppError::AccountWorkerBusy)
     }
 
     /// Return every declared NIP-65 relay for backward-compatible list editing.
@@ -2087,31 +3745,38 @@ impl MarmotApp {
         Ok(self.account_relay_list_status(label)?.inbox.relays)
     }
 
+    /// Legacy direct-app seam retained for API compatibility; use
+    /// [`MarmotAppRuntime::set_account_nip65_relays`]. This method always fails
+    /// before reading the role-preserving relay-list cache or publishing.
     pub async fn set_account_nip65_relays(
         &self,
-        label: &str,
-        relays: Vec<TransportEndpoint>,
-        bootstrap_relays: Vec<TransportEndpoint>,
+        _label: &str,
+        _relays: Vec<TransportEndpoint>,
+        _bootstrap_relays: Vec<TransportEndpoint>,
     ) -> Result<AccountRelayListStatus, AppError> {
-        let current = self.account_relay_list_status(label)?.nip65;
-        let relay_set = nip65_relay_set_preserving_roles(&current, relays);
-        self.publish_account_nip65_relay_set(
-            label,
-            relay_set.read_relays,
-            relay_set.write_relays,
-            bootstrap_relays,
-        )
-        .await
+        Err(AppError::AccountWorkerBusy)
     }
 
-    /// Replace the account's NIP-65 list while preserving explicit relay
-    /// directions in the published kind-10002 event.
+    /// Legacy direct-app seam retained for API compatibility; use
+    /// [`MarmotAppRuntime::publish_account_nip65_relay_set`]. This method
+    /// always fails before signing or relay I/O.
     pub async fn publish_account_nip65_relay_set(
+        &self,
+        _label: &str,
+        _read_relays: Vec<TransportEndpoint>,
+        _write_relays: Vec<TransportEndpoint>,
+        _bootstrap_relays: Vec<TransportEndpoint>,
+    ) -> Result<AccountRelayListStatus, AppError> {
+        Err(AppError::AccountWorkerBusy)
+    }
+
+    pub(crate) async fn publish_account_nip65_relay_set_for_session(
         &self,
         label: &str,
         read_relays: Vec<TransportEndpoint>,
         write_relays: Vec<TransportEndpoint>,
         bootstrap_relays: Vec<TransportEndpoint>,
+        session_admission: &AccountSessionAdmissionToken,
     ) -> Result<AccountRelayListStatus, AppError> {
         let relay_set = NostrNip65RelaySet {
             read_relays: unique_transport_endpoints(read_relays),
@@ -2122,48 +3787,38 @@ impl MarmotApp {
             AccountRelayListBootstrap::new(relay_set.write_relays.clone(), bootstrap_relays),
             &[NostrAccountRelayListKind::Nip65],
             Some(&relay_set),
+            AccountRelayListMutationAdmission::Active(session_admission),
         )
         .await
     }
 
-    pub async fn set_account_inbox_relays(
+    pub(crate) async fn publish_account_inbox_relays_for_session(
         &self,
         label: &str,
         relays: Vec<TransportEndpoint>,
         bootstrap_relays: Vec<TransportEndpoint>,
+        session_admission: &AccountSessionAdmissionToken,
     ) -> Result<AccountRelayListStatus, AppError> {
-        self.set_account_relay_list_kind(
-            label,
-            NostrAccountRelayListKind::Inbox,
-            relays,
-            bootstrap_relays,
-        )
-        .await
-    }
-
-    async fn set_account_relay_list_kind(
-        &self,
-        label: &str,
-        list_kind: NostrAccountRelayListKind,
-        relays: Vec<TransportEndpoint>,
-        bootstrap_relays: Vec<TransportEndpoint>,
-    ) -> Result<AccountRelayListStatus, AppError> {
-        self.publish_selected_account_relay_lists(
+        self.publish_selected_account_relay_lists_with_nip65(
             label,
             AccountRelayListBootstrap::new(relays, bootstrap_relays),
-            &[list_kind],
+            &[NostrAccountRelayListKind::Inbox],
+            None,
+            AccountRelayListMutationAdmission::Active(session_admission),
         )
         .await
     }
 
-    async fn publish_selected_account_relay_lists(
+    /// Legacy direct-app seam retained for API compatibility; use
+    /// [`MarmotAppRuntime::set_account_inbox_relays`]. This method always fails
+    /// before signing, relay I/O, or cache mutation.
+    pub async fn set_account_inbox_relays(
         &self,
-        label: &str,
-        bootstrap: AccountRelayListBootstrap,
-        list_kinds: &[NostrAccountRelayListKind],
+        _label: &str,
+        _relays: Vec<TransportEndpoint>,
+        _bootstrap_relays: Vec<TransportEndpoint>,
     ) -> Result<AccountRelayListStatus, AppError> {
-        self.publish_selected_account_relay_lists_with_nip65(label, bootstrap, list_kinds, None)
-            .await
+        Err(AppError::AccountWorkerBusy)
     }
 
     async fn publish_selected_account_relay_lists_with_nip65(
@@ -2172,6 +3827,7 @@ impl MarmotApp {
         bootstrap: AccountRelayListBootstrap,
         list_kinds: &[NostrAccountRelayListKind],
         nip65_relay_set: Option<&NostrNip65RelaySet>,
+        admission: AccountRelayListMutationAdmission<'_>,
     ) -> Result<AccountRelayListStatus, AppError> {
         let has_directional_nip65_relays = nip65_relay_set.is_some_and(|relays| {
             !relays.read_relays.is_empty() || !relays.write_relays.is_empty()
@@ -2180,10 +3836,55 @@ impl MarmotApp {
             return Err(AppError::MissingDefaultRelays);
         }
         self.validate_account_relay_list_declarations(&bootstrap, nip65_relay_set)?;
+        let mut proposed_key_package_relays = None;
+        if list_kinds.contains(&NostrAccountRelayListKind::Nip65) {
+            let proposed = nip65_relay_set
+                .map(|relay_set| relay_set.write_relays.clone())
+                .unwrap_or_else(|| bootstrap.default_relays.clone());
+            proposed_key_package_relays =
+                Some(self.sanitize_key_package_deletion_endpoints(proposed)?);
+        }
+        // Inbox mutations use the same route lock as NIP-65. This gives
+        // teardown one final boundary for every signed relay-list event and
+        // prevents a retained caller from repopulating account caches after
+        // sign-out has completed.
+        let key_package_route_lock = self.key_package_route_lock(label);
+        let _key_package_route_guard = key_package_route_lock.lock().await;
         let account = self.account_home().account(label)?;
+        let admission_is_current = || match admission {
+            AccountRelayListMutationAdmission::Active(token) => {
+                account.is_active_signing()
+                    && account.account_id_hex == token.account_id_hex
+                    && self.active_account_session_admission_is_current(label, token)
+            }
+            AccountRelayListMutationAdmission::Setup(admission) => {
+                admission.is_current()
+                    && account.account_id_hex == admission.account_id_hex()
+                    && account.signed_out == admission.started_signed_out()
+                    && account.can_sign()
+            }
+        };
+        if !admission_is_current() {
+            return Err(AppError::AccountWorkerBusy);
+        }
         let signer = self.account_signer_for_summary(&account)?;
+        if proposed_key_package_relays.is_some() {
+            // A prior process may have exposed the new route-list event and
+            // died before committing its local projection. Replay the exact
+            // signed event (when still unacknowledged) and finish that durable
+            // intent before authoring another replaceable revision.
+            if !admission_is_current() {
+                return Err(AppError::AccountWorkerBusy);
+            }
+            self.recover_pending_nip65_route_mutation(label, signer.as_nostr_signer())
+                .await?;
+        }
+        let nip65_created_at = list_kinds
+            .contains(&NostrAccountRelayListKind::Nip65)
+            .then(|| self.next_locally_authored_nip65_created_at(label))
+            .transpose()?;
         let account_id = MemberId::new(hex::decode(&account.account_id_hex)?);
-        let account_id_hex = account.account_id_hex;
+        let account_id_hex = account.account_id_hex.clone();
         // Outbox routing: publish relay-list events to the account's own NIP-65
         // write relays; fall back to the bootstrap/seed relays on first publish
         // (no NIP-65 yet). The declared list (content) is `default_relays`, but
@@ -2204,8 +3905,9 @@ impl MarmotApp {
         let relay_client =
             self.relay_client_for_account_id(&account_id_hex, signer.as_nostr_signer());
         let mut requests = Vec::with_capacity(list_kinds.len());
+        let mut pending_nip65 = None;
         for list_kind in list_kinds {
-            let event = if *list_kind == NostrAccountRelayListKind::Nip65
+            let mut event = if *list_kind == NostrAccountRelayListKind::Nip65
                 && let Some(relays) = nip65_relay_set
             {
                 NostrNip65RelayListPublication {
@@ -2223,17 +3925,87 @@ impl MarmotApp {
                 }
                 .to_event()?
             };
+            if *list_kind == NostrAccountRelayListKind::Nip65 {
+                event.created_at =
+                    nip65_created_at.expect("a NIP-65 relay-list batch has an authoring timestamp");
+                event = self
+                    .sign_account_transport_event(signer.as_nostr_signer(), event)
+                    .await?;
+                if !admission_is_current() {
+                    return Err(AppError::AccountWorkerBusy);
+                }
+                let nip65 = relay_list_state_from_event(&event).ok_or_else(|| {
+                    AppError::Publish("signed NIP-65 event has no relay-list state".into())
+                })?;
+                let generation = Nip65RouteGeneration {
+                    created_at: event.created_at,
+                    event_id: event.id.clone(),
+                    nip65: nip65.clone(),
+                };
+                pending_nip65 = Some(PendingNip65RouteMutation {
+                    account_id_hex: account_id_hex.clone(),
+                    nip65,
+                    bootstrap_relays: endpoints
+                        .iter()
+                        .map(|endpoint| endpoint.0.clone())
+                        .collect(),
+                    publish_endpoints: endpoints
+                        .iter()
+                        .map(|endpoint| endpoint.0.clone())
+                        .collect(),
+                    signed_event: Some(event.clone()),
+                    generation,
+                    network_accepted: false,
+                    source: Nip65RouteMutationSource::AccountMutation,
+                });
+            }
             requests.push(NostrEventPublishRequest {
                 endpoints: endpoints.clone(),
                 event,
                 required_acks: 1,
             });
         }
-        for outcome in relay_client.publish_events(&requests).await {
+        if let Some(pending) = pending_nip65.as_ref() {
+            if !admission_is_current() {
+                return Err(AppError::AccountWorkerBusy);
+            }
+            // The intent precedes both the durable SQL gate and any network
+            // I/O. A crash at either following boundary therefore leaves a
+            // restart-readable reason to refuse kind-30443 publication.
+            let _root_mutation = self.begin_root_mutation("stage pending NIP-65 route mutation")?;
+            self.write_pending_nip65_route_mutation(label, pending)?;
+            self.invalidate_key_package_cutover_scan_for_route_mutation(label)?;
+            self.arm_key_package_cutover_publication_gate_for_relays(
+                label,
+                proposed_key_package_relays
+                    .as_deref()
+                    .expect("NIP-65 mutation has a proposed write-relay set"),
+            )?;
+        }
+        if !admission_is_current() {
+            return Err(AppError::AccountWorkerBusy);
+        }
+        let outcomes = relay_client.publish_events(&requests).await;
+        if outcomes.len() != list_kinds.len() {
+            return Err(AppError::Publish(format!(
+                "account relay-list batch returned {} outcomes for {} events",
+                outcomes.len(),
+                list_kinds.len()
+            )));
+        }
+        for (list_kind, outcome) in list_kinds.iter().zip(outcomes) {
             if outcome?.accepted.is_empty() {
                 return Err(AppError::Publish(
                     "relay acknowledged zero account relay-list events".to_owned(),
                 ));
+            }
+            if *list_kind == NostrAccountRelayListKind::Nip65
+                && let Some(pending) = pending_nip65.as_mut()
+            {
+                pending.network_accepted = true;
+                let _root_mutation =
+                    self.begin_root_mutation("record NIP-65 route acknowledgement")?;
+                self.write_pending_nip65_route_mutation(label, pending)?;
             }
         }
 
@@ -2246,35 +4018,11 @@ impl MarmotApp {
         for list_kind in list_kinds {
             match list_kind {
                 NostrAccountRelayListKind::Nip65 => {
-                    let (read_relays, write_relays) = nip65_relay_set
-                        .map(|relays| {
-                            (
-                                relays
-                                    .read_relays
-                                    .iter()
-                                    .map(|endpoint| endpoint.0.clone())
-                                    .collect::<Vec<_>>(),
-                                relays
-                                    .write_relays
-                                    .iter()
-                                    .map(|endpoint| endpoint.0.clone())
-                                    .collect::<Vec<_>>(),
-                            )
-                        })
-                        .unwrap_or_else(|| {
-                            let relays = bootstrap
-                                .default_relays
-                                .iter()
-                                .map(|endpoint| endpoint.0.clone())
-                                .collect::<Vec<_>>();
-                            (relays.clone(), relays)
-                        });
-                    status.nip65 = AccountRelayListState {
-                        kind: KIND_NIP65_RELAY_LIST,
-                        relays: write_relays.clone(),
-                        read_relays,
-                        write_relays,
-                    };
+                    status.nip65 = pending_nip65
+                        .as_ref()
+                        .expect("published NIP-65 event has durable intent")
+                        .nip65
+                        .clone();
                 }
                 NostrAccountRelayListKind::Inbox => {
                     status.inbox = AccountRelayListState {
@@ -2295,7 +4043,21 @@ impl MarmotApp {
             endpoints.iter().map(|endpoint| endpoint.0.clone()),
         );
         status.refresh();
+        let _root_mutation = self.begin_root_mutation("commit account relay-list publication")?;
+        let _frontier_mutation = self
+            .key_package_frontier_mutation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(pending) = pending_nip65.as_ref() {
+            // Route authority precedes its cache projection. The still-present
+            // pending intent and SQL gate make a crash between these writes
+            // restartable without exposing the previous route.
+            self.write_nip65_route_generation(label, &pending.generation)?;
+        }
         self.remember_directory_relay_lists(&account_id_hex, &status)?;
+        if pending_nip65.is_some() {
+            self.clear_pending_nip65_route_mutation(label)?;
+        }
         Ok(status)
     }
 
@@ -3476,6 +5238,7 @@ impl MarmotApp {
         Ok(group)
     }
 
+    #[cfg(test)]
     fn open_account(
         &self,
         label: &str,
@@ -3483,6 +5246,33 @@ impl MarmotApp {
         defer_group_hydration: bool,
     ) -> Result<OpenAppAccount, AppError> {
         let account = self.account_home().account(label)?;
+        let session_admission =
+            self.capture_account_session_admission(&account.label, &account.account_id_hex)?;
+        self.open_account_with_admission(
+            &account.label,
+            relay_plane,
+            defer_group_hydration,
+            AccountSessionAdmission::Active(session_admission),
+        )
+    }
+
+    fn open_account_with_admission(
+        &self,
+        label: &str,
+        relay_plane: &MarmotRelayPlane,
+        defer_group_hydration: bool,
+        session_admission: AccountSessionAdmission,
+    ) -> Result<OpenAppAccount, AppError> {
+        let account = self.account_home().account(label)?;
+        let admitted_account_id_hex = match &session_admission {
+            AccountSessionAdmission::Active(token) => &token.account_id_hex,
+            AccountSessionAdmission::Teardown(token) => &token.account_id_hex,
+        };
+        if account.account_id_hex != *admitted_account_id_hex
+            || !self.account_open_admission_is_current(&account.label, &session_admission)
+        {
+            return Err(AppError::AccountWorkerBusy);
+        }
         // Account refs may be labels, hex pubkeys, or npubs. Ownership is keyed
         // by the canonical stored label so aliases cannot open a second engine.
         let label = account.label.as_str();
@@ -3559,8 +5349,28 @@ impl MarmotApp {
             session_config = session_config.recorder(recorder);
         }
         self.ensure_strict_cutover_replacement_intent_before_session_open(label)?;
+        self.canonicalize_key_package_lifecycle_targets_before_session_open(label)?;
+        // `AccountDeviceSession` opens its own SQLCipher connection rather than
+        // cloning `account_storages`. Hold storage-open admission until that
+        // connection is published into the terminal-close registry: the close
+        // writer must see either no connection or a closeable handle for every
+        // successfully opened session.
+        let storage_lifecycle = self.begin_storage_open("account session storage")?;
         let session =
             AccountDeviceSession::open(session_config).map_err(external_signer_session_error)?;
+        self.account_session_storages
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(label.to_owned(), session.storage_handle());
+        // Do not carry the read guard into `routing_for`: its database helpers
+        // take their own storage-open admission, and a pending close writer
+        // could otherwise turn that nested read into a self-deadlock. The
+        // session is now published, so terminal close can safely proceed.
+        drop(storage_lifecycle);
+
+        if !self.account_open_admission_is_current(label, &session_admission) {
+            return Err(AppError::AccountWorkerBusy);
+        }
 
         let publish_client =
             self.relay_client_for_account_id(&account.account_id_hex, nostr_signer.clone());
@@ -3583,18 +5393,29 @@ impl MarmotApp {
             publish_client,
             Some(recovery_marker),
         );
+        self.account_session_adapters
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(label.to_owned(), adapter.clone());
 
         let key_packages = AppKeyPackagePublisher {
             app: self.clone(),
             account_label: label.to_owned(),
             signer: signer.clone(),
+            session_admission: session_admission.clone(),
         };
         let routing = self.routing_for(&state)?;
-        let runtime =
+        let mut runtime =
             AccountDeviceRuntime::new(session, adapter.clone(), routing.clone(), key_packages);
+        // Schema-51 retained only one overwritten Welcome-consumption marker.
+        // Resolve that one-time ambiguity synchronously under the newly opened
+        // account writer before transport activation can ingest another Welcome
+        // and destroy the detectable legacy shape.
+        runtime.sweep_expired_key_package_private_material()?;
         Ok(OpenAppAccount {
             runtime,
             session_guard,
+            session_admission,
             adapter,
             routing,
             state,
@@ -3615,7 +5436,17 @@ impl MarmotApp {
         Ok(AppAccountSessionGuard {
             label: label.to_owned(),
             owners: self.account_session_owners.clone(),
+            storages: self.account_session_storages.clone(),
+            adapters: self.account_session_adapters.clone(),
         })
+    }
+
+    fn account_session_adapter(&self, label: &str) -> Option<MarmotRelayPlaneAccountAdapter> {
+        self.account_session_adapters
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(label)
+            .cloned()
     }
 
     fn routing_for(&self, state: &AccountState) -> Result<AppTransportRouting, AppError> {
@@ -3706,20 +5537,24 @@ impl MarmotApp {
         Ok(key_package.with_protocol_profile(metadata.protocol_profile))
     }
 
-    /// Best-effort public-event cleanup after the session has already
-    /// transactionally removed the matching non-current private bundle.
-    ///
-    /// A failed relay deletion deliberately leaves the cache record in place:
-    /// the current replacement then reuses the same replaceable-event `d`
-    /// slot, superseding the legacy event wherever the deletion was missed.
-    /// If replacement publication also fails, the next account open retries
-    /// from the unchanged cache.
-    async fn retire_cached_non_current_key_package(&self, label: &str) -> bool {
+    /// Durably admit an exact non-current cache revision before any deletion or
+    /// replacement publication can escape. Historical endpoints come only from
+    /// the account-private observation of this exact event; current routing is
+    /// never substituted. Unknown provenance, malformed JSON, invalid ids, and
+    /// capacity-deferred endpoints keep both the cache and cutover pending.
+    fn retire_cached_non_current_key_package(
+        &self,
+        label: &str,
+        runtime: &mut AppRuntime,
+    ) -> CachedKeyPackageRetirementAdmission {
         let path = self.key_package_record_path(label);
         let record = match read_json::<KeyPackageRecord>(&path) {
             Ok(record) => record,
             Err(AppError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
-                return false;
+                return CachedKeyPackageRetirementAdmission {
+                    complete: true,
+                    event_id: None,
+                };
             }
             Err(error) => {
                 tracing::warn!(
@@ -3728,83 +5563,559 @@ impl MarmotApp {
                     error_kind = error.privacy_safe_kind(),
                     "could not classify cached key package after strict cutover"
                 );
-                if !self.mark_key_package_cutover_replacement_pending(label) {
-                    return false;
-                }
-                match fs::remove_file(&path) {
-                    Ok(()) => {}
-                    Err(remove_error) if remove_error.kind() == std::io::ErrorKind::NotFound => {}
-                    Err(remove_error) => tracing::warn!(
-                        target: "marmot_app::key_packages",
-                        method = "retire_cached_non_current_key_package",
-                        error_kind = AppError::from(remove_error).privacy_safe_kind(),
-                        "could not remove invalid key package cache"
-                    ),
-                }
-                return true;
+                let _ = self.mark_key_package_cutover_replacement_pending(label);
+                return CachedKeyPackageRetirementAdmission {
+                    complete: false,
+                    event_id: None,
+                };
             }
         };
-        let is_current = key_package_from_hex_with_optional_source(
+        let current_metadata = key_package_from_hex_with_optional_source(
             &record.key_package_hex,
             &record.key_package_event_id,
         )
         .ok()
-        .and_then(|key_package| key_package_metadata(&key_package).ok())
-        .is_some_and(|metadata| {
-            self.key_package_metadata_matches_current_support(&metadata)
-                && metadata.credential_identity_hex == record.account_id_hex
-        });
-        if is_current {
-            return false;
-        }
-        if !self.mark_key_package_cutover_replacement_pending(label) {
-            return false;
-        }
-
-        if record.key_package_event_id.is_empty() {
-            match fs::remove_file(path) {
-                Ok(()) => {}
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-                Err(error) => tracing::warn!(
+        .and_then(|key_package| key_package_metadata(&key_package).ok());
+        let account = match self.account_home().account(label) {
+            Ok(account) => account,
+            Err(error) => {
+                tracing::warn!(
                     target: "marmot_app::key_packages",
                     method = "retire_cached_non_current_key_package",
                     error_kind = AppError::from(error).privacy_safe_kind(),
-                    "could not remove unpublished non-current key package cache"
-                ),
+                    "could not resolve cached key package account"
+                );
+                return CachedKeyPackageRetirementAdmission {
+                    complete: false,
+                    event_id: None,
+                };
             }
-            return true;
+        };
+        let lifecycle = runtime.key_package_maintenance_status().ok().flatten();
+        let parsed_event_id = (!record.key_package_event_id.is_empty()).then(|| {
+            parse_key_package_event_id_hex(&record.key_package_event_id).and_then(|event_id_hex| {
+                hex::decode(event_id_hex)
+                    .map(MessageId::new)
+                    .map_err(AppError::from)
+            })
+        });
+        let (exact_cached_endpoints, exact_cached_created_at) = parsed_event_id
+            .as_ref()
+            .and_then(|result| result.as_ref().ok())
+            .map(|_| {
+                self.cached_key_package_provenance(
+                    &account,
+                    &record,
+                    (!record.key_package_ref_hex.is_empty())
+                        .then_some(record.key_package_ref_hex.as_str()),
+                )
+            })
+            .unwrap_or_default();
+        let cache_matches_local_coordinate = lifecycle.as_ref().is_some_and(|lifecycle| {
+            !lifecycle.stable_slot_id.is_empty()
+                && lifecycle.stable_slot_id == record.key_package_id
+                && record.account_id_hex == account.account_id_hex
+        });
+        if current_metadata.as_ref().is_some_and(|metadata| {
+            self.key_package_metadata_matches_current_support(metadata)
+                && metadata.credential_identity_hex == account.account_id_hex
+                && (record.key_package_ref_hex.is_empty()
+                    || record
+                        .key_package_ref_hex
+                        .eq_ignore_ascii_case(&metadata.key_package_ref_hex))
+        }) && cache_matches_local_coordinate
+            && let Some(lifecycle) = lifecycle.as_ref()
+        {
+            if parsed_event_id.is_none() {
+                let matches_current_ref = current_metadata.as_ref().is_some_and(|metadata| {
+                    lifecycle
+                        .current_key_package_ref
+                        .as_ref()
+                        .is_some_and(|current_ref| {
+                            hex::encode(current_ref)
+                                .eq_ignore_ascii_case(&metadata.key_package_ref_hex)
+                        })
+                });
+                if matches_current_ref {
+                    return CachedKeyPackageRetirementAdmission {
+                        complete: true,
+                        event_id: None,
+                    };
+                }
+            } else if let Some(Ok(event_id)) = parsed_event_id.as_ref() {
+                let cached_endpoints_are_covered =
+                    |targets: &[cgka_traits::TransportFanoutTarget]| {
+                        exact_cached_endpoints.iter().all(|endpoint| {
+                            targets.iter().any(|target| target.endpoint == *endpoint)
+                        })
+                    };
+                let signed_live_exact = lifecycle
+                    .authored_signed_event
+                    .as_ref()
+                    .is_some_and(|artifact| artifact.id == *event_id)
+                    && !lifecycle.publication_targets.is_empty()
+                    && cached_endpoints_are_covered(&lifecycle.publication_targets);
+                let imported_live_exact = lifecycle.authored_event_id.as_ref() == Some(event_id)
+                    && !exact_cached_endpoints.is_empty()
+                    && exact_cached_endpoints.iter().all(|endpoint| {
+                        lifecycle
+                            .publication_targets
+                            .iter()
+                            .any(|target| target.endpoint == *endpoint)
+                    });
+                let pending_exact = lifecycle
+                    .pending_replacement
+                    .as_ref()
+                    .and_then(|pending| {
+                        pending
+                            .signed_event
+                            .as_ref()
+                            .map(|artifact| (pending, artifact))
+                    })
+                    .is_some_and(|(pending, artifact)| {
+                        artifact.id == *event_id
+                            && !pending.targets.is_empty()
+                            && cached_endpoints_are_covered(&pending.targets)
+                    });
+                if signed_live_exact || imported_live_exact || pending_exact {
+                    return CachedKeyPackageRetirementAdmission {
+                        complete: true,
+                        event_id: None,
+                    };
+                }
+                let exact_retired = lifecycle
+                    .retired_publications_pending_deletion
+                    .iter()
+                    .find(|retired| retired.event_id == *event_id);
+                if exact_retired.is_some_and(|retired| {
+                    !retired.deletion_targets.is_empty()
+                        && cached_endpoints_are_covered(&retired.deletion_targets)
+                }) {
+                    return CachedKeyPackageRetirementAdmission {
+                        complete: true,
+                        event_id: Some(event_id.clone()),
+                    };
+                }
+            }
+        }
+        if !self.mark_key_package_cutover_replacement_pending(label) {
+            return CachedKeyPackageRetirementAdmission {
+                complete: false,
+                event_id: None,
+            };
         }
 
-        match self
-            .delete_key_package_event(label, &record.key_package_event_id, Vec::new())
-            .await
-        {
-            Ok(accepted) => tracing::info!(
-                target: "marmot_app::key_packages",
-                method = "retire_cached_non_current_key_package",
-                relay_accept_count = accepted,
-                "retired cached non-current key package event"
-            ),
-            Err(error) => tracing::warn!(
-                target: "marmot_app::key_packages",
-                method = "retire_cached_non_current_key_package",
-                error_kind = error.privacy_safe_kind(),
-                "could not delete cached non-current key package event; current replacement will supersede its slot"
-            ),
+        if record.key_package_event_id.is_empty() {
+            let complete = match fs::remove_file(path) {
+                Ok(()) => true,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => true,
+                Err(error) => {
+                    tracing::warn!(
+                        target: "marmot_app::key_packages",
+                        method = "retire_cached_non_current_key_package",
+                        error_kind = AppError::from(error).privacy_safe_kind(),
+                        "could not remove unpublished non-current key package cache"
+                    );
+                    false
+                }
+            };
+            return CachedKeyPackageRetirementAdmission {
+                complete,
+                event_id: None,
+            };
         }
-        true
+        let event_id = match parsed_event_id.expect("non-empty cached event id was parsed") {
+            Ok(event_id) => event_id,
+            Err(error) => {
+                tracing::warn!(
+                    target: "marmot_app::key_packages",
+                    method = "retire_cached_non_current_key_package",
+                    error_kind = error.privacy_safe_kind(),
+                    "could not durably admit cached key package event with invalid identity"
+                );
+                return CachedKeyPackageRetirementAdmission {
+                    complete: false,
+                    event_id: None,
+                };
+            }
+        };
+        if record.account_id_hex != account.account_id_hex {
+            return CachedKeyPackageRetirementAdmission {
+                complete: false,
+                event_id: Some(event_id),
+            };
+        }
+        let historical_endpoints = exact_cached_endpoints;
+        if record.key_package_id.is_empty() || historical_endpoints.is_empty() {
+            return CachedKeyPackageRetirementAdmission {
+                complete: false,
+                event_id: Some(event_id),
+            };
+        }
+        let complete = match runtime.journal_discovered_unparsed_key_package_publication(
+            record.key_package_id.clone(),
+            event_id.clone(),
+            Timestamp(
+                exact_cached_created_at
+                    .map(|cached| cached.max(record.published_at))
+                    .unwrap_or(record.published_at),
+            ),
+            historical_endpoints,
+        ) {
+            Ok((_admitted, deferred)) => deferred.is_empty(),
+            Err(error) => {
+                tracing::warn!(
+                    target: "marmot_app::key_packages",
+                    method = "retire_cached_non_current_key_package",
+                    error_kind = AppError::from(error).privacy_safe_kind(),
+                    "could not durably admit cached key package deletion liability"
+                );
+                false
+            }
+        };
+        CachedKeyPackageRetirementAdmission {
+            complete,
+            event_id: Some(event_id),
+        }
     }
 
-    /// Scan the account's authoritative KeyPackage relays and best-effort
-    /// delete every still-discoverable legacy event. This runs on each account
-    /// open, so a crash or partial relay outage simply leaves work for the next
-    /// restart. Local private bundles have already been retired synchronously.
-    async fn retire_relay_non_current_key_packages(&self, label: &str) -> bool {
-        if self.key_package_cutover_scan_complete(label)
-            && !self.key_package_cutover_replacement_pending(label)
+    fn remove_terminal_cached_key_package_record(&self, label: &str, event_id: &MessageId) {
+        let Ok(Some(lifecycle)) = self
+            .account_storage(label)
+            .and_then(|storage| storage.key_package_lifecycle().map_err(AppError::from))
+        else {
+            // Failure to prove terminal durable state must retain the only
+            // local exact-event cache rather than turn a read error into loss.
+            return;
+        };
+        if lifecycle
+            .retired_publications_pending_deletion
+            .iter()
+            .any(|retired| retired.event_id == *event_id)
         {
-            return false;
+            return;
         }
+        let path = self.key_package_record_path(label);
+        let Ok(record) = read_json::<KeyPackageRecord>(&path) else {
+            return;
+        };
+        let Ok(record_event_id_hex) = parse_key_package_event_id_hex(&record.key_package_event_id)
+        else {
+            return;
+        };
+        if record_event_id_hex != hex::encode(event_id.as_slice()) {
+            // A concurrent cache refresh may already have installed another
+            // exact revision. Never remove it while finalizing this one.
+            return;
+        }
+        match fs::remove_file(path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => tracing::warn!(
+                target: "marmot_app::key_packages",
+                method = "remove_terminal_cached_key_package_record",
+                error_kind = AppError::from(error).privacy_safe_kind(),
+                "could not remove terminal cached key package record"
+            ),
+        }
+    }
+
+    fn journal_unparsed_relay_key_package_revision(
+        &self,
+        runtime: &mut AppRuntime,
+        stable_slot_id: &str,
+        event_id_hex: &str,
+        authored_created_at: u64,
+        source_endpoints: Vec<TransportEndpoint>,
+    ) -> Result<(usize, usize), AppError> {
+        let event_id_hex = parse_key_package_event_id_hex(event_id_hex)?;
+        let event_id = MessageId::new(hex::decode(event_id_hex)?);
+        let (admitted, deferred) = runtime
+            .journal_discovered_unparsed_key_package_publication(
+                stable_slot_id.to_owned(),
+                event_id,
+                Timestamp(authored_created_at),
+                source_endpoints,
+            )
+            .map_err(AppError::from)?;
+        Ok((admitted.len(), deferred.len()))
+    }
+
+    fn admit_relay_key_package_records(
+        &self,
+        label: &str,
+        runtime: &mut AppRuntime,
+        records: Vec<RelayEventRecord>,
+        delete_without_successor: bool,
+    ) -> Result<KeyPackageRelayAdmissionSummary, AppError> {
+        let lifecycle = runtime
+            .key_package_maintenance_status()
+            .map_err(AppError::from)?
+            .filter(|lifecycle| !lifecycle.stable_slot_id.is_empty())
+            .ok_or_else(|| {
+                AppError::Publish(
+                    "relay key package retirement requires lifecycle slot authority".into(),
+                )
+            })?;
+        let stable_slot_id = lifecycle.stable_slot_id.clone();
+        let mut live_event_ids = HashSet::new();
+        if let Some(event_id) = lifecycle
+            .authored_event_id
+            .as_ref()
+            .filter(|event_id| !lifecycle.deleted_live_revision_event_ids.contains(event_id))
+        {
+            live_event_ids.insert(hex::encode(event_id.as_slice()));
+        }
+        if let Some(artifact) = lifecycle.authored_signed_event.as_ref().filter(|artifact| {
+            !lifecycle
+                .deleted_live_revision_event_ids
+                .contains(&artifact.id)
+        }) {
+            live_event_ids.insert(hex::encode(artifact.id.as_slice()));
+        }
+        if let Some(artifact) = lifecycle
+            .pending_replacement
+            .as_ref()
+            .and_then(|pending| pending.signed_event.as_ref())
+            .filter(|artifact| {
+                !lifecycle
+                    .deleted_live_revision_event_ids
+                    .contains(&artifact.id)
+            })
+        {
+            live_event_ids.insert(hex::encode(artifact.id.as_slice()));
+        }
+        let local_live_artifact_created_at = lifecycle
+            .authored_signed_event
+            .as_ref()
+            .map(|artifact| artifact.created_at.0)
+            .into_iter()
+            .chain(
+                lifecycle
+                    .pending_replacement
+                    .as_ref()
+                    .and_then(|pending| pending.signed_event.as_ref())
+                    .map(|artifact| artifact.created_at.0),
+            )
+            .max();
+
+        let mut summary = KeyPackageRelayAdmissionSummary::default();
+        for record in records {
+            let event_id = record.event.id.clone();
+            let authored_created_at = record.event.created_at;
+            let raw_endpoints = record.endpoints.clone();
+            if record.event.tag_value("d") != Some(stable_slot_id.as_str()) {
+                // One Nostr account can have several device-local `d` slots.
+                // An account-wide relay query must not turn a sibling device's
+                // revision into deletion work for this lifecycle.
+                continue;
+            }
+            if live_event_ids.contains(&event_id) {
+                let observed = hex::decode(&event_id)
+                    .map(MessageId::new)
+                    .map_err(AppError::from)
+                    .and_then(|event_id| {
+                        runtime
+                            .observe_live_key_package_publication(
+                                stable_slot_id.clone(),
+                                &event_id,
+                                Timestamp(authored_created_at),
+                                raw_endpoints.clone(),
+                            )
+                            .map_err(AppError::from)
+                    });
+                match observed {
+                    Ok((_admitted, deferred)) if deferred.is_empty() => {}
+                    Ok((_admitted, deferred)) => {
+                        summary.deferred_endpoint_count = summary
+                            .deferred_endpoint_count
+                            .saturating_add(deferred.len());
+                        summary.admission_failure_count += 1;
+                    }
+                    Err(_) => summary.admission_failure_count += 1,
+                }
+                continue;
+            }
+
+            match key_package_from_record(record) {
+                Ok(fetched) => {
+                    if fetched.key_package_id != stable_slot_id {
+                        continue;
+                    }
+                    let metadata = match key_package_metadata(&fetched.key_package) {
+                        Ok(metadata) => metadata,
+                        Err(_) => {
+                            if !self.mark_key_package_cutover_replacement_pending(label) {
+                                summary.admission_failure_count += 1;
+                            }
+                            summary.non_current_event_count += 1;
+                            match self.journal_unparsed_relay_key_package_revision(
+                                runtime,
+                                &stable_slot_id,
+                                &fetched.key_package_event_id,
+                                fetched.created_at,
+                                fetched
+                                    .source_relays
+                                    .into_iter()
+                                    .map(TransportEndpoint)
+                                    .collect(),
+                            ) {
+                                Ok((_admitted, deferred)) => {
+                                    summary.deferred_endpoint_count =
+                                        summary.deferred_endpoint_count.saturating_add(deferred);
+                                    if deferred > 0 {
+                                        summary.admission_failure_count += 1;
+                                    }
+                                }
+                                Err(_) => summary.admission_failure_count += 1,
+                            }
+                            continue;
+                        }
+                    };
+                    // NIP-33 resolves equal timestamps by event-id tie-break.
+                    // This is already a different exact id, so equality is not
+                    // enough to prove the local artifact will supersede it.
+                    let discovered_can_compete_with_local_artifact = local_live_artifact_created_at
+                        .is_none_or(|created_at| fetched.created_at >= created_at);
+                    if (!self.key_package_metadata_matches_current_support(&metadata)
+                        || discovered_can_compete_with_local_artifact)
+                        && !self.mark_key_package_cutover_replacement_pending(label)
+                    {
+                        summary.admission_failure_count += 1;
+                    }
+                    let event_id_hex =
+                        match parse_key_package_event_id_hex(&fetched.key_package_event_id) {
+                            Ok(event_id_hex) => event_id_hex,
+                            Err(_) => {
+                                summary.admission_failure_count += 1;
+                                continue;
+                            }
+                        };
+                    let key_package_ref = match hex::decode(&fetched.key_package_ref_hex) {
+                        Ok(key_package_ref) => key_package_ref,
+                        Err(_) => {
+                            summary.admission_failure_count += 1;
+                            continue;
+                        }
+                    };
+                    let endpoints = match self.sanitize_key_package_deletion_endpoints(
+                        fetched
+                            .source_relays
+                            .into_iter()
+                            .map(TransportEndpoint)
+                            .collect(),
+                    ) {
+                        Ok(endpoints) if !endpoints.is_empty() => endpoints,
+                        Ok(_) | Err(_) => {
+                            summary.admission_failure_count += 1;
+                            continue;
+                        }
+                    };
+                    let event_id = MessageId::new(
+                        hex::decode(event_id_hex)
+                            .expect("validated key package event id remains hex"),
+                    );
+                    match runtime.journal_discovered_retired_key_package_publication_with_policy(
+                        stable_slot_id.clone(),
+                        event_id,
+                        Timestamp(fetched.created_at),
+                        key_package_ref,
+                        Timestamp(metadata.not_after),
+                        endpoints,
+                        delete_without_successor,
+                    ) {
+                        Ok((_admitted, deferred)) => {
+                            summary.discovered_current_revision_count += 1;
+                            summary.deferred_endpoint_count = summary
+                                .deferred_endpoint_count
+                                .saturating_add(deferred.len());
+                            if !deferred.is_empty() {
+                                summary.admission_failure_count += 1;
+                            }
+                        }
+                        Err(_) => summary.admission_failure_count += 1,
+                    }
+                }
+                Err(_) => {
+                    if !self.mark_key_package_cutover_replacement_pending(label) {
+                        summary.admission_failure_count += 1;
+                    }
+                    summary.non_current_event_count += 1;
+                    match self.journal_unparsed_relay_key_package_revision(
+                        runtime,
+                        &stable_slot_id,
+                        &event_id,
+                        authored_created_at,
+                        raw_endpoints,
+                    ) {
+                        Ok((_admitted, deferred)) => {
+                            summary.deferred_endpoint_count =
+                                summary.deferred_endpoint_count.saturating_add(deferred);
+                            if deferred > 0 {
+                                summary.admission_failure_count += 1;
+                            }
+                        }
+                        Err(_) => summary.admission_failure_count += 1,
+                    }
+                }
+            }
+        }
+        Ok(summary)
+    }
+
+    fn retired_key_package_deletion_target_endpoints(
+        runtime: &AppRuntime,
+    ) -> Result<Vec<TransportEndpoint>, AppError> {
+        let mut endpoints = runtime
+            .key_package_maintenance_status()
+            .map_err(AppError::from)?
+            .into_iter()
+            .flat_map(|lifecycle| lifecycle.retired_publications_pending_deletion)
+            .flat_map(|retired| retired.deletion_targets)
+            .map(|target| target.endpoint)
+            .collect::<Vec<_>>();
+        endpoints.sort();
+        endpoints.dedup();
+        Ok(endpoints)
+    }
+
+    /// Scan the account's authoritative KeyPackage relays for revisions in this
+    /// device's stable slot. Valid current-profile predecessors are durably
+    /// journaled before any deletion I/O, then retried through the account
+    /// runtime so successor eligibility and per-endpoint receipts remain
+    /// authoritative. Sibling-device slots and the exact live current/pending
+    /// ids are never classified as local retirement work.
+    async fn retire_relay_non_current_key_packages(
+        &self,
+        label: &str,
+        runtime: &mut AppRuntime,
+    ) -> bool {
+        self.retire_relay_non_current_key_packages_with_policy(label, runtime, false)
+            .await
+    }
+
+    async fn retire_relay_non_current_key_packages_for_teardown(
+        &self,
+        label: &str,
+        runtime: &mut AppRuntime,
+    ) -> bool {
+        self.retire_relay_non_current_key_packages_with_policy(label, runtime, true)
+            .await
+    }
+
+    async fn retire_relay_non_current_key_packages_with_policy(
+        &self,
+        label: &str,
+        runtime: &mut AppRuntime,
+        authorize_without_successor: bool,
+    ) -> bool {
+        let destructive_cleanup_was_durable = match self.key_package_teardown_cleanup_pending(label)
+        {
+            Ok(pending) => pending,
+            Err(_) => return false,
+        };
+        let authorize_without_successor =
+            authorize_without_successor || destructive_cleanup_was_durable;
         let account = match self.account_home().account(label) {
             Ok(account) => account,
             Err(error) => {
@@ -3837,73 +6148,637 @@ impl MarmotApp {
             .cloned()
             .map(TransportEndpoint)
             .collect::<Vec<_>>();
-        if source_relays.is_empty() {
+        let source_relays = match self.sanitize_key_package_deletion_endpoints(source_relays) {
+            Ok(source_relays) if !source_relays.is_empty() => source_relays,
+            Ok(_) | Err(_) => return false,
+        };
+        let history_lock = self.key_package_history_lock(label);
+        let history_guard = history_lock.lock().await;
+        let lifecycle = match runtime.key_package_maintenance_status() {
+            Ok(Some(lifecycle)) if !lifecycle.stable_slot_id.is_empty() => lifecycle,
+            Ok(_) => {
+                tracing::warn!(
+                    target: "marmot_app::key_packages",
+                    method = "retire_relay_non_current_key_packages",
+                    error_kind = "missing_stable_slot",
+                    "deferred relay key package retirement scan without lifecycle slot authority"
+                );
+                return false;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    target: "marmot_app::key_packages",
+                    method = "retire_relay_non_current_key_packages",
+                    error_kind = AppError::from(error).privacy_safe_kind(),
+                    "could not read lifecycle authority for relay key package retirement"
+                );
+                return false;
+            }
+        };
+        if authorize_without_successor
+            && runtime
+                .authorize_teardown_key_package_deletions_without_successor()
+                .is_err()
+        {
             return false;
         }
-        let records = match self
-            .fetch_key_package_events_for_account_id_with_limit(
-                &account.account_id_hex,
-                &source_relays,
-                KEY_PACKAGE_CUTOVER_RELAY_SCAN_LIMIT,
-            )
-            .await
+        let known_history_relays = match self.key_package_lifecycle_history_endpoints(&lifecycle) {
+            Ok(endpoints) => endpoints,
+            Err(_) => return false,
+        };
+        let durable_history_relays = match self.key_package_cutover_relay_history(label) {
+            Ok(endpoints) => endpoints,
+            Err(_) => return false,
+        };
+        if self.key_package_cutover_scan_complete_for_relays(label, &source_relays) {
+            // A fresh-account proof is endpoint-independent only until the
+            // account's first completed open. Bind it to the then-current
+            // authoritative set so later NIP-65 additions/re-additions re-arm
+            // the scan instead of inheriting the one-time creation proof.
+            if runtime
+                .finalize_key_package_cutover_consumption_evidence()
+                .is_err()
+            {
+                return false;
+            }
+            let Ok(_root_mutation) =
+                self.begin_root_mutation("bind fresh KeyPackage cutover scan marker")
+            else {
+                return false;
+            };
+            let proof_relays = source_relays
+                .iter()
+                .cloned()
+                .chain(known_history_relays.iter().cloned())
+                .collect::<BTreeSet<_>>();
+            return self
+                .mark_key_package_cutover_scan_complete_for_relays(
+                    label,
+                    &source_relays,
+                    &proof_relays,
+                )
+                .is_ok();
+        }
         {
-            Ok(records) => records,
+            let Ok(_root_mutation) =
+                self.begin_root_mutation("invalidate incomplete KeyPackage history proof")
+            else {
+                return false;
+            };
+            let _frontier_mutation = self
+                .key_package_frontier_mutation_lock
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if self
+                .invalidate_key_package_cutover_scan_marker(label)
+                .is_err()
+            {
+                return false;
+            }
+        }
+        let mut relay_frontier = match self.key_package_cutover_relay_frontier(label) {
+            Ok(frontier) => frontier,
             Err(error) => {
                 tracing::warn!(
                     target: "marmot_app::key_packages",
                     method = "retire_relay_non_current_key_packages",
                     error_kind = error.privacy_safe_kind(),
-                    "deferred relay key package retirement scan"
+                    "could not read the durable KeyPackage relay-history frontier"
                 );
                 return false;
             }
         };
-
+        // An aggregate directory fetch is intentionally partial-success: if
+        // one relay connects, callers can still use what it returned. That is
+        // not strong enough for a durable scan-complete proof. Query each
+        // authoritative relay and every crash-recovery frontier relay
+        // independently and in parallel, requiring this invocation's own EOSE
+        // from each endpoint. A historical frontier relay can be absent from
+        // the current NIP-65 route and must not be forgotten for that reason.
+        let stable_slot_id = lifecycle.stable_slot_id.clone();
+        let mut live_event_ids = HashSet::new();
+        if let Some(event_id) = lifecycle
+            .authored_event_id
+            .as_ref()
+            .filter(|event_id| !lifecycle.deleted_live_revision_event_ids.contains(event_id))
+        {
+            live_event_ids.insert(hex::encode(event_id.as_slice()));
+        }
+        if let Some(artifact) = lifecycle.authored_signed_event.as_ref().filter(|artifact| {
+            !lifecycle
+                .deleted_live_revision_event_ids
+                .contains(&artifact.id)
+        }) {
+            live_event_ids.insert(hex::encode(artifact.id.as_slice()));
+        }
+        if let Some(artifact) = lifecycle
+            .pending_replacement
+            .as_ref()
+            .and_then(|pending| pending.signed_event.as_ref())
+            .filter(|artifact| {
+                !lifecycle
+                    .deleted_live_revision_event_ids
+                    .contains(&artifact.id)
+            })
+        {
+            live_event_ids.insert(hex::encode(artifact.id.as_slice()));
+        }
+        let local_live_artifact_created_at = lifecycle
+            .authored_signed_event
+            .as_ref()
+            .map(|artifact| artifact.created_at.0)
+            .into_iter()
+            .chain(
+                lifecycle
+                    .pending_replacement
+                    .as_ref()
+                    .and_then(|pending| pending.signed_event.as_ref())
+                    .map(|artifact| artifact.created_at.0),
+            )
+            .max();
+        let scan_relays = source_relays
+            .iter()
+            .cloned()
+            .chain(relay_frontier.iter().cloned())
+            // A settled historical relay carries its last strict short-page
+            // proof in the monotonic ledger. Do not make every later route
+            // edit depend on an offline retired relay forever. Current source
+            // relays and any newly armed deletion frontier are always scanned
+            // again; lifecycle-only history needs a fresh scan only until its
+            // first proof is durably transferred into that ledger.
+            .chain(
+                known_history_relays
+                    .difference(&durable_history_relays)
+                    .cloned(),
+            )
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let per_relay_records = futures::future::join_all(scan_relays.iter().map(|endpoint| {
+            self.fetch_key_package_events_for_account_id_with_limit_strict(
+                &account.account_id_hex,
+                std::slice::from_ref(endpoint),
+                KEY_PACKAGE_CUTOVER_RELAY_SCAN_LIMIT,
+            )
+        }))
+        .await;
+        let mut records = Vec::new();
+        let mut all_required_relays_scanned = true;
+        let mut scan_was_truncated = false;
+        let mut frontier_clear_candidates = BTreeSet::new();
+        let mut scanned_history_relays = durable_history_relays;
+        for (endpoint, fetched) in scan_relays.iter().zip(per_relay_records) {
+            let relay_records = match fetched {
+                Ok(records) => records,
+                Err(error) => {
+                    all_required_relays_scanned = false;
+                    tracing::warn!(
+                        target: "marmot_app::key_packages",
+                        method = "retire_relay_non_current_key_packages",
+                        error_kind = error.privacy_safe_kind(),
+                        "required relay did not complete a strict EOSE scan; processing reachable relay revisions while retaining the cutover gate"
+                    );
+                    continue;
+                }
+            };
+            let page_was_truncated = relay_records.len() >= KEY_PACKAGE_CUTOVER_RELAY_SCAN_LIMIT;
+            scan_was_truncated |= page_was_truncated;
+            if !page_was_truncated {
+                scanned_history_relays.insert(endpoint.clone());
+            }
+            if relay_frontier.contains(endpoint) && !page_was_truncated {
+                frontier_clear_candidates.insert(endpoint.clone());
+            }
+            records.extend(relay_records);
+        }
         let mut non_current_event_count = 0usize;
-        let mut accepted_delete_count = 0usize;
-        let mut delete_failure_count = 0usize;
+        let mut discovered_current_revision_count = 0usize;
+        let mut deferred_endpoint_count = 0usize;
+        let mut admission_failure_count = 0usize;
         for record in records {
             let event_id = record.event.id.clone();
-            let endpoints = record.endpoints.clone();
-            let is_current = key_package_from_record(record)
-                .ok()
-                .and_then(|fetched| key_package_metadata(&fetched.key_package).ok())
-                .is_some_and(|metadata| {
-                    self.key_package_metadata_matches_current_support(&metadata)
-                });
-            if is_current {
+            let authored_created_at = record.event.created_at;
+            let raw_endpoints = record.endpoints.clone();
+            if record.event.tag_value("d") != Some(stable_slot_id.as_str()) {
+                // One Nostr account can have several device-local `d` slots.
+                // An account-wide relay query must not turn a sibling device's
+                // revision into deletion work for this lifecycle.
                 continue;
             }
-            if !self.mark_key_package_cutover_replacement_pending(label) {
-                delete_failure_count += 1;
+            if live_event_ids.contains(&event_id) {
+                let observed = hex::decode(&event_id)
+                    .map(MessageId::new)
+                    .map_err(AppError::from)
+                    .and_then(|event_id| {
+                        runtime
+                            .observe_live_key_package_publication(
+                                stable_slot_id.clone(),
+                                &event_id,
+                                Timestamp(authored_created_at),
+                                raw_endpoints.clone(),
+                            )
+                            .map_err(AppError::from)
+                    });
+                match observed {
+                    Ok((_admitted, deferred)) if deferred.is_empty() => {}
+                    Ok((_admitted, deferred)) => {
+                        deferred_endpoint_count =
+                            deferred_endpoint_count.saturating_add(deferred.len());
+                        admission_failure_count += 1;
+                    }
+                    Err(_) => admission_failure_count += 1,
+                }
                 continue;
             }
-            non_current_event_count += 1;
-            match self
-                .delete_key_package_event(label, &event_id, endpoints)
-                .await
+
+            match key_package_from_record(record) {
+                Ok(fetched) => {
+                    if fetched.key_package_id != stable_slot_id {
+                        continue;
+                    }
+                    let metadata = match key_package_metadata(&fetched.key_package) {
+                        Ok(metadata) => metadata,
+                        Err(_) => {
+                            if !self.mark_key_package_cutover_replacement_pending(label) {
+                                admission_failure_count += 1;
+                            }
+                            non_current_event_count += 1;
+                            match self.journal_unparsed_relay_key_package_revision(
+                                runtime,
+                                &stable_slot_id,
+                                &fetched.key_package_event_id,
+                                fetched.created_at,
+                                fetched
+                                    .source_relays
+                                    .into_iter()
+                                    .map(TransportEndpoint)
+                                    .collect(),
+                            ) {
+                                Ok((_admitted, deferred)) => {
+                                    deferred_endpoint_count =
+                                        deferred_endpoint_count.saturating_add(deferred);
+                                    if deferred > 0 {
+                                        admission_failure_count += 1;
+                                    }
+                                }
+                                Err(_) => admission_failure_count += 1,
+                            }
+                            continue;
+                        }
+                    };
+                    // NIP-33 resolves equal timestamps by event-id tie-break.
+                    // This is already a different exact id, so equality is not
+                    // enough to prove the local artifact will supersede it.
+                    let discovered_can_compete_with_local_artifact = local_live_artifact_created_at
+                        .is_none_or(|created_at| fetched.created_at >= created_at);
+                    if (!self.key_package_metadata_matches_current_support(&metadata)
+                        || discovered_can_compete_with_local_artifact)
+                        && !self.mark_key_package_cutover_replacement_pending(label)
+                    {
+                        admission_failure_count += 1;
+                    }
+                    let event_id_hex =
+                        match parse_key_package_event_id_hex(&fetched.key_package_event_id) {
+                            Ok(event_id_hex) => event_id_hex,
+                            Err(_) => {
+                                admission_failure_count += 1;
+                                continue;
+                            }
+                        };
+                    let key_package_ref = match hex::decode(&fetched.key_package_ref_hex) {
+                        Ok(key_package_ref) => key_package_ref,
+                        Err(_) => {
+                            admission_failure_count += 1;
+                            continue;
+                        }
+                    };
+                    let endpoints = match self.sanitize_key_package_deletion_endpoints(
+                        fetched
+                            .source_relays
+                            .into_iter()
+                            .map(TransportEndpoint)
+                            .collect(),
+                    ) {
+                        Ok(endpoints) if !endpoints.is_empty() => endpoints,
+                        Ok(_) | Err(_) => {
+                            admission_failure_count += 1;
+                            continue;
+                        }
+                    };
+                    let event_id = MessageId::new(
+                        hex::decode(event_id_hex)
+                            .expect("validated key package event id remains hex"),
+                    );
+                    match runtime.journal_discovered_retired_key_package_publication_with_policy(
+                        stable_slot_id.clone(),
+                        event_id,
+                        Timestamp(fetched.created_at),
+                        key_package_ref,
+                        Timestamp(metadata.not_after),
+                        endpoints,
+                        authorize_without_successor,
+                    ) {
+                        Ok((_admitted, deferred)) => {
+                            discovered_current_revision_count += 1;
+                            deferred_endpoint_count =
+                                deferred_endpoint_count.saturating_add(deferred.len());
+                            if !deferred.is_empty() {
+                                admission_failure_count += 1;
+                            }
+                        }
+                        Err(_) => admission_failure_count += 1,
+                    }
+                }
+                Err(_) => {
+                    if !self.mark_key_package_cutover_replacement_pending(label) {
+                        admission_failure_count += 1;
+                    }
+                    non_current_event_count += 1;
+                    match self.journal_unparsed_relay_key_package_revision(
+                        runtime,
+                        &stable_slot_id,
+                        &event_id,
+                        authored_created_at,
+                        raw_endpoints,
+                    ) {
+                        Ok((_admitted, deferred)) => {
+                            deferred_endpoint_count =
+                                deferred_endpoint_count.saturating_add(deferred);
+                            if deferred > 0 {
+                                admission_failure_count += 1;
+                            }
+                        }
+                        Err(_) => admission_failure_count += 1,
+                    }
+                }
+            }
+        }
+
+        let mut summary = KeyPackageRelayAdmissionSummary {
+            non_current_event_count,
+            discovered_current_revision_count,
+            deferred_endpoint_count,
+            admission_failure_count,
+        };
+        if authorize_without_successor
+            && runtime
+                .authorize_teardown_key_package_deletions_without_successor()
+                .is_err()
+        {
+            summary.admission_failure_count += 1;
+        }
+
+        // Move every successfully admitted strict short-page proof into a
+        // monotonic ledger before clearing any crash frontier. If another
+        // relay fails later, a restart still knows to include these historical
+        // endpoints even after their terminal SQL liabilities are pruned.
+        if summary.admission_failure_count == 0
+            && self
+                .extend_key_package_cutover_relay_history(label, &scanned_history_relays)
+                .is_err()
+        {
+            summary.admission_failure_count += 1;
+        }
+
+        // A strict short-page replay discharges a frontier written by an
+        // earlier process before exact deletion. If this write fails, retain
+        // the in-memory frontier too so this invocation cannot manufacture a
+        // completion proof that the durable state does not carry.
+        if all_required_relays_scanned
+            && summary.admission_failure_count == 0
+            && !scan_was_truncated
+            && !frontier_clear_candidates.is_empty()
+        {
+            match self.remove_key_package_cutover_relay_frontier_endpoints(
+                label,
+                &frontier_clear_candidates,
+            ) {
+                Ok(frontier) => relay_frontier = frontier,
+                Err(_) => summary.admission_failure_count += 1,
+            }
+        }
+        // Deletion takes this same lock around frontier arm and network I/O.
+        // Release before the runtime invokes the publisher, then reacquire for
+        // the strict post-delete replay and conditional discharge.
+        drop(history_guard);
+
+        // A relay may expose parameterized-replaceable history one winner at
+        // a time. The AppKeyPackagePublisher deletion boundary durably arms
+        // the exact canonical endpoint before kind-5 I/O, including for
+        // ordinary maintenance outside this cutover. After every attempt,
+        // strictly rescan the complete durable frontier: an error or explicit
+        // failed receipt can still be ambiguous about relay-side acceptance.
+        // The bounded loop keeps one open responsive; exhaustion leaves the
+        // publication gate restart-readable.
+        let mut retry_failure_count = 0usize;
+        let mut peeling_failed = false;
+        let mut peeling_exhausted = false;
+        let mut uncovered_eligible_deletion = false;
+        for pass_index in 0..KEY_PACKAGE_CUTOVER_MAX_DELETION_PASSES {
+            let pending_endpoints =
+                match Self::retired_key_package_deletion_target_endpoints(runtime) {
+                    Ok(endpoints) => endpoints,
+                    Err(_) => {
+                        peeling_failed = true;
+                        break;
+                    }
+                };
+            if pending_endpoints.is_empty() && relay_frontier.is_empty() {
+                uncovered_eligible_deletion = false;
+                break;
+            }
+
+            let (report_failed, terminal_endpoints) = if pending_endpoints.is_empty() {
+                (false, BTreeSet::new())
+            } else {
+                match runtime
+                    .retry_retired_key_package_deletions_once_reported()
+                    .await
+                {
+                    Ok(report) => {
+                        uncovered_eligible_deletion = report.has_uncovered_eligible_deletion;
+                        match self
+                            .sanitize_key_package_deletion_endpoints(report.terminal_endpoints)
+                        {
+                            Ok(endpoints) => {
+                                (false, endpoints.into_iter().collect::<BTreeSet<_>>())
+                            }
+                            Err(_) => {
+                                peeling_failed = true;
+                                break;
+                            }
+                        }
+                    }
+                    Err(_) => {
+                        retry_failure_count += 1;
+                        peeling_failed = true;
+                        (true, BTreeSet::new())
+                    }
+                }
+            };
+            let history_guard = history_lock.lock().await;
+            relay_frontier = match self.key_package_cutover_relay_frontier(label) {
+                Ok(frontier) => frontier,
+                Err(_) => {
+                    peeling_failed = true;
+                    drop(history_guard);
+                    break;
+                }
+            };
+            if !terminal_endpoints.is_subset(&relay_frontier) {
+                // A terminal SQLite receipt without its pre-I/O relay intent
+                // would reopen the exact crash window this frontier closes.
+                peeling_failed = true;
+                drop(history_guard);
+                break;
+            }
+            if relay_frontier.is_empty() {
+                drop(history_guard);
+                break;
+            }
+
+            let frontier_endpoints = relay_frontier.iter().cloned().collect::<Vec<_>>();
+            let refetched = futures::future::join_all(frontier_endpoints.iter().map(|endpoint| {
+                self.fetch_key_package_events_for_account_id_with_limit_strict(
+                    &account.account_id_hex,
+                    std::slice::from_ref(endpoint),
+                    KEY_PACKAGE_CUTOVER_RELAY_SCAN_LIMIT,
+                )
+            }))
+            .await;
+            let mut revealed_revision = false;
+            let mut refetch_complete = true;
+            let mut frontier_clear_candidates = BTreeSet::new();
+            for (endpoint, fetched) in frontier_endpoints.iter().zip(refetched) {
+                let records = match fetched {
+                    Ok(records) => records,
+                    Err(_) => {
+                        refetch_complete = false;
+                        continue;
+                    }
+                };
+                let page_was_truncated = records.len() >= KEY_PACKAGE_CUTOVER_RELAY_SCAN_LIMIT;
+                scan_was_truncated |= page_was_truncated;
+                let admitted = match self.admit_relay_key_package_records(
+                    label,
+                    runtime,
+                    records,
+                    authorize_without_successor,
+                ) {
+                    Ok(admitted) => admitted,
+                    Err(_) => {
+                        refetch_complete = false;
+                        continue;
+                    }
+                };
+                if authorize_without_successor
+                    && runtime
+                        .authorize_teardown_key_package_deletions_without_successor()
+                        .is_err()
+                {
+                    refetch_complete = false;
+                }
+                let endpoint_revealed = admitted.non_current_event_count > 0
+                    || admitted.discovered_current_revision_count > 0;
+                revealed_revision |= endpoint_revealed;
+                let endpoint_complete =
+                    !page_was_truncated && admitted.admission_failure_count == 0;
+                summary.absorb(admitted);
+                if endpoint_complete {
+                    frontier_clear_candidates.insert(endpoint.clone());
+                } else {
+                    refetch_complete = false;
+                }
+            }
+            if self
+                .extend_key_package_cutover_relay_history(label, &frontier_clear_candidates)
+                .is_err()
             {
-                Ok(accepted) => accepted_delete_count += accepted,
-                Err(_) => delete_failure_count += 1,
+                refetch_complete = false;
+            }
+            if refetch_complete {
+                match self.remove_key_package_cutover_relay_frontier_endpoints(
+                    label,
+                    &frontier_clear_candidates,
+                ) {
+                    Ok(frontier) => relay_frontier = frontier,
+                    Err(_) => refetch_complete = false,
+                }
+            }
+            drop(history_guard);
+            if !refetch_complete {
+                peeling_failed = true;
+                break;
+            }
+            if report_failed {
+                // The strict replay discharged the ambiguous relay-side
+                // frontier, but the deletion obligation itself remains
+                // retryable and this invocation cannot claim success.
+                break;
+            }
+            if !uncovered_eligible_deletion && !revealed_revision {
+                break;
+            }
+            if pass_index + 1 == KEY_PACKAGE_CUTOVER_MAX_DELETION_PASSES {
+                peeling_exhausted = true;
             }
         }
-        if delete_failure_count == 0 {
-            // The marker helper emits its own privacy-safe warning. It is not
-            // a relay deletion failure, so do not fold it into this counter.
-            let _ = self.mark_key_package_cutover_scan_complete(label);
+
+        let final_history_guard = history_lock.lock().await;
+        let frontier_is_empty = self
+            .key_package_cutover_relay_frontier(label)
+            .is_ok_and(|frontier| frontier.is_empty());
+        let mut scan_complete = all_required_relays_scanned
+            && summary.admission_failure_count == 0
+            && !scan_was_truncated
+            && !peeling_failed
+            && !peeling_exhausted
+            && !uncovered_eligible_deletion
+            && frontier_is_empty;
+        if scan_complete {
+            scan_complete = runtime
+                .finalize_key_package_cutover_consumption_evidence()
+                .is_ok();
         }
-        if non_current_event_count > 0 {
+        if scan_complete {
+            // Persistence is part of the proof: a failed marker write must
+            // leave the runtime publication interlock armed for the next open.
+            scan_complete = self
+                .begin_root_mutation("persist completed KeyPackage cutover scan marker")
+                .and_then(|_root_mutation| {
+                    self.mark_key_package_cutover_scan_complete_for_relays(
+                        label,
+                        &source_relays,
+                        &scanned_history_relays,
+                    )
+                })
+                .is_ok();
+        }
+        drop(final_history_guard);
+        if scan_complete
+            && destructive_cleanup_was_durable
+            && self
+                .clear_key_package_teardown_cleanup_pending(label)
+                .is_err()
+        {
+            scan_complete = false;
+        }
+        if summary.non_current_event_count > 0 || summary.discovered_current_revision_count > 0 {
             tracing::info!(
                 target: "marmot_app::key_packages",
                 method = "retire_relay_non_current_key_packages",
-                non_current_event_count,
-                accepted_delete_count,
-                delete_failure_count,
+                non_current_event_count = summary.non_current_event_count,
+                discovered_current_revision_count = summary.discovered_current_revision_count,
+                deferred_endpoint_count = summary.deferred_endpoint_count,
+                admission_failure_count = summary.admission_failure_count,
+                retry_failure_count,
+                all_required_relays_scanned,
+                scan_was_truncated,
+                peeling_exhausted,
                 "completed relay key package retirement scan"
             );
         }
-        non_current_event_count > 0
+        scan_complete
     }
 
     fn key_package_cutover_replacement_pending_path(&self, label: &str) -> PathBuf {
@@ -3912,10 +6787,1191 @@ impl MarmotApp {
             .join(format!("{label}.capability-refresh-v1-replacement-pending"))
     }
 
-    fn key_package_cutover_scan_complete_path(&self, label: &str) -> PathBuf {
+    fn generated_initial_key_package_publication_hold_path(&self, label: &str) -> PathBuf {
+        self.key_package_cache_dir()
+            .join(KEY_PACKAGE_DIR)
+            .join(format!(
+                "{label}.generated-initial-key-package-publication-hold-v1"
+            ))
+    }
+
+    fn generated_initial_key_package_publication_held(
+        &self,
+        label: &str,
+    ) -> Result<bool, AppError> {
+        self.generated_initial_key_package_publication_hold_path(label)
+            .try_exists()
+            .map_err(AppError::from)
+    }
+
+    /// Create a private child directory and durably publish its directory
+    /// entry before any load-bearing file is written inside it. Syncing only
+    /// the child after `mkdir` is insufficient: a power loss can otherwise
+    /// discard the entire child namespace even though its files were synced.
+    fn ensure_private_directory_entry_durable(&self, directory: &Path) -> Result<(), AppError> {
+        fs_private::create_dir_all_private(directory)?;
+        #[cfg(unix)]
+        if let Some(parent) = directory.parent() {
+            std::fs::File::open(parent)?.sync_all()?;
+        }
+        Ok(())
+    }
+
+    /// Persist the setup-owned publication hold before any initial KeyPackage
+    /// can be prepared. This method only creates the crash-safe file; SQL
+    /// mirroring is a separate route-serialized step so it can never recreate
+    /// a hold that an explicit publisher already cleared.
+    fn arm_generated_initial_key_package_publication_hold(
+        &self,
+        label: &str,
+    ) -> Result<(), AppError> {
+        let _root_mutation =
+            self.begin_root_mutation("arm generated initial KeyPackage publication hold")?;
+        let path = self.generated_initial_key_package_publication_hold_path(label);
+        let parent = path.parent().ok_or_else(|| {
+            AppError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "generated initial KeyPackage publication hold has no parent directory",
+            ))
+        })?;
+        self.ensure_private_directory_entry_durable(parent)?;
+        fs_private::write_private_atomic(&path, b"held\n")?;
+        Ok(())
+    }
+
+    /// Arm only before the first lifecycle exists. Once an initial lifecycle
+    /// is durable, an absent file is itself the durable record that an explicit
+    /// publisher released setup ownership; resume must never resurrect it.
+    fn ensure_generated_initial_key_package_publication_hold_before_preparation(
+        &self,
+        label: &str,
+    ) -> Result<(), AppError> {
+        let lifecycle_exists = if self.account_storage_path(label).exists() {
+            self.account_storage(label)?
+                .key_package_lifecycle()?
+                .is_some()
+        } else {
+            false
+        };
+        if lifecycle_exists {
+            return Ok(());
+        }
+        self.arm_generated_initial_key_package_publication_hold(label)
+    }
+
+    /// Mirror an existing file-backed hold into SQL without creating it. The
+    /// route lock orders this check/write against explicit generated-route
+    /// recovery, hold clearing, and the final kind-30443 boundary.
+    async fn mirror_generated_initial_key_package_publication_hold_into_lifecycle(
+        &self,
+        label: &str,
+    ) -> Result<(), AppError> {
+        let route_lock = self.key_package_route_lock(label);
+        let _route_guard = route_lock.lock().await;
+        if !self.generated_initial_key_package_publication_held(label)? {
+            return Ok(());
+        }
+        let storage = self.account_storage(label)?;
+        let Some(mut lifecycle) = storage.key_package_lifecycle()? else {
+            return Err(AppError::AccountSetupRetryRequired);
+        };
+        if !lifecycle.cutover_publication_blocked {
+            lifecycle.cutover_publication_blocked = true;
+            storage.put_key_package_lifecycle(&lifecycle)?;
+        }
+        Ok(())
+    }
+
+    fn clear_generated_initial_key_package_publication_hold(
+        &self,
+        label: &str,
+    ) -> Result<(), AppError> {
+        let _root_mutation =
+            self.begin_root_mutation("clear generated initial KeyPackage publication hold")?;
+        let path = self.generated_initial_key_package_publication_hold_path(label);
+        let parent_exists = match path.parent() {
+            Some(parent) => parent.try_exists()?,
+            None => false,
+        };
+        if !path.try_exists()? && !parent_exists {
+            return Ok(());
+        }
+        remove_file_if_present(path)
+    }
+
+    pub(crate) async fn clear_generated_initial_key_package_publication_hold_for_session(
+        &self,
+        label: &str,
+        session_admission: &AccountSessionAdmissionToken,
+    ) -> Result<(), AppError> {
+        let route_lock = self.key_package_route_lock(label);
+        let _route_guard = route_lock.lock().await;
+        if !self.active_account_session_admission_is_current(label, session_admission) {
+            return Err(AppError::AccountWorkerBusy);
+        }
+        self.clear_generated_initial_key_package_publication_hold(label)
+    }
+
+    fn key_package_cutover_relay_frontier_path(&self, label: &str) -> PathBuf {
+        self.key_package_cache_dir()
+            .join(KEY_PACKAGE_DIR)
+            .join(format!("{label}.capability-refresh-v2-relay-frontier.json"))
+    }
+
+    fn key_package_cutover_relay_history_path(&self, label: &str) -> PathBuf {
+        self.key_package_cache_dir()
+            .join(KEY_PACKAGE_DIR)
+            .join(format!("{label}.capability-refresh-v2-relay-history.json"))
+    }
+
+    fn key_package_teardown_cleanup_pending_path(&self, label: &str) -> PathBuf {
+        self.key_package_cache_dir()
+            .join(KEY_PACKAGE_DIR)
+            .join(format!(
+                "{label}.capability-refresh-v2-destructive-cleanup-pending"
+            ))
+    }
+
+    fn key_package_teardown_cleanup_pending(&self, label: &str) -> Result<bool, AppError> {
+        self.key_package_teardown_cleanup_pending_path(label)
+            .try_exists()
+            .map_err(AppError::from)
+    }
+
+    fn mark_key_package_teardown_cleanup_pending(&self, label: &str) -> Result<(), AppError> {
+        let _root_mutation =
+            self.begin_root_mutation("arm destructive KeyPackage teardown cleanup")?;
+        let path = self.key_package_teardown_cleanup_pending_path(label);
+        let parent = path.parent().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "destructive KeyPackage cleanup marker has no parent directory",
+            )
+        })?;
+        self.ensure_private_directory_entry_durable(parent)?;
+        // Persist the destructive mode before invalidating the ordinary proof.
+        // A crash between these writes still makes marker admission reject the
+        // old proof because retirement consults this mode directly.
+        fs_private::write_private_atomic(&path, b"pending\n")?;
+        self.invalidate_key_package_cutover_scan_marker(label)
+    }
+
+    fn clear_key_package_teardown_cleanup_pending(&self, label: &str) -> Result<(), AppError> {
+        let _root_mutation =
+            self.begin_root_mutation("clear destructive KeyPackage teardown cleanup")?;
+        let path = self.key_package_teardown_cleanup_pending_path(label);
+        match fs::remove_file(&path) {
+            Ok(()) => {
+                #[cfg(unix)]
+                if let Some(parent) = path.parent() {
+                    std::fs::File::open(parent)?.sync_all()?;
+                }
+                Ok(())
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    /// Relays that must receive one strict stored-history scan before the
+    /// upgrade cutover may complete.
+    ///
+    /// The frontier is written before exact deletion I/O. It therefore covers
+    /// the crash window in which deleting a parameterized-replaceable winner
+    /// reveals an older same-slot revision, including on a historical relay
+    /// that is no longer in the account's current NIP-65 set.
+    fn key_package_cutover_relay_frontier(
+        &self,
+        label: &str,
+    ) -> Result<BTreeSet<TransportEndpoint>, AppError> {
+        let path = self.key_package_cutover_relay_frontier_path(label);
+        let frontier = match read_json::<KeyPackageCutoverRelayFrontier>(&path) {
+            Ok(frontier) => frontier,
+            Err(AppError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(BTreeSet::new());
+            }
+            Err(error) => return Err(error),
+        };
+        let endpoints = frontier
+            .relays
+            .into_iter()
+            .map(TransportEndpoint)
+            .collect::<Vec<_>>();
+        Ok(self
+            .sanitize_key_package_deletion_endpoints(endpoints)?
+            .into_iter()
+            .collect())
+    }
+
+    /// Monotonic set of relays whose KeyPackage history has mattered to this
+    /// account. It survives route removal, terminal SQL-liability pruning, and
+    /// completion-marker invalidation so a later cutover cannot silently
+    /// forget a historical endpoint that only an older generation knew.
+    fn key_package_cutover_relay_history(
+        &self,
+        label: &str,
+    ) -> Result<BTreeSet<TransportEndpoint>, AppError> {
+        let path = self.key_package_cutover_relay_history_path(label);
+        let history = match read_json::<KeyPackageCutoverRelayFrontier>(&path) {
+            Ok(history) => history,
+            Err(AppError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(BTreeSet::new());
+            }
+            Err(error) => return Err(error),
+        };
+        let endpoints = history
+            .relays
+            .into_iter()
+            .map(TransportEndpoint)
+            .collect::<Vec<_>>();
+        Ok(self
+            .sanitize_key_package_deletion_endpoints(endpoints)?
+            .into_iter()
+            .collect())
+    }
+
+    fn extend_key_package_cutover_relay_history(
+        &self,
+        label: &str,
+        endpoints: &BTreeSet<TransportEndpoint>,
+    ) -> Result<BTreeSet<TransportEndpoint>, AppError> {
+        if endpoints.is_empty() {
+            return self.key_package_cutover_relay_history(label);
+        }
+        let _root_mutation = self.begin_root_mutation("extend KeyPackage cutover relay history")?;
+        let _frontier_mutation = self
+            .key_package_frontier_mutation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        self.extend_key_package_cutover_relay_history_under_root(label, endpoints)
+    }
+
+    fn extend_key_package_cutover_relay_history_under_root(
+        &self,
+        label: &str,
+        endpoints: &BTreeSet<TransportEndpoint>,
+    ) -> Result<BTreeSet<TransportEndpoint>, AppError> {
+        let mut history = self.key_package_cutover_relay_history(label)?;
+        history.extend(endpoints.iter().cloned());
+        let frontier = self.key_package_cutover_relay_frontier(label)?;
+        let mut projected_history = self.key_package_history_endpoints(label)?;
+        projected_history.extend(history.iter().cloned());
+        projected_history.extend(frontier);
+        projected_history.extend(self.key_package_current_route_history_endpoints(label)?);
+        if self.pending_nip65_route_mutation(label) {
+            let pending = self.read_pending_nip65_route_mutation(label)?;
+            projected_history.extend(
+                self.sanitize_key_package_deletion_endpoints(
+                    pending
+                        .nip65
+                        .relays
+                        .into_iter()
+                        .map(TransportEndpoint)
+                        .collect(),
+                )?,
+            );
+        }
+        if projected_history.len() > KEY_PACKAGE_CUTOVER_RELAY_HISTORY_CAPACITY {
+            return Err(AppError::Publish(
+                "KeyPackage relay-history journal is full".into(),
+            ));
+        }
+        let path = self.key_package_cutover_relay_history_path(label);
+        let parent = path.parent().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "cutover relay history has no parent directory",
+            )
+        })?;
+        self.ensure_private_directory_entry_durable(parent)?;
+        let marker = KeyPackageCutoverRelayFrontier {
+            relays: history.iter().map(|endpoint| endpoint.0.clone()).collect(),
+        };
+        let bytes = serde_json::to_vec(&marker).map_err(std::io::Error::other)?;
+        fs_private::write_private_atomic(&path, &bytes)?;
+        Ok(history)
+    }
+
+    /// Durably union exact-deletion endpoints into the frontier while holding
+    /// the root mutation lease across the read/modify/write sequence.
+    fn extend_key_package_cutover_relay_frontier(
+        &self,
+        label: &str,
+        endpoints: Vec<TransportEndpoint>,
+    ) -> Result<(), AppError> {
+        let endpoints = self
+            .sanitize_key_package_deletion_endpoints(endpoints)?
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+        if endpoints.is_empty() {
+            return Err(AppError::Publish(
+                "cannot arm KeyPackage cutover frontier without a safe relay endpoint".into(),
+            ));
+        }
+        let _root_mutation = self.begin_root_mutation("arm KeyPackage cutover relay frontier")?;
+        let _frontier_mutation = self
+            .key_package_frontier_mutation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let history = self.key_package_history_endpoints(label)?;
+        let mut frontier = self.key_package_cutover_relay_frontier(label)?;
+        let mut projected_history = history;
+        projected_history.extend(frontier.iter().cloned());
+        projected_history.extend(endpoints.iter().cloned());
+        projected_history.extend(self.key_package_current_route_history_endpoints(label)?);
+        if self.pending_nip65_route_mutation(label) {
+            let pending = self.read_pending_nip65_route_mutation(label)?;
+            projected_history.extend(
+                self.sanitize_key_package_deletion_endpoints(
+                    pending
+                        .nip65
+                        .relays
+                        .into_iter()
+                        .map(TransportEndpoint)
+                        .collect(),
+                )?,
+            );
+        }
+        if projected_history.len() > KEY_PACKAGE_CUTOVER_RELAY_HISTORY_CAPACITY {
+            return Err(AppError::Publish(
+                "KeyPackage relay-history journal is full; refusing exact deletion I/O".into(),
+            ));
+        }
+        frontier.extend(endpoints);
+        self.write_key_package_cutover_relay_frontier_under_root(label, &frontier)?;
+        // Persisting the frontier first is load-bearing: a crash before this
+        // invalidation still leaves the old marker unusable because marker
+        // admission also requires an empty frontier. Removing the marker
+        // before network I/O prevents a later strict scan from temporarily
+        // emptying the frontier and reviving a pre-peeling completion proof.
+        self.invalidate_key_package_cutover_scan_marker(label)?;
+        Ok(())
+    }
+
+    /// Remove only endpoints covered by the caller's completed strict scan.
+    /// The locked re-read preserves any distinct endpoint armed by another
+    /// app clone before this mutation acquired the file lock.
+    fn remove_key_package_cutover_relay_frontier_endpoints(
+        &self,
+        label: &str,
+        endpoints: &BTreeSet<TransportEndpoint>,
+    ) -> Result<BTreeSet<TransportEndpoint>, AppError> {
+        if endpoints.is_empty() {
+            return self.key_package_cutover_relay_frontier(label);
+        }
+        let _root_mutation =
+            self.begin_root_mutation("discharge KeyPackage cutover relay frontier")?;
+        let _frontier_mutation = self
+            .key_package_frontier_mutation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut frontier = self.key_package_cutover_relay_frontier(label)?;
+        frontier.retain(|endpoint| !endpoints.contains(endpoint));
+        self.write_key_package_cutover_relay_frontier_under_root(label, &frontier)?;
+        Ok(frontier)
+    }
+
+    fn write_key_package_cutover_relay_frontier_under_root(
+        &self,
+        label: &str,
+        frontier: &BTreeSet<TransportEndpoint>,
+    ) -> Result<(), AppError> {
+        let path = self.key_package_cutover_relay_frontier_path(label);
+        if frontier.is_empty() {
+            match fs::remove_file(&path) {
+                Ok(()) => {
+                    #[cfg(unix)]
+                    if let Some(parent) = path.parent() {
+                        std::fs::File::open(parent)?.sync_all()?;
+                    }
+                    return Ok(());
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+                Err(error) => return Err(error.into()),
+            }
+        }
+        let parent = path.parent().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "cutover relay frontier has no parent directory",
+            )
+        })?;
+        self.ensure_private_directory_entry_durable(parent)?;
+        let marker = KeyPackageCutoverRelayFrontier {
+            relays: frontier.iter().map(|endpoint| endpoint.0.clone()).collect(),
+        };
+        let bytes = serde_json::to_vec(&marker).map_err(std::io::Error::other)?;
+        fs_private::write_private_atomic(&path, &bytes)?;
+        Ok(())
+    }
+
+    fn pending_nip65_route_mutation_path(&self, label: &str) -> PathBuf {
+        self.key_package_cache_dir()
+            .join(KEY_PACKAGE_DIR)
+            .join(format!("{label}.nip65-route-mutation-v1.json"))
+    }
+
+    fn nip65_route_generation_path(&self, label: &str) -> PathBuf {
+        self.key_package_cache_dir()
+            .join(KEY_PACKAGE_DIR)
+            .join(format!("{label}.nip65-route-generation-v1.json"))
+    }
+
+    fn pending_nip65_route_mutation(&self, label: &str) -> bool {
+        self.pending_nip65_route_mutation_path(label).exists()
+    }
+
+    fn read_pending_nip65_route_mutation(
+        &self,
+        label: &str,
+    ) -> Result<PendingNip65RouteMutation, AppError> {
+        read_json(self.pending_nip65_route_mutation_path(label))
+    }
+
+    fn write_pending_nip65_route_mutation(
+        &self,
+        label: &str,
+        pending: &PendingNip65RouteMutation,
+    ) -> Result<(), AppError> {
+        self.write_private_json(
+            &self.pending_nip65_route_mutation_path(label),
+            pending,
+            "pending NIP-65 route mutation",
+        )
+    }
+
+    fn clear_pending_nip65_route_mutation(&self, label: &str) -> Result<(), AppError> {
+        remove_file_if_present(self.pending_nip65_route_mutation_path(label))
+    }
+
+    /// Read and validate the durable local kind-10002 authority without
+    /// treating a malformed or unreadable journal as an absent generation.
+    /// The exact parsed relay state is bound to the same event coordinate, so
+    /// every security-sensitive routing decision can fail closed instead of
+    /// consulting a whole-record directory-cache winner.
+    fn read_nip65_route_generation_for_authoring(
+        &self,
+        label: &str,
+    ) -> Result<Option<Nip65RouteGeneration>, AppError> {
+        match read_json(self.nip65_route_generation_path(label)) {
+            Ok(generation) => {
+                self.validate_nip65_route_generation(&generation)?;
+                Ok(Some(generation))
+            }
+            Err(AppError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Canonicalize each NIP-65 compatibility/directional endpoint vector for
+    /// semantic authority comparisons. Persisted event order and URL aliases
+    /// must not make the same relay declaration look different, while a
+    /// malformed or unsafe alias still fails closed.
+    fn canonical_nip65_route_state(
+        &self,
+        state: &AccountRelayListState,
+    ) -> Result<CanonicalNip65RouteState, AppError> {
+        if state.kind != KIND_NIP65_RELAY_LIST {
+            return Err(AppError::Publish(
+                "NIP-65 authority comparison received the wrong event kind".into(),
+            ));
+        }
+        let canonicalize = |relays: &[String]| {
+            self.sanitize_key_package_deletion_endpoints(
+                relays
+                    .iter()
+                    .cloned()
+                    .map(TransportEndpoint)
+                    .collect::<Vec<_>>(),
+            )
+        };
+        Ok((
+            canonicalize(&state.relays)?,
+            canonicalize(&state.read_relays)?,
+            canonicalize(&state.write_relays)?,
+        ))
+    }
+
+    fn validate_nip65_route_generation(
+        &self,
+        generation: &Nip65RouteGeneration,
+    ) -> Result<Vec<TransportEndpoint>, AppError> {
+        if generation.nip65.kind != KIND_NIP65_RELAY_LIST {
+            return Err(AppError::Publish(
+                "durable NIP-65 route generation has the wrong event kind".into(),
+            ));
+        }
+        let event_id = hex::decode(&generation.event_id)?;
+        if event_id.len() != 32 {
+            return Err(AppError::Publish(
+                "durable NIP-65 route generation has an invalid event id".into(),
+            ));
+        }
+        let endpoints = generation
+            .nip65
+            .relays
+            .iter()
+            .cloned()
+            .map(TransportEndpoint)
+            .collect::<Vec<_>>();
+        let endpoints = self.sanitize_key_package_deletion_endpoints(endpoints)?;
+        if endpoints.is_empty() {
+            return Err(AppError::MissingRelayLists(vec![
+                MissingRelayListKind::Nip65,
+            ]));
+        }
+        Ok(endpoints)
+    }
+
+    fn next_locally_authored_nip65_created_at(&self, label: &str) -> Result<u64, AppError> {
+        let now = unix_now_seconds();
+        let created_at = match self.read_nip65_route_generation_for_authoring(label)? {
+            Some(generation) => generation
+                .created_at
+                .checked_add(1)
+                .ok_or_else(|| {
+                    AppError::Publish("cannot advance the durable NIP-65 route generation".into())
+                })?
+                .max(now),
+            None => now,
+        };
+        if !DirectoryFreshness::from_unix_time(now, self.config.directory_max_future_skew)
+            .accepts_created_at(created_at)
+        {
+            return Err(AppError::Publish(
+                "cannot author a NIP-65 route revision beyond the directory future-skew bound"
+                    .into(),
+            ));
+        }
+        Ok(created_at)
+    }
+
+    fn write_nip65_route_generation(
+        &self,
+        label: &str,
+        generation: &Nip65RouteGeneration,
+    ) -> Result<(), AppError> {
+        self.write_private_json(
+            &self.nip65_route_generation_path(label),
+            generation,
+            "NIP-65 route generation",
+        )
+    }
+
+    fn write_private_json<T: Serialize>(
+        &self,
+        path: &Path,
+        value: &T,
+        context: &str,
+    ) -> Result<(), AppError> {
+        let parent = path.parent().ok_or_else(|| {
+            AppError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("{context} has no parent directory"),
+            ))
+        })?;
+        self.ensure_private_directory_entry_durable(parent)?;
+        let bytes = serde_json::to_vec(value)?;
+        fs_private::write_private_atomic(path, &bytes)?;
+        Ok(())
+    }
+
+    fn local_account_label_for_id(&self, account_id_hex: &str) -> Option<String> {
+        self.account_home()
+            .accounts()
+            .ok()?
+            .into_iter()
+            .find(|account| account.account_id_hex == account_id_hex)
+            .map(|account| account.label)
+    }
+
+    fn authoritative_key_package_relays(
+        &self,
+        label: &str,
+    ) -> Result<Vec<TransportEndpoint>, AppError> {
+        let Some(generation) = self.read_nip65_route_generation_for_authoring(label)? else {
+            return Err(AppError::Publish(
+                "local NIP-65 route authority is unavailable".into(),
+            ));
+        };
+        self.validate_nip65_route_generation(&generation)
+    }
+
+    async fn sign_account_transport_event(
+        &self,
+        signer: Arc<dyn nostr::NostrSigner>,
+        event: NostrTransportEvent,
+    ) -> Result<NostrTransportEvent, AppError> {
+        if event.sig.is_some() {
+            event
+                .to_verified_nostr_event()
+                .map_err(|error| AppError::Publish(format!("invalid signed event: {error}")))?;
+            return Ok(event);
+        }
+        let public_key = signer
+            .get_public_key()
+            .await
+            .map_err(|error| AppError::Publish(format!("signer public key: {error}")))?;
+        if event.pubkey != public_key.to_hex() {
+            return Err(AppError::Publish(
+                "relay-list event author does not match the selected account signer".into(),
+            ));
+        }
+        let kind = u16::try_from(event.kind)
+            .map(Kind::from)
+            .map_err(|_| AppError::Publish(format!("unsupported event kind {}", event.kind)))?;
+        let tags = event
+            .tags
+            .into_iter()
+            .map(Tag::parse)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| AppError::Publish(format!("relay-list event tags: {error}")))?;
+        let unsigned = EventBuilder::new(kind, event.content)
+            .tags(tags)
+            .custom_created_at(NostrTimestamp::from_secs(event.created_at))
+            .build(public_key);
+        let signed = signer
+            .sign_event(unsigned)
+            .await
+            .map_err(|error| AppError::Publish(format!("sign relay-list event: {error}")))?;
+        NostrTransportEvent::from_nostr_event(&signed)
+            .map_err(|error| AppError::Publish(format!("signed relay-list event: {error}")))
+    }
+
+    fn validate_pending_nip65_route_mutation(
+        &self,
+        label: &str,
+        pending: &PendingNip65RouteMutation,
+    ) -> Result<Vec<TransportEndpoint>, AppError> {
+        let account = self.account_home().account(label)?;
+        if pending.account_id_hex != account.account_id_hex
+            || pending.nip65.kind != KIND_NIP65_RELAY_LIST
+            || pending.generation.nip65 != pending.nip65
+        {
+            return Err(AppError::Publish(
+                "pending NIP-65 route mutation does not match the local account".into(),
+            ));
+        }
+        let event_id = hex::decode(&pending.generation.event_id)?;
+        if event_id.len() != 32 {
+            return Err(AppError::Publish(
+                "pending NIP-65 route generation has an invalid event id".into(),
+            ));
+        }
+        let proposed = pending
+            .nip65
+            .relays
+            .iter()
+            .cloned()
+            .map(TransportEndpoint)
+            .collect::<Vec<_>>();
+        let proposed = self.sanitize_key_package_deletion_endpoints(proposed)?;
+        if proposed.is_empty() {
+            return Err(AppError::MissingRelayLists(vec![
+                MissingRelayListKind::Nip65,
+            ]));
+        }
+        if let Some(event) = pending.signed_event.as_ref() {
+            event
+                .to_verified_nostr_event()
+                .map_err(|error| AppError::Publish(format!("pending route event: {error}")))?;
+            if event.id != pending.generation.event_id
+                || event.created_at != pending.generation.created_at
+                || event.pubkey != pending.account_id_hex
+                || event.kind != KIND_NIP65_RELAY_LIST
+                || relay_list_state_from_event(event).as_ref() != Some(&pending.nip65)
+            {
+                return Err(AppError::Publish(
+                    "pending NIP-65 route event does not match its durable intent".into(),
+                ));
+            }
+        }
+        Ok(proposed)
+    }
+
+    fn canonical_nip65_publication_endpoints(
+        &self,
+        endpoints: Vec<TransportEndpoint>,
+        context: &str,
+    ) -> Result<Vec<TransportEndpoint>, AppError> {
+        let mut endpoints = self
+            .relay_plane
+            .sanitize_relay_endpoints(endpoints, context)
+            .map_err(|error| {
+                AppError::Transport(cgka_traits::TransportAdapterError::Publish(error))
+            })?;
+        endpoints.sort();
+        endpoints.dedup();
+        Ok(endpoints)
+    }
+
+    fn pending_nip65_route_mutation_preserves_generated_fresh_proof(
+        &self,
+        label: &str,
+        pending: &PendingNip65RouteMutation,
+    ) -> Result<bool, AppError> {
+        if pending.source != Nip65RouteMutationSource::GeneratedAccountBootstrap
+            || !self.key_package_cutover_has_fresh_account_proof(label)
+        {
+            return Ok(false);
+        }
+        let Some(setup) = self.account_home().account_setup_state(label)? else {
+            return Ok(false);
+        };
+        if setup.kind != AccountSetupKind::GeneratedIdentity
+            || setup.account_id_hex != pending.account_id_hex
+            || matches!(
+                setup.phase,
+                AccountSetupPhase::KeyPackagePublicationConfirmed
+            )
+            || pending.signed_event.is_none()
+        {
+            return Ok(false);
+        }
+        let proposed_endpoints = self.validate_pending_nip65_route_mutation(label, pending)?;
+        let Some(lifecycle) = self.account_storage(label)?.key_package_lifecycle()? else {
+            return Ok(false);
+        };
+        Ok(self.key_package_lifecycle_has_prepared_cutover_replacement(
+            label,
+            &lifecycle,
+            &proposed_endpoints,
+        ))
+    }
+
+    fn generated_account_fresh_replacement_can_open_cutover_gate(
+        &self,
+        label: &str,
+        lifecycle: &cgka_traits::KeyPackageLifecycleState,
+    ) -> Result<bool, AppError> {
+        if !self.key_package_cutover_replacement_pending(label)
+            || !self.key_package_cutover_has_fresh_account_proof(label)
+        {
+            return Ok(false);
+        }
+        let Some(setup) = self.account_home().account_setup_state(label)? else {
+            return Ok(false);
+        };
+        if setup.kind != AccountSetupKind::GeneratedIdentity
+            || !matches!(
+                setup.phase,
+                AccountSetupPhase::LocalReady
+                    | AccountSetupPhase::BootstrapPublicationStarted
+                    | AccountSetupPhase::BootstrapPublicationConfirmed
+                    | AccountSetupPhase::KeyPackagePublicationStarted
+            )
+        {
+            return Ok(false);
+        }
+        let authoritative_endpoints = if self.pending_nip65_route_mutation(label) {
+            let pending = self.read_pending_nip65_route_mutation(label)?;
+            if !self
+                .pending_nip65_route_mutation_preserves_generated_fresh_proof(label, &pending)?
+            {
+                return Ok(false);
+            }
+            self.validate_pending_nip65_route_mutation(label, &pending)?
+        } else {
+            let Some(generation) = self.read_nip65_route_generation_for_authoring(label)? else {
+                return Ok(false);
+            };
+            self.validate_nip65_route_generation(&generation)?
+        };
+        Ok(self.key_package_lifecycle_has_prepared_cutover_replacement(
+            label,
+            lifecycle,
+            &authoritative_endpoints,
+        ))
+    }
+
+    fn commit_pending_nip65_route_mutation(
+        &self,
+        label: &str,
+        pending: &PendingNip65RouteMutation,
+    ) -> Result<AccountRelayListStatus, AppError> {
+        let _root_mutation = self.begin_root_mutation("commit pending NIP-65 route mutation")?;
+        let _frontier_mutation = self
+            .key_package_frontier_mutation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // The generation-bound state is the authority and the directory row is
+        // only its projection. Persist authority first: a crash before the
+        // cache write leaves the pending intent/gate in place, and restart can
+        // safely repeat the projection without ever reading the old route.
+        self.write_nip65_route_generation(label, &pending.generation)?;
+        let mut status = self.account_relay_list_status(label)?;
+        status.nip65 = pending.nip65.clone();
+        push_unique_strings(
+            &mut status.bootstrap_relays,
+            pending.bootstrap_relays.iter().cloned(),
+        );
+        status.refresh();
+        self.remember_directory_relay_lists(&pending.account_id_hex, &status)?;
+        self.clear_pending_nip65_route_mutation(label)?;
+        Ok(status)
+    }
+
+    async fn recover_pending_nip65_route_mutation(
+        &self,
+        label: &str,
+        signer: Arc<dyn nostr::NostrSigner>,
+    ) -> Result<Option<AccountRelayListStatus>, AppError> {
+        self.recover_pending_nip65_route_mutation_inner(label, signer, false)
+            .await
+    }
+
+    /// Recover a generated-bootstrap intent only after its caller validated
+    /// the exact durable setup authority while holding the account route lock.
+    /// Keeping this capability separate prevents generic startup maintenance
+    /// from replaying a stale generated intent after context validation failed.
+    async fn recover_validated_generated_nip65_route_mutation(
+        &self,
+        label: &str,
+        signer: Arc<dyn nostr::NostrSigner>,
+    ) -> Result<Option<AccountRelayListStatus>, AppError> {
+        self.recover_pending_nip65_route_mutation_inner(label, signer, true)
+            .await
+    }
+
+    async fn recover_pending_nip65_route_mutation_inner(
+        &self,
+        label: &str,
+        signer: Arc<dyn nostr::NostrSigner>,
+        generated_setup_authority_validated: bool,
+    ) -> Result<Option<AccountRelayListStatus>, AppError> {
+        if !self.pending_nip65_route_mutation(label) {
+            return Ok(None);
+        }
+        let mut pending = self.read_pending_nip65_route_mutation(label)?;
+        if pending.source == Nip65RouteMutationSource::GeneratedAccountBootstrap
+            && !generated_setup_authority_validated
+        {
+            return Err(AppError::Publish(
+                "generated-account NIP-65 recovery requires durable setup-context validation"
+                    .into(),
+            ));
+        }
+        let proposed = self.validate_pending_nip65_route_mutation(label, &pending)?;
+        // Always re-evaluate the marker before recovery I/O. Only the exact
+        // generated-account bootstrap intent may retain a fresh-identity
+        // proof; every legacy or ordinary intent re-arms the SQL gate. This
+        // also handles a crash after the intent file was synced but before the
+        // original mutator reached its gate write.
+        {
+            let _root_mutation =
+                self.begin_root_mutation("re-arm pending NIP-65 route mutation")?;
+            let fresh_account_proof_preserved =
+                self.invalidate_key_package_cutover_scan_for_route_mutation(label)?;
+            if !fresh_account_proof_preserved {
+                self.arm_key_package_cutover_publication_gate_for_relays(label, &proposed)?;
+            }
+        }
+        if !pending.network_accepted {
+            let event = pending.signed_event.clone().ok_or_else(|| {
+                AppError::Publish(
+                    "unacknowledged pending NIP-65 route mutation has no exact signed event".into(),
+                )
+            })?;
+            let publish_endpoints = self
+                .relay_plane
+                .sanitize_relay_endpoints(
+                    pending
+                        .publish_endpoints
+                        .iter()
+                        .cloned()
+                        .map(TransportEndpoint)
+                        .collect(),
+                    "pending NIP-65 route mutation publish",
+                )
+                .map_err(|error| {
+                    AppError::Transport(cgka_traits::TransportAdapterError::Publish(error))
+                })?;
+            if publish_endpoints.is_empty() {
+                return Err(AppError::MissingDefaultRelays);
+            }
+            let relay_client =
+                self.relay_client_for_account_id(&pending.account_id_hex, signer.clone());
+            let outcome = relay_client
+                .publish_event(&publish_endpoints, &event, 1)
+                .await
+                .map_err(|error| AppError::Publish(error.to_string()))?;
+            if outcome.accepted.is_empty() {
+                return Err(AppError::Publish(
+                    "relay acknowledged zero pending NIP-65 route events".into(),
+                ));
+            }
+            pending.network_accepted = true;
+            let _root_mutation =
+                self.begin_root_mutation("record pending NIP-65 route acknowledgement")?;
+            self.write_pending_nip65_route_mutation(label, &pending)?;
+        }
+        self.commit_pending_nip65_route_mutation(label, &pending)
+            .map(Some)
+    }
+
+    pub(crate) async fn ingest_local_nip65_relay_event_serialized(
+        &self,
+        label: &str,
+        record: RelayEventRecord,
+    ) -> Result<AccountRelayListStatus, AppError> {
+        let route_lock = self.key_package_route_lock(label);
+        let _route_guard = route_lock.lock().await;
+        self.ingest_local_nip65_relay_event_unlocked(label, record)
+    }
+
+    fn ingest_local_nip65_relay_event_unlocked(
+        &self,
+        label: &str,
+        record: RelayEventRecord,
+    ) -> Result<AccountRelayListStatus, AppError> {
+        let account = self.account_home().account(label)?;
+        if record.event.pubkey != account.account_id_hex
+            || record.event.kind != KIND_NIP65_RELAY_LIST
+            || !self.directory_freshness().accepts(&record)
+        {
+            return self.account_relay_list_status(label);
+        }
+        let nip65 = relay_list_state_from_event(&record.event).ok_or_else(|| {
+            AppError::RelayDirectory("self NIP-65 event has no relay-list state".into())
+        })?;
+        let generation = Nip65RouteGeneration {
+            created_at: record.event.created_at,
+            event_id: record.event.id.clone(),
+            nip65: nip65.clone(),
+        };
+        if self
+            .read_nip65_route_generation_for_authoring(label)?
+            .is_some_and(|current| {
+                !nostr_replaceable_coordinate_is_newer(
+                    generation.created_at,
+                    &generation.event_id,
+                    current.created_at,
+                    &current.event_id,
+                )
+            })
+        {
+            return self.account_relay_list_status(label);
+        }
+        let proposed = self.sanitize_key_package_deletion_endpoints(
+            nip65
+                .relays
+                .iter()
+                .cloned()
+                .map(TransportEndpoint)
+                .collect(),
+        )?;
+        if proposed.is_empty() {
+            return Err(AppError::MissingRelayLists(vec![
+                MissingRelayListKind::Nip65,
+            ]));
+        }
+        let pending = PendingNip65RouteMutation {
+            account_id_hex: account.account_id_hex,
+            nip65,
+            bootstrap_relays: record
+                .endpoints
+                .iter()
+                .map(|endpoint| endpoint.0.clone())
+                .collect(),
+            publish_endpoints: Vec::new(),
+            signed_event: record.event.sig.is_some().then_some(record.event),
+            generation,
+            network_accepted: true,
+            source: Nip65RouteMutationSource::AccountMutation,
+        };
+        {
+            let _root_mutation =
+                self.begin_root_mutation("stage observed self NIP-65 route mutation")?;
+            self.write_pending_nip65_route_mutation(label, &pending)?;
+            self.invalidate_key_package_cutover_scan_for_route_mutation(label)?;
+            self.arm_key_package_cutover_publication_gate_for_relays(label, &proposed)?;
+        }
+        self.commit_pending_nip65_route_mutation(label, &pending)
+    }
+
+    fn key_package_route_lock(&self, label: &str) -> Arc<tokio::sync::Mutex<()>> {
+        self.key_package_route_locks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .entry(label.to_owned())
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
+    }
+
+    fn key_package_history_lock(&self, label: &str) -> Arc<tokio::sync::Mutex<()>> {
+        self.key_package_history_locks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .entry(label.to_owned())
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
+    }
+
+    fn key_package_lifecycle_history_endpoints(
+        &self,
+        lifecycle: &cgka_traits::KeyPackageLifecycleState,
+    ) -> Result<BTreeSet<TransportEndpoint>, AppError> {
+        let target_may_have_been_exposed = |target: &&cgka_traits::TransportFanoutTarget| {
+            target.state == cgka_traits::TransportFanoutAttemptState::Accepted
+                || target.attempt_count > 0
+                || target.last_attempt_at.is_some()
+        };
+        let endpoints = lifecycle
+            .publication_targets
+            .iter()
+            .filter(target_may_have_been_exposed)
+            .map(|target| target.endpoint.clone())
+            .chain(
+                lifecycle
+                    .pending_replacement
+                    .iter()
+                    .flat_map(|pending| pending.targets.iter())
+                    .filter(target_may_have_been_exposed)
+                    .map(|target| target.endpoint.clone()),
+            )
+            .chain(
+                lifecycle
+                    .retired_publications_pending_deletion
+                    .iter()
+                    .flat_map(|retired| retired.deletion_targets.iter())
+                    .map(|target| target.endpoint.clone()),
+            )
+            .collect::<Vec<_>>();
+        // An unsafe exact liability must remain byte-for-byte durable, but it
+        // is not a relay we can dial or strictly scan. Canonicalize each
+        // endpoint independently so one unsafe legacy sibling cannot prevent
+        // a distinct safe sibling from reaching deletion I/O and having its
+        // terminal ACK pruned. The unsafe target remains in the lifecycle and
+        // therefore keeps cleanup incomplete and retryable.
+        Ok(endpoints
+            .into_iter()
+            .filter_map(|endpoint| {
+                self.canonicalize_key_package_endpoint(&endpoint, "key package lifecycle history")
+                    .ok()
+            })
+            .collect())
+    }
+
+    fn key_package_history_endpoints(
+        &self,
+        label: &str,
+    ) -> Result<BTreeSet<TransportEndpoint>, AppError> {
+        let mut endpoints = self.key_package_cutover_relay_history(label)?;
+        let Some(lifecycle) = self.account_storage(label)?.key_package_lifecycle()? else {
+            return Ok(endpoints);
+        };
+        endpoints.extend(self.key_package_lifecycle_history_endpoints(&lifecycle)?);
+        Ok(endpoints)
+    }
+
+    fn key_package_current_route_history_endpoints(
+        &self,
+        label: &str,
+    ) -> Result<BTreeSet<TransportEndpoint>, AppError> {
+        let Some(generation) = self.read_nip65_route_generation_for_authoring(label)? else {
+            return Ok(BTreeSet::new());
+        };
+        Ok(self
+            .validate_nip65_route_generation(&generation)?
+            .into_iter()
+            .collect())
+    }
+
+    fn invalidate_key_package_cutover_scan_for_route_mutation(
+        &self,
+        label: &str,
+    ) -> Result<bool, AppError> {
+        // Preserve a new identity's no-predecessor proof only for its exact,
+        // locally-authored initial bootstrap intent. Pre-field journals and
+        // every ordinary route mutation default to invalidating the proof.
+        if self.pending_nip65_route_mutation(label) {
+            let pending = self.read_pending_nip65_route_mutation(label)?;
+            if self.pending_nip65_route_mutation_preserves_generated_fresh_proof(label, &pending)? {
+                return Ok(true);
+            }
+        }
+        self.invalidate_key_package_cutover_scan_marker(label)
+            .map(|()| false)
+    }
+
+    fn invalidate_key_package_cutover_scan_marker(&self, label: &str) -> Result<(), AppError> {
+        let path = self.key_package_cutover_scan_complete_path(label);
+        match fs::remove_file(&path) {
+            Ok(()) => {
+                #[cfg(unix)]
+                if let Some(parent) = path.parent() {
+                    std::fs::File::open(parent)?.sync_all()?;
+                }
+                Ok(())
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    fn arm_key_package_cutover_publication_gate_for_relays(
+        &self,
+        label: &str,
+        proposed_relays: &[TransportEndpoint],
+    ) -> Result<(), AppError> {
+        let _frontier_mutation = self
+            .key_package_frontier_mutation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let history = self.key_package_history_endpoints(label)?;
+        let frontier = self.key_package_cutover_relay_frontier(label)?;
+        let proposed = self
+            .sanitize_key_package_deletion_endpoints(proposed_relays.to_vec())?
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+        let mut projected_history = history;
+        projected_history.extend(frontier);
+        projected_history.extend(proposed);
+        projected_history.extend(self.key_package_current_route_history_endpoints(label)?);
+        if projected_history.len() > KEY_PACKAGE_CUTOVER_RELAY_HISTORY_CAPACITY {
+            return Err(AppError::Publish(
+                "KeyPackage relay-history journal is full; refusing route mutation".into(),
+            ));
+        }
+        if self.key_package_cutover_scan_complete_for_relays(label, proposed_relays)
+            && !self.key_package_cutover_replacement_pending(label)
+        {
+            return Ok(());
+        }
+        if !self.account_storage_path(label).exists() {
+            return Ok(());
+        }
+        let storage = self.account_storage(label)?;
+        let Some(mut lifecycle) = storage.key_package_lifecycle()? else {
+            return Ok(());
+        };
+        if lifecycle.stable_slot_id.is_empty() {
+            return Err(AppError::Publish(
+                "cannot arm key package cutover publication interlock without a stable slot".into(),
+            ));
+        }
+        if !lifecycle.cutover_publication_blocked {
+            lifecycle.cutover_publication_blocked = true;
+            storage.put_key_package_lifecycle(&lifecycle)?;
+        }
+        Ok(())
+    }
+
+    fn legacy_key_package_cutover_scan_complete_path(&self, label: &str) -> PathBuf {
         self.key_package_cache_dir()
             .join(KEY_PACKAGE_DIR)
             .join(format!("{label}.capability-refresh-v1-relay-scan-complete"))
+    }
+
+    fn key_package_cutover_scan_complete_path(&self, label: &str) -> PathBuf {
+        self.key_package_cache_dir()
+            .join(KEY_PACKAGE_DIR)
+            .join(format!("{label}.capability-refresh-v2-relay-scan-complete"))
+    }
+
+    #[cfg(test)]
+    fn key_package_cutover_scan_complete(&self, label: &str) -> bool {
+        self.key_package_cutover_scan_complete_path(label).exists()
     }
 
     fn key_package_cutover_replacement_pending(&self, label: &str) -> bool {
@@ -3925,23 +7981,24 @@ impl MarmotApp {
 
     fn mark_key_package_cutover_replacement_pending(&self, label: &str) -> bool {
         let path = self.key_package_cutover_replacement_pending_path(label);
-        let result = path
-            .parent()
-            .ok_or_else(|| {
-                std::io::Error::new(
+        let result = (|| -> Result<(), AppError> {
+            let parent = path.parent().ok_or_else(|| {
+                AppError::Io(std::io::Error::new(
                     std::io::ErrorKind::InvalidInput,
                     "cutover marker has no parent directory",
-                )
-            })
-            .and_then(fs_private::create_dir_all_private)
-            .and_then(|()| fs_private::write_private(&path, b"pending\n"));
+                ))
+            })?;
+            self.ensure_private_directory_entry_durable(parent)?;
+            fs_private::write_private_atomic(&path, b"pending\n")?;
+            Ok(())
+        })();
         match result {
             Ok(()) => true,
             Err(error) => {
                 tracing::warn!(
                     target: "marmot_app::key_packages",
                     method = "mark_key_package_cutover_replacement_pending",
-                    error_kind = AppError::from(error).privacy_safe_kind(),
+                    error_kind = error.privacy_safe_kind(),
                     "could not persist key package cutover replacement intent"
                 );
                 false
@@ -3949,18 +8006,496 @@ impl MarmotApp {
         }
     }
 
-    fn clear_key_package_cutover_replacement_pending(&self, label: &str) {
+    fn clear_key_package_cutover_replacement_pending(&self, label: &str) -> Result<(), AppError> {
         let path = self.key_package_cutover_replacement_pending_path(label);
-        match fs::remove_file(path) {
-            Ok(()) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => tracing::warn!(
-                target: "marmot_app::key_packages",
-                method = "clear_key_package_cutover_replacement_pending",
-                error_kind = AppError::from(error).privacy_safe_kind(),
-                "could not clear completed key package replacement intent"
+        remove_file_if_present(path)
+    }
+
+    fn removed_local_key_package_tombstone_root(&self) -> PathBuf {
+        self.key_package_cache_dir()
+            .join(KEY_PACKAGE_DIR)
+            .join(REMOVED_LOCAL_KEY_PACKAGE_TOMBSTONE_DIR)
+    }
+
+    fn removed_local_key_package_account_tombstone_dir(
+        &self,
+        account_id_hex: &str,
+    ) -> Result<PathBuf, AppError> {
+        Ok(self
+            .removed_local_key_package_tombstone_root()
+            .join(parse_account_id_hex(account_id_hex)?))
+    }
+
+    fn removed_local_key_package_tombstone_path(
+        &self,
+        account_id_hex: &str,
+        stable_slot_id: Option<&str>,
+    ) -> Result<PathBuf, AppError> {
+        let file_name = match stable_slot_id {
+            Some(stable_slot_id) => format!(
+                "slot-{}.json",
+                hex::encode(Sha256::digest(stable_slot_id.as_bytes()))
             ),
+            None => "all.json".to_owned(),
+        };
+        Ok(self
+            .removed_local_key_package_account_tombstone_dir(account_id_hex)?
+            .join(file_name))
+    }
+
+    fn removed_local_key_package_tombstone_journal_path(
+        &self,
+        account_id_hex: &str,
+    ) -> Result<PathBuf, AppError> {
+        Ok(self
+            .removed_local_key_package_account_tombstone_dir(account_id_hex)?
+            .join(REMOVED_LOCAL_KEY_PACKAGE_TOMBSTONE_JOURNAL))
+    }
+
+    fn load_removed_local_key_package_tombstone_journal(
+        &self,
+        account_id_hex: &str,
+    ) -> Result<RemovedLocalKeyPackageTombstoneJournal, AppError> {
+        let mut journal = RemovedLocalKeyPackageTombstoneJournal {
+            account_id_hex: account_id_hex.to_owned(),
+            retired_stable_slot_ids: Vec::new(),
+            account_wide: false,
+        };
+        let journal_path = self.removed_local_key_package_tombstone_journal_path(account_id_hex)?;
+        if journal_path.try_exists()? {
+            journal = read_json(&journal_path)?;
+            Self::canonicalize_removed_local_key_package_tombstone_journal(
+                &mut journal,
+                account_id_hex,
+            )?;
         }
+        let dir = self.removed_local_key_package_account_tombstone_dir(account_id_hex)?;
+        if dir.try_exists()? {
+            for entry in std::fs::read_dir(&dir)? {
+                let path = entry?.path();
+                let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+                    continue;
+                };
+                if name == "all.json" {
+                    self.validate_removed_local_key_package_tombstone(&path, account_id_hex, None)?;
+                    journal.account_wide = true;
+                } else if name.starts_with("slot-")
+                    && name.ends_with(".json")
+                    && let Some(slot) =
+                        self.legacy_exact_slot_tombstone_identity(&path, account_id_hex)?
+                {
+                    Self::admit_removed_local_key_package_tombstone_slot(&mut journal, &slot)?;
+                }
+            }
+        }
+        Self::canonicalize_removed_local_key_package_tombstone_journal(
+            &mut journal,
+            account_id_hex,
+        )?;
+        Ok(journal)
+    }
+
+    fn canonicalize_removed_local_key_package_tombstone_journal(
+        journal: &mut RemovedLocalKeyPackageTombstoneJournal,
+        account_id_hex: &str,
+    ) -> Result<(), AppError> {
+        if journal.account_id_hex != account_id_hex {
+            return Err(AppError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "removed-local KeyPackage tombstone journal does not match its path",
+            )));
+        }
+        let mut seen = HashSet::new();
+        let mut canonical = Vec::new();
+        for slot in std::mem::take(&mut journal.retired_stable_slot_ids) {
+            if slot.is_empty() {
+                return Err(AppError::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "removed-local KeyPackage tombstone journal contains an empty slot",
+                )));
+            }
+            if seen.insert(slot.clone()) {
+                canonical.push(slot);
+            }
+        }
+        if canonical.len() > MAX_REMOVED_LOCAL_KEY_PACKAGE_TOMBSTONE_SLOTS {
+            return Err(AppError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "removed-local KeyPackage tombstone slot capacity reached",
+            )));
+        }
+        journal.retired_stable_slot_ids = canonical;
+        Ok(())
+    }
+
+    fn legacy_exact_slot_tombstone_identity(
+        &self,
+        path: &Path,
+        account_id_hex: &str,
+    ) -> Result<Option<String>, AppError> {
+        let marker: RemovedLocalKeyPackageTombstone = read_json(path)?;
+        if marker.account_id_hex != account_id_hex {
+            return Err(AppError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "removed-local KeyPackage tombstone does not match its path",
+            )));
+        }
+        let Some(slot) = marker.stable_slot_id else {
+            return Ok(None);
+        };
+        let expected_name = format!("slot-{}.json", hex::encode(Sha256::digest(slot.as_bytes())));
+        let actual_name = path.file_name().and_then(|name| name.to_str());
+        if actual_name != Some(expected_name.as_str()) {
+            return Ok(None);
+        }
+        Ok(Some(slot))
+    }
+
+    fn admit_removed_local_key_package_tombstone_slot(
+        journal: &mut RemovedLocalKeyPackageTombstoneJournal,
+        stable_slot_id: &str,
+    ) -> Result<(), AppError> {
+        if journal
+            .retired_stable_slot_ids
+            .iter()
+            .any(|slot| slot == stable_slot_id)
+        {
+            return Ok(());
+        }
+        if journal.retired_stable_slot_ids.len() >= MAX_REMOVED_LOCAL_KEY_PACKAGE_TOMBSTONE_SLOTS {
+            return Err(AppError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "removed-local KeyPackage tombstone slot capacity reached",
+            )));
+        }
+        journal
+            .retired_stable_slot_ids
+            .push(stable_slot_id.to_owned());
+        Ok(())
+    }
+
+    /// Compact exact-slot files into the bounded per-account journal after the
+    /// journal itself is durable. Exact identities stay in
+    /// `retired_stable_slot_ids`; leftover files are unlinked with parent
+    /// fsync.
+    fn coalesce_removed_local_key_package_tombstones(
+        &self,
+        account_id_hex: &str,
+        journal: &RemovedLocalKeyPackageTombstoneJournal,
+    ) -> Result<(), AppError> {
+        let dir = self.removed_local_key_package_account_tombstone_dir(account_id_hex)?;
+        if !dir.try_exists()? {
+            return Ok(());
+        }
+        for entry in std::fs::read_dir(&dir)? {
+            let path = entry?.path();
+            let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            if name == REMOVED_LOCAL_KEY_PACKAGE_TOMBSTONE_JOURNAL {
+                continue;
+            }
+            if name == "all.json" {
+                if journal.account_wide {
+                    remove_file_if_present(&path)?;
+                }
+                continue;
+            }
+            if name.starts_with("slot-") && name.ends_with(".json") {
+                let Some(slot) =
+                    self.legacy_exact_slot_tombstone_identity(&path, account_id_hex)?
+                else {
+                    continue;
+                };
+                if journal
+                    .retired_stable_slot_ids
+                    .iter()
+                    .any(|retired| retired == &slot)
+                {
+                    remove_file_if_present(&path)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_removed_local_key_package_tombstone(
+        &self,
+        path: &Path,
+        account_id_hex: &str,
+        stable_slot_id: Option<&str>,
+    ) -> Result<(), AppError> {
+        let marker: RemovedLocalKeyPackageTombstone = read_json(path)?;
+        if marker.account_id_hex != account_id_hex
+            || marker.stable_slot_id.as_deref() != stable_slot_id
+        {
+            return Err(AppError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "removed-local KeyPackage tombstone does not match its path",
+            )));
+        }
+        if let Some(slot) = stable_slot_id {
+            let expected_name =
+                format!("slot-{}.json", hex::encode(Sha256::digest(slot.as_bytes())));
+            if path.file_name().and_then(|name| name.to_str()) != Some(expected_name.as_str()) {
+                return Err(AppError::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "removed-local KeyPackage tombstone does not match its path",
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn active_local_key_package_slot_is_authorized_for_admitted_account(
+        &self,
+        account_id_hex: &str,
+        stable_slot_id: &str,
+        account: Option<&AccountSummary>,
+    ) -> Result<bool, AppError> {
+        let Some(account) = account else {
+            return Ok(false);
+        };
+        if !account.is_active_signing() || account.account_id_hex != account_id_hex {
+            return Ok(false);
+        }
+        Ok(self
+            .account_storage(&account.label)?
+            .key_package_lifecycle()?
+            .is_some_and(|lifecycle| lifecycle.stable_slot_id == stable_slot_id))
+    }
+
+    fn active_local_key_package_slot_is_authorized(
+        &self,
+        account_id_hex: &str,
+        stable_slot_id: &str,
+    ) -> Result<bool, AppError> {
+        let Some(account) = self.local_signing_account_for_id(account_id_hex)? else {
+            return Ok(false);
+        };
+        let admission = self
+            .account_session_admissions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let admission_open = admission
+            .get(&account.label)
+            .is_none_or(|state| state.account_id_hex != account.account_id_hex || state.open);
+        let active_account = (admission_open && account.is_active_signing()).then_some(&account);
+        self.active_local_key_package_slot_is_authorized_for_admitted_account(
+            account_id_hex,
+            stable_slot_id,
+            active_account,
+        )
+    }
+
+    /// Admission-aware variant for callers already holding the account-session
+    /// mutex. It must not try to reacquire that non-reentrant mutex while
+    /// proving the active lifecycle exception to an account-wide legacy
+    /// marker.
+    pub(crate) fn removed_local_key_package_slot_is_retired_for_admitted_account(
+        &self,
+        account_id_hex: &str,
+        stable_slot_id: &str,
+        local_signing_account: Option<&AccountSummary>,
+    ) -> Result<bool, AppError> {
+        let account_id_hex = parse_account_id_hex(account_id_hex)?;
+        self.removed_local_key_package_slot_is_retired_with_active_check(
+            &account_id_hex,
+            stable_slot_id,
+            |slot| {
+                self.active_local_key_package_slot_is_authorized_for_admitted_account(
+                    &account_id_hex,
+                    slot,
+                    local_signing_account,
+                )
+            },
+        )
+    }
+
+    /// Whether a directory/publication candidate belongs to private local MLS
+    /// material that this installation has irreversibly removed.
+    ///
+    /// Exact stable-slot tombstones always win. The account-wide marker is a
+    /// legacy fail-closed fallback; a later explicit re-import may use only a
+    /// newly minted slot proven by its active local lifecycle.
+    pub(crate) fn removed_local_key_package_slot_is_retired(
+        &self,
+        account_id_hex: &str,
+        stable_slot_id: &str,
+    ) -> Result<bool, AppError> {
+        let account_id_hex = parse_account_id_hex(account_id_hex)?;
+        self.removed_local_key_package_slot_is_retired_with_active_check(
+            &account_id_hex,
+            stable_slot_id,
+            |slot| self.active_local_key_package_slot_is_authorized(&account_id_hex, slot),
+        )
+    }
+
+    fn removed_local_key_package_slot_is_retired_with_active_check(
+        &self,
+        account_id_hex: &str,
+        stable_slot_id: &str,
+        active_authorized: impl Fn(&str) -> Result<bool, AppError>,
+    ) -> Result<bool, AppError> {
+        let account_tombstone_dir =
+            self.removed_local_key_package_account_tombstone_dir(account_id_hex)?;
+        if !account_tombstone_dir.try_exists()? {
+            return Ok(false);
+        }
+        let journal = self.load_removed_local_key_package_tombstone_journal(account_id_hex)?;
+        if journal
+            .retired_stable_slot_ids
+            .iter()
+            .any(|slot| slot == stable_slot_id)
+        {
+            return Ok(true);
+        }
+        let exact =
+            self.removed_local_key_package_tombstone_path(account_id_hex, Some(stable_slot_id))?;
+        if exact.try_exists()? {
+            self.validate_removed_local_key_package_tombstone(
+                &exact,
+                account_id_hex,
+                Some(stable_slot_id),
+            )?;
+            return Ok(true);
+        }
+        if !journal.account_wide {
+            let account_wide =
+                self.removed_local_key_package_tombstone_path(account_id_hex, None)?;
+            if !account_wide.try_exists()? {
+                return Ok(false);
+            }
+            self.validate_removed_local_key_package_tombstone(&account_wide, account_id_hex, None)?;
+        }
+        Ok(!active_authorized(stable_slot_id)?)
+    }
+
+    fn removed_local_key_package_scope(
+        &self,
+        account: &AccountSummary,
+    ) -> Option<RemovedLocalKeyPackageScope> {
+        if !account.can_sign() {
+            return None;
+        }
+        if self.account_storage_path(&account.label).exists()
+            && let Ok(storage) = self.account_storage(&account.label)
+            && let Ok(Some(lifecycle)) = storage.key_package_lifecycle()
+            && !lifecycle.stable_slot_id.is_empty()
+        {
+            return Some(RemovedLocalKeyPackageScope::StableSlot(
+                lifecycle.stable_slot_id,
+            ));
+        }
+        if let Ok(Some(stable_slot_id)) =
+            self.reusable_key_package_slot_id(&account.label, &account.account_id_hex)
+        {
+            return Some(RemovedLocalKeyPackageScope::StableSlot(stable_slot_id));
+        }
+        Some(RemovedLocalKeyPackageScope::AccountWideLegacy)
+    }
+
+    fn purge_removed_local_key_package_projections(
+        &self,
+        account_id_hex: &str,
+        scope: &RemovedLocalKeyPackageScope,
+    ) -> Result<(), AppError> {
+        self.member_key_package_prewarm_cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(account_id_hex);
+        let stable_slot_id = match scope {
+            RemovedLocalKeyPackageScope::StableSlot(stable_slot_id) => {
+                Some(stable_slot_id.as_str())
+            }
+            RemovedLocalKeyPackageScope::AccountWideLegacy => None,
+        };
+        let shared = self.shared_storage()?;
+        if let Some(record) = shared.public_directory_user(account_id_hex)?
+            && let Some(key_package_json) = record.key_package_json.as_deref()
+        {
+            let should_clear = stable_slot_id.is_none_or(|stable_slot_id| {
+                serde_json::from_str::<DirectoryKeyPackage>(key_package_json)
+                    .is_ok_and(|key_package| key_package.key_package_id == stable_slot_id)
+            });
+            if should_clear {
+                let _ = shared.clear_public_directory_key_package_if_matches(
+                    account_id_hex,
+                    key_package_json,
+                )?;
+            }
+        }
+        for cache in self.directory_caches()? {
+            let _ = cache.clear_key_package_if_slot(account_id_hex, stable_slot_id)?;
+        }
+        self.request_directory_sync_rebuild();
+        Ok(())
+    }
+
+    /// Persist the immutable local-removal authority before any account
+    /// artifact or AccountHome bytes are deleted, then scrub its cached
+    /// projections. Marker persistence is the destructive commit prerequisite;
+    /// projection cleanup is retryable because every read/write path consults
+    /// the marker.
+    pub(crate) fn persist_removed_local_key_package_tombstone(
+        &self,
+        account: &AccountSummary,
+    ) -> Result<(), AppError> {
+        let Some(scope) = self.removed_local_key_package_scope(account) else {
+            return Ok(());
+        };
+        let stable_slot_id = match &scope {
+            RemovedLocalKeyPackageScope::StableSlot(stable_slot_id) => {
+                Some(stable_slot_id.as_str())
+            }
+            RemovedLocalKeyPackageScope::AccountWideLegacy => None,
+        };
+        {
+            let _mutation = self
+                .removed_local_key_package_mutation_lock
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            // Create and sync each namespace level separately. `create_dir_all`
+            // followed only by a sync of the deepest parent would not durably
+            // publish a newly created top-level `key-packages` entry.
+            self.ensure_private_directory_entry_durable(
+                &self.key_package_cache_dir().join(KEY_PACKAGE_DIR),
+            )?;
+            let root = self.removed_local_key_package_tombstone_root();
+            self.ensure_private_directory_entry_durable(&root)?;
+            let account_dir =
+                self.removed_local_key_package_account_tombstone_dir(&account.account_id_hex)?;
+            self.ensure_private_directory_entry_durable(&account_dir)?;
+            let mut journal =
+                self.load_removed_local_key_package_tombstone_journal(&account.account_id_hex)?;
+            match stable_slot_id {
+                Some(slot) => {
+                    Self::admit_removed_local_key_package_tombstone_slot(&mut journal, slot)?
+                }
+                None => journal.account_wide = true,
+            }
+            self.write_private_json(
+                &self.removed_local_key_package_tombstone_journal_path(&account.account_id_hex)?,
+                &journal,
+                "removed-local KeyPackage tombstone journal",
+            )?;
+            self.coalesce_removed_local_key_package_tombstones(&account.account_id_hex, &journal)?;
+        }
+        // The immutable marker now gates every writer. Release the mutation
+        // mutex before opening caches: one-time legacy migration takes that
+        // same mutex and will either have completed before the marker or will
+        // observe it before importing any old projection.
+        if let Err(error) =
+            self.purge_removed_local_key_package_projections(&account.account_id_hex, &scope)
+        {
+            tracing::warn!(
+                target: "marmot_app::key_packages",
+                method = "persist_removed_local_key_package_tombstone",
+                error_kind = error.privacy_safe_kind(),
+                "removed-local KeyPackage tombstone committed but projection scrub is pending"
+            );
+        }
+        Ok(())
     }
 
     /// Remove compatibility artifacts that live outside the account directory.
@@ -3969,34 +8504,186 @@ impl MarmotApp {
         for path in [
             self.key_package_record_path(label),
             self.key_package_cutover_replacement_pending_path(label),
+            self.generated_initial_key_package_publication_hold_path(label),
+            self.key_package_cutover_relay_frontier_path(label),
+            self.key_package_cutover_relay_history_path(label),
+            self.key_package_teardown_cleanup_pending_path(label),
+            self.pending_nip65_route_mutation_path(label),
+            self.nip65_route_generation_path(label),
+            self.legacy_key_package_cutover_scan_complete_path(label),
             self.key_package_cutover_scan_complete_path(label),
         ] {
-            match fs::remove_file(path) {
-                Ok(()) => {}
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-                Err(error) => return Err(error.into()),
-            }
+            remove_file_if_present(path)?;
         }
         Ok(())
     }
 
-    fn key_package_cutover_scan_complete(&self, label: &str) -> bool {
-        self.key_package_cutover_scan_complete_path(label).exists()
+    fn key_package_cutover_has_fresh_account_proof(&self, label: &str) -> bool {
+        read_json::<KeyPackageCutoverScanMarker>(self.key_package_cutover_scan_complete_path(label))
+            .is_ok_and(|marker| marker.strict_history_peeling && marker.fresh_account_proof)
     }
 
     fn mark_key_package_cutover_scan_complete(&self, label: &str) -> Result<(), AppError> {
-        let path = self.key_package_cutover_scan_complete_path(label);
-        let result = path
-            .parent()
+        self.write_key_package_cutover_scan_marker(
+            label,
+            &KeyPackageCutoverScanMarker {
+                strict_history_peeling: true,
+                fresh_account_proof: true,
+                authoritative_relays: Vec::new(),
+                history_relays: Vec::new(),
+                route_created_at: None,
+                route_event_id: None,
+            },
+        )
+    }
+
+    fn key_package_cutover_scan_complete_for_relays(
+        &self,
+        label: &str,
+        source_relays: &[TransportEndpoint],
+    ) -> bool {
+        if !self
+            .key_package_teardown_cleanup_pending(label)
+            .is_ok_and(|pending| !pending)
+        {
+            return false;
+        }
+        if !self
+            .key_package_cutover_relay_frontier(label)
+            .is_ok_and(|frontier| frontier.is_empty())
+        {
+            return false;
+        }
+        let Ok(marker) = read_json::<KeyPackageCutoverScanMarker>(
+            self.key_package_cutover_scan_complete_path(label),
+        ) else {
+            return false;
+        };
+        if !marker.strict_history_peeling {
+            return false;
+        }
+        if marker.fresh_account_proof && !self.pending_nip65_route_mutation(label) {
+            return true;
+        }
+        let Ok(required_history) = self.key_package_history_endpoints(label) else {
+            return false;
+        };
+        let history_was_covered = required_history
+            .iter()
+            .all(|endpoint| marker.history_relays.binary_search(&endpoint.0).is_ok());
+        if !history_was_covered {
+            return false;
+        }
+        let mut expected = source_relays
+            .iter()
+            .map(|endpoint| endpoint.0.clone())
+            .collect::<Vec<_>>();
+        expected.sort();
+        expected.dedup();
+        let Ok(Some(current_generation)) = self.read_nip65_route_generation_for_authoring(label)
+        else {
+            return false;
+        };
+        let Ok(authoritative_endpoints) = self.validate_nip65_route_generation(&current_generation)
+        else {
+            return false;
+        };
+        let mut generation_relays = authoritative_endpoints
+            .into_iter()
+            .map(|endpoint| endpoint.0)
+            .collect::<Vec<_>>();
+        generation_relays.sort();
+        generation_relays.dedup();
+        marker.authoritative_relays == expected
+            && expected == generation_relays
+            && marker.route_created_at == Some(current_generation.created_at)
+            && marker.route_event_id == Some(current_generation.event_id)
+    }
+
+    fn mark_key_package_cutover_scan_complete_for_relays(
+        &self,
+        label: &str,
+        source_relays: &[TransportEndpoint],
+        scanned_history_relays: &BTreeSet<TransportEndpoint>,
+    ) -> Result<(), AppError> {
+        let _frontier_mutation = self
+            .key_package_frontier_mutation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !self.key_package_cutover_relay_frontier(label)?.is_empty() {
+            return Err(AppError::Publish(
+                "cannot complete KeyPackage cutover with relay-history scans pending".into(),
+            ));
+        }
+        let mut authoritative_relays = source_relays
+            .iter()
+            .map(|endpoint| endpoint.0.clone())
+            .collect::<Vec<_>>();
+        authoritative_relays.sort();
+        authoritative_relays.dedup();
+        let generation = self
+            .read_nip65_route_generation_for_authoring(label)?
             .ok_or_else(|| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    "cutover marker has no parent directory",
+                AppError::Publish(
+                    "cannot complete KeyPackage cutover without local NIP-65 route authority"
+                        .into(),
                 )
-            })
-            .and_then(fs_private::create_dir_all_private)
-            .and_then(|()| fs_private::write_private(&path, b"complete\n"))
-            .map_err(AppError::from);
+            })?;
+        let mut generation_relays = self
+            .validate_nip65_route_generation(&generation)?
+            .into_iter()
+            .map(|endpoint| endpoint.0)
+            .collect::<Vec<_>>();
+        generation_relays.sort();
+        generation_relays.dedup();
+        if authoritative_relays != generation_relays {
+            return Err(AppError::Publish(
+                "cannot bind a KeyPackage cutover marker to stale NIP-65 relays".into(),
+            ));
+        }
+        let required_history_relays = self
+            .account_storage(label)?
+            .key_package_lifecycle()?
+            .as_ref()
+            .map(|lifecycle| self.key_package_lifecycle_history_endpoints(lifecycle))
+            .transpose()?
+            .unwrap_or_default()
+            .into_iter()
+            .chain(source_relays.iter().cloned())
+            .collect::<BTreeSet<_>>();
+        if !required_history_relays.is_subset(scanned_history_relays) {
+            return Err(AppError::Publish(
+                "cannot complete KeyPackage cutover with an unscanned historical relay".into(),
+            ));
+        }
+        let durable_history_relays = self
+            .extend_key_package_cutover_relay_history_under_root(label, scanned_history_relays)?;
+        let mut history_relays = durable_history_relays
+            .iter()
+            .map(|endpoint| endpoint.0.clone())
+            .collect::<Vec<_>>();
+        history_relays.sort();
+        history_relays.dedup();
+        self.write_key_package_cutover_scan_marker(
+            label,
+            &KeyPackageCutoverScanMarker {
+                strict_history_peeling: true,
+                fresh_account_proof: false,
+                authoritative_relays,
+                history_relays,
+                route_created_at: Some(generation.created_at),
+                route_event_id: Some(generation.event_id),
+            },
+        )
+    }
+
+    fn write_key_package_cutover_scan_marker(
+        &self,
+        label: &str,
+        marker: &KeyPackageCutoverScanMarker,
+    ) -> Result<(), AppError> {
+        let path = self.key_package_cutover_scan_complete_path(label);
+        let result = self.write_private_json(&path, marker, "completed KeyPackage relay scan");
         if let Err(error) = &result {
             tracing::warn!(
                 target: "marmot_app::key_packages",
@@ -4006,6 +8693,20 @@ impl MarmotApp {
             );
         }
         result
+    }
+
+    fn key_package_cutover_publication_allowed(&self, label: &str) -> bool {
+        // A prepared route mutation is publication-relevant even before its
+        // kind-10002 has an acknowledgement. This file is written before the
+        // durable lifecycle gate is armed, so it is also the crash-safe fence
+        // for that narrow pre-arm window.
+        if self.pending_nip65_route_mutation(label) {
+            return false;
+        }
+        let Ok(source_relays) = self.authoritative_key_package_relays(label) else {
+            return false;
+        };
+        self.key_package_cutover_scan_complete_for_relays(label, &source_relays)
     }
 
     pub fn local_key_package_records(
@@ -4026,6 +8727,7 @@ impl MarmotApp {
             let mut key_package_id = metadata.key_package_ref_hex.clone();
             let mut key_package_event_id = String::new();
             let mut published_at = 0;
+            let mut record_source_relays = source_relays.clone();
 
             if let Some(lifecycle) = lifecycle.as_ref() {
                 if lifecycle.current_key_package_ref.as_deref() == Some(&key_package_ref) {
@@ -4039,6 +8741,13 @@ impl MarmotApp {
                         .authored_event_created_at
                         .map(|created_at| created_at.0)
                         .unwrap_or_default();
+                    push_unique_strings(
+                        &mut record_source_relays,
+                        lifecycle
+                            .publication_targets
+                            .iter()
+                            .map(|target| target.endpoint.0.clone()),
+                    );
                 } else if let Some(pending) = lifecycle
                     .pending_replacement
                     .as_ref()
@@ -4055,6 +8764,13 @@ impl MarmotApp {
                         .as_ref()
                         .map(|event| event.created_at.0)
                         .unwrap_or(pending.authored_created_at.0);
+                    push_unique_strings(
+                        &mut record_source_relays,
+                        pending
+                            .targets
+                            .iter()
+                            .map(|target| target.endpoint.0.clone()),
+                    );
                 } else if let Some(retained) = lifecycle
                     .retained_private_material
                     .iter()
@@ -4088,12 +8804,75 @@ impl MarmotApp {
                 key_package_event_id,
                 published_at,
                 key_package_bytes: key_package.bytes().len(),
-                source_relays: source_relays.clone(),
+                source_relays: record_source_relays,
                 local: true,
                 relay: false,
             });
         }
         Ok(records)
+    }
+
+    /// Exact locally-authored event ids and historical target snapshots that
+    /// teardown must delete even when relay discovery is unavailable.
+    ///
+    /// This is deliberately a deletion-target projection, not a synthetic
+    /// [`AccountKeyPackageRecord`]: retired signed revisions no longer own MLS
+    /// private material and must never be reported as `local` KeyPackages.
+    pub(crate) fn durable_key_package_deletion_targets(
+        &self,
+        label: &str,
+    ) -> Result<Vec<KeyPackageDeletionTarget>, AppError> {
+        let Some(lifecycle) = self.account_storage(label)?.key_package_lifecycle()? else {
+            return Ok(Vec::new());
+        };
+        let mut targets = Vec::new();
+        let mut push = |event_id: &cgka_traits::MessageId, endpoints: Vec<TransportEndpoint>| {
+            if !endpoints.is_empty() {
+                targets.push(KeyPackageDeletionTarget {
+                    event_id_hex: hex::encode(event_id.as_slice()),
+                    source_relays: endpoints,
+                });
+            }
+        };
+
+        if let Some(event_id) = lifecycle
+            .authored_signed_event
+            .as_ref()
+            .map(|artifact| &artifact.id)
+            .or(lifecycle.authored_event_id.as_ref())
+        {
+            push(
+                event_id,
+                lifecycle
+                    .publication_targets
+                    .iter()
+                    .map(|target| target.endpoint.clone())
+                    .collect(),
+            );
+        }
+        if let Some(pending) = lifecycle.pending_replacement.as_ref()
+            && let Some(artifact) = pending.signed_event.as_ref()
+        {
+            push(
+                &artifact.id,
+                pending
+                    .targets
+                    .iter()
+                    .map(|target| target.endpoint.clone())
+                    .collect(),
+            );
+        }
+        for retired in &lifecycle.retired_publications_pending_deletion {
+            push(
+                &retired.event_id,
+                retired
+                    .deletion_targets
+                    .iter()
+                    .map(|target| target.endpoint.clone())
+                    .collect(),
+            );
+        }
+        Ok(targets)
     }
 
     pub async fn account_key_package_records(
@@ -4103,7 +8882,7 @@ impl MarmotApp {
         owned_key_packages: Vec<KeyPackage>,
     ) -> Result<Vec<AccountKeyPackageRecord>, AppError> {
         let account = self.account_home().account(label)?;
-        let account_id_hex = account.account_id_hex;
+        let account_id_hex = account.account_id_hex.clone();
         let mut packages = self.local_key_package_records(label, owned_key_packages)?;
 
         let has_explicit_bootstrap_relays = !bootstrap_relays.is_empty();
@@ -4172,44 +8951,199 @@ impl MarmotApp {
         Ok(merge_key_package_records(packages))
     }
 
+    /// Legacy direct-app seam retained for API compatibility.
+    ///
+    /// Every KeyPackage deletion requires a durable runtime admission and
+    /// pre-I/O recovery journal, including relay-discovered unknown revisions.
+    /// Use [`MarmotAppRuntime::delete_key_package`]; this method validates the
+    /// event-id shape, then always fails before storage, signing, or relay I/O.
     pub async fn delete_key_package_event(
         &self,
-        label: &str,
+        _label: &str,
         event_id_hex: &str,
-        source_relays: Vec<TransportEndpoint>,
+        _source_relays: Vec<TransportEndpoint>,
     ) -> Result<usize, AppError> {
-        let mut outcomes = self
-            .delete_key_package_events(
-                label,
-                vec![KeyPackageDeletionTarget {
-                    event_id_hex: event_id_hex.to_owned(),
-                    source_relays,
-                }],
+        parse_key_package_event_id_hex(event_id_hex)?;
+        Err(AppError::Publish(
+            "direct KeyPackage deletion requires durable runtime admission".to_owned(),
+        ))
+    }
+
+    /// Canonicalize deletion endpoint keys through the relay dial policy
+    /// without applying the live-route cardinality cap to a historical cleanup
+    /// obligation. Each returned key has independently passed the same safety
+    /// validation used at I/O, and canonical aliases collapse before durable
+    /// admission or publication.
+    fn sanitize_key_package_deletion_endpoints(
+        &self,
+        endpoints: Vec<TransportEndpoint>,
+    ) -> Result<Vec<TransportEndpoint>, AppError> {
+        self.key_package_deletion_endpoint_aliases(&endpoints)
+            .map(|(canonical, _aliases)| canonical)
+    }
+
+    fn canonicalize_key_package_endpoint(
+        &self,
+        endpoint: &TransportEndpoint,
+        context: &str,
+    ) -> Result<TransportEndpoint, AppError> {
+        let mut canonical = self
+            .relay_plane
+            .sanitize_relay_endpoints(vec![endpoint.clone()], context)
+            .map_err(|error| {
+                AppError::Transport(cgka_traits::TransportAdapterError::Publish(error))
+            })?;
+        canonical.pop().ok_or_else(|| {
+            AppError::Publish(
+                "key package endpoint canonicalization produced no endpoint".to_owned(),
             )
-            .await?;
-        outcomes
-            .pop()
-            .expect("single-event deletion batch returns one outcome")
-            .result
+        })
+    }
+
+    /// Return both the deduplicated canonical I/O keys and the exact durable
+    /// keys from which they came. The alias map lets active maintenance read a
+    /// legacy noncanonical journal row, perform I/O only with a safety-approved
+    /// canonical URL, and translate the receipt back to the exact key that its
+    /// transport-generic lifecycle owner must prune.
+    fn key_package_deletion_endpoint_aliases(
+        &self,
+        endpoints: &[TransportEndpoint],
+    ) -> Result<KeyPackageDeletionEndpointAliases, AppError> {
+        let mut sanitized = Vec::with_capacity(endpoints.len());
+        let mut aliases = Vec::with_capacity(endpoints.len());
+        for requested_endpoint in endpoints {
+            let canonical_endpoint = self.canonicalize_key_package_endpoint(
+                requested_endpoint,
+                "key package deletion publish",
+            )?;
+            aliases.push((requested_endpoint.clone(), canonical_endpoint.clone()));
+            sanitized.push(canonical_endpoint);
+        }
+        sanitized.sort();
+        sanitized.dedup();
+        Ok((sanitized, aliases))
+    }
+
+    /// Repair valid legacy endpoint aliases while the account worker is
+    /// quiesced. Unsafe/invalid keys remain byte-for-byte intact and therefore
+    /// fail closed when selected; they are never silently erased as part of an
+    /// upgrade. Canonical collisions merge into one target while retaining the
+    /// strongest absence, acceptance, or possible-exposure evidence.
+    fn canonicalize_quiesced_key_package_lifecycle_targets(
+        &self,
+        lifecycle: &mut cgka_traits::KeyPackageLifecycleState,
+    ) -> bool {
+        let mut changed = canonicalize_key_package_fanout_targets(
+            &mut lifecycle.publication_targets,
+            |endpoint| {
+                self.canonicalize_key_package_endpoint(
+                    endpoint,
+                    "key package lifecycle endpoint repair",
+                )
+                .ok()
+            },
+        );
+        if let Some(pending) = lifecycle.pending_replacement.as_mut() {
+            changed |= canonicalize_key_package_fanout_targets(&mut pending.targets, |endpoint| {
+                self.canonicalize_key_package_endpoint(
+                    endpoint,
+                    "key package lifecycle endpoint repair",
+                )
+                .ok()
+            });
+        }
+        for retired in &mut lifecycle.retired_publications_pending_deletion {
+            changed |= canonicalize_key_package_fanout_targets(
+                &mut retired.deletion_targets,
+                |endpoint| {
+                    self.canonicalize_key_package_endpoint(
+                        endpoint,
+                        "key package lifecycle endpoint repair",
+                    )
+                    .ok()
+                },
+            );
+        }
+        changed
+    }
+
+    /// Normalize valid persisted relay aliases while the account-session guard
+    /// is held but before the transport-generic runtime reads the lifecycle.
+    /// This gives successor eligibility and deletion pruning one durable
+    /// endpoint identity across upgrades. Unsafe legacy keys remain unchanged
+    /// and therefore retry fail-closed through the publisher boundary.
+    fn canonicalize_key_package_lifecycle_targets_before_session_open(
+        &self,
+        label: &str,
+    ) -> Result<(), AppError> {
+        let storage = self.account_storage(label)?;
+        let Some(mut lifecycle) = storage.key_package_lifecycle()? else {
+            return Ok(());
+        };
+        if self.canonicalize_quiesced_key_package_lifecycle_targets(&mut lifecycle) {
+            storage.put_key_package_lifecycle(&lifecycle)?;
+        }
+        Ok(())
     }
 
     pub(crate) async fn delete_key_package_events(
         &self,
         label: &str,
         targets: Vec<KeyPackageDeletionTarget>,
+        session_admission: AccountSessionAdmission,
     ) -> Result<Vec<KeyPackageDeletionResult>, AppError> {
+        // Active deletion serializes its final capability proof with teardown.
+        // Teardown cleanup already owns the route lock while peeling history,
+        // so its exact cleanup capability must not recursively acquire it.
+        let active_route_lock = matches!(&session_admission, AccountSessionAdmission::Active(_))
+            .then(|| self.key_package_route_lock(label));
+        let _active_route_guard = match active_route_lock.as_ref() {
+            Some(lock) => Some(lock.lock().await),
+            None => None,
+        };
+        let history_lock = self.key_package_history_lock(label);
+        let _history_guard = history_lock.lock().await;
         let account = self.account_home().account(label)?;
+        let admission_is_current = || match &session_admission {
+            AccountSessionAdmission::Active(token) => {
+                account.is_active_signing()
+                    && account.account_id_hex == token.account_id_hex
+                    && self.active_account_session_admission_is_current(label, token)
+            }
+            AccountSessionAdmission::Teardown(token) => {
+                account.signed_out
+                    && account.account_id_hex == token.account_id_hex
+                    && self.account_teardown_session_admission_is_current(label, token)
+            }
+        };
+        if !admission_is_current() {
+            return Err(AppError::AccountWorkerBusy);
+        }
         let signer = self.account_signer_for_summary(&account)?;
-        let account_id_hex = account.account_id_hex;
+        let account_id_hex = account.account_id_hex.clone();
+        // This is the lowest kind-5 I/O boundary. A process-local session
+        // capability proves who may act, but it does not prove that the exact
+        // relay side effect is crash-recoverable. Re-read the SQL lifecycle
+        // journal only after the route/history admission locks are held, then
+        // require every exact event/endpoint pair below to remain selected.
+        // Active callers persist this row through
+        // `prepare_key_package_deletion_recovery`; quiesced teardown persists
+        // it through `prepare_quiesced_key_package_deletion_recovery`.
+        let deletion_journal = self.account_storage(label)?.key_package_lifecycle()?;
         let mut results = targets
             .iter()
             .map(|target| KeyPackageDeletionResult {
                 event_id_hex: target.event_id_hex.clone(),
+                accepted_endpoints: Vec::new(),
+                confirmed_absent_endpoints: Vec::new(),
+                failed_endpoints: Vec::new(),
                 result: Err(AppError::Publish("deletion was not attempted".to_owned())),
             })
             .collect::<Vec<_>>();
         let mut requests = Vec::new();
-        let mut request_indices = Vec::new();
+        let mut request_targets = Vec::new();
+        let mut attempted = vec![false; results.len()];
+        let mut errors = (0..results.len()).map(|_| None).collect::<Vec<_>>();
 
         for (index, target) in targets.into_iter().enumerate() {
             let event_id_hex = match parse_key_package_event_id_hex(&target.event_id_hex) {
@@ -4236,47 +9170,175 @@ impl MarmotApp {
                 ]));
                 continue;
             }
-            let endpoints = match self
-                .relay_plane
-                .sanitize_relay_endpoints(endpoints, "key package deletion publish")
-            {
+            let endpoints = match self.sanitize_key_package_deletion_endpoints(endpoints) {
                 Ok(endpoints) => endpoints,
                 Err(error) => {
-                    results[index].result = Err(AppError::Transport(
-                        cgka_traits::TransportAdapterError::Publish(error),
-                    ));
+                    results[index].result = Err(error);
                     continue;
                 }
             };
-            requests.push(NostrEventPublishRequest {
-                endpoints,
-                event: NostrTransportEvent::new_unsigned(
-                    account_id_hex.clone(),
-                    5,
-                    vec![
-                        vec!["e".into(), event_id_hex],
-                        vec!["k".into(), KIND_MARMOT_KEY_PACKAGE.to_string()],
-                    ],
-                    String::new(),
-                ),
-                required_acks: 1,
+            let event_id = MessageId::new(
+                hex::decode(&event_id_hex)
+                    .expect("validated KeyPackage event id remains canonical hex"),
+            );
+            let durably_selected = deletion_journal.as_ref().is_some_and(|lifecycle| {
+                lifecycle
+                    .retired_publications_pending_deletion
+                    .iter()
+                    .find(|retired| retired.event_id == event_id)
+                    .is_some_and(|retired| {
+                        endpoints.iter().all(|canonical_endpoint| {
+                            retired.deletion_targets.iter().any(|durable_target| {
+                                durable_target.failure_code.as_deref() != Some("confirmed_absent")
+                                    && self
+                                        .key_package_deletion_endpoint_aliases(
+                                            std::slice::from_ref(&durable_target.endpoint),
+                                        )
+                                        .is_ok_and(|(_canonical, aliases)| {
+                                            aliases.iter().any(|(durable_key, canonical_key)| {
+                                                durable_key == &durable_target.endpoint
+                                                    && canonical_key == canonical_endpoint
+                                            })
+                                        })
+                            })
+                        })
+                    })
             });
-            request_indices.push(index);
+            if !durably_selected {
+                results[index].result = Err(AppError::Publish(
+                    "key package deletion target was not durably selected by the account lifecycle journal"
+                        .to_owned(),
+                ));
+                continue;
+            }
+            let event = NostrTransportEvent::new_unsigned(
+                account_id_hex.clone(),
+                5,
+                vec![
+                    vec!["e".into(), event_id_hex],
+                    vec!["k".into(), KIND_MARMOT_KEY_PACKAGE.to_string()],
+                ],
+                String::new(),
+            );
+            // One request per endpoint is load-bearing. The SDK completes a
+            // request once its required acknowledgement count is met; a single
+            // multi-endpoint request with `required_acks = 1` can therefore
+            // cancel the remaining sends and falsely report whole-event
+            // deletion after only one relay accepted it.
+            for endpoint in endpoints {
+                attempted[index] = true;
+                requests.push(NostrEventPublishRequest {
+                    endpoints: vec![endpoint.clone()],
+                    event: event.clone(),
+                    required_acks: 1,
+                });
+                request_targets.push((index, endpoint));
+            }
         }
 
         if !requests.is_empty() {
+            if !admission_is_current() {
+                return Err(AppError::AccountWorkerBusy);
+            }
+            // Universal pre-I/O crash boundary for every kind-5 KeyPackage
+            // deletion, including quiesced logout cleanup and low-level
+            // relay-discovered retirement. A later accepted or ambiguous send
+            // can reveal older parameterized-replaceable history, so future
+            // publication remains blocked until these endpoints receive a
+            // strict short-page replay.
+            self.extend_key_package_cutover_relay_frontier(
+                label,
+                request_targets
+                    .iter()
+                    .map(|(_index, endpoint)| endpoint.clone())
+                    .collect(),
+            )?;
             let relay_client =
                 self.relay_client_for_account_id(&account_id_hex, signer.as_nostr_signer());
-            let outcomes = relay_client.publish_events(&requests).await;
-            for (index, outcome) in request_indices.into_iter().zip(outcomes) {
-                results[index].result = match outcome {
-                    Ok(outcome) if !outcome.accepted.is_empty() => Ok(outcome.accepted.len()),
-                    Ok(_) => Err(AppError::Publish(
-                        "relay acknowledged zero key package deletions".to_owned(),
-                    )),
-                    Err(error) => Err(error.into()),
+            let mut outcomes = relay_client.publish_events(&requests).await.into_iter();
+            for (index, endpoint) in request_targets {
+                let Some(outcome) = outcomes.next() else {
+                    if !results[index].failed_endpoints.contains(&endpoint) {
+                        results[index].failed_endpoints.push(endpoint);
+                    }
+                    errors[index].get_or_insert_with(|| {
+                        AppError::Publish(
+                            "relay returned no result for a key package deletion".to_owned(),
+                        )
+                    });
+                    continue;
                 };
+                match outcome {
+                    Ok(outcome)
+                        if outcome
+                            .accepted
+                            .iter()
+                            .any(|receipt| receipt.endpoint == endpoint) =>
+                    {
+                        if !results[index].accepted_endpoints.contains(&endpoint) {
+                            results[index].accepted_endpoints.push(endpoint);
+                        }
+                    }
+                    Ok(_) => {
+                        if !results[index].failed_endpoints.contains(&endpoint) {
+                            results[index].failed_endpoints.push(endpoint);
+                        }
+                        errors[index].get_or_insert_with(|| {
+                            AppError::Publish(
+                                "relay acknowledged zero key package deletions".to_owned(),
+                            )
+                        });
+                    }
+                    Err(error) => {
+                        let target_is_confirmed_absent =
+                            error.publish_endpoint_failures().iter().any(|failure| {
+                                failure.endpoint == endpoint && failure.confirms_target_absence()
+                            });
+                        if target_is_confirmed_absent {
+                            if !results[index]
+                                .confirmed_absent_endpoints
+                                .contains(&endpoint)
+                            {
+                                results[index].confirmed_absent_endpoints.push(endpoint);
+                            }
+                        } else if !results[index].failed_endpoints.contains(&endpoint) {
+                            results[index].failed_endpoints.push(endpoint);
+                        }
+                        if !target_is_confirmed_absent && errors[index].is_none() {
+                            errors[index] = Some(error.into());
+                        }
+                    }
+                }
             }
+        }
+
+        for (index, was_attempted) in attempted.into_iter().enumerate() {
+            if !was_attempted {
+                continue;
+            }
+            results[index].accepted_endpoints.sort();
+            results[index].accepted_endpoints.dedup();
+            results[index].confirmed_absent_endpoints.sort();
+            results[index].confirmed_absent_endpoints.dedup();
+            results[index].failed_endpoints.sort();
+            results[index].failed_endpoints.dedup();
+            let terminal_endpoint_count = results[index]
+                .accepted_endpoints
+                .len()
+                .saturating_add(results[index].confirmed_absent_endpoints.len());
+            results[index].result = if terminal_endpoint_count == 0 {
+                Err(errors[index].take().unwrap_or_else(|| {
+                    AppError::Publish("key package deletion produced no relay result".to_owned())
+                }))
+            } else if !results[index].failed_endpoints.is_empty() {
+                Err(errors[index].take().unwrap_or_else(|| {
+                    AppError::Publish(
+                        "one or more relay key package deletions remain retryable".to_owned(),
+                    )
+                }))
+            } else {
+                Ok(terminal_endpoint_count)
+            };
         }
 
         let path = self.key_package_record_path(label);
@@ -4296,6 +9358,437 @@ impl MarmotApp {
         }
 
         Ok(results)
+    }
+
+    /// Persist recovery intent before quiesced teardown can send a kind-5 for
+    /// the current or pending revision.
+    ///
+    /// The caller must own the account teardown barrier: this whole-row
+    /// lifecycle mutation is not safe beside the serialized account worker.
+    pub(crate) fn prepare_quiesced_key_package_deletion_recovery(
+        &self,
+        label: &str,
+        targets: &[KeyPackageDeletionTarget],
+    ) -> Result<KeyPackageDeletionAdmission, AppError> {
+        let _root_mutation =
+            self.begin_root_mutation("prepare quiesced KeyPackage deletion recovery")?;
+        if !targets.is_empty() {
+            // Invalidate before changing the SQL journal. A crash after the
+            // lifecycle commit but before removing an older completion marker
+            // could otherwise let teardown's focused peel take the stale fast
+            // path and erase the only retry evidence without another scan.
+            self.invalidate_key_package_cutover_scan_marker(label)?;
+        }
+        let storage = self.account_storage(label)?;
+        let mut lifecycle = match storage.key_package_lifecycle()? {
+            Some(lifecycle) => lifecycle,
+            None => {
+                let account = self.account_home().account(label)?;
+                let stable_slot_id = self
+                    .reusable_key_package_slot_id(label, &account.account_id_hex)?
+                    .ok_or_else(|| {
+                        AppError::Publish(
+                            "cannot durably journal KeyPackage deletion without a stable slot"
+                                .to_owned(),
+                        )
+                    })?;
+                cgka_traits::KeyPackageLifecycleState::slot_only(stable_slot_id)
+            }
+        };
+        let mut changed = self.canonicalize_quiesced_key_package_lifecycle_targets(&mut lifecycle);
+
+        // Resolve every target into the exact liability that can escape in the
+        // following kind-5 send. Unknown relay-discovered event ids (including
+        // other stable `d` slots) are not covered by a later local NIP-33
+        // replacement and therefore need the same durable per-endpoint retry
+        // journal as locally authored revisions.
+        let mut deletion_liabilities: Vec<(
+            String,
+            MessageId,
+            Vec<TransportEndpoint>,
+            Vec<TransportEndpoint>,
+        )> = Vec::new();
+        let mut invalid_targets = Vec::new();
+        for target in targets {
+            let event_id_hex = match parse_key_package_event_id_hex(&target.event_id_hex) {
+                Ok(event_id_hex) => event_id_hex,
+                Err(error) => {
+                    invalid_targets.push(KeyPackageDeletionInvalidTarget {
+                        target: target.clone(),
+                        reason: error.to_string(),
+                    });
+                    continue;
+                }
+            };
+            if target.source_relays.is_empty() {
+                invalid_targets.push(KeyPackageDeletionInvalidTarget {
+                    target: KeyPackageDeletionTarget {
+                        event_id_hex,
+                        source_relays: Vec::new(),
+                    },
+                    reason: "key package deletion target has no relay endpoints".to_owned(),
+                });
+                continue;
+            }
+            let mut safe_endpoints = Vec::new();
+            let mut unsafe_endpoints = Vec::new();
+            for endpoint in &target.source_relays {
+                match self
+                    .canonicalize_key_package_endpoint(endpoint, "key package deletion publish")
+                {
+                    Ok(canonical) => safe_endpoints.push(canonical),
+                    Err(_) => unsafe_endpoints.push(endpoint.clone()),
+                }
+            }
+            safe_endpoints.sort();
+            safe_endpoints.dedup();
+            unsafe_endpoints.sort();
+            unsafe_endpoints.dedup();
+            let event_id = MessageId::new(
+                hex::decode(&event_id_hex)
+                    .map_err(|_| AppError::Publish("invalid key package event id".to_owned()))?,
+            );
+            if let Some((_, _, existing_safe, existing_unsafe)) = deletion_liabilities
+                .iter_mut()
+                .find(|(existing_id, _, _, _)| existing_id == &event_id_hex)
+            {
+                existing_safe.extend(safe_endpoints);
+                existing_safe.sort();
+                existing_safe.dedup();
+                existing_unsafe.extend(unsafe_endpoints);
+                existing_unsafe.sort();
+                existing_unsafe.dedup();
+            } else {
+                deletion_liabilities.push((
+                    event_id_hex,
+                    event_id,
+                    safe_endpoints,
+                    unsafe_endpoints,
+                ));
+            }
+        }
+
+        let mut exact_liabilities = HashSet::new();
+        let mut include_targets =
+            |event_id: &MessageId, targets: &[cgka_traits::TransportFanoutTarget]| {
+                for target in targets {
+                    if target.failure_code.as_deref() != Some("confirmed_absent") {
+                        exact_liabilities
+                            .insert((event_id.as_slice().to_vec(), target.endpoint.clone()));
+                    }
+                }
+            };
+        if let Some(artifact) = lifecycle.authored_signed_event.as_ref() {
+            include_targets(&artifact.id, &lifecycle.publication_targets);
+        }
+        if let Some(event_id) = lifecycle.authored_event_id.as_ref() {
+            // Pre-artifact upgrade rows can retain the exact current event id
+            // and endpoint exposure set without the signed bytes. Count those
+            // pairs before admitting any new deletion liability. If a corrupt
+            // row carries two differing identity representations, including
+            // both is the conservative capacity decision.
+            include_targets(event_id, &lifecycle.publication_targets);
+        }
+        if let Some(pending) = lifecycle.pending_replacement.as_ref()
+            && let Some(artifact) = pending.signed_event.as_ref()
+        {
+            include_targets(&artifact.id, &pending.targets);
+        }
+        for retired in &lifecycle.retired_publications_pending_deletion {
+            include_targets(&retired.event_id, &retired.deletion_targets);
+        }
+        let mut admitted_targets = Vec::new();
+        let mut deferred_targets = Vec::new();
+        let mut unsafe_targets = Vec::new();
+        let mut journaled_liabilities = Vec::new();
+        let mut live_event_ids = HashSet::new();
+        if let Some(artifact) = lifecycle.authored_signed_event.as_ref() {
+            live_event_ids.insert(artifact.id.as_slice().to_vec());
+        }
+        if let Some(event_id) = lifecycle.authored_event_id.as_ref() {
+            live_event_ids.insert(event_id.as_slice().to_vec());
+        }
+        if let Some(artifact) = lifecycle
+            .pending_replacement
+            .as_ref()
+            .and_then(|pending| pending.signed_event.as_ref())
+        {
+            live_event_ids.insert(artifact.id.as_slice().to_vec());
+        }
+        for (event_id_hex, event_id, safe_endpoints, unsafe_endpoints) in deletion_liabilities {
+            let is_live_revision = live_event_ids.contains(event_id.as_slice());
+            let mut requested_endpoints = safe_endpoints
+                .iter()
+                .chain(&unsafe_endpoints)
+                .cloned()
+                .collect::<Vec<_>>();
+            requested_endpoints.sort();
+            requested_endpoints.dedup();
+            let required_new_liabilities = requested_endpoints
+                .iter()
+                .filter(|endpoint| {
+                    !exact_liabilities
+                        .contains(&(event_id.as_slice().to_vec(), (*endpoint).clone()))
+                })
+                .count();
+            let liability_capacity = if is_live_revision {
+                cgka_traits::maintenance::MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES_WITH_LIVE_DELETION_OVERFLOW
+            } else {
+                cgka_traits::maintenance::MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES
+            };
+            if required_new_liabilities > liability_capacity.saturating_sub(exact_liabilities.len())
+            {
+                // No exact event can be deleted at only a subset of its
+                // requested endpoints. Unknown ids do not prove a sibling
+                // slot; a later replacement could hide the old exact id while
+                // an unjournaled endpoint remains. Defer the whole event: no
+                // kind-5 target, unsafe admission, or live marker is produced
+                // until every new pair fits in the bounded reserve.
+                deferred_targets.push(KeyPackageDeletionTarget {
+                    event_id_hex,
+                    source_relays: requested_endpoints,
+                });
+                continue;
+            }
+            let mut admitted_endpoints = Vec::new();
+            let mut journaled_unsafe_endpoints = Vec::new();
+            let mut deferred_endpoints = Vec::new();
+            for (endpoint, safe_for_io) in safe_endpoints
+                .into_iter()
+                .map(|endpoint| (endpoint, true))
+                .chain(
+                    unsafe_endpoints
+                        .into_iter()
+                        .map(|endpoint| (endpoint, false)),
+                )
+            {
+                let liability = (event_id.as_slice().to_vec(), endpoint.clone());
+                if exact_liabilities.contains(&liability)
+                    || exact_liabilities.len() < liability_capacity
+                {
+                    exact_liabilities.insert(liability);
+                    if safe_for_io {
+                        admitted_endpoints.push(endpoint);
+                    } else {
+                        journaled_unsafe_endpoints.push(endpoint);
+                    }
+                } else {
+                    deferred_endpoints.push(endpoint);
+                }
+            }
+            if !admitted_endpoints.is_empty() {
+                admitted_targets.push(KeyPackageDeletionTarget {
+                    event_id_hex: event_id_hex.clone(),
+                    source_relays: admitted_endpoints.clone(),
+                });
+            }
+            if !journaled_unsafe_endpoints.is_empty() {
+                unsafe_targets.push(KeyPackageDeletionTarget {
+                    event_id_hex: event_id_hex.clone(),
+                    source_relays: journaled_unsafe_endpoints.clone(),
+                });
+            }
+            let mut journaled_endpoints = admitted_endpoints;
+            journaled_endpoints.extend(journaled_unsafe_endpoints);
+            if !journaled_endpoints.is_empty() {
+                journaled_liabilities.push((event_id, journaled_endpoints, is_live_revision));
+            }
+            if !deferred_endpoints.is_empty() {
+                deferred_targets.push(KeyPackageDeletionTarget {
+                    event_id_hex,
+                    source_relays: deferred_endpoints,
+                });
+            }
+        }
+
+        let pending_event_id = lifecycle
+            .pending_replacement
+            .as_ref()
+            .and_then(|pending| pending.signed_event.as_ref())
+            .map(|artifact| artifact.id.clone());
+        for (event_id, endpoints, live_admission) in journaled_liabilities {
+            let deletes_current = lifecycle
+                .authored_signed_event
+                .as_ref()
+                .is_some_and(|artifact| artifact.id == event_id)
+                || lifecycle.authored_event_id.as_ref() == Some(&event_id);
+            if live_admission
+                && (deletes_current || pending_event_id.as_ref() == Some(&event_id))
+                && !lifecycle
+                    .deleted_live_revision_event_ids
+                    .contains(&event_id)
+            {
+                lifecycle
+                    .deleted_live_revision_event_ids
+                    .push(event_id.clone());
+                changed = true;
+            }
+            if let Some(retired) = lifecycle
+                .retired_publications_pending_deletion
+                .iter_mut()
+                .find(|retired| retired.event_id == event_id)
+            {
+                changed |= !retired.delete_without_successor;
+                retired.delete_without_successor = true;
+                for endpoint in endpoints {
+                    if !retired
+                        .deletion_targets
+                        .iter()
+                        .any(|target| target.endpoint == endpoint)
+                    {
+                        retired
+                            .deletion_targets
+                            .push(cgka_traits::TransportFanoutTarget {
+                                endpoint,
+                                state: cgka_traits::TransportFanoutAttemptState::Unattempted,
+                                attempt_count: 0,
+                                last_attempt_at: None,
+                                failure_code: None,
+                            });
+                        changed = true;
+                    }
+                }
+            } else {
+                lifecycle.retired_publications_pending_deletion.push(
+                    cgka_traits::RetiredKeyPackagePublication {
+                        event_id,
+                        authored_created_at: cgka_traits::Timestamp(0),
+                        key_package_ref: None,
+                        package_not_after: None,
+                        delete_without_successor: true,
+                        deletion_targets: endpoints
+                            .into_iter()
+                            .map(|endpoint| cgka_traits::TransportFanoutTarget {
+                                endpoint,
+                                state: cgka_traits::TransportFanoutAttemptState::Unattempted,
+                                attempt_count: 0,
+                                last_attempt_at: None,
+                                failure_code: None,
+                            })
+                            .collect(),
+                    },
+                );
+                changed = true;
+            }
+        }
+        if changed {
+            storage.put_key_package_lifecycle(&lifecycle)?;
+        }
+        Ok(KeyPackageDeletionAdmission {
+            admitted: admitted_targets,
+            deferred: deferred_targets,
+            unsafe_targets,
+            invalid_targets,
+        })
+    }
+
+    /// Commit endpoint-level acknowledgements for retired signed revisions.
+    ///
+    /// Call only while the account worker is quiesced. Active maintenance owns
+    /// the same lifecycle row and performs this pruning inside the serialized
+    /// account runtime instead.
+    pub(crate) fn acknowledge_retired_key_package_deletions(
+        &self,
+        label: &str,
+        results: &[KeyPackageDeletionResult],
+    ) -> Result<(), AppError> {
+        let storage = self.account_storage(label)?;
+        let Some(mut lifecycle) = storage.key_package_lifecycle()? else {
+            return Ok(());
+        };
+        let mut changed = false;
+        let mut completed_retired_event_ids = Vec::new();
+        for result in results {
+            let mut terminal_endpoints = result.accepted_endpoints.clone();
+            terminal_endpoints.extend(result.confirmed_absent_endpoints.clone());
+            if terminal_endpoints.is_empty() {
+                continue;
+            }
+            let deleted_current_revision = lifecycle
+                .authored_signed_event
+                .as_ref()
+                .is_some_and(|artifact| hex::encode(artifact.id.as_slice()) == result.event_id_hex)
+                || lifecycle
+                    .authored_event_id
+                    .as_ref()
+                    .is_some_and(|event_id| {
+                        hex::encode(event_id.as_slice()) == result.event_id_hex
+                    });
+            let deleted_pending_revision = lifecycle
+                .pending_replacement
+                .as_ref()
+                .and_then(|pending| pending.signed_event.as_ref())
+                .is_some_and(|artifact| hex::encode(artifact.id.as_slice()) == result.event_id_hex);
+            if deleted_current_revision
+                && let Some(event_id) = lifecycle
+                    .authored_signed_event
+                    .as_ref()
+                    .map(|artifact| artifact.id.clone())
+                && !lifecycle
+                    .deleted_live_revision_event_ids
+                    .contains(&event_id)
+            {
+                lifecycle.deleted_live_revision_event_ids.push(event_id);
+                changed = true;
+            }
+            if deleted_pending_revision
+                && let Some(event_id) = lifecycle
+                    .pending_replacement
+                    .as_ref()
+                    .and_then(|pending| pending.signed_event.as_ref())
+                    .map(|artifact| artifact.id.clone())
+                && !lifecycle
+                    .deleted_live_revision_event_ids
+                    .contains(&event_id)
+            {
+                lifecycle.deleted_live_revision_event_ids.push(event_id);
+                changed = true;
+            }
+            if deleted_current_revision {
+                for target in &mut lifecycle.publication_targets {
+                    if terminal_endpoints.contains(&target.endpoint) {
+                        target.state = cgka_traits::TransportFanoutAttemptState::AttemptedFailed;
+                        target.failure_code = Some("confirmed_absent".into());
+                        changed = true;
+                    }
+                }
+            }
+            if deleted_pending_revision
+                && let Some(pending) = lifecycle.pending_replacement.as_mut()
+            {
+                for target in &mut pending.targets {
+                    if terminal_endpoints.contains(&target.endpoint) {
+                        target.state = cgka_traits::TransportFanoutAttemptState::AttemptedFailed;
+                        target.failure_code = Some("confirmed_absent".into());
+                        changed = true;
+                    }
+                }
+            }
+            let Some(retired) = lifecycle
+                .retired_publications_pending_deletion
+                .iter_mut()
+                .find(|retired| hex::encode(retired.event_id.as_slice()) == result.event_id_hex)
+            else {
+                continue;
+            };
+            let before = retired.deletion_targets.len();
+            retired
+                .deletion_targets
+                .retain(|target| !terminal_endpoints.contains(&target.endpoint));
+            if retired.deletion_targets.len() != before {
+                changed = true;
+                if retired.deletion_targets.is_empty() {
+                    completed_retired_event_ids.push(retired.event_id.clone());
+                }
+            }
+        }
+        lifecycle
+            .retired_publications_pending_deletion
+            .retain(|retired| !completed_retired_event_ids.contains(&retired.event_id));
+        if changed {
+            storage.put_key_package_lifecycle(&lifecycle)?;
+        }
+        Ok(())
     }
 
     fn key_package_record_path(&self, label: &str) -> PathBuf {
@@ -4360,6 +9853,277 @@ impl MarmotApp {
             .then_some(key_package)
     }
 
+    /// Historical relay provenance for a legacy cache can come only from a
+    /// locally cached observation of that exact signed revision. Current
+    /// NIP-65 or configured routing says where a replacement would publish
+    /// today; projecting it onto an older event would invent exposure and can
+    /// send deletion traffic to the wrong relay after an account route change.
+    /// Read the account-private cache directly: the shared public projection
+    /// intentionally strips source relays, and signed-out accounts are omitted
+    /// from the aggregate active-account cache view.
+    ///
+    /// Directory-cache failures and mismatches deliberately degrade to
+    /// unknown provenance. Account open must remain a local operation, and an
+    /// unknown endpoint set must stay empty rather than falling back to live
+    /// routing.
+    fn cached_key_package_provenance(
+        &self,
+        account: &AccountSummary,
+        record: &KeyPackageRecord,
+        expected_key_package_ref_hex: Option<&str>,
+    ) -> (Vec<TransportEndpoint>, Option<u64>) {
+        let Some(cached) = self
+            .directory_cache_for_account(account)
+            .ok()
+            .and_then(|cache| cache.entry(&account.account_id_hex).ok().flatten())
+            .and_then(|entry| entry.key_package)
+        else {
+            return (Vec::new(), None);
+        };
+        if !cached
+            .key_package_event_id
+            .eq_ignore_ascii_case(&record.key_package_event_id)
+            || cached.key_package_id != record.key_package_id
+            || (!record.key_package_ref_hex.is_empty()
+                && !cached
+                    .key_package_ref_hex
+                    .eq_ignore_ascii_case(&record.key_package_ref_hex))
+            || expected_key_package_ref_hex
+                .is_some_and(|expected| !cached.key_package_ref_hex.eq_ignore_ascii_case(expected))
+        {
+            return (Vec::new(), None);
+        }
+
+        let authored_created_at = cached.created_at;
+        // Preserve the exact observed endpoint keys, including historical
+        // values that today's dial policy rejects. The durable lifecycle must
+        // retain possible exposure at those endpoints; the publisher boundary
+        // partitions unsafe keys into failed receipts without dialing them.
+        let mut endpoints = cached
+            .source_relays
+            .into_iter()
+            .map(TransportEndpoint)
+            .collect::<Vec<_>>();
+        endpoints.sort();
+        endpoints.dedup();
+        (endpoints, Some(authored_created_at))
+    }
+
+    /// Upgrade a pre-lifecycle current-profile cache into the durable account
+    /// lifecycle. A matching OpenMLS bundle becomes the projected current
+    /// package (even when the legacy cache has no event id). Conversely, a
+    /// valid event id whose bundle is already gone becomes a retired
+    /// liability. Exact cached source relays make that liability actionable;
+    /// unknown provenance retains only the event identity, without inventing
+    /// an endpoint. Both shapes preserve lifetime and stable-slot high-water.
+    fn import_cached_current_key_package_lifecycle(&self, label: &str) -> Result<bool, AppError> {
+        let storage = self.account_storage(label)?;
+        let Some(mut lifecycle) = storage.key_package_lifecycle()? else {
+            return Ok(false);
+        };
+        if lifecycle.stable_slot_id.is_empty()
+            || lifecycle.current_key_package.is_some()
+            || lifecycle.pending_replacement.is_some()
+        {
+            return Ok(false);
+        }
+        let record = match read_json::<KeyPackageRecord>(self.key_package_record_path(label)) {
+            Ok(record) => record,
+            Err(AppError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(false);
+            }
+            Err(_) => return Ok(false),
+        };
+        let account = self.account_home().account(label)?;
+        if record.account_id_hex != account.account_id_hex
+            || record.key_package_id != lifecycle.stable_slot_id
+        {
+            return Ok(false);
+        }
+        let event_id = if record.key_package_event_id.is_empty() {
+            None
+        } else {
+            let event_id_hex = match parse_key_package_event_id_hex(&record.key_package_event_id) {
+                Ok(event_id_hex) => event_id_hex,
+                Err(_) => return Ok(false),
+            };
+            Some(MessageId::new(hex::decode(event_id_hex)?))
+        };
+        let key_package = match self.validated_current_local_key_package(label) {
+            Some(key_package) => key_package,
+            None => return Ok(false),
+        };
+        let metadata = key_package_metadata(&key_package)
+            .map_err(|error| AppError::InvalidKeyPackageEvent(error.to_string()))?;
+        if !record.key_package_ref_hex.is_empty()
+            && !record
+                .key_package_ref_hex
+                .eq_ignore_ascii_case(&metadata.key_package_ref_hex)
+        {
+            return Ok(false);
+        }
+        let key_package_ref = hex::decode(&metadata.key_package_ref_hex)?;
+        let owns_private_bundle = cgka_engine::key_package::durably_owned_key_packages(
+            &storage,
+            cgka_traits::group::ProtocolProfile::Current,
+        )
+        .map_err(cgka_session::SessionError::from)?
+        .iter()
+        .any(|owned| {
+            key_package_metadata(owned).is_ok_and(|owned_metadata| {
+                owned_metadata
+                    .key_package_ref_hex
+                    .eq_ignore_ascii_case(&metadata.key_package_ref_hex)
+            })
+        });
+        let (endpoints, cached_authored_created_at) = event_id
+            .as_ref()
+            .map(|_| {
+                self.cached_key_package_provenance(
+                    &account,
+                    &record,
+                    Some(&metadata.key_package_ref_hex),
+                )
+            })
+            .unwrap_or_default();
+
+        let authored_created_at = Timestamp(
+            cached_authored_created_at
+                .map(|cached| cached.max(record.published_at))
+                .unwrap_or(record.published_at),
+        );
+        lifecycle.authored_event_created_at = Some(
+            lifecycle
+                .authored_event_created_at
+                .map(|current| current.max(authored_created_at))
+                .unwrap_or(authored_created_at),
+        );
+        if owns_private_bundle {
+            lifecycle.current_key_package = Some(key_package);
+            lifecycle.current_key_package_ref = Some(key_package_ref.clone());
+            lifecycle.current_not_before = Some(Timestamp(metadata.not_before));
+            lifecycle.current_not_after = Some(Timestamp(metadata.not_after));
+            lifecycle.authored_event_id = event_id;
+            lifecycle.authored_signed_event = None;
+            lifecycle.publication_targets = if lifecycle.authored_event_id.is_some() {
+                endpoints
+                    .into_iter()
+                    .map(|endpoint| cgka_traits::TransportFanoutTarget {
+                        endpoint,
+                        state: cgka_traits::TransportFanoutAttemptState::AttemptedFailed,
+                        attempt_count: 1,
+                        last_attempt_at: Some(authored_created_at),
+                        failure_code: Some("possible_exposure".into()),
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            if lifecycle.authored_event_id.is_some() && lifecycle.publication_targets.is_empty() {
+                let event_id = lifecycle
+                    .authored_event_id
+                    .clone()
+                    .expect("cached event id remains selected during legacy import");
+                retain_imported_legacy_key_package_publication(
+                    &mut lifecycle,
+                    cgka_traits::RetiredKeyPackagePublication {
+                        event_id,
+                        authored_created_at,
+                        key_package_ref: Some(key_package_ref.clone()),
+                        package_not_after: Some(Timestamp(metadata.not_after)),
+                        delete_without_successor: false,
+                        deletion_targets: Vec::new(),
+                    },
+                );
+            }
+        } else if let Some(event_id) = event_id {
+            let imported_targets = endpoints
+                .into_iter()
+                .map(|endpoint| cgka_traits::TransportFanoutTarget {
+                    endpoint,
+                    state: cgka_traits::TransportFanoutAttemptState::Unattempted,
+                    attempt_count: 0,
+                    last_attempt_at: None,
+                    failure_code: None,
+                })
+                .collect::<Vec<_>>();
+            retain_imported_legacy_key_package_publication(
+                &mut lifecycle,
+                cgka_traits::RetiredKeyPackagePublication {
+                    event_id,
+                    authored_created_at,
+                    key_package_ref: Some(key_package_ref),
+                    package_not_after: Some(Timestamp(metadata.not_after)),
+                    delete_without_successor: true,
+                    deletion_targets: imported_targets,
+                },
+            );
+        } else {
+            return Ok(false);
+        }
+        lifecycle.refresh_at = Some(Timestamp(0));
+        lifecycle.upgrade_rotation_recorded = false;
+        lifecycle.phase = cgka_traits::MaintenancePhase::Retry;
+        self.canonicalize_quiesced_key_package_lifecycle_targets(&mut lifecycle);
+        if key_package_lifecycle_endpoint_liability_count(&lifecycle)
+            > cgka_traits::maintenance::MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES
+        {
+            return Err(AppError::Publish(
+                "key package signed-publication endpoint-liability journal is full".into(),
+            ));
+        }
+        storage.put_key_package_lifecycle(&lifecycle)?;
+        Ok(true)
+    }
+
+    /// Arm the transport-generic publication interlock while account storage
+    /// is still quiesced. Managed runtime startup performs fallible sync before
+    /// its network-maintenance finish hook; persisting here prevents an
+    /// immediate worker tick from publishing through that failure window.
+    fn arm_key_package_cutover_publication_gate_before_session_open(
+        &self,
+        label: &str,
+    ) -> Result<(), AppError> {
+        if self.key_package_cutover_publication_allowed(label)
+            && !self.key_package_cutover_replacement_pending(label)
+        {
+            return Ok(());
+        }
+        let storage = self.account_storage(label)?;
+        let Some(mut lifecycle) = storage.key_package_lifecycle()? else {
+            // An upgraded account whose database predates lifecycle state is
+            // already fail-closed: the replacement-intent file keeps ordinary
+            // admission blocked, and the final publisher rejects a missing
+            // lifecycle row. Preserve that detectable shape so setup can
+            // surface the typed consent-gated recovery state instead of
+            // turning it into an unrelated publication error.
+            return Ok(());
+        };
+        // A generated identity's first session deliberately staged and signed
+        // its exact replacement while the gate was armed. Once that durable
+        // replacement exists, its no-predecessor marker is sufficient to open
+        // the SQL gate for setup-priority publication. A pending initial
+        // NIP-65 intent remains a second, file-backed fence at the final relay
+        // boundary; ordinary and legacy intents cannot enter this branch.
+        if self.generated_account_fresh_replacement_can_open_cutover_gate(label, &lifecycle)? {
+            if lifecycle.cutover_publication_blocked {
+                lifecycle.cutover_publication_blocked = false;
+                storage.put_key_package_lifecycle(&lifecycle)?;
+            }
+            return Ok(());
+        }
+        if lifecycle.stable_slot_id.is_empty() {
+            return Err(AppError::Publish(
+                "cannot arm key package cutover publication interlock without a stable slot".into(),
+            ));
+        }
+        if !lifecycle.cutover_publication_blocked {
+            lifecycle.cutover_publication_blocked = true;
+            storage.put_key_package_lifecycle(&lifecycle)?;
+        }
+        Ok(())
+    }
+
     /// Persist strict-cutover replacement intent before the session layer can
     /// delete unpublished non-current private bundles during open.
     fn ensure_strict_cutover_replacement_intent_before_session_open(
@@ -4367,14 +10131,41 @@ impl MarmotApp {
         label: &str,
     ) -> Result<(), AppError> {
         let account_storage_preexisted = self.account_storage_path(label).exists();
-        let setup_in_progress = self.account_home().account_setup_state(label)?.is_some();
+        let setup_state = self.account_home().account_setup_state(label)?;
+        let setup_in_progress = setup_state.is_some();
         let storage = self.account_storage(label)?;
         let existing_lifecycle = storage.key_package_lifecycle()?;
-        if existing_lifecycle
+        if let Some(lifecycle) = existing_lifecycle
             .as_ref()
-            .is_some_and(|lifecycle| !lifecycle.stable_slot_id.is_empty())
+            .filter(|lifecycle| !lifecycle.stable_slot_id.is_empty())
         {
-            return Ok(());
+            // Older builds wrote this load-bearing marker without syncing its
+            // directory entry. An interrupted generated setup may therefore
+            // retain the exact lifecycle but lose only the marker. Rebuild it
+            // from the durable generated-setup provenance unless a current
+            // acknowledged cutover revision proves the marker was cleared on
+            // purpose after successful publication.
+            if setup_state.as_ref().is_some_and(|state| {
+                state.kind == AccountSetupKind::GeneratedIdentity
+                    && state.phase != AccountSetupPhase::KeyPackagePublicationConfirmed
+            }) && !self.key_package_cutover_replacement_pending(label)
+                && !self.key_package_lifecycle_has_current_cutover_revision(label, lifecycle)
+                && !self.mark_key_package_cutover_replacement_pending(label)
+            {
+                return Err(AppError::Io(std::io::Error::other(
+                    "could not restore generated setup cutover replacement intent",
+                )));
+            }
+            self.import_cached_current_key_package_lifecycle(label)?;
+            if self.key_package_record_path(label).exists()
+                && self.validated_current_local_key_package(label).is_none()
+                && !self.mark_key_package_cutover_replacement_pending(label)
+            {
+                return Err(AppError::Io(std::io::Error::other(
+                    "could not persist strict cutover replacement intent before session open",
+                )));
+            }
+            return self.arm_key_package_cutover_publication_gate_before_session_open(label);
         }
         let current_cache = self.validated_current_local_key_package(label).is_some();
         match self.reusable_key_package_slot_id(
@@ -4387,8 +10178,10 @@ impl MarmotApp {
                     .unwrap_or_else(|| empty_key_package_lifecycle(String::new()));
                 lifecycle.stable_slot_id = stable_slot_id;
                 storage.put_key_package_lifecycle(&lifecycle)?;
+                self.import_cached_current_key_package_lifecycle(label)?;
                 if current_cache || self.mark_key_package_cutover_replacement_pending(label) {
-                    return Ok(());
+                    return self
+                        .arm_key_package_cutover_publication_gate_before_session_open(label);
                 }
             }
             Ok(None)
@@ -4404,7 +10197,8 @@ impl MarmotApp {
                 storage
                     .put_key_package_lifecycle(&empty_key_package_lifecycle(hex::encode(slot)))?;
                 if self.mark_key_package_cutover_replacement_pending(label) {
-                    return Ok(());
+                    return self
+                        .arm_key_package_cutover_publication_gate_before_session_open(label);
                 }
             }
             Ok(None) | Err(_) if account_storage_preexisted && !setup_in_progress => {
@@ -4414,7 +10208,8 @@ impl MarmotApp {
                 // mint a second slot. Keep normal account reads available; the
                 // setup publication boundary surfaces the typed recovery state.
                 if self.mark_key_package_cutover_replacement_pending(label) {
-                    return Ok(());
+                    return self
+                        .arm_key_package_cutover_publication_gate_before_session_open(label);
                 }
             }
             Ok(None) | Err(_) => {
@@ -4422,12 +10217,13 @@ impl MarmotApp {
                 // refuse to mint a second slot until migration can recover the
                 // original `d` value.
                 if self.mark_key_package_cutover_replacement_pending(label) {
-                    return Ok(());
+                    return self
+                        .arm_key_package_cutover_publication_gate_before_session_open(label);
                 }
             }
         }
         if self.key_package_cutover_replacement_pending(label) {
-            return Ok(());
+            return self.arm_key_package_cutover_publication_gate_before_session_open(label);
         }
         Err(AppError::Io(std::io::Error::other(
             "could not persist strict cutover replacement intent before session open",
@@ -4489,15 +10285,13 @@ impl MarmotApp {
                     .await?;
                 let mut fetched = fresh_or_cached_key_package(
                     &account_id,
-                    latest_fresh_key_package_from_records(
-                        &account_id,
-                        records,
-                        self.directory_freshness(),
-                    )?,
+                    self.latest_fresh_non_retired_key_package_from_records(&account_id, records)?,
                     Some(entry.clone()),
                 )?;
                 fetched.relay_lists = entry.relay_lists;
-                self.remember_directory_key_package(&fetched)?;
+                if !self.remember_directory_key_package_if_live(&fetched)? {
+                    return Err(AppError::MissingKeyPackage(account_id));
+                }
                 return Ok(fetched.key_package);
             }
         }
@@ -4713,13 +10507,29 @@ impl MarmotApp {
         frontiers_to_clear: &[(String, u64)],
         application_event_ids_to_ack: &[MessageId],
     ) -> Result<(), AppError> {
+        self.save_state_delta_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
+            delta,
+            frontiers_to_clear,
+            application_event_ids_to_ack,
+            &[],
+        )
+    }
+
+    fn save_state_delta_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
+        &self,
+        delta: &AccountState,
+        frontiers_to_clear: &[(String, u64)],
+        application_event_ids_to_ack: &[MessageId],
+        visibility_batch_ids_to_ack: &[Vec<u8>],
+    ) -> Result<(), AppError> {
         self.account_storage(&delta.label)?
-            .save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events(
+            .save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
                 &stored_state_from_account_state(delta),
                 MAX_SEEN_EVENT_IDS,
                 TRANSPORT_CURSOR_MAX_FUTURE_SKEW.as_secs(),
                 frontiers_to_clear,
                 application_event_ids_to_ack,
+                visibility_batch_ids_to_ack,
             )?;
         self.chat_list_projection_stale
             .lock()
@@ -4733,6 +10543,7 @@ impl MarmotApp {
         delta: &AccountState,
         frontiers_to_clear: &[(String, u64)],
         application_event_ids_to_ack: &[MessageId],
+        visibility_batch_ids_to_ack: &[Vec<u8>],
         group_id_hex: &str,
     ) -> Result<ChatListRow, AppError> {
         let account = self.account_home().account(&delta.label)?;
@@ -4743,12 +10554,13 @@ impl MarmotApp {
             .any(|group| group.group_id_hex != group_id_hex);
         let mut row = self
             .account_storage(&delta.label)?
-            .save_account_projection_delta_and_refresh_chat_list_row(
+            .save_account_projection_delta_and_refresh_chat_list_row_acking_application_events_and_visibility_batches(
                 &stored_state_from_account_state(delta),
                 MAX_SEEN_EVENT_IDS,
                 TRANSPORT_CURSOR_MAX_FUTURE_SKEW.as_secs(),
                 frontiers_to_clear,
                 application_event_ids_to_ack,
+                visibility_batch_ids_to_ack,
                 &account.account_id_hex,
                 group_id_hex,
                 &classifier,
@@ -4985,11 +10797,14 @@ impl MarmotApp {
     /// runtime lease, so nothing this process owns holds a file lock inside the
     /// Marmot root.
     ///
-    /// Callers must quiesce first — this closes databases out from under any
-    /// work still running (see [`SqliteAccountStorage::close`] for what that
-    /// does to in-flight transactions). [`MarmotAppRuntime::shutdown_and_close`]
-    /// is the sequenced entry point host apps should use; it drains the account
-    /// workers before calling this.
+    /// Direct callers that need graceful completion should quiesce first — this
+    /// closes databases out from under any work still running (see
+    /// [`SqliteAccountStorage::close`] for what that does to in-flight
+    /// transactions). [`MarmotAppRuntime::shutdown_and_close`] is the terminal
+    /// entry point host apps should use: it closes runtime admission, gives
+    /// admitted account teardown a bounded chance to finish, then prioritizes
+    /// closing storage and releasing the root lease before graceful worker
+    /// cleanup continues.
     ///
     /// **Terminal.** [`Self::storage_is_closed`] latches, and every database
     /// accessor then fails with
@@ -5013,6 +10828,14 @@ impl MarmotApp {
     /// error is returned once all of them have been closed.
     pub fn close_storage(&self) -> Result<(), AppError> {
         let started_at = Instant::now();
+        // Root mutations are admitted before database opens in the few paths
+        // that need both. Taking this writer first preserves that lock order
+        // and keeps the lease until every already-admitted bounded file commit
+        // has finished.
+        let _root_mutation = self
+            .root_mutation_lifecycle
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         // Exclusive for the whole teardown. The `storage_closed` flag alone
         // would not make this atomic: two concurrent closes could interleave so
         // that one released the root lease and returned while the other was
@@ -5037,6 +10860,13 @@ impl MarmotApp {
             .drain()
             .map(|(_, storage)| storage)
             .collect::<Vec<_>>();
+        let account_session_storages = self
+            .account_session_storages
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .drain()
+            .map(|(_, storage)| storage)
+            .collect::<Vec<_>>();
         let directory_caches = self
             .directory_caches
             .lock()
@@ -5051,6 +10881,12 @@ impl MarmotApp {
             .take();
 
         for storage in account_storages {
+            closed += 1;
+            if let Err(error) = storage.close() {
+                first_error.get_or_insert(AppError::from(error));
+            }
+        }
+        for storage in account_session_storages {
             closed += 1;
             if let Err(error) = storage.close() {
                 first_error.get_or_insert(AppError::from(error));
@@ -5131,6 +10967,23 @@ impl MarmotApp {
             .read()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         self.ensure_storage_open(database)?;
+        Ok(guard)
+    }
+
+    /// Admit one bounded synchronous mutation inside the Marmot root.
+    ///
+    /// Callers must drop the returned guard before any network or worker await.
+    /// Terminal close takes the writer and latches `storage_closed` before it
+    /// releases the cross-process root lease.
+    pub(crate) fn begin_root_mutation(
+        &self,
+        operation: &'static str,
+    ) -> Result<RwLockReadGuard<'_, ()>, AppError> {
+        let guard = self
+            .root_mutation_lifecycle
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        self.ensure_storage_open(operation)?;
         Ok(guard)
     }
 
@@ -5535,31 +11388,81 @@ impl MarmotApp {
         self.root.clone()
     }
 
-    /// Evict every in-memory handle and warm flag bound to `label`.
+    /// Close and evict every in-memory handle and warm flag bound to `label`.
     ///
     /// Must be called before the account directory is deleted on removal or
-    /// setup-failure rollback. Without this, the cached `SqliteAccountStorage`
-    /// connection in `account_storages` (and the `directory_caches` handle)
-    /// keeps pointing at the now-unlinked inode: after the user re-imports the
-    /// same account, the session DB is rebuilt fresh while projection paths
-    /// keep writing through the stale handle, silently losing data. Clearing
-    /// the warm/stale/ready flags forces the rebuilt account to re-warm its
-    /// projections from the fresh database.
+    /// setup-failure rollback. Without this, the cached projection connection,
+    /// the independently opened account-session connection, or the directory
+    /// cache can keep pointing at the now-unlinked inode: after the user
+    /// re-imports the same account, the session DB is rebuilt fresh while a
+    /// stale handle silently loses writes. Clearing the warm/stale/ready flags
+    /// forces the rebuilt account to re-warm its projections from the fresh
+    /// database.
     fn drop_account_caches(&self, label: &str) {
         if let Ok(account) = self.account_home().account(label) {
             self.account_publish_clients
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .remove(&account.account_id_hex);
+            self.member_key_package_prewarm_cache
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .remove(&account.account_id_hex);
         }
-        self.account_storages
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .remove(label);
-        self.directory_caches
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .remove(label);
+        // Eviction alone is not enough: an unabortable `spawn_blocking`
+        // account open can still own clones after its async worker was reaped.
+        // Closing the shared handles makes every such clone inert before the
+        // cache entry becomes unreachable to terminal `close_storage`. Each
+        // close stays under its registry mutex so terminal draining cannot
+        // miss a removed handle whose close is still in progress.
+        {
+            let mut storages = self
+                .account_storages
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if let Some(storage) = storages.remove(label)
+                && let Err(error) = storage.close()
+            {
+                tracing::warn!(
+                    target: "marmot_app::storage",
+                    method = "drop_account_caches",
+                    error_kind = AppError::from(error).privacy_safe_kind(),
+                    "failed to close evicted account storage",
+                );
+            }
+        }
+        {
+            let mut storages = self
+                .account_session_storages
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if let Some(storage) = storages.remove(label)
+                && let Err(error) = storage.close()
+            {
+                tracing::warn!(
+                    target: "marmot_app::storage",
+                    method = "drop_account_caches",
+                    error_kind = AppError::from(error).privacy_safe_kind(),
+                    "failed to close evicted account session storage",
+                );
+            }
+        }
+        {
+            let mut caches = self
+                .directory_caches
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if let Some(cache) = caches.remove(label)
+                && let Err(error) = cache.close()
+            {
+                tracing::warn!(
+                    target: "marmot_app::storage",
+                    method = "drop_account_caches",
+                    error_kind = error.privacy_safe_kind(),
+                    "failed to close evicted directory cache",
+                );
+            }
+        }
         self.account_state_ready
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -5967,6 +11870,7 @@ struct AppKeyPackagePublisher {
     app: MarmotApp,
     account_label: String,
     signer: AccountSigner,
+    session_admission: AccountSessionAdmission,
 }
 
 impl AppKeyPackagePublisher {
@@ -6027,6 +11931,14 @@ impl KeyPackagePublisher for AppKeyPackagePublisher {
             .map_err(|error| KeyPackagePublishError::unexposed(error.to_string()))
     }
 
+    fn signed_artifact_reauthor_at_age_secs(&self) -> Option<u64> {
+        // Buzz rejects timestamps differing from relay time by more than 900
+        // seconds. Reauthor at signed-revision age >= 600 seconds, reserving
+        // 300 seconds for combined clock skew, scheduling/signing delay, and
+        // delivery across the relay set.
+        Some(KEY_PACKAGE_REAUTHOR_AT_AGE_SECS)
+    }
+
     async fn prepare_key_package(
         &self,
         publication: KeyPackagePublication,
@@ -6073,7 +11985,17 @@ impl KeyPackagePublisher for AppKeyPackagePublisher {
         publication: &KeyPackagePublication,
         artifact: &cgka_traits::SignedPublicationArtifact,
     ) -> Result<KeyPackagePublishReceipt, KeyPackagePublishError> {
-        let nostr_publication = self.nostr_publication(publication)?;
+        self.publish_prepared_key_package_detailed(publication, artifact)
+            .await
+            .map(Into::into)
+    }
+
+    async fn publish_prepared_key_package_detailed(
+        &self,
+        publication: &KeyPackagePublication,
+        artifact: &cgka_traits::SignedPublicationArtifact,
+    ) -> Result<DetailedKeyPackagePublishReceipt, KeyPackagePublishError> {
+        let mut nostr_publication = self.nostr_publication(publication)?;
         let event: NostrTransportEvent = serde_json::from_slice(&artifact.bytes)
             .map_err(|error| KeyPackagePublishError::unexposed(error.to_string()))?;
         if event.id != hex::encode(artifact.id.as_slice())
@@ -6083,6 +12005,178 @@ impl KeyPackagePublisher for AppKeyPackagePublisher {
                 "persisted KeyPackage event identity does not match lifecycle record",
             ));
         }
+        let mut canonical_publish_endpoints = Vec::new();
+        let mut endpoint_aliases = Vec::new();
+        let mut failed = Vec::new();
+        for requested_endpoint in &publication.endpoints {
+            match self
+                .app
+                .canonicalize_key_package_endpoint(requested_endpoint, "key package publish")
+            {
+                Ok(canonical_endpoint) => {
+                    canonical_publish_endpoints.push(canonical_endpoint.clone());
+                    endpoint_aliases.push((requested_endpoint.clone(), canonical_endpoint));
+                }
+                Err(_) => failed.push(requested_endpoint.clone()),
+            }
+        }
+        canonical_publish_endpoints.sort();
+        canonical_publish_endpoints.dedup();
+        if canonical_publish_endpoints.is_empty() {
+            return Err(KeyPackagePublishError::unexposed(
+                "no safe KeyPackage publication endpoint remains after validation",
+            ));
+        }
+        let key_package_route_lock = self.app.key_package_route_lock(&self.account_label);
+        let _key_package_route_guard = key_package_route_lock.lock().await;
+        let publication_account_id_hex = hex::encode(publication.account_id.as_slice());
+        let live_account_matches = self
+            .app
+            .account_home()
+            .account(&self.account_label)
+            .is_ok_and(|account| {
+                account.is_active_signing() && account.account_id_hex == publication_account_id_hex
+            });
+        let active_admission_is_current = match &self.session_admission {
+            AccountSessionAdmission::Active(token) => self
+                .app
+                .account_session_admission_is_current(&self.account_label, token),
+            // Teardown cleanup may delete or retire KeyPackages, but can never
+            // author a replacement. This is a categorical mode check in
+            // addition to the teardown runtime's durable publication block.
+            AccountSessionAdmission::Teardown(_) => false,
+        };
+        if !live_account_matches || !active_admission_is_current {
+            return Err(KeyPackagePublishError::unexposed(
+                "key package publisher account is signed out, removed, or no longer matches the live account record",
+            ));
+        }
+        if self
+            .app
+            .removed_local_key_package_slot_is_retired(
+                &publication_account_id_hex,
+                &publication.slot_id,
+            )
+            .map_err(|error| KeyPackagePublishError::unexposed(error.to_string()))?
+        {
+            return Err(KeyPackagePublishError::unexposed(
+                "prepared KeyPackage uses a stable slot retired by local account removal",
+            ));
+        }
+        let key_package_history_lock = self.app.key_package_history_lock(&self.account_label);
+        let _key_package_history_guard = key_package_history_lock.lock().await;
+        let incomplete_generated_setup_has_valid_context = self
+            .app
+            .account_home()
+            .account_setup_state(&self.account_label)
+            .map_err(|error| KeyPackagePublishError::unexposed(error.to_string()))?
+            .filter(|state| state.kind == AccountSetupKind::GeneratedIdentity)
+            .map(|_| {
+                self.app
+                    .account_home()
+                    .account_setup_context(&self.account_label)
+                    .ok()
+                    .flatten()
+                    .is_some_and(|bytes| {
+                        serde_json::from_slice::<runtime::GeneratedAccountSetupContext>(&bytes)
+                            .is_ok()
+                    })
+            })
+            .unwrap_or(true);
+        if !incomplete_generated_setup_has_valid_context
+            || !self
+                .app
+                .generated_initial_key_package_publication_held(&self.account_label)
+                .is_ok_and(|held| !held)
+        {
+            return Err(KeyPackagePublishError::unexposed(
+                "generated initial KeyPackage publication remains durably held",
+            ));
+        }
+        let lifecycle = self
+            .app
+            .account_storage(&self.account_label)
+            .and_then(|storage| storage.key_package_lifecycle().map_err(AppError::from))
+            .map_err(|error| KeyPackagePublishError::unexposed(error.to_string()))?
+            .ok_or_else(|| {
+                KeyPackagePublishError::unexposed(
+                    "key package lifecycle is unavailable at the final publication boundary",
+                )
+            })?;
+        if lifecycle.cutover_publication_blocked
+            || !self
+                .app
+                .key_package_cutover_publication_allowed(&self.account_label)
+        {
+            return Err(KeyPackagePublishError::unexposed(
+                "key package publication is blocked until strict relay cutover completes",
+            ));
+        }
+        let key_package_ref = hex::decode(&nostr_publication.key_package_ref)
+            .map_err(|error| KeyPackagePublishError::unexposed(error.to_string()))?;
+        if lifecycle.stable_slot_id != publication.slot_id
+            || lifecycle.key_package_ref_is_consumed(&key_package_ref)
+            || lifecycle
+                .deleted_live_revision_event_ids
+                .contains(&artifact.id)
+        {
+            return Err(KeyPackagePublishError::unexposed(
+                "prepared KeyPackage revision is no longer live in the durable lifecycle",
+            ));
+        }
+        let target_was_durably_admitted =
+            |targets: &[cgka_traits::TransportFanoutTarget], endpoint: &TransportEndpoint| {
+                targets.iter().any(|target| {
+                    target.endpoint == *endpoint
+                        && target.state
+                            != cgka_traits::TransportFanoutAttemptState::PolicyProhibited
+                        && (target.state == cgka_traits::TransportFanoutAttemptState::Accepted
+                            || (target.attempt_count > 0 && target.last_attempt_at.is_some()))
+                })
+            };
+        let matches_current = lifecycle.current_key_package.as_ref()
+            == Some(&publication.key_package)
+            && lifecycle.current_key_package_ref.as_ref() == Some(&key_package_ref)
+            && lifecycle.authored_signed_event.as_ref() == Some(artifact)
+            && lifecycle.authored_event_id.as_ref() == Some(&artifact.id)
+            && canonical_publish_endpoints.iter().all(|endpoint| {
+                target_was_durably_admitted(&lifecycle.publication_targets, endpoint)
+            });
+        let matches_pending = lifecycle
+            .pending_replacement
+            .as_ref()
+            .is_some_and(|pending| {
+                pending.key_package == publication.key_package
+                    && pending.key_package_ref == key_package_ref
+                    && pending.signed_event.as_ref() == Some(artifact)
+                    && pending.authored_created_at == artifact.created_at
+                    && canonical_publish_endpoints
+                        .iter()
+                        .all(|endpoint| target_was_durably_admitted(&pending.targets, endpoint))
+            });
+        if !matches_current && !matches_pending {
+            return Err(KeyPackagePublishError::unexposed(
+                "prepared KeyPackage artifact or endpoint attempt is not the durable live revision",
+            ));
+        }
+        let authoritative_endpoints = self
+            .app
+            .authoritative_key_package_relays(&self.account_label)
+            .map_err(|_| {
+                KeyPackagePublishError::unexposed(
+                    "could not validate authoritative KeyPackage publication endpoints",
+                )
+            })?;
+        if authoritative_endpoints.is_empty()
+            || canonical_publish_endpoints
+                .iter()
+                .any(|endpoint| !authoritative_endpoints.contains(endpoint))
+        {
+            return Err(KeyPackagePublishError::unexposed(
+                "prepared KeyPackage publication targets are outside the authoritative relay set",
+            ));
+        }
+        nostr_publication.publish_endpoints = canonical_publish_endpoints;
         let relay_client = self.app.relay_client_for_account_id(
             &hex::encode(publication.account_id.as_slice()),
             self.signer.as_nostr_signer(),
@@ -6091,22 +12185,23 @@ impl KeyPackagePublisher for AppKeyPackagePublisher {
             .publish_prepared_key_package(&nostr_publication, &event)
             .await
             .map_err(|e| KeyPackagePublishError::exposed(e.to_string()))?;
-        let accepted = outcome
+        let canonical_accepted = outcome
             .accepted
             .into_iter()
             .map(|receipt| receipt.endpoint)
             .collect::<Vec<_>>();
-        let failed = outcome
-            .failed
-            .into_iter()
-            .map(|failure| failure.endpoint)
-            .collect::<Vec<_>>();
+        let mut canonical_rejected = Vec::new();
+        for failure in outcome.failed {
+            if failure.rejection_category.is_some() {
+                canonical_rejected.push(failure.endpoint);
+            }
+        }
 
         // SQLCipher lifecycle state remains authoritative. This directory row
         // is only a best-effort projection for local invite lookups, which
         // otherwise could reuse a consumed package until the next relay fetch.
-        if !accepted.is_empty() {
-            let account_id_hex = hex::encode(publication.account_id.as_slice());
+        if !canonical_accepted.is_empty() {
+            let account_id_hex = publication_account_id_hex;
             let relay_lists = self
                 .app
                 .account_relay_list_status_for_account_id(&account_id_hex)
@@ -6118,10 +12213,18 @@ impl KeyPackagePublisher for AppKeyPackagePublisher {
                 key_package_ref_hex: nostr_publication.key_package_ref,
                 key_package_event_id: hex::encode(artifact.id.as_slice()),
                 created_at: artifact.created_at.0,
-                source_relays: accepted.iter().map(|endpoint| endpoint.0.clone()).collect(),
+                source_relays: canonical_accepted
+                    .iter()
+                    .map(|endpoint| endpoint.0.clone())
+                    .collect(),
                 relay_lists,
             };
-            if self.app.remember_directory_key_package(&fetched).is_err() {
+            if self
+                .app
+                .begin_root_mutation("project acknowledged local KeyPackage")
+                .and_then(|_root_mutation| self.app.remember_directory_key_package(&fetched))
+                .is_err()
+            {
                 tracing::warn!(
                     target: "marmot_app::key_packages",
                     method = "publish_prepared_key_package",
@@ -6130,7 +12233,128 @@ impl KeyPackagePublisher for AppKeyPackagePublisher {
             }
         }
 
-        Ok(KeyPackagePublishReceipt { accepted, failed })
+        let mut accepted = Vec::new();
+        let mut rejected = Vec::new();
+        for (requested, canonical) in endpoint_aliases {
+            if canonical_accepted.contains(&canonical) {
+                accepted.push(requested);
+            } else if canonical_rejected.contains(&canonical) {
+                rejected.push(requested);
+            } else {
+                // Includes explicit transport failures and a malformed/missing
+                // per-endpoint receipt. Neither may erase the durable exact
+                // requested key's possible-exposure evidence.
+                failed.push(requested);
+            }
+        }
+        accepted.sort();
+        accepted.dedup();
+        rejected.sort();
+        rejected.dedup();
+        rejected.retain(|endpoint| !accepted.contains(endpoint));
+        failed.sort();
+        failed.dedup();
+        failed.retain(|endpoint| !accepted.contains(endpoint) && !rejected.contains(endpoint));
+
+        Ok(DetailedKeyPackagePublishReceipt {
+            accepted,
+            rejected,
+            confirmed_absent: Vec::new(),
+            failed,
+        })
+    }
+
+    async fn delete_key_package_revision(
+        &self,
+        event_id: &cgka_traits::MessageId,
+        endpoints: &[TransportEndpoint],
+    ) -> Result<DetailedKeyPackagePublishReceipt, KeyPackagePublishError> {
+        // Legacy lifecycle rows can contain both noncanonical valid aliases
+        // and unsafe keys from before relay validation happened at durable
+        // admission. Partition them per target: unsafe exact keys remain
+        // retryable without reaching I/O, while safe siblings share one
+        // canonical deletion whose receipt expands back to every requested
+        // durable alias.
+        if endpoints.is_empty() {
+            return Err(KeyPackagePublishError::unexposed(
+                "key package deletion requires at least one relay endpoint",
+            ));
+        }
+        let mut canonical_endpoints = Vec::new();
+        let mut endpoint_aliases = Vec::new();
+        let mut failed = Vec::new();
+        for requested_endpoint in endpoints {
+            match self.app.canonicalize_key_package_endpoint(
+                requested_endpoint,
+                "key package deletion publish",
+            ) {
+                Ok(canonical_endpoint) => {
+                    canonical_endpoints.push(canonical_endpoint.clone());
+                    endpoint_aliases.push((requested_endpoint.clone(), canonical_endpoint));
+                }
+                Err(_) => failed.push(requested_endpoint.clone()),
+            }
+        }
+        canonical_endpoints.sort();
+        canonical_endpoints.dedup();
+        if canonical_endpoints.is_empty() {
+            failed.sort();
+            failed.dedup();
+            return Ok(DetailedKeyPackagePublishReceipt {
+                accepted: Vec::new(),
+                rejected: Vec::new(),
+                confirmed_absent: Vec::new(),
+                failed,
+            });
+        }
+        let mut results = self
+            .app
+            .delete_key_package_events(
+                &self.account_label,
+                vec![KeyPackageDeletionTarget {
+                    event_id_hex: hex::encode(event_id.as_slice()),
+                    source_relays: canonical_endpoints,
+                }],
+                self.session_admission.clone(),
+            )
+            .await
+            .map_err(|error| KeyPackagePublishError::exposed(error.to_string()))?;
+        let result = results
+            .pop()
+            .expect("single retired-revision deletion returns one outcome");
+        let expand_receipts = |canonical_receipts: &[TransportEndpoint]| {
+            let mut requested = endpoint_aliases
+                .iter()
+                .filter(|(_requested, canonical)| canonical_receipts.contains(canonical))
+                .map(|(requested, _canonical)| requested.clone())
+                .collect::<Vec<_>>();
+            requested.sort();
+            requested.dedup();
+            requested
+        };
+        let accepted = expand_receipts(&result.accepted_endpoints);
+        let confirmed_absent = expand_receipts(&result.confirmed_absent_endpoints);
+        for (requested, canonical) in endpoint_aliases {
+            if !result.accepted_endpoints.contains(&canonical)
+                && !result.confirmed_absent_endpoints.contains(&canonical)
+            {
+                // Includes explicit failure, a malformed/missing endpoint
+                // receipt, and an aggregate deletion error. None proves the
+                // exact durable alias absent.
+                failed.push(requested);
+            }
+        }
+        failed.sort();
+        failed.dedup();
+        failed.retain(|endpoint| {
+            !accepted.contains(endpoint) && !confirmed_absent.contains(endpoint)
+        });
+        Ok(DetailedKeyPackagePublishReceipt {
+            accepted,
+            rejected: Vec::new(),
+            confirmed_absent,
+            failed,
+        })
     }
 }
 
@@ -6164,13 +12388,21 @@ pub(crate) struct DirectoryFreshness {
 
 impl DirectoryFreshness {
     fn from_now(max_future_skew: Duration) -> Self {
+        Self::from_unix_time(unix_now_seconds(), max_future_skew)
+    }
+
+    fn from_unix_time(now: u64, max_future_skew: Duration) -> Self {
         Self {
-            max_created_at: unix_now_seconds().saturating_add(max_future_skew.as_secs()),
+            max_created_at: now.saturating_add(max_future_skew.as_secs()),
         }
     }
 
+    fn accepts_created_at(self, created_at: u64) -> bool {
+        created_at <= self.max_created_at
+    }
+
     pub(crate) fn accepts(self, record: &RelayEventRecord) -> bool {
-        record.event.created_at <= self.max_created_at
+        self.accepts_created_at(record.event.created_at)
     }
 }
 
@@ -6185,8 +12417,23 @@ fn sort_directory_records(records: &mut [RelayEventRecord]) {
         a.event
             .created_at
             .cmp(&b.event.created_at)
-            .then_with(|| a.event.id.cmp(&b.event.id))
+            // Callers fold in order and retain the last replaceable event.
+            // NIP-01 selects the lowest id when timestamps tie, so sort equal
+            // timestamps in descending id order.
+            .then_with(|| b.event.id.cmp(&a.event.id))
     });
+}
+
+/// NIP-01 replaceable-event ordering: greater `created_at` wins; at equal
+/// timestamps the lexicographically lowest event id wins.
+fn nostr_replaceable_coordinate_is_newer(
+    candidate_created_at: u64,
+    candidate_event_id: &str,
+    current_created_at: u64,
+    current_event_id: &str,
+) -> bool {
+    candidate_created_at > current_created_at
+        || (candidate_created_at == current_created_at && candidate_event_id < current_event_id)
 }
 
 fn sqlite_file_requires_key(path: &Path) -> bool {
@@ -6326,6 +12573,32 @@ fn push_unique_strings(values: &mut Vec<String>, candidates: impl IntoIterator<I
 fn read_json<T: for<'de> Deserialize<'de>>(path: impl AsRef<Path>) -> Result<T, AppError> {
     let bytes = fs::read(path)?;
     Ok(serde_json::from_slice(&bytes)?)
+}
+
+fn remove_file_if_present(path: impl AsRef<Path>) -> Result<(), AppError> {
+    let path = path.as_ref();
+    match fs::remove_file(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    };
+    // Persist both a new unlink and a previously unsynced absence before a
+    // caller reports the transition complete. This is load-bearing when an
+    // atomically written successor record must survive without its
+    // predecessor.
+    #[cfg(unix)]
+    if let Some(parent) = path.parent() {
+        // A missing parent already proves the child absent. This keeps
+        // idempotent rollback valid when no compatibility namespace was ever
+        // created, while still persisting an unlink (or an earlier unsynced
+        // absence) whenever the parent directory exists.
+        match std::fs::File::open(parent) {
+            Ok(directory) => directory.sync_all()?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/marmot-app/src/relay_plane/directory.rs
+++ b/crates/marmot-app/src/relay_plane/directory.rs
@@ -4,16 +4,21 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use cgka_traits::TransportEndpoint;
-use nostr_sdk::prelude::{Client as NostrSdkClient, Event, Filter, Kind, PublicKey, RelayUrl};
+use nostr_sdk::prelude::{
+    Client as NostrSdkClient, Event, Filter, Kind, PublicKey, RelayMessage, RelayPoolNotification,
+    RelayUrl, SubscriptionId,
+};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, oneshot};
 use tokio::task::JoinSet;
-use tokio::time::timeout;
+use tokio::time::{Instant, sleep, timeout};
 use transport_nostr_peeler::NostrTransportEvent;
 
 use super::DIRECTORY_RELAY_CONNECT_WAIT;
 
 const DIRECTORY_RELAY_FETCH_WAIT: Duration = Duration::from_secs(3);
+const STRICT_DIRECTORY_RELAY_FETCH_INACTIVITY_WAIT: Duration = Duration::from_secs(3);
+const STRICT_DIRECTORY_RELAY_FETCH_OVERALL_WAIT: Duration = Duration::from_secs(30);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DirectoryRelayConnectOutcome {
@@ -120,6 +125,26 @@ pub(crate) trait DirectoryRelayFetcher: Send + Sync {
         &self,
         request: DirectoryFetchRequest,
     ) -> Result<Vec<DirectoryRelayEventRecord>, String>;
+
+    /// Fetch stored events only when every subscribed relay explicitly reports
+    /// EOSE. Privacy cutover scans must not interpret SDK silence or an overall
+    /// request timeout as a complete empty/short result.
+    async fn fetch_directory_events_strict(
+        &self,
+        request: DirectoryFetchRequest,
+    ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
+        #[cfg(test)]
+        {
+            // Unit-test fetchers model a complete finite response unless they
+            // override this method with an explicit incomplete script.
+            self.fetch_directory_events(request).await
+        }
+        #[cfg(not(test))]
+        {
+            let _ = request;
+            Err("strict directory fetch completion is unsupported".to_owned())
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -232,6 +257,43 @@ impl DirectoryRelayPlane {
             .map_err(|_| "directory fetch owner dropped before completing".to_owned())?
     }
 
+    /// Run a completion-sensitive fetch outside the ordinary coalescing map.
+    /// A strict cutover caller must receive this invocation's own EOSE proof;
+    /// sharing an in-flight ordinary fetch would erase that distinction.
+    pub(crate) async fn fetch_events_strict(
+        &self,
+        request: DirectoryFetchRequest,
+    ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
+        let (tx, rx) = oneshot::channel();
+        let fetcher = self.fetcher.clone();
+        let state = self.state.clone();
+        tokio::spawn(async move {
+            // The supervisor outlives caller cancellation, so the strict
+            // fetcher can unsubscribe and the health counters still record its
+            // eventual outcome. The inner task turns a fetcher panic into the
+            // same explicit failure shape as ordinary directory fetches.
+            let result =
+                match tokio::spawn(
+                    async move { fetcher.fetch_directory_events_strict(request).await },
+                )
+                .await
+                {
+                    Ok(result) => result,
+                    Err(_) => Err("strict directory fetch task failed".to_owned()),
+                };
+            let mut state = state.lock().await;
+            if result.is_ok() {
+                state.completed_fetches += 1;
+            } else {
+                state.failed_fetches += 1;
+            }
+            let _ = tx.send(result);
+        });
+
+        rx.await
+            .map_err(|_| "strict directory fetch owner dropped before completing".to_owned())?
+    }
+
     pub(crate) async fn stats(&self) -> DirectoryRelayStats {
         let state = self.state.lock().await;
         DirectoryRelayStats {
@@ -330,40 +392,24 @@ impl NostrSdkDirectoryRelayFetcher {
     pub(crate) fn standalone() -> Self {
         Self::new(NostrSdkClient::builder().build())
     }
-}
 
-fn validated_directory_event(
-    event: &Event,
-    query: &DirectoryEventQuery,
-) -> Option<NostrTransportEvent> {
-    if event.verify().is_err()
-        || u64::from(event.kind.as_u16()) != query.kind
-        || !query
-            .authors
-            .iter()
-            .any(|author| author == &event.pubkey.to_hex())
-    {
-        return None;
-    }
-    NostrTransportEvent::from_nostr_event(event).ok()
-}
-
-#[async_trait]
-impl DirectoryRelayFetcher for NostrSdkDirectoryRelayFetcher {
-    async fn fetch_directory_events(
+    async fn connected_relay_urls(
         &self,
-        request: DirectoryFetchRequest,
-    ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
-        let relay_urls = parsed_directory_relay_urls(&request.endpoints)?;
+        endpoints: &[TransportEndpoint],
+        require_all: bool,
+    ) -> Result<Vec<RelayUrl>, String> {
+        let relay_urls = parsed_directory_relay_urls(endpoints)?;
+        let requested_relay_count = relay_urls.len();
         let mut connect_candidates = Vec::new();
-        let mut added = vec![false; relay_urls.len()];
+        let mut newly_added = vec![false; relay_urls.len()];
         let mut add_failure_count = 0usize;
         for (index, relay_url) in relay_urls.iter().cloned().enumerate() {
-            if self.client.add_relay(relay_url.clone()).await.is_ok() {
-                added[index] = true;
-                connect_candidates.push((index, relay_url));
-            } else {
-                add_failure_count += 1;
+            match self.client.add_relay(relay_url.clone()).await {
+                Ok(added) => {
+                    newly_added[index] = added;
+                    connect_candidates.push((index, relay_url));
+                }
+                Err(_) => add_failure_count += 1,
             }
         }
         let mut connects = JoinSet::new();
@@ -399,10 +445,11 @@ impl DirectoryRelayFetcher for NostrSdkDirectoryRelayFetcher {
                 Err(_) => task_failure_count += 1,
             }
         }
-        // A task that panics or is cancelled never flips its index to
-        // connected, so this also removes relays from failed JoinSet tasks.
         for (index, relay_url) in relay_urls.iter().cloned().enumerate() {
-            if added[index] && !connected[index] {
+            // Never remove a pre-existing relay owned by another subscription
+            // merely because this fetch's connection attempt failed. Only a
+            // relay inserted by this invocation is ours to clean up.
+            if newly_added[index] && !connected[index] {
                 let _ = self.client.remove_relay(relay_url).await;
             }
         }
@@ -416,6 +463,163 @@ impl DirectoryRelayFetcher for NostrSdkDirectoryRelayFetcher {
                 "connect relays failed: add_failures={add_failure_count}, connect_timeouts={connect_timeout_count}, connect_failures={connect_failure_count}, task_failures={task_failure_count}"
             ));
         }
+        if require_all && relay_urls.len() != requested_relay_count {
+            return Err(format!(
+                "strict directory connect completed on {} of {requested_relay_count} relays: add_failures={add_failure_count}, connect_timeouts={connect_timeout_count}, connect_failures={connect_failure_count}, task_failures={task_failure_count}",
+                relay_urls.len()
+            ));
+        }
+        Ok(relay_urls)
+    }
+}
+
+fn validated_directory_event(
+    event: &Event,
+    query: &DirectoryEventQuery,
+) -> Option<NostrTransportEvent> {
+    if event.verify().is_err()
+        || u64::from(event.kind.as_u16()) != query.kind
+        || !query
+            .authors
+            .iter()
+            .any(|author| author == &event.pubkey.to_hex())
+    {
+        return None;
+    }
+    NostrTransportEvent::from_nostr_event(event).ok()
+}
+
+async fn collect_strict_directory_query(
+    mut notifications: tokio::sync::broadcast::Receiver<RelayPoolNotification>,
+    request_id: &SubscriptionId,
+    expected_relays: &HashSet<RelayUrl>,
+    query: &DirectoryEventQuery,
+    inactivity_wait: Duration,
+    overall_wait: Duration,
+) -> Result<Vec<DirectoryRelayEventRecord>, String> {
+    let mut completed_relays = HashSet::new();
+    let mut pre_eose_delivery_counts = HashMap::<RelayUrl, usize>::new();
+    let mut accepted_event_ids = HashMap::<RelayUrl, HashSet<String>>::new();
+    let mut records = Vec::new();
+    let mut inactivity = Box::pin(sleep(inactivity_wait));
+    let mut overall = Box::pin(sleep(overall_wait));
+    loop {
+        let relevant_activity = tokio::select! {
+            // A constantly active relay that never sends EOSE must not keep a
+            // completion-sensitive fetch alive forever. Check the absolute
+            // bound before the resettable inactivity timer and notifications
+            // when multiple branches become ready together.
+            biased;
+            _ = &mut overall => {
+                return Err(
+                    "strict directory fetch exceeded its overall deadline before EOSE".to_owned()
+                );
+            }
+            _ = &mut inactivity => {
+                return Err("strict directory fetch inactive before EOSE".to_owned());
+            }
+            notification = notifications.recv() => {
+                match notification {
+                Ok(RelayPoolNotification::Message {
+                    relay_url,
+                    message:
+                        RelayMessage::Event {
+                            subscription_id,
+                            event,
+                        },
+                }) if subscription_id.as_ref() == request_id
+                    && expected_relays.contains(&relay_url) =>
+                {
+                    // EOSE terminates the stored-event page for this relay.
+                    // Live events received afterward belong to a different
+                    // semantic window and must neither consume another relay's
+                    // bounded result capacity nor extend its inactivity window.
+                    if completed_relays.contains(&relay_url) {
+                        false
+                    } else {
+                        // Any event delivered under this exact subscription is
+                        // relevant relay activity and consumes one result-page
+                        // position, including duplicate or malformed events.
+                        // Reaching the requested limit is inconclusive: the
+                        // relay may have more stored events, so a privacy
+                        // cutover must remain gated rather than treating a
+                        // deduplicated short result as complete.
+                        let delivery_count = pre_eose_delivery_counts
+                            .entry(relay_url.clone())
+                            .or_default();
+                        *delivery_count = delivery_count.saturating_add(1);
+                        let event = validated_directory_event(event.as_ref(), query).ok_or_else(|| {
+                            "strict directory exact subscription delivered an invalid or unrelated event"
+                                .to_owned()
+                        })?;
+                        if *delivery_count >= query.limit {
+                            return Err(
+                                "strict directory fetch reached its bounded query capacity before EOSE"
+                                    .to_owned(),
+                            );
+                        }
+                        let relay_event_ids =
+                            accepted_event_ids.entry(relay_url.clone()).or_default();
+                        if relay_event_ids.insert(event.id.clone()) {
+                            records.push(DirectoryRelayEventRecord {
+                                endpoints: vec![TransportEndpoint(relay_url.to_string())],
+                                event,
+                            });
+                        }
+                        true
+                    }
+                }
+                Ok(RelayPoolNotification::Message {
+                    relay_url,
+                    message: RelayMessage::EndOfStoredEvents(subscription_id),
+                }) if subscription_id.as_ref() == request_id
+                    && expected_relays.contains(&relay_url) =>
+                {
+                    let newly_completed = completed_relays.insert(relay_url);
+                    if completed_relays.len() == expected_relays.len() {
+                        return Ok(records);
+                    }
+                    newly_completed
+                }
+                Ok(RelayPoolNotification::Message {
+                    relay_url,
+                    message:
+                        RelayMessage::Closed {
+                            subscription_id, ..
+                        },
+                }) if subscription_id.as_ref() == request_id
+                    && expected_relays.contains(&relay_url) =>
+                {
+                    return Err("strict directory subscription closed before EOSE".to_owned());
+                }
+                Ok(RelayPoolNotification::Shutdown) => {
+                    return Err("relay pool shut down before strict directory EOSE".to_owned());
+                }
+                Ok(_) => false,
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                    return Err(
+                        "strict directory notification stream lagged before EOSE".to_owned()
+                    );
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    return Err("strict directory notification stream ended before EOSE".to_owned());
+                }
+                }
+            }
+        };
+        if relevant_activity {
+            inactivity.as_mut().reset(Instant::now() + inactivity_wait);
+        }
+    }
+}
+
+#[async_trait]
+impl DirectoryRelayFetcher for NostrSdkDirectoryRelayFetcher {
+    async fn fetch_directory_events(
+        &self,
+        request: DirectoryFetchRequest,
+    ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
+        let relay_urls = self.connected_relay_urls(&request.endpoints, false).await?;
 
         let mut records = Vec::new();
         for query in request.queries {
@@ -445,6 +649,66 @@ impl DirectoryRelayFetcher for NostrSdkDirectoryRelayFetcher {
                     event,
                 });
             }
+        }
+        Ok(records)
+    }
+
+    async fn fetch_directory_events_strict(
+        &self,
+        request: DirectoryFetchRequest,
+    ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
+        let relay_urls = self.connected_relay_urls(&request.endpoints, true).await?;
+        let mut records = Vec::new();
+        for query in request.queries {
+            let kind = u16::try_from(query.kind)
+                .map(Kind::from)
+                .map_err(|_| format!("unsupported Nostr kind {}", query.kind))?;
+            let public_keys = query
+                .authors
+                .iter()
+                .map(|author| PublicKey::parse(author).map_err(|_| "invalid query author"))
+                .collect::<Result<Vec<_>, _>>()?;
+            let filter = Filter::new()
+                .authors(public_keys)
+                .kind(kind)
+                .limit(query.limit);
+            let request_id = SubscriptionId::generate();
+            // Subscribe the receiver first: a fast relay may return its event
+            // and EOSE before subscribe_with_id_to finishes registering every
+            // target, and broadcast retains those notifications for us.
+            let notifications = self.client.notifications();
+            let output = match self
+                .client
+                .subscribe_with_id_to(relay_urls.clone(), request_id.clone(), filter, None)
+                .await
+            {
+                Ok(output) => output,
+                Err(_) => {
+                    self.client.unsubscribe(&request_id).await;
+                    return Err("strict directory subscribe failed".to_owned());
+                }
+            };
+            if output.success.len() != relay_urls.len() || !output.failed.is_empty() {
+                self.client.unsubscribe(&request_id).await;
+                return Err(format!(
+                    "strict directory subscribe registered on {} of {} relays with {} failures",
+                    output.success.len(),
+                    relay_urls.len(),
+                    output.failed.len()
+                ));
+            }
+            let expected_relays = output.success;
+            let completion = collect_strict_directory_query(
+                notifications,
+                &request_id,
+                &expected_relays,
+                &query,
+                STRICT_DIRECTORY_RELAY_FETCH_INACTIVITY_WAIT,
+                STRICT_DIRECTORY_RELAY_FETCH_OVERALL_WAIT,
+            )
+            .await;
+            self.client.unsubscribe(&request_id).await;
+            records.extend(completion?);
         }
         Ok(records)
     }
@@ -509,6 +773,386 @@ mod tests {
 
         assert_eq!(error, "invalid relay URL");
         assert!(!error.contains(secret_url));
+    }
+
+    #[tokio::test]
+    async fn strict_sdk_fetcher_rejects_invalid_url_before_subscription() {
+        let secret_url = "not-a-strict-relay-with-secret-token";
+        let request = DirectoryFetchRequest::new(
+            vec![TransportEndpoint(secret_url.to_owned())],
+            vec![DirectoryEventQuery::new(0, vec!["11".repeat(32)], 1)],
+        )
+        .unwrap();
+
+        let error = NostrSdkDirectoryRelayFetcher::standalone()
+            .fetch_directory_events_strict(request)
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, "invalid relay URL");
+        assert!(!error.contains(secret_url));
+    }
+
+    #[tokio::test]
+    async fn strict_query_returns_only_pre_eose_per_relay_records() {
+        use nostr_sdk::prelude::{EventBuilder, Keys};
+
+        let alice = Keys::generate();
+        let bob = Keys::generate();
+        let alice_stored = EventBuilder::new(Kind::Metadata, r#"{"name":"alice-stored"}"#)
+            .sign_with_keys(&alice)
+            .unwrap();
+        let alice_live = EventBuilder::new(Kind::Metadata, r#"{"name":"alice-live"}"#)
+            .sign_with_keys(&alice)
+            .unwrap();
+        let bob_stored = EventBuilder::new(Kind::Metadata, r#"{"name":"bob-stored"}"#)
+            .sign_with_keys(&bob)
+            .unwrap();
+        let query = DirectoryEventQuery::new(
+            0,
+            vec![alice.public_key().to_hex(), bob.public_key().to_hex()],
+            2,
+        );
+        let relay_a = RelayUrl::parse("wss://a.relay.example").unwrap();
+        let relay_b = RelayUrl::parse("wss://b.relay.example").unwrap();
+        let expected_relays = HashSet::from([relay_a.clone(), relay_b.clone()]);
+        let request_id = SubscriptionId::generate();
+        let unrelated_id = SubscriptionId::generate();
+        let (sender, receiver) = tokio::sync::broadcast::channel(16);
+        let send = |relay_url: RelayUrl, message: RelayMessage<'static>| {
+            sender
+                .send(RelayPoolNotification::Message { relay_url, message })
+                .unwrap();
+        };
+
+        send(
+            relay_a.clone(),
+            RelayMessage::event(unrelated_id, alice_live.clone()),
+        );
+        send(
+            relay_a.clone(),
+            RelayMessage::event(request_id.clone(), alice_stored.clone()),
+        );
+        send(relay_a.clone(), RelayMessage::eose(request_id.clone()));
+        // This is a live event, not part of relay A's finite stored page.
+        send(relay_a, RelayMessage::event(request_id.clone(), alice_live));
+        send(
+            relay_b.clone(),
+            RelayMessage::event(request_id.clone(), bob_stored.clone()),
+        );
+        send(relay_b, RelayMessage::eose(request_id.clone()));
+
+        let records = collect_strict_directory_query(
+            receiver,
+            &request_id,
+            &expected_relays,
+            &query,
+            Duration::from_secs(1),
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].event.id, alice_stored.id.to_hex());
+        assert_eq!(records[1].event.id, bob_stored.id.to_hex());
+        assert_ne!(records[0].endpoints, records[1].endpoints);
+    }
+
+    #[tokio::test]
+    async fn strict_query_allows_slow_progress_beyond_one_inactivity_window() {
+        use nostr_sdk::prelude::{EventBuilder, Keys};
+
+        let author = Keys::generate();
+        let first = EventBuilder::new(Kind::Metadata, r#"{"name":"first"}"#)
+            .sign_with_keys(&author)
+            .unwrap();
+        let second = EventBuilder::new(Kind::Metadata, r#"{"name":"second"}"#)
+            .sign_with_keys(&author)
+            .unwrap();
+        let query = DirectoryEventQuery::new(0, vec![author.public_key().to_hex()], 3);
+        let relay = RelayUrl::parse("wss://slow.relay.example").unwrap();
+        let expected_relays = HashSet::from([relay.clone()]);
+        let request_id = SubscriptionId::generate();
+        let (sender, receiver) = tokio::sync::broadcast::channel(8);
+        let producer_request_id = request_id.clone();
+        let producer_relay = relay.clone();
+        let first_for_producer = first.clone();
+        let second_for_producer = second.clone();
+        let producer = tokio::spawn(async move {
+            for event in [first_for_producer, second_for_producer] {
+                sleep(Duration::from_millis(75)).await;
+                sender
+                    .send(RelayPoolNotification::Message {
+                        relay_url: producer_relay.clone(),
+                        message: RelayMessage::event(producer_request_id.clone(), event),
+                    })
+                    .expect("strict query receiver remains active");
+            }
+            sleep(Duration::from_millis(75)).await;
+            sender
+                .send(RelayPoolNotification::Message {
+                    relay_url: producer_relay,
+                    message: RelayMessage::eose(producer_request_id),
+                })
+                .expect("strict query receiver remains active");
+        });
+        let inactivity_wait = Duration::from_millis(200);
+        let started_at = Instant::now();
+
+        let records = collect_strict_directory_query(
+            receiver,
+            &request_id,
+            &expected_relays,
+            &query,
+            inactivity_wait,
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap();
+        producer.await.unwrap();
+
+        assert!(
+            started_at.elapsed() > inactivity_wait,
+            "incremental relay activity must let a finite page outlive one idle interval"
+        );
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].event.id, first.id.to_hex());
+        assert_eq!(records[1].event.id, second.id.to_hex());
+    }
+
+    #[tokio::test]
+    async fn strict_query_rejects_invalid_or_unrelated_exact_subscription_events() {
+        use nostr_sdk::prelude::{Event, EventBuilder, JsonUtil, Keys};
+
+        let expected = Keys::generate();
+        let unexpected = Keys::generate();
+        let valid = EventBuilder::new(Kind::Metadata, r#"{"name":"valid"}"#)
+            .sign_with_keys(&expected)
+            .unwrap();
+        let wrong_author = EventBuilder::new(Kind::Metadata, r#"{"name":"wrong-author"}"#)
+            .sign_with_keys(&unexpected)
+            .unwrap();
+        let wrong_kind = EventBuilder::new(Kind::from(3_u16), String::new())
+            .sign_with_keys(&expected)
+            .unwrap();
+        let mut tampered = serde_json::to_value(&valid).unwrap();
+        tampered["content"] = serde_json::Value::String(r#"{"name":"tampered"}"#.to_owned());
+        let invalid_signature = Event::from_json(tampered.to_string()).unwrap();
+        let query = DirectoryEventQuery::new(0, vec![expected.public_key().to_hex()], 4);
+        let relay = RelayUrl::parse("wss://strict-validation.relay.example").unwrap();
+        let expected_relays = HashSet::from([relay.clone()]);
+
+        for event in [wrong_author, wrong_kind, invalid_signature] {
+            let request_id = SubscriptionId::generate();
+            let (sender, receiver) = tokio::sync::broadcast::channel(4);
+            sender
+                .send(RelayPoolNotification::Message {
+                    relay_url: relay.clone(),
+                    message: RelayMessage::event(request_id.clone(), event),
+                })
+                .unwrap();
+            sender
+                .send(RelayPoolNotification::Message {
+                    relay_url: relay.clone(),
+                    message: RelayMessage::eose(request_id.clone()),
+                })
+                .unwrap();
+
+            let error = collect_strict_directory_query(
+                receiver,
+                &request_id,
+                &expected_relays,
+                &query,
+                Duration::from_secs(1),
+                Duration::from_secs(2),
+            )
+            .await
+            .unwrap_err();
+
+            assert_eq!(
+                error,
+                "strict directory exact subscription delivered an invalid or unrelated event"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn strict_query_counts_duplicate_deliveries_toward_capacity() {
+        use nostr_sdk::prelude::{EventBuilder, Keys};
+
+        let author = Keys::generate();
+        let event = EventBuilder::new(Kind::Metadata, r#"{"name":"duplicate"}"#)
+            .sign_with_keys(&author)
+            .unwrap();
+        let query = DirectoryEventQuery::new(0, vec![author.public_key().to_hex()], 2);
+        let relay = RelayUrl::parse("wss://strict-capacity.relay.example").unwrap();
+        let expected_relays = HashSet::from([relay.clone()]);
+        let request_id = SubscriptionId::generate();
+        let (sender, receiver) = tokio::sync::broadcast::channel(4);
+        for delivered in [event.clone(), event] {
+            sender
+                .send(RelayPoolNotification::Message {
+                    relay_url: relay.clone(),
+                    message: RelayMessage::event(request_id.clone(), delivered),
+                })
+                .unwrap();
+        }
+        sender
+            .send(RelayPoolNotification::Message {
+                relay_url: relay,
+                message: RelayMessage::eose(request_id.clone()),
+            })
+            .unwrap();
+
+        let error = collect_strict_directory_query(
+            receiver,
+            &request_id,
+            &expected_relays,
+            &query,
+            Duration::from_secs(1),
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            "strict directory fetch reached its bounded query capacity before EOSE"
+        );
+    }
+
+    #[tokio::test]
+    async fn strict_query_reports_closed_stream_and_inactivity_before_all_eose() {
+        let relay_a = RelayUrl::parse("wss://a.relay.example").unwrap();
+        let relay_b = RelayUrl::parse("wss://b.relay.example").unwrap();
+        let expected_relays = HashSet::from([relay_a.clone(), relay_b.clone()]);
+        let query = DirectoryEventQuery::new(0, vec!["11".repeat(32)], 1);
+        let request_id = SubscriptionId::generate();
+        let (sender, receiver) = tokio::sync::broadcast::channel(4);
+        sender
+            .send(RelayPoolNotification::Message {
+                relay_url: relay_a,
+                message: RelayMessage::eose(request_id.clone()),
+            })
+            .unwrap();
+        sender
+            .send(RelayPoolNotification::Message {
+                relay_url: relay_b,
+                message: RelayMessage::closed(request_id.clone(), "closed by relay"),
+            })
+            .unwrap();
+
+        let error = collect_strict_directory_query(
+            receiver,
+            &request_id,
+            &expected_relays,
+            &query,
+            Duration::from_secs(1),
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error, "strict directory subscription closed before EOSE");
+
+        let (_sender, receiver) = tokio::sync::broadcast::channel(1);
+        let error = collect_strict_directory_query(
+            receiver,
+            &request_id,
+            &expected_relays,
+            &query,
+            Duration::from_millis(10),
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error, "strict directory fetch inactive before EOSE");
+    }
+
+    #[tokio::test]
+    async fn strict_query_overall_deadline_bounds_progress_without_eose() {
+        use nostr_sdk::prelude::{EventBuilder, Keys};
+
+        let author = Keys::generate();
+        let events = (0..16)
+            .map(|index| {
+                EventBuilder::new(Kind::Metadata, format!(r#"{{"index":{index}}}"#))
+                    .sign_with_keys(&author)
+                    .unwrap()
+            })
+            .collect::<Vec<_>>();
+        let query = DirectoryEventQuery::new(0, vec![author.public_key().to_hex()], events.len());
+        let relay = RelayUrl::parse("wss://active-without-eose.relay.example").unwrap();
+        let expected_relays = HashSet::from([relay.clone()]);
+        let request_id = SubscriptionId::generate();
+        let (sender, receiver) = tokio::sync::broadcast::channel(32);
+        let producer_request_id = request_id.clone();
+        let producer = tokio::spawn(async move {
+            for event in events {
+                sleep(Duration::from_millis(40)).await;
+                if sender
+                    .send(RelayPoolNotification::Message {
+                        relay_url: relay.clone(),
+                        message: RelayMessage::event(producer_request_id.clone(), event),
+                    })
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        });
+
+        let error = timeout(
+            Duration::from_secs(1),
+            collect_strict_directory_query(
+                receiver,
+                &request_id,
+                &expected_relays,
+                &query,
+                Duration::from_millis(120),
+                Duration::from_millis(300),
+            ),
+        )
+        .await
+        .expect("the strict query must honor its absolute deadline")
+        .unwrap_err();
+        producer.abort();
+        let _ = producer.await;
+
+        assert_eq!(
+            error,
+            "strict directory fetch exceeded its overall deadline before EOSE"
+        );
+    }
+
+    #[tokio::test]
+    async fn strict_query_reports_notification_lag_before_eose() {
+        let relay = RelayUrl::parse("wss://relay.example").unwrap();
+        let expected_relays = HashSet::from([relay]);
+        let query = DirectoryEventQuery::new(0, vec!["11".repeat(32)], 1);
+        let request_id = SubscriptionId::generate();
+        let (sender, receiver) = tokio::sync::broadcast::channel(1);
+        sender
+            .send(RelayPoolNotification::Shutdown)
+            .expect("receiver is active");
+        sender
+            .send(RelayPoolNotification::Shutdown)
+            .expect("receiver is active");
+
+        let error = collect_strict_directory_query(
+            receiver,
+            &request_id,
+            &expected_relays,
+            &query,
+            Duration::from_secs(1),
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(
+            error,
+            "strict directory notification stream lagged before EOSE"
+        );
     }
 
     #[test]

--- a/crates/marmot-app/src/relay_plane/mod.rs
+++ b/crates/marmot-app/src/relay_plane/mod.rs
@@ -127,6 +127,14 @@ pub struct MarmotRelayPlaneAccountAdapter {
     publish_client: Arc<dyn NostrRelayClient>,
     delivery_rx: Arc<Mutex<mpsc::Receiver<AccountDeliveryEvent>>>,
     delivery_overflow: Arc<AccountDeliveryOverflowState>,
+    /// Revocable capability shared by every clone of one account session's
+    /// adapter. Teardown flips it under `activity` before returning so a stale
+    /// AppClient cannot reactivate subscriptions or publish afterward.
+    active: Arc<AtomicBool>,
+    /// Linearize teardown revocation with subscription and publish I/O. A
+    /// writer waits for already-started outbound work; later readers observe
+    /// `active = false` and fail without reaching the relay.
+    activity: Arc<tokio::sync::RwLock<()>>,
 }
 
 #[derive(Clone)]
@@ -698,6 +706,8 @@ impl MarmotRelayPlane {
             publish_client,
             delivery_rx: Arc::new(Mutex::new(delivery_rx)),
             delivery_overflow,
+            active: Arc::new(AtomicBool::new(true)),
+            activity: Arc::new(tokio::sync::RwLock::new(())),
         }
     }
 
@@ -714,6 +724,22 @@ impl MarmotRelayPlane {
                 .is_ok(),
             None => false,
         }
+    }
+
+    /// Remove one account's local delivery route and transport subscriptions.
+    /// Account teardown calls this independently of whether a managed worker or
+    /// a temporary client was able to open, so no-group and degraded-open paths
+    /// cannot leave a signed-out identity active in the shared relay plane.
+    pub(crate) async fn deactivate_account(
+        &self,
+        account_id: &MemberId,
+    ) -> Result<(), TransportAdapterError> {
+        account_deliveries_write(&self.inner.transport.account_deliveries).remove(account_id);
+        self.inner
+            .transport
+            .adapter
+            .deactivate_account(account_id)
+            .await
     }
 
     pub(crate) fn sanitize_relay_endpoints(
@@ -918,6 +944,23 @@ impl MarmotRelayPlane {
         self.inner
             .directory
             .fetch_events(DirectoryFetchRequest::new(endpoints, queries)?)
+            .await
+    }
+
+    /// Fetch a finite directory page with explicit per-relay EOSE completion.
+    /// Silence, disconnect, notification loss, and the deadline are errors.
+    pub(crate) async fn fetch_directory_events_strict(
+        &self,
+        endpoints: Vec<TransportEndpoint>,
+        queries: Vec<DirectoryEventQuery>,
+    ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
+        let endpoints = self
+            .inner
+            .relay_safety
+            .sanitize_endpoints(endpoints, "strict directory fetch")?;
+        self.inner
+            .directory
+            .fetch_events_strict(DirectoryFetchRequest::new(endpoints, queries)?)
             .await
     }
 
@@ -1730,6 +1773,14 @@ fn recover_relay_notification_forwarder(
 }
 
 impl MarmotRelayPlaneAccountAdapter {
+    fn ensure_active(&self, account_id: &MemberId) -> Result<(), TransportAdapterError> {
+        if account_id == &self.account_id && self.active.load(Ordering::Acquire) {
+            Ok(())
+        } else {
+            Err(TransportAdapterError::AccountNotActive(account_id.clone()))
+        }
+    }
+
     /// The account this adapter is bound to — the `MemberId` every subscription
     /// issued through it carries (activation and group sync reject any other
     /// id), and the key its registrations bucket under on the shared relay
@@ -1859,6 +1910,8 @@ impl MarmotRelayPlaneAccountAdapter {
         &self,
         group: TransportGroupSubscription,
     ) -> Result<String, TransportAdapterError> {
+        let _activity = self.activity.read().await;
+        self.ensure_active(&self.account_id)?;
         let sync = self
             .relay_plane
             .inner
@@ -1883,6 +1936,10 @@ impl MarmotRelayPlaneAccountAdapter {
     }
 
     pub(crate) async fn group_maintenance_any_eose(&self, subscription_id: &str) -> Option<bool> {
+        let _activity = self.activity.read().await;
+        if self.ensure_active(&self.account_id).is_err() {
+            return None;
+        }
         self.relay_plane
             .inner
             .transport
@@ -1897,6 +1954,10 @@ impl MarmotRelayPlaneAccountAdapter {
     /// The epoch-gap backfill drain reads this to tell a relay that has
     /// finished replaying stored history from one that has simply gone quiet.
     pub(crate) async fn account_subscription_eose(&self) -> AccountSubscriptionEose {
+        let _activity = self.activity.read().await;
+        if self.ensure_active(&self.account_id).is_err() {
+            return AccountSubscriptionEose::default();
+        }
         let mut eose = self
             .relay_plane
             .inner
@@ -1959,6 +2020,8 @@ impl MarmotRelayPlaneAccountAdapter {
         &self,
         group: &TransportGroupSubscription,
     ) -> Result<(), TransportAdapterError> {
+        let _activity = self.activity.read().await;
+        self.ensure_active(&self.account_id)?;
         let sync = self
             .relay_plane
             .inner
@@ -1994,11 +2057,8 @@ impl TransportAdapter for MarmotRelayPlaneAccountAdapter {
         &self,
         activation: TransportAccountActivation,
     ) -> Result<(), TransportAdapterError> {
-        if activation.account_id != self.account_id {
-            return Err(TransportAdapterError::AccountNotActive(
-                activation.account_id,
-            ));
-        }
+        let _activity = self.activity.read().await;
+        self.ensure_active(&activation.account_id)?;
         let activation = self
             .relay_plane
             .inner
@@ -2017,9 +2077,8 @@ impl TransportAdapter for MarmotRelayPlaneAccountAdapter {
         &self,
         sync: TransportGroupSync,
     ) -> Result<(), TransportAdapterError> {
-        if sync.account_id != self.account_id {
-            return Err(TransportAdapterError::AccountNotActive(sync.account_id));
-        }
+        let _activity = self.activity.read().await;
+        self.ensure_active(&sync.account_id)?;
         let sync = self
             .relay_plane
             .inner
@@ -2038,23 +2097,19 @@ impl TransportAdapter for MarmotRelayPlaneAccountAdapter {
         if account_id != &self.account_id {
             return Err(TransportAdapterError::AccountNotActive(account_id.clone()));
         }
-        account_deliveries_write(&self.relay_plane.inner.transport.account_deliveries)
-            .remove(account_id);
-        self.relay_plane
-            .inner
-            .transport
-            .adapter
-            .deactivate_account(account_id)
-            .await
+        let _activity = self.activity.write().await;
+        // Revoke before network cleanup. Even when unsubscribe fails, this
+        // session can no longer recreate its subscriptions or publish.
+        self.active.store(false, Ordering::Release);
+        self.relay_plane.deactivate_account(account_id).await
     }
 
     async fn publish(
         &self,
         request: TransportPublishRequest,
     ) -> Result<TransportPublishReport, TransportAdapterError> {
-        if request.account_id != self.account_id {
-            return Err(TransportAdapterError::AccountNotActive(request.account_id));
-        }
+        let _activity = self.activity.read().await;
+        self.ensure_active(&request.account_id)?;
         let request = self
             .relay_plane
             .inner
@@ -2095,8 +2150,12 @@ impl TransportAdapter for MarmotRelayPlaneAccountAdapter {
     }
 
     async fn receive(&self) -> Result<Option<TransportDelivery>, TransportAdapterError> {
+        self.ensure_active(&self.account_id)?;
         match self.receive_account_delivery().await? {
-            Some(AccountDeliveryReceive::Delivery(delivery)) => Ok(Some(*delivery)),
+            Some(AccountDeliveryReceive::Delivery(delivery)) => {
+                self.ensure_active(&self.account_id)?;
+                Ok(Some(*delivery))
+            }
             Some(AccountDeliveryReceive::Overflow(_)) => Err(TransportAdapterError::Other(
                 "account delivery overflow recovery required".to_owned(),
             )),

--- a/crates/marmot-app/src/relay_plane/mod.rs
+++ b/crates/marmot-app/src/relay_plane/mod.rs
@@ -1672,25 +1672,24 @@ async fn handle_relay_notification(
                     event,
                 },
         } => {
-            // Raw per-relay copy (not deduplicated): telemetry
-            // only, so cross-relay arrival spread and per-relay
-            // first-event timing see every relay's copy. Delivery
-            // happens on the deduplicated `Event` arm above. Keep
-            // this in sync with the relay plane's own tap; the
-            // SDK client's standalone forwarder is unused here.
+            // Raw per-relay copy (not deduplicated): always retain it for
+            // telemetry. An active post-join maintenance subscription also
+            // needs its account-scoped copy: nostr-sdk suppresses the ordinary
+            // deduplicated Event when another local account already cached the
+            // stored replay. Ordinary raw copies remain telemetry-only.
             if let Ok(event) = NostrTransportEvent::from_nostr_event(&event) {
                 tracing::trace!(
                     target: "marmot_app::relay_plane",
                     method = "handle_relay_notification",
                     "observing per-relay event copy"
                 );
-                adapter
-                    .observe_relay_event(transport_nostr_adapter::NostrRelayEvent {
-                        endpoint: TransportEndpoint(relay_url.to_string()),
-                        subscription_id: Some(subscription_id.to_string()),
-                        event,
-                    })
-                    .await;
+                let relay_event = transport_nostr_adapter::NostrRelayEvent {
+                    endpoint: TransportEndpoint(relay_url.to_string()),
+                    subscription_id: Some(subscription_id.to_string()),
+                    event,
+                };
+                adapter.observe_relay_event(relay_event.clone()).await;
+                let _ = adapter.handle_group_maintenance_replay(relay_event).await;
             }
             false
         }

--- a/crates/marmot-app/src/relay_plane/tests.rs
+++ b/crates/marmot-app/src/relay_plane/tests.rs
@@ -409,7 +409,7 @@ async fn managed_account_worker_reopens_transport_after_notification_recovery() 
         RelayNotificationConsumerExit::Lagged(3),
     );
 
-    timeout(Duration::from_secs(5), async {
+    timeout(Duration::from_secs(10), async {
         loop {
             let inbox_subscriptions = relay
                 .subscriptions

--- a/crates/marmot-app/src/relay_plane/tests.rs
+++ b/crates/marmot-app/src/relay_plane/tests.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 
@@ -726,6 +727,40 @@ struct PanicOnceDirectoryFetcher {
     panicked: AtomicBool,
 }
 
+struct SplitDirectoryFetcher {
+    normal_fetch_count: AtomicUsize,
+    strict_fetch_count: AtomicUsize,
+    normal_started: Notify,
+    normal_release: Notify,
+    normal_events: Vec<DirectoryRelayEventRecord>,
+    strict_results: StdMutex<VecDeque<Result<Vec<DirectoryRelayEventRecord>, String>>>,
+}
+
+#[async_trait]
+impl DirectoryRelayFetcher for SplitDirectoryFetcher {
+    async fn fetch_directory_events(
+        &self,
+        _request: DirectoryFetchRequest,
+    ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
+        self.normal_fetch_count.fetch_add(1, Ordering::SeqCst);
+        self.normal_started.notify_one();
+        self.normal_release.notified().await;
+        Ok(self.normal_events.clone())
+    }
+
+    async fn fetch_directory_events_strict(
+        &self,
+        _request: DirectoryFetchRequest,
+    ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
+        self.strict_fetch_count.fetch_add(1, Ordering::SeqCst);
+        self.strict_results
+            .lock()
+            .unwrap()
+            .pop_front()
+            .expect("strict test result is scripted")
+    }
+}
+
 #[async_trait]
 impl DirectoryRelayFetcher for PanicOnceDirectoryFetcher {
     async fn fetch_directory_events(
@@ -1088,6 +1123,114 @@ async fn directory_fetches_coalesce_identical_inflight_requests() {
     assert_eq!(health.directory_completed_fetches, 1);
     assert_eq!(health.directory_coalesced_waiters, 1);
     assert_eq!(health.directory_failed_fetches, 0);
+}
+
+#[tokio::test]
+async fn strict_directory_fetch_propagates_incomplete_eose_errors() {
+    let relay = Arc::new(RecordingRelayClient::default());
+    let errors = [
+        "strict directory subscription closed before EOSE",
+        "strict directory fetch timed out before EOSE",
+    ];
+    let directory_fetcher = Arc::new(SplitDirectoryFetcher {
+        normal_fetch_count: AtomicUsize::new(0),
+        strict_fetch_count: AtomicUsize::new(0),
+        normal_started: Notify::new(),
+        normal_release: Notify::new(),
+        normal_events: Vec::new(),
+        strict_results: StdMutex::new(
+            errors
+                .iter()
+                .map(|error| Err((*error).to_owned()))
+                .collect(),
+        ),
+    });
+    let relay_plane = relay_plane_with_directory_fetcher(relay, directory_fetcher.clone());
+    let endpoints = vec![TransportEndpoint("wss://relay.example".into())];
+    let queries = vec![DirectoryEventQuery::new(0, vec!["11".repeat(32)], 12)];
+
+    for expected in errors {
+        let error = relay_plane
+            .fetch_directory_events_strict(endpoints.clone(), queries.clone())
+            .await
+            .expect_err("strict incomplete response must remain an error");
+        assert_eq!(error, expected);
+    }
+
+    assert_eq!(
+        directory_fetcher.normal_fetch_count.load(Ordering::SeqCst),
+        0,
+        "strict requests must never fall back to the ordinary fetch method"
+    );
+    assert_eq!(
+        directory_fetcher.strict_fetch_count.load(Ordering::SeqCst),
+        2
+    );
+    let health = relay_plane.relay_health().await;
+    assert_eq!(health.directory_completed_fetches, 0);
+    assert_eq!(health.directory_failed_fetches, 2);
+    assert_eq!(health.directory_inflight_fetches, 0);
+    assert_eq!(health.directory_coalesced_waiters, 0);
+}
+
+#[tokio::test]
+async fn strict_directory_fetch_uses_its_own_completed_response_without_coalescing() {
+    let relay = Arc::new(RecordingRelayClient::default());
+    let normal_event = DirectoryRelayEventRecord {
+        endpoints: vec![TransportEndpoint("wss://normal.relay.example".into())],
+        event: group_event("normal-response", &[0x61; 32]),
+    };
+    let strict_event = DirectoryRelayEventRecord {
+        endpoints: vec![TransportEndpoint("wss://strict.relay.example".into())],
+        event: group_event("strict-response", &[0x62; 32]),
+    };
+    let directory_fetcher = Arc::new(SplitDirectoryFetcher {
+        normal_fetch_count: AtomicUsize::new(0),
+        strict_fetch_count: AtomicUsize::new(0),
+        normal_started: Notify::new(),
+        normal_release: Notify::new(),
+        normal_events: vec![normal_event.clone()],
+        strict_results: StdMutex::new(VecDeque::from([Ok(vec![strict_event.clone()])])),
+    });
+    let relay_plane = relay_plane_with_directory_fetcher(relay, directory_fetcher.clone());
+    let endpoints = vec![TransportEndpoint("wss://relay.example".into())];
+    let queries = vec![DirectoryEventQuery::new(0, vec!["11".repeat(32)], 12)];
+
+    let ordinary_plane = relay_plane.clone();
+    let ordinary_endpoints = endpoints.clone();
+    let ordinary_queries = queries.clone();
+    let ordinary = tokio::spawn(async move {
+        ordinary_plane
+            .fetch_directory_events(ordinary_endpoints, ordinary_queries)
+            .await
+    });
+    directory_fetcher.normal_started.notified().await;
+
+    let strict = relay_plane
+        .fetch_directory_events_strict(endpoints, queries)
+        .await
+        .unwrap();
+    assert_eq!(strict, vec![strict_event]);
+    assert!(
+        !ordinary.is_finished(),
+        "the strict response must not wait on or join the ordinary inflight owner"
+    );
+
+    directory_fetcher.normal_release.notify_one();
+    assert_eq!(ordinary.await.unwrap().unwrap(), vec![normal_event]);
+    assert_eq!(
+        directory_fetcher.normal_fetch_count.load(Ordering::SeqCst),
+        1
+    );
+    assert_eq!(
+        directory_fetcher.strict_fetch_count.load(Ordering::SeqCst),
+        1
+    );
+    let health = relay_plane.relay_health().await;
+    assert_eq!(health.directory_completed_fetches, 2);
+    assert_eq!(health.directory_failed_fetches, 0);
+    assert_eq!(health.directory_inflight_fetches, 0);
+    assert_eq!(health.directory_coalesced_waiters, 0);
 }
 
 #[tokio::test]

--- a/crates/marmot-app/src/removed_local_key_package_tests.rs
+++ b/crates/marmot-app/src/removed_local_key_package_tests.rs
@@ -1,0 +1,867 @@
+use super::*;
+
+fn directory_key_package(stable_slot_id: &str, created_at: u64) -> DirectoryKeyPackage {
+    DirectoryKeyPackage {
+        key_package_id: stable_slot_id.to_owned(),
+        key_package_ref_hex: "11".repeat(32),
+        key_package_event_id: format!("{created_at:064x}"),
+        key_package_hex: "33".repeat(32),
+        created_at,
+        source_relays: vec!["wss://relay.example".to_owned()],
+    }
+}
+
+async fn fresh_key_package_for_removed_slot_test(
+    app: &MarmotApp,
+    account: &AccountSummary,
+) -> KeyPackage {
+    let signer = app.account_signer_for_summary(account).unwrap();
+    let session_path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+    let keys = app
+        .account_home()
+        .load_signing_keys(&account.label)
+        .unwrap();
+    let session_key = app
+        .sqlcipher_key(
+            &account.label,
+            &keys,
+            session_path.as_ref(),
+            SqlcipherDatabaseKind::Session,
+        )
+        .unwrap();
+    let account_id = MemberId::new(hex::decode(&account.account_id_hex).unwrap());
+    let config = SessionConfig::new(
+        session_path.to_path_buf(),
+        session_key,
+        account_id.as_slice().to_vec(),
+        Box::new(NostrMlsPeeler::new().with_welcome_signer(signer.as_nostr_signer())),
+    )
+    .account_identity_proof_signer(signer.as_proof_signer())
+    .feature_registry(app_feature_registry())
+    .supported_app_components(app.supported_app_component_ids());
+    AccountDeviceSession::open(config)
+        .unwrap()
+        .fresh_key_package()
+        .await
+        .unwrap()
+}
+
+fn key_package_event_for_removed_slot_test(
+    account: &AccountSummary,
+    key_package: KeyPackage,
+    stable_slot_id: &str,
+) -> NostrTransportEvent {
+    let metadata = cgka_engine::key_package::key_package_metadata(&key_package).unwrap();
+    transport_nostr_adapter::NostrKeyPackagePublication {
+        account_id: MemberId::new(hex::decode(&account.account_id_hex).unwrap()),
+        key_package,
+        key_package_slot_id: stable_slot_id.to_owned(),
+        key_package_ref: metadata.key_package_ref_hex,
+        mls_ciphersuite: format!("0x{:04x}", metadata.ciphersuite),
+        mls_extensions: metadata
+            .mls_extensions
+            .iter()
+            .map(|id| format!("0x{id:04x}"))
+            .collect(),
+        mls_proposals: metadata
+            .mls_proposals
+            .iter()
+            .map(|id| format!("0x{id:04x}"))
+            .collect(),
+        app_components: metadata
+            .app_components
+            .iter()
+            .filter(|id| **id >= cgka_traits::app_components::PRIVATE_USE_APP_COMPONENT_ID_START)
+            .map(|id| format!("0x{id:04x}"))
+            .collect(),
+        publish_endpoints: vec![TransportEndpoint("wss://relay.example".to_owned())],
+    }
+    .to_event()
+    .unwrap()
+}
+
+#[test]
+fn exact_removed_local_slot_is_durable_and_scrubs_every_projection() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    let removed = home.create_account("removed").unwrap();
+    let viewer = home.create_account("viewer").unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    app.account_storage(&removed.label)
+        .unwrap()
+        .put_key_package_lifecycle(&cgka_traits::KeyPackageLifecycleState::slot_only(
+            "removed-slot".to_owned(),
+        ))
+        .unwrap();
+
+    let mut entry = app.empty_directory_record(&removed.account_id_hex);
+    entry.profile = Some(UserProfileMetadata {
+        name: Some("still-public".to_owned()),
+        created_at: 10,
+        ..UserProfileMetadata::default()
+    });
+    entry.follows = vec![viewer.account_id_hex.clone()];
+    entry.key_package = Some(directory_key_package("removed-slot", 20));
+    app.save_directory_entry(&entry).unwrap();
+    let viewer_cache = app
+        .directory_cache_for_account(&app.account_home().account(&viewer.label).unwrap())
+        .unwrap();
+    assert_eq!(
+        viewer_cache
+            .entry(&removed.account_id_hex)
+            .unwrap()
+            .unwrap()
+            .key_package
+            .unwrap()
+            .key_package_id,
+        "removed-slot"
+    );
+
+    app.persist_removed_local_key_package_tombstone(&removed)
+        .unwrap();
+    assert!(
+        app.removed_local_key_package_slot_is_retired(&removed.account_id_hex, "removed-slot")
+            .unwrap()
+    );
+    assert!(
+        !app.removed_local_key_package_slot_is_retired(&removed.account_id_hex, "sibling-slot")
+            .unwrap()
+    );
+    let shared = app
+        .shared_storage()
+        .unwrap()
+        .public_directory_user(&removed.account_id_hex)
+        .unwrap()
+        .unwrap();
+    assert!(shared.key_package_json.is_none());
+    assert_eq!(
+        shared
+            .profile_json
+            .as_deref()
+            .map(serde_json::from_str::<UserProfileMetadata>)
+            .transpose()
+            .unwrap()
+            .and_then(|profile| profile.name),
+        Some("still-public".to_owned())
+    );
+    let cached = viewer_cache
+        .entry(&removed.account_id_hex)
+        .unwrap()
+        .unwrap();
+    assert!(cached.key_package.is_none());
+    assert_eq!(cached.follows, vec![viewer.account_id_hex.clone()]);
+
+    // A delayed echo or an unrelated profile update carrying the stale whole
+    // record cannot copy the removed slot back into either projection.
+    app.save_directory_entry(&entry).unwrap();
+    assert!(
+        app.shared_storage()
+            .unwrap()
+            .public_directory_user(&removed.account_id_hex)
+            .unwrap()
+            .unwrap()
+            .key_package_json
+            .is_none()
+    );
+    assert!(
+        viewer_cache
+            .entry(&removed.account_id_hex)
+            .unwrap()
+            .unwrap()
+            .key_package
+            .is_none()
+    );
+
+    let marker = app
+        .removed_local_key_package_account_tombstone_dir(&removed.account_id_hex)
+        .unwrap()
+        .join("slots.json");
+    assert!(marker.exists());
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        assert_eq!(
+            std::fs::metadata(&marker).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert_eq!(
+            std::fs::metadata(marker.parent().unwrap())
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+    }
+
+    app.drop_account_caches(&removed.label);
+    app.account_home().remove_account(&removed.label).unwrap();
+    let mut sibling = app.empty_directory_record(&removed.account_id_hex);
+    sibling.key_package = Some(directory_key_package("sibling-slot", 30));
+    app.save_directory_entry(&sibling).unwrap();
+    assert_eq!(
+        app.directory_entry_for_account_id(&removed.account_id_hex)
+            .unwrap()
+            .unwrap()
+            .key_package
+            .unwrap()
+            .key_package_id,
+        "sibling-slot",
+        "retiring one local device slot must preserve a sibling device"
+    );
+
+    // A stale read-modify-write can carry the removed slot alongside a newer
+    // independent profile coordinate. Filtering that slot must not let the
+    // profile timestamp erase the already cached sibling-device package.
+    let mut stale_profile_update = entry.clone();
+    stale_profile_update.profile.as_mut().unwrap().created_at = 40;
+    app.save_directory_entry(&stale_profile_update).unwrap();
+    let merged = app
+        .directory_entry_for_account_id(&removed.account_id_hex)
+        .unwrap()
+        .unwrap();
+    assert_eq!(merged.profile.unwrap().created_at, 40);
+    assert_eq!(
+        merged.key_package.unwrap().key_package_id,
+        "sibling-slot",
+        "an independent profile update must not erase a live sibling slot"
+    );
+
+    drop(viewer_cache);
+    drop(app);
+    let reopened = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    assert!(
+        reopened
+            .removed_local_key_package_slot_is_retired(&removed.account_id_hex, "removed-slot")
+            .unwrap(),
+        "the removal authority must survive a process restart"
+    );
+    assert_eq!(
+        reopened
+            .directory_entry_for_account_id(&removed.account_id_hex)
+            .unwrap()
+            .unwrap()
+            .key_package
+            .unwrap()
+            .key_package_id,
+        "sibling-slot"
+    );
+}
+
+#[tokio::test]
+async fn account_manager_commits_slot_tombstone_before_account_home_removal() {
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("removed-by-manager")
+        .unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    app.account_storage(&account.label)
+        .unwrap()
+        .put_key_package_lifecycle(&cgka_traits::KeyPackageLifecycleState::slot_only(
+            "manager-slot".to_owned(),
+        ))
+        .unwrap();
+    let runtime = MarmotAppRuntime::new(app.clone());
+
+    runtime
+        .accounts()
+        .remove_account(&account.label)
+        .await
+        .unwrap();
+
+    assert!(matches!(
+        app.account_home().account(&account.label),
+        Err(AccountHomeError::UnknownAccount(_))
+    ));
+    assert!(
+        app.removed_local_key_package_slot_is_retired(&account.account_id_hex, "manager-slot")
+            .unwrap()
+    );
+    assert!(
+        app.removed_local_key_package_account_tombstone_dir(&account.account_id_hex)
+            .unwrap()
+            .join("slots.json")
+            .exists()
+    );
+    runtime.shutdown().await;
+}
+
+#[test]
+fn directory_warm_retries_a_post_tombstone_projection_scrub() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    let removed = home.create_account("crash-window-removed").unwrap();
+    let viewer = home.create_account("crash-window-viewer").unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    app.account_storage(&removed.label)
+        .unwrap()
+        .put_key_package_lifecycle(&cgka_traits::KeyPackageLifecycleState::slot_only(
+            "crash-window-slot".to_owned(),
+        ))
+        .unwrap();
+    let mut stale = app.empty_directory_record(&removed.account_id_hex);
+    stale.key_package = Some(directory_key_package("crash-window-slot", 20));
+    app.save_directory_entry(&stale).unwrap();
+    app.persist_removed_local_key_package_tombstone(&removed)
+        .unwrap();
+
+    // Model a process dying after the atomic marker rename but before its
+    // best-effort scrub. These direct storage calls intentionally bypass the
+    // production admission gate to reconstruct that crash residue.
+    app.shared_storage()
+        .unwrap()
+        .put_public_directory_user(
+            &crate::directory::records::public_directory_user_record(&stale).unwrap(),
+        )
+        .unwrap();
+    let viewer_cache = app
+        .directory_cache_for_account(&app.account_home().account(&viewer.label).unwrap())
+        .unwrap();
+    viewer_cache.put(&stale).unwrap();
+    drop(viewer_cache);
+    drop(app);
+
+    let reopened = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    reopened.warm_directory_storage().unwrap();
+    assert!(
+        reopened
+            .shared_storage()
+            .unwrap()
+            .public_directory_user(&removed.account_id_hex)
+            .unwrap()
+            .unwrap()
+            .key_package_json
+            .is_none()
+    );
+    let viewer_cache = reopened
+        .directory_cache_for_account(&reopened.account_home().account(&viewer.label).unwrap())
+        .unwrap();
+    assert!(
+        viewer_cache
+            .entry(&removed.account_id_hex)
+            .unwrap()
+            .unwrap()
+            .key_package
+            .is_none()
+    );
+}
+
+#[test]
+fn account_wide_legacy_fallback_allows_only_a_new_active_lifecycle_slot() {
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("legacy")
+        .unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+
+    // No lifecycle and no compatibility record means the old slot is
+    // unprovable; removal must record the explicit account-wide fallback.
+    app.persist_removed_local_key_package_tombstone(&account)
+        .unwrap();
+    assert!(
+        app.removed_local_key_package_slot_is_retired(&account.account_id_hex, "unknown-old-slot")
+            .unwrap()
+    );
+
+    let key_package_ref = vec![0x11; 32];
+    let event_id = cgka_traits::MessageId::new(vec![0x22; 32]);
+    let mut lifecycle =
+        cgka_traits::KeyPackageLifecycleState::slot_only("fresh-reimport-slot".to_owned());
+    lifecycle.current_key_package_ref = Some(key_package_ref.clone());
+    lifecycle.authored_event_id = Some(event_id.clone());
+    app.account_storage(&account.label)
+        .unwrap()
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+    assert!(
+        !app.removed_local_key_package_slot_is_retired(
+            &account.account_id_hex,
+            "fresh-reimport-slot"
+        )
+        .unwrap()
+    );
+    assert!(
+        app.removed_local_key_package_slot_is_retired(&account.account_id_hex, "unknown-old-slot")
+            .unwrap()
+    );
+
+    // Relay admission already owns the non-reentrant session mutex. The
+    // account-wide fallback must consume that proof through hydration and the
+    // cache-write boundary instead of trying to lock the mutex a second time.
+    let fetched = FetchedKeyPackage {
+        account_id_hex: account.account_id_hex.clone(),
+        key_package: KeyPackage::new(vec![0x33; 32]),
+        key_package_id: "fresh-reimport-slot".to_owned(),
+        key_package_ref_hex: hex::encode(key_package_ref),
+        key_package_event_id: hex::encode(event_id.as_slice()),
+        created_at: 30,
+        source_relays: vec!["wss://relay.example".to_owned()],
+        relay_lists: AccountRelayListStatus::empty(),
+    };
+    let worker_app = app.clone();
+    let (finished_tx, finished_rx) = std::sync::mpsc::channel();
+    let worker = std::thread::spawn(move || {
+        let result = worker_app.remember_directory_key_package_if_live(&fetched);
+        let _ = finished_tx.send(result);
+    });
+    assert!(
+        finished_rx
+            .recv_timeout(std::time::Duration::from_secs(3))
+            .expect("legacy re-import KeyPackage admission must not deadlock")
+            .unwrap()
+    );
+    worker.join().unwrap();
+    assert_eq!(
+        app.directory_entry_for_account_id(&account.account_id_hex)
+            .unwrap()
+            .unwrap()
+            .key_package
+            .unwrap()
+            .key_package_id,
+        "fresh-reimport-slot"
+    );
+}
+
+#[tokio::test]
+async fn mismatched_legacy_key_package_cannot_choose_an_exact_removed_slot() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    let removed = home.create_account("legacy-removed").unwrap();
+    let other = home.create_account("legacy-other").unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    let other_key_package = fresh_key_package_for_removed_slot_test(&app, &other).await;
+    let claimed_slot = "untrusted-legacy-slot";
+    write_json(
+        app.key_package_record_path(&removed.label),
+        &KeyPackageRecord {
+            account_label: removed.label.clone(),
+            account_id_hex: removed.account_id_hex.clone(),
+            key_package_id: claimed_slot.to_owned(),
+            key_package_ref_hex: String::new(),
+            key_package_event_id: String::new(),
+            published_at: 1,
+            key_package_hex: hex::encode(other_key_package.bytes()),
+        },
+    )
+    .unwrap();
+
+    app.persist_removed_local_key_package_tombstone(&removed)
+        .unwrap();
+
+    assert!(
+        app.removed_local_key_package_account_tombstone_dir(&removed.account_id_hex)
+            .unwrap()
+            .join("slots.json")
+            .exists(),
+        "an unverifiable compatibility record must fall back to account-wide retirement"
+    );
+    let exact_marker = app
+        .removed_local_key_package_tombstone_path(&removed.account_id_hex, Some(claimed_slot))
+        .unwrap();
+    assert!(
+        !exact_marker.exists(),
+        "a mismatched credential must not authorize an exact-slot tombstone"
+    );
+    assert!(
+        app.removed_local_key_package_slot_is_retired(&removed.account_id_hex, claimed_slot)
+            .unwrap()
+    );
+}
+
+#[tokio::test]
+async fn account_wide_legacy_fallback_does_not_deadlock_live_relay_ingest() {
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("legacy-ingest")
+        .unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    app.persist_removed_local_key_package_tombstone(&account)
+        .unwrap();
+
+    let stable_slot_id = "fresh-ingest-slot";
+    let key_package = fresh_key_package_for_removed_slot_test(&app, &account).await;
+    let metadata = cgka_engine::key_package::key_package_metadata(&key_package).unwrap();
+    let event =
+        key_package_event_for_removed_slot_test(&account, key_package.clone(), stable_slot_id);
+    let mut lifecycle = cgka_traits::KeyPackageLifecycleState::slot_only(stable_slot_id.to_owned());
+    lifecycle.current_key_package = Some(key_package);
+    lifecycle.current_key_package_ref = Some(hex::decode(&metadata.key_package_ref_hex).unwrap());
+    lifecycle.authored_event_id =
+        Some(cgka_traits::MessageId::new(hex::decode(&event.id).unwrap()));
+    app.account_storage(&account.label)
+        .unwrap()
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+
+    let record = crate::relay_plane::DirectoryRelayEventRecord {
+        endpoints: vec![TransportEndpoint("wss://relay.example".to_owned())],
+        event,
+    };
+    let worker_app = app.clone();
+    let (finished_tx, finished_rx) = std::sync::mpsc::channel();
+    let worker = std::thread::spawn(move || {
+        let result = worker_app.ingest_directory_relay_event(record);
+        let _ = finished_tx.send(result);
+    });
+    finished_rx
+        .recv_timeout(std::time::Duration::from_secs(3))
+        .expect("legacy re-import relay ingestion must not deadlock")
+        .unwrap();
+    worker.join().unwrap();
+    assert_eq!(
+        app.directory_entry_for_account_id(&account.account_id_hex)
+            .unwrap()
+            .unwrap()
+            .key_package
+            .unwrap()
+            .key_package_id,
+        stable_slot_id
+    );
+}
+
+#[test]
+fn tombstone_persistence_failure_leaves_account_bytes_intact() {
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("failure")
+        .unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    app.account_storage(&account.label)
+        .unwrap()
+        .put_key_package_lifecycle(&cgka_traits::KeyPackageLifecycleState::slot_only(
+            "slot".to_owned(),
+        ))
+        .unwrap();
+
+    let tombstone_root = app.removed_local_key_package_tombstone_root();
+    std::fs::create_dir_all(tombstone_root.parent().unwrap()).unwrap();
+    std::fs::write(&tombstone_root, b"path collision").unwrap();
+
+    assert!(
+        app.persist_removed_local_key_package_tombstone(&account)
+            .is_err()
+    );
+    assert!(app.account_home().account(&account.label).is_ok());
+    assert!(app.account_storage_path(&account.label).exists());
+    assert!(app.account_home().load_signing_keys(&account.label).is_ok());
+}
+
+#[test]
+fn distinct_slot_tombstones_keep_exact_retired_slot_proof() {
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("coalesce-slots")
+        .unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    app.account_storage(&account.label)
+        .unwrap()
+        .put_key_package_lifecycle(&cgka_traits::KeyPackageLifecycleState::slot_only(
+            "first-slot".to_owned(),
+        ))
+        .unwrap();
+    app.persist_removed_local_key_package_tombstone(&account)
+        .unwrap();
+    assert!(
+        app.removed_local_key_package_slot_is_retired(&account.account_id_hex, "first-slot")
+            .unwrap()
+    );
+
+    let second = app
+        .removed_local_key_package_tombstone_path(&account.account_id_hex, Some("second-slot"))
+        .unwrap();
+    write_json(
+        &second,
+        &serde_json::json!({
+            "account_id_hex": account.account_id_hex,
+            "stable_slot_id": "second-slot",
+        }),
+    )
+    .unwrap();
+    app.persist_removed_local_key_package_tombstone(&account)
+        .unwrap();
+
+    let account_wide = app
+        .removed_local_key_package_tombstone_path(&account.account_id_hex, None)
+        .unwrap();
+    assert!(
+        !account_wide.exists(),
+        "a second exact slot must not collapse retired-slot proof into all.json"
+    );
+    assert!(
+        app.removed_local_key_package_slot_is_retired(&account.account_id_hex, "first-slot")
+            .unwrap()
+            && app
+                .removed_local_key_package_slot_is_retired(&account.account_id_hex, "second-slot")
+                .unwrap(),
+        "exact retired-slot identities must survive compaction into the bounded journal"
+    );
+    let tombstone_dir = app
+        .removed_local_key_package_account_tombstone_dir(&account.account_id_hex)
+        .unwrap();
+    let leftover = std::fs::read_dir(&tombstone_dir)
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.file_name())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        leftover.len(),
+        1,
+        "compaction must leave one journal file, got {leftover:?}"
+    );
+
+    app.account_storage(&account.label)
+        .unwrap()
+        .put_key_package_lifecycle(&cgka_traits::KeyPackageLifecycleState::slot_only(
+            "first-slot".to_owned(),
+        ))
+        .unwrap();
+    assert!(
+        app.removed_local_key_package_slot_is_retired(&account.account_id_hex, "first-slot")
+            .unwrap(),
+        "re-admitting a retired lifecycle must not resurrect it without an exact marker"
+    );
+}
+
+#[test]
+fn removed_local_key_package_tombstone_journal_fails_closed_at_capacity() {
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("tombstone-cap")
+        .unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    let journal_dir = app
+        .removed_local_key_package_account_tombstone_dir(&account.account_id_hex)
+        .unwrap();
+    std::fs::create_dir_all(&journal_dir).unwrap();
+    let retired = (0..256)
+        .map(|index| format!("filled-slot-{index}"))
+        .collect::<Vec<_>>();
+    write_json(
+        journal_dir.join("slots.json"),
+        &serde_json::json!({
+            "account_id_hex": account.account_id_hex,
+            "retired_stable_slot_ids": retired,
+            "account_wide": false,
+        }),
+    )
+    .unwrap();
+    app.account_storage(&account.label)
+        .unwrap()
+        .put_key_package_lifecycle(&cgka_traits::KeyPackageLifecycleState::slot_only(
+            "overflow-slot".to_owned(),
+        ))
+        .unwrap();
+    assert!(
+        app.persist_removed_local_key_package_tombstone(&account)
+            .is_err(),
+        "a 257th distinct retired slot must fail closed"
+    );
+    assert!(
+        !app.removed_local_key_package_slot_is_retired(&account.account_id_hex, "overflow-slot")
+            .unwrap(),
+        "a rejected overflow slot must not be recorded as retired"
+    );
+}
+
+#[test]
+fn oversized_tombstone_journal_fails_closed_without_cleanup() {
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("tombstone-oversized")
+        .unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    let journal_dir = app
+        .removed_local_key_package_account_tombstone_dir(&account.account_id_hex)
+        .unwrap();
+    std::fs::create_dir_all(&journal_dir).unwrap();
+    let retired = (0..257)
+        .map(|index| format!("oversized-slot-{index}"))
+        .collect::<Vec<_>>();
+    write_json(
+        journal_dir.join("slots.json"),
+        &serde_json::json!({
+            "account_id_hex": account.account_id_hex,
+            "retired_stable_slot_ids": retired,
+            "account_wide": false,
+        }),
+    )
+    .unwrap();
+    app.account_storage(&account.label)
+        .unwrap()
+        .put_key_package_lifecycle(&cgka_traits::KeyPackageLifecycleState::slot_only(
+            "fresh-slot".to_owned(),
+        ))
+        .unwrap();
+    assert!(
+        app.persist_removed_local_key_package_tombstone(&account)
+            .is_err(),
+        "an oversized slots.json must fail closed before write or cleanup"
+    );
+    let loaded: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(journal_dir.join("slots.json")).unwrap()).unwrap();
+    assert_eq!(
+        loaded["retired_stable_slot_ids"].as_array().map(Vec::len),
+        Some(257),
+        "rejection must preserve the oversized journal"
+    );
+    assert!(
+        app.removed_local_key_package_slot_is_retired(&account.account_id_hex, "oversized-slot-0")
+            .is_err(),
+        "an oversized journal must not be treated as a successful retirement read"
+    );
+}
+
+#[test]
+fn malformed_legacy_exact_slot_tombstone_is_not_deleted_on_compaction() {
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("tombstone-malformed")
+        .unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    let journal_dir = app
+        .removed_local_key_package_account_tombstone_dir(&account.account_id_hex)
+        .unwrap();
+    std::fs::create_dir_all(&journal_dir).unwrap();
+    let none_path = app
+        .removed_local_key_package_tombstone_path(&account.account_id_hex, Some("slot-a"))
+        .unwrap();
+    write_json(
+        &none_path,
+        &serde_json::json!({
+            "account_id_hex": account.account_id_hex,
+            "stable_slot_id": serde_json::Value::Null,
+        }),
+    )
+    .unwrap();
+    let mismatched_path = app
+        .removed_local_key_package_tombstone_path(&account.account_id_hex, Some("slot-c"))
+        .unwrap();
+    write_json(
+        &mismatched_path,
+        &RemovedLocalKeyPackageTombstone {
+            account_id_hex: account.account_id_hex.clone(),
+            stable_slot_id: Some("slot-b".to_owned()),
+        },
+    )
+    .unwrap();
+    app.account_storage(&account.label)
+        .unwrap()
+        .put_key_package_lifecycle(&cgka_traits::KeyPackageLifecycleState::slot_only(
+            "sibling-slot".to_owned(),
+        ))
+        .unwrap();
+    app.persist_removed_local_key_package_tombstone(&account)
+        .unwrap();
+
+    assert!(
+        none_path.exists(),
+        "a None payload on slot-A's filename must survive compaction"
+    );
+    assert!(
+        mismatched_path.exists(),
+        "a slot-C file carrying slot-B must survive compaction"
+    );
+    assert!(
+        app.removed_local_key_package_slot_is_retired(&account.account_id_hex, "sibling-slot")
+            .unwrap()
+    );
+    assert!(
+        app.removed_local_key_package_slot_is_retired(&account.account_id_hex, "slot-a")
+            .is_err(),
+        "the remaining None marker must keep slot-A fail-closed"
+    );
+    assert!(
+        app.removed_local_key_package_slot_is_retired(&account.account_id_hex, "slot-c")
+            .is_err(),
+        "the remaining mismatched marker must keep slot-C fail-closed"
+    );
+    let journal: RemovedLocalKeyPackageTombstoneJournal = read_json(
+        app.removed_local_key_package_tombstone_journal_path(&account.account_id_hex)
+            .unwrap(),
+    )
+    .unwrap();
+    assert!(
+        !journal
+            .retired_stable_slot_ids
+            .iter()
+            .any(|slot| slot == "slot-a" || slot == "slot-c" || slot == "slot-b"),
+        "malformed legacy markers must not be imported as retired identities"
+    );
+}
+
+#[test]
+fn merged_legacy_tombstones_fail_closed_before_exceeding_capacity() {
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("tombstone-merged-cap")
+        .unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    let journal_dir = app
+        .removed_local_key_package_account_tombstone_dir(&account.account_id_hex)
+        .unwrap();
+    std::fs::create_dir_all(&journal_dir).unwrap();
+    let retired = (0..256)
+        .map(|index| format!("filled-slot-{index}"))
+        .collect::<Vec<_>>();
+    write_json(
+        journal_dir.join("slots.json"),
+        &serde_json::json!({
+            "account_id_hex": account.account_id_hex,
+            "retired_stable_slot_ids": retired,
+            "account_wide": false,
+        }),
+    )
+    .unwrap();
+    let extra_path = app
+        .removed_local_key_package_tombstone_path(
+            &account.account_id_hex,
+            Some("imported-overflow"),
+        )
+        .unwrap();
+    write_json(
+        &extra_path,
+        &RemovedLocalKeyPackageTombstone {
+            account_id_hex: account.account_id_hex.clone(),
+            stable_slot_id: Some("imported-overflow".to_owned()),
+        },
+    )
+    .unwrap();
+    app.account_storage(&account.label)
+        .unwrap()
+        .put_key_package_lifecycle(&cgka_traits::KeyPackageLifecycleState::slot_only(
+            "fresh-slot".to_owned(),
+        ))
+        .unwrap();
+    assert!(
+        app.persist_removed_local_key_package_tombstone(&account)
+            .is_err(),
+        "importing a 257th legacy slot must fail before write or cleanup"
+    );
+    assert!(
+        extra_path.exists(),
+        "capacity rejection must preserve the unimported legacy proof"
+    );
+}
+
+#[test]
+fn tracked_only_removal_does_not_create_local_slot_authority() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    let tracked = home
+        .add_public_account(&nostr_sdk::prelude::Keys::generate().public_key().to_hex())
+        .unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+
+    app.persist_removed_local_key_package_tombstone(&tracked)
+        .unwrap();
+    assert!(
+        !app.removed_local_key_package_slot_is_retired(&tracked.account_id_hex, "remote-slot")
+            .unwrap()
+    );
+    assert!(
+        !app.removed_local_key_package_account_tombstone_dir(&tracked.account_id_hex)
+            .unwrap()
+            .exists()
+    );
+}

--- a/crates/marmot-app/src/removed_local_key_package_tests.rs
+++ b/crates/marmot-app/src/removed_local_key_package_tests.rs
@@ -713,6 +713,76 @@ fn oversized_tombstone_journal_fails_closed_without_cleanup() {
 }
 
 #[test]
+fn partial_or_typoed_tombstone_journal_fails_closed() {
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("tombstone-partial")
+        .unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    let journal_path = app
+        .removed_local_key_package_tombstone_journal_path(&account.account_id_hex)
+        .unwrap();
+    std::fs::create_dir_all(journal_path.parent().unwrap()).unwrap();
+    app.account_storage(&account.label)
+        .unwrap()
+        .put_key_package_lifecycle(&cgka_traits::KeyPackageLifecycleState::slot_only(
+            "fresh-slot".to_owned(),
+        ))
+        .unwrap();
+
+    let cases = [
+        (
+            "account-id only",
+            serde_json::json!({
+                "account_id_hex": account.account_id_hex,
+            }),
+        ),
+        (
+            "missing retired slots",
+            serde_json::json!({
+                "account_id_hex": account.account_id_hex,
+                "account_wide": false,
+            }),
+        ),
+        (
+            "missing account-wide proof",
+            serde_json::json!({
+                "account_id_hex": account.account_id_hex,
+                "retired_stable_slot_ids": ["retired-slot"],
+            }),
+        ),
+        (
+            "typoed proof field",
+            serde_json::json!({
+                "account_id_hex": account.account_id_hex,
+                "retired_stable_slot_id": ["retired-slot"],
+                "account_wide": false,
+            }),
+        ),
+    ];
+
+    for (label, value) in cases {
+        write_json(&journal_path, &value).unwrap();
+        let before = std::fs::read(&journal_path).unwrap();
+        assert!(
+            app.removed_local_key_package_slot_is_retired(&account.account_id_hex, "retired-slot",)
+                .is_err(),
+            "{label} must not deserialize as an empty retirement proof"
+        );
+        assert!(
+            app.persist_removed_local_key_package_tombstone(&account)
+                .is_err(),
+            "{label} must abort removal before rewriting tombstone state"
+        );
+        assert_eq!(
+            std::fs::read(&journal_path).unwrap(),
+            before,
+            "{label} must remain untouched for explicit recovery"
+        );
+    }
+}
+
+#[test]
 fn malformed_legacy_exact_slot_tombstone_is_not_deleted_on_compaction() {
     let dir = tempfile::tempdir().unwrap();
     let account = AccountHome::open(dir.path())

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -3249,7 +3249,23 @@ async fn handle_account_worker_command(
                 .retry_pending_runtime_group_subscription_refresh()
                 .await
             {
-                Ok(pending) => pending,
+                Ok(pending) => {
+                    if !pending
+                        && let Err(error) =
+                            client.advance_post_join_maintenance_subscriptions().await
+                    {
+                        publish_app_runtime_account_error(
+                            events,
+                            account_id_hex,
+                            account_label,
+                            account_error_message(
+                                "post-join maintenance subscription failed",
+                                &error,
+                            ),
+                        );
+                    }
+                    pending
+                }
                 Err(error) => {
                     publish_app_runtime_account_error(
                         events,

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -20,9 +20,9 @@ use tokio::time::{Instant as TokioInstant, MissedTickBehavior, Sleep, interval, 
 use zeroize::Zeroizing;
 
 use super::{
-    MarmotAppEvent, RuntimeAccountError, RuntimeAgentStreamMessage, RuntimeGroupEvent,
-    RuntimeLifecycle, RuntimeMessageReceived, RuntimeProjectionUpdate, RuntimeSharedServices,
-    wait_for_runtime_shutdown,
+    GeneratedAccountSetupContext, MarmotAppEvent, RuntimeAccountError, RuntimeAgentStreamMessage,
+    RuntimeGroupEvent, RuntimeLifecycle, RuntimeMessageReceived, RuntimeProjectionUpdate,
+    RuntimeSharedServices, wait_for_runtime_shutdown,
 };
 use crate::app_telemetry::{AppPerformanceOperation, SyncFailureClassification, SyncFailureStage};
 use crate::client::{
@@ -41,7 +41,7 @@ use crate::{
     MediaDownloadResult, MediaUploadRequest, MediaUploadResult, NotificationSettings,
     PendingWelcomeDelivery, PushPlatform, PushRegistration, PushRegistrationShareOutcome,
     PushRegistrationSyncResult, ReceivedMessage, RetentionSweepReport, SecureDeleteExpiredResult,
-    SendSummary, SyncSummary,
+    SendSummary, SyncFailure, SyncSummary,
 };
 use cgka_traits::app_event::MarmotAppEvent as MarmotInnerEvent;
 
@@ -101,6 +101,12 @@ pub(crate) struct AccountWorkerRuntime {
 pub(crate) enum AccountWorkerCommand {
     CatchUp {
         respond: oneshot::Sender<Result<(), AccountCatchUpFailure>>,
+    },
+    /// Caller-visible sync that preserves the exact durably applied prefix on
+    /// failure. Unlike `CatchUp`, this is not coalesced because its caller must
+    /// receive the summary produced by its own FIFO position.
+    SyncWithPartialProgress {
+        respond: oneshot::Sender<Result<SyncSummary, SyncFailure>>,
     },
     /// Startup-coalesced catch-up response held in the same FIFO as deferred
     /// mutations so later live reads cannot bypass those mutations.
@@ -326,6 +332,31 @@ pub(crate) enum AccountWorkerCommand {
         message_id_hex: String,
         respond: oneshot::Sender<Result<SendSummary, AppError>>,
     },
+    DeleteKeyPackageRevision {
+        event_id: cgka_traits::MessageId,
+        endpoints: Vec<cgka_traits::TransportEndpoint>,
+        respond: oneshot::Sender<Result<usize, AppError>>,
+    },
+    PublishNip65RelaySet {
+        read_relays: Vec<cgka_traits::TransportEndpoint>,
+        write_relays: Vec<cgka_traits::TransportEndpoint>,
+        bootstrap_relays: Vec<cgka_traits::TransportEndpoint>,
+        respond: oneshot::Sender<Result<crate::AccountRelayListStatus, AppError>>,
+    },
+    SetNip65Relays {
+        relays: Vec<cgka_traits::TransportEndpoint>,
+        bootstrap_relays: Vec<cgka_traits::TransportEndpoint>,
+        respond: oneshot::Sender<Result<crate::AccountRelayListStatus, AppError>>,
+    },
+    PublishInboxRelayList {
+        relays: Vec<cgka_traits::TransportEndpoint>,
+        bootstrap_relays: Vec<cgka_traits::TransportEndpoint>,
+        respond: oneshot::Sender<Result<crate::AccountRelayListStatus, AppError>>,
+    },
+    IngestSelfNip65RelayEvent {
+        record: crate::relay_plane::DirectoryRelayEventRecord,
+        respond: oneshot::Sender<Result<crate::AccountRelayListStatus, AppError>>,
+    },
     PublishKeyPackage {
         respond: oneshot::Sender<Result<usize, AppError>>,
     },
@@ -409,19 +440,6 @@ pub(crate) enum AccountWorkerCommand {
     UnhydratedGroupCount {
         respond: oneshot::Sender<usize>,
     },
-}
-
-impl AccountWorkerCommand {
-    fn may_change_push_registration_work(&self) -> bool {
-        matches!(
-            self,
-            Self::SharePushRegistration { .. }
-                | Self::UpsertPushRegistration { .. }
-                | Self::ClearPushRegistration { .. }
-                | Self::SetNativePushEnabled { .. }
-                | Self::RemovePushRegistration { .. }
-        )
-    }
 }
 
 /// A command held back during the initial background catch-up, replayed in
@@ -563,8 +581,18 @@ async fn run_app_runtime_account_worker(
     // still background work, and that task may advance the journal as soon as
     // the ready signal is observed. Capturing here preserves the narrow
     // priority lane for the exact locally prepared KeyPackage.
-    let setup_key_package_priority =
-        setup_key_package_priority(app.account_home().account_setup_state(&account_label));
+    let setup_key_package_priority = setup_key_package_priority(
+        app.account_home().account_setup_state(&account_label),
+        || {
+            let bytes = app
+                .account_home()
+                .account_setup_context(&account_label)?
+                .ok_or(AppError::AccountSetupRetryRequired)?;
+            Ok(serde_json::from_slice::<GeneratedAccountSetupContext>(
+                &bytes,
+            )?)
+        },
+    );
     if let Err(error) = &setup_key_package_priority {
         publish_app_runtime_account_error(
             &events,
@@ -591,6 +619,7 @@ async fn run_app_runtime_account_worker(
         Ok(SetupKeyPackagePriority::PublishExactDurableInitial) => {
             let started_at = Instant::now();
             let result = async {
+                client.recover_generated_setup_nip65_authority().await?;
                 let key_package = client.publish_setup_key_package().await?;
                 Ok(key_package.bytes().len())
             }
@@ -687,22 +716,18 @@ async fn run_app_runtime_account_worker(
     let sync_started_at = Instant::now();
     let startup_stage_telemetry = shared.app_performance_telemetry();
     let startup_sync_result = {
-        let mut initial_sync = std::pin::pin!(async {
-            let summary = client
-                .sync_with_stage_telemetry(&startup_stage_telemetry)
-                .await?;
-            app.finish_client_open_network_maintenance(&mut client)
-                .await;
-            Ok::<_, ClassifiedSyncFailure>(summary)
-        });
-        loop {
+        let mut initial_sync =
+            std::pin::pin!(client.sync_with_stage_telemetry(&startup_stage_telemetry));
+        'initial_sync: loop {
             tokio::select! {
-                _ = wait_for_runtime_shutdown(&mut lifecycle_shutdown) => return,
-                _ = &mut shutdown => return,
-                result = &mut initial_sync => break result,
+                _ = wait_for_runtime_shutdown(&mut lifecycle_shutdown) => {
+                    break 'initial_sync None
+                },
+                _ = &mut shutdown => break 'initial_sync None,
+                result = &mut initial_sync => break 'initial_sync Some(result),
                 command = commands.recv() => {
                     match command {
-                        None => return,
+                        None => break 'initial_sync None,
                         Some(AccountWorkerCommand::Members { group_id, respond }) => {
                             match &read_snapshot {
                                 Some(snapshot) => {
@@ -792,6 +817,21 @@ async fn run_app_runtime_account_worker(
             }
         }
     };
+    let Some(startup_sync_result) = startup_sync_result else {
+        // The selected sync future has been dropped, releasing its `&mut`
+        // borrow. Synchronously checkpoint any V1 prefix, then hand off V2
+        // before honoring shutdown. If that save fails, V1 remains replayable
+        // on the next open.
+        let _ = publish_pending_checkpointed_sync_summary_handoff(
+            &mut client,
+            &events,
+            &account_id_hex,
+            &account_label,
+            &shared,
+            "startup_cancelled_fallback",
+        );
+        return;
+    };
     shared.app_performance_telemetry().record_sync_result(
         AppPerformanceOperation::AccountSync,
         sync_started_at.elapsed(),
@@ -802,7 +842,14 @@ async fn run_app_runtime_account_worker(
     );
     let catch_up_result = match startup_sync_result {
         Ok(summary) => {
-            publish_app_runtime_summary(&events, &account_id_hex, &account_label, &summary);
+            publish_sync_summary_with_audit(
+                &events,
+                &account_id_hex,
+                &account_label,
+                &summary,
+                &shared,
+                "startup_sync",
+            );
             start_post_join_history_after_visibility(
                 &mut client,
                 &summary,
@@ -811,8 +858,14 @@ async fn run_app_runtime_account_worker(
                 &account_label,
             )
             .await;
+            // Startup network maintenance is intentionally after app
+            // visibility. It may await relay work, so keeping it inside the
+            // shutdown-selected sync future would put the only returned
+            // summary back on a cancellable stack after its ACK committed.
+            app.finish_client_open_network_maintenance(&mut client)
+                .await;
             schedule_pending_convergence_groups(&mut scheduled_convergence, &mut client);
-            let backfill_result = run_pending_epoch_backfill_reporting_arm(
+            run_pending_epoch_backfill_reporting_arm(
                 &mut client,
                 &events,
                 &account_id_hex,
@@ -820,11 +873,7 @@ async fn run_app_runtime_account_worker(
                 &shared,
                 EpochBackfillExecutionSeam::Startup,
             )
-            .await;
-            if sync_summary_triggers_audit_tracker_update(&summary) {
-                shared.schedule_audit_log_tracker_update("startup_sync");
-            }
-            backfill_result
+            .await
         }
         Err(failure) => {
             publish_sync_summary_with_audit(
@@ -835,14 +884,13 @@ async fn run_app_runtime_account_worker(
                 &shared,
                 "startup_sync",
             );
-            start_post_join_history_after_visibility(
-                &mut client,
-                &failure.partial_summary,
-                &events,
-                &account_id_hex,
-                &account_label,
-            )
-            .await;
+            schedule_pending_convergence_groups(&mut scheduled_convergence, &mut client);
+            scheduled_runtime_group_subscription_refresh.observe_pending(
+                client.has_pending_runtime_group_subscription_refresh(),
+                &command_tx,
+            );
+            scheduled_push_retry
+                .observe_pending(client.has_pending_push_registration_work(), &command_tx);
             // A failed initial catch-up surfaces as an account error but must not
             // fail worker readiness — readiness was already signalled above.
             let message = account_error_message("runtime startup receive failed", &failure.source);
@@ -852,6 +900,21 @@ async fn run_app_runtime_account_worker(
                 &account_label,
                 message.clone(),
             );
+            start_post_join_history_after_visibility(
+                &mut client,
+                &failure.partial_summary,
+                &events,
+                &account_id_hex,
+                &account_label,
+            )
+            .await;
+            schedule_pending_convergence_groups(&mut scheduled_convergence, &mut client);
+            scheduled_runtime_group_subscription_refresh.observe_pending(
+                client.has_pending_runtime_group_subscription_refresh(),
+                &command_tx,
+            );
+            scheduled_push_retry
+                .observe_pending(client.has_pending_push_registration_work(), &command_tx);
             // Hydration may already have scheduled durable queued intents from
             // a prior process. Initial transport activation failed before the
             // normal sync path could drain those engine effects, so transfer
@@ -860,7 +923,21 @@ async fn run_app_runtime_account_worker(
             // failure remains retryable and is reported separately.
             match client.drain_pending_session_events().await {
                 Ok(summary) => {
-                    publish_app_runtime_summary(&events, &account_id_hex, &account_label, &summary);
+                    publish_sync_summary_with_audit(
+                        &events,
+                        &account_id_hex,
+                        &account_label,
+                        &summary,
+                        &shared,
+                        "startup_queued_work",
+                    );
+                    schedule_pending_convergence_groups(&mut scheduled_convergence, &mut client);
+                    scheduled_runtime_group_subscription_refresh.observe_pending(
+                        client.has_pending_runtime_group_subscription_refresh(),
+                        &command_tx,
+                    );
+                    scheduled_push_retry
+                        .observe_pending(client.has_pending_push_registration_work(), &command_tx);
                     start_post_join_history_after_visibility(
                         &mut client,
                         &summary,
@@ -869,8 +946,37 @@ async fn run_app_runtime_account_worker(
                         &account_label,
                     )
                     .await;
+                    schedule_pending_convergence_groups(&mut scheduled_convergence, &mut client);
+                    scheduled_runtime_group_subscription_refresh.observe_pending(
+                        client.has_pending_runtime_group_subscription_refresh(),
+                        &command_tx,
+                    );
+                    scheduled_push_retry
+                        .observe_pending(client.has_pending_push_registration_work(), &command_tx);
                 }
                 Err(drain_error) => {
+                    let published_visibility = publish_pending_checkpointed_sync_summary_handoff(
+                        &mut client,
+                        &events,
+                        &account_id_hex,
+                        &account_label,
+                        &shared,
+                        "startup_queued_work_fallback",
+                    );
+                    if published_visibility.is_some() {
+                        schedule_pending_convergence_groups(
+                            &mut scheduled_convergence,
+                            &mut client,
+                        );
+                        scheduled_runtime_group_subscription_refresh.observe_pending(
+                            client.has_pending_runtime_group_subscription_refresh(),
+                            &command_tx,
+                        );
+                        scheduled_push_retry.observe_pending(
+                            client.has_pending_push_registration_work(),
+                            &command_tx,
+                        );
+                    }
                     publish_app_runtime_account_error(
                         &events,
                         &account_id_hex,
@@ -880,6 +986,29 @@ async fn run_app_runtime_account_worker(
                             &drain_error,
                         ),
                     );
+                    if let Some(summary) = published_visibility.as_ref() {
+                        finish_sync_summary_followups(
+                            &mut client,
+                            summary,
+                            &events,
+                            &account_id_hex,
+                            &account_label,
+                            &shared,
+                        )
+                        .await;
+                        schedule_pending_convergence_groups(
+                            &mut scheduled_convergence,
+                            &mut client,
+                        );
+                        scheduled_runtime_group_subscription_refresh.observe_pending(
+                            client.has_pending_runtime_group_subscription_refresh(),
+                            &command_tx,
+                        );
+                        scheduled_push_retry.observe_pending(
+                            client.has_pending_push_registration_work(),
+                            &command_tx,
+                        );
+                    }
                 }
             }
             Err(AccountCatchUpFailure::new(
@@ -930,6 +1059,13 @@ async fn run_app_runtime_account_worker(
                         account_id_hex: &account_id_hex,
                         account_label: &account_label,
                         shared: &shared,
+                        pending_work_schedulers: Some(AccountWorkerPendingWorkSchedulers {
+                            convergence: &mut scheduled_convergence,
+                            runtime_group_subscription_refresh:
+                                &mut scheduled_runtime_group_subscription_refresh,
+                            push_retry: &mut scheduled_push_retry,
+                            commands: &command_tx,
+                        }),
                     },
                 )
                 .await;
@@ -947,11 +1083,49 @@ async fn run_app_runtime_account_worker(
                         account_label: &account_label,
                         shared: &shared,
                         media_http: &media_http,
+                        pending_work_schedulers: Some(AccountWorkerPendingWorkSchedulers {
+                            convergence: &mut scheduled_convergence,
+                            runtime_group_subscription_refresh:
+                                &mut scheduled_runtime_group_subscription_refresh,
+                            push_retry: &mut scheduled_push_retry,
+                            commands: &command_tx,
+                        }),
                     },
                 )
                 .await;
             }
         }
+        if publish_pending_checkpointed_sync_summary(
+            &mut client,
+            &events,
+            &account_id_hex,
+            &account_label,
+            &shared,
+            "deferred_command_fallback",
+        )
+        .await
+        {
+            scheduled_runtime_group_subscription_refresh.observe_pending(
+                client.has_pending_runtime_group_subscription_refresh(),
+                &command_tx,
+            );
+            scheduled_push_retry
+                .observe_pending(client.has_pending_push_registration_work(), &command_tx);
+        }
+        schedule_pending_convergence_groups(&mut scheduled_convergence, &mut client);
+    }
+    if publish_pending_checkpointed_sync_summary(
+        &mut client,
+        &events,
+        &account_id_hex,
+        &account_label,
+        &shared,
+        "startup_tail_fallback",
+    )
+    .await
+    {
+        scheduled_push_retry
+            .observe_pending(client.has_pending_push_registration_work(), &command_tx);
         schedule_pending_convergence_groups(&mut scheduled_convergence, &mut client);
     }
     scheduled_runtime_group_subscription_refresh.observe_pending(
@@ -961,11 +1135,26 @@ async fn run_app_runtime_account_worker(
     // Automatic gossip is best-effort network work. Run it only after startup
     // callers have received their deferred responses so a degraded relay cannot
     // extend account-open latency.
-    let push_work_pending = client
-        .retry_pending_push_registration_shares_best_effort()
-        .await;
+    let push_work_pending = retry_pending_push_registration_shares_with_visibility(
+        &mut client,
+        &events,
+        &account_id_hex,
+        &account_label,
+        &shared,
+    )
+    .await;
     scheduled_push_retry.schedule_after_attempt(push_work_pending, &command_tx);
-    publish_client_pending_applied_summary(&mut client, &events, &account_id_hex, &account_label);
+    publish_client_pending_applied_summary(
+        &mut client,
+        &events,
+        &account_id_hex,
+        &account_label,
+        &shared,
+    );
+    scheduled_runtime_group_subscription_refresh.observe_pending(
+        client.has_pending_runtime_group_subscription_refresh(),
+        &command_tx,
+    );
 
     // #637: mutations replayed during deferred startup (e.g. a queued SendMessage
     // / InviteMembers) can buffer convergence groups. The steady-state arms below
@@ -994,14 +1183,31 @@ async fn run_app_runtime_account_worker(
                 drain_waiters: Vec::new(),
             }
         });
+    let mut epoch_backfill_journal_error_reported = false;
 
     'worker: loop {
+        match client.ensure_epoch_backfill_intent_journal_persisted() {
+            Ok(()) => epoch_backfill_journal_error_reported = false,
+            Err(error) => {
+                if !epoch_backfill_journal_error_reported {
+                    publish_app_runtime_account_error(
+                        &events,
+                        &account_id_hex,
+                        &account_label,
+                        account_error_message("epoch-backfill intent persistence failed", &error),
+                    );
+                    epoch_backfill_journal_error_reported = true;
+                }
+            }
+        }
         tokio::select! {
             biased;
             _ = wait_for_runtime_shutdown(&mut lifecycle_shutdown) => {
+                let _ = client.ensure_epoch_backfill_intent_journal_persisted();
                 return;
             }
             _ = &mut shutdown => {
+                let _ = client.ensure_epoch_backfill_intent_journal_persisted();
                 return;
             }
             recovered = async {
@@ -1039,8 +1245,9 @@ async fn run_app_runtime_account_worker(
                 let groups = scheduled_convergence.take_ready();
                 match client.sync_runtime_groups().await {
                     Ok(()) => {
+                        let mut groups = groups.into_iter();
                         let mut remaining = groups.len();
-                        for group_id in groups {
+                        while let Some(group_id) = groups.next() {
                             // Each group's convergence pass is a long blocking
                             // stretch of synchronous engine + SQLite work with
                             // no await inside it, so `JoinHandle::abort` cannot
@@ -1063,8 +1270,25 @@ async fn run_app_runtime_account_worker(
                             }
                             remaining -= 1;
                             match client.advance_convergence_after_runtime_sync(&group_id).await {
-                                Ok(summary) => {
-                                    publish_app_runtime_summary(&events, &account_id_hex, &account_label, &summary);
+                                Ok(visibility) => {
+                                    publish_sync_summary_with_followups(
+                                        &mut client,
+                                        &events,
+                                        &account_id_hex,
+                                        &account_label,
+                                        &visibility.summary,
+                                        &shared,
+                                        "scheduled_convergence",
+                                    )
+                                    .await;
+                                    scheduled_runtime_group_subscription_refresh.observe_pending(
+                                        client.has_pending_runtime_group_subscription_refresh(),
+                                        &command_tx,
+                                    );
+                                    scheduled_push_retry.observe_pending(
+                                        client.has_pending_push_registration_work(),
+                                        &command_tx,
+                                    );
                                     match client.convergence_schedule_state(&group_id) {
                                         Ok(state) => scheduled_convergence
                                             .schedule_after_pass(&group_id, state),
@@ -1095,21 +1319,104 @@ async fn run_app_runtime_account_worker(
                                         EpochBackfillExecutionSeam::Maintenance,
                                     )
                                     .await;
-                                    if sync_summary_triggers_audit_tracker_update(&summary) {
-                                        shared.schedule_audit_log_tracker_update("scheduled_convergence");
-                                    }
+                                    schedule_pending_convergence_groups(
+                                        &mut scheduled_convergence,
+                                        &mut client,
+                                    );
+                                    scheduled_runtime_group_subscription_refresh.observe_pending(
+                                        client.has_pending_runtime_group_subscription_refresh(),
+                                        &command_tx,
+                                    );
+                                    scheduled_push_retry.observe_pending(
+                                        client.has_pending_push_registration_work(),
+                                        &command_tx,
+                                    );
                                 }
                                 Err(err) => {
                                     let mut retry_groups = client.take_pending_convergence_groups();
                                     retry_groups.push(group_id.clone());
+                                    // A failed operation can retain a durable
+                                    // visibility suffix under its original
+                                    // source. Do not start another group's
+                                    // lower operation until that suffix has
+                                    // replayed; reschedule every undispatched
+                                    // group and stop this batch after publishing
+                                    // the exact completed prefix.
+                                    retry_groups.extend(groups.by_ref());
                                     scheduled_convergence.schedule_retry_groups(retry_groups);
+                                    let published_visibility =
+                                        publish_pending_checkpointed_sync_summary_handoff(
+                                        &mut client,
+                                        &events,
+                                        &account_id_hex,
+                                        &account_label,
+                                        &shared,
+                                        "scheduled_convergence_error_fallback",
+                                    );
+                                    schedule_pending_convergence_groups(
+                                        &mut scheduled_convergence,
+                                        &mut client,
+                                    );
+                                    scheduled_runtime_group_subscription_refresh.observe_pending(
+                                        client.has_pending_runtime_group_subscription_refresh(),
+                                        &command_tx,
+                                    );
+                                    scheduled_push_retry.observe_pending(
+                                        client.has_pending_push_registration_work(),
+                                        &command_tx,
+                                    );
                                     publish_app_runtime_account_error(
                                         &events,
                                         &account_id_hex,
                                         &account_label,
                                         account_error_message("scheduled convergence failed", &err),
                                     );
+                                    if let Some(summary) = published_visibility.as_ref() {
+                                        finish_sync_summary_followups(
+                                            &mut client,
+                                            summary,
+                                            &events,
+                                            &account_id_hex,
+                                            &account_label,
+                                            &shared,
+                                        )
+                                        .await;
+                                        scheduled_runtime_group_subscription_refresh
+                                            .observe_pending(
+                                                client
+                                                    .has_pending_runtime_group_subscription_refresh(),
+                                                &command_tx,
+                                            );
+                                        scheduled_push_retry.observe_pending(
+                                            client.has_pending_push_registration_work(),
+                                            &command_tx,
+                                        );
+                                    }
+                                    break;
                                 }
+                            }
+                            if publish_pending_checkpointed_sync_summary(
+                                &mut client,
+                                &events,
+                                &account_id_hex,
+                                &account_label,
+                                &shared,
+                                "scheduled_convergence_fallback",
+                            )
+                            .await
+                            {
+                                schedule_pending_convergence_groups(
+                                    &mut scheduled_convergence,
+                                    &mut client,
+                                );
+                                scheduled_runtime_group_subscription_refresh.observe_pending(
+                                    client.has_pending_runtime_group_subscription_refresh(),
+                                    &command_tx,
+                                );
+                                scheduled_push_retry.observe_pending(
+                                    client.has_pending_push_registration_work(),
+                                    &command_tx,
+                                );
                             }
                         }
                     }
@@ -1159,8 +1466,6 @@ async fn run_app_runtime_account_worker(
                                 }
                                 command => command,
                             };
-                            let may_change_push_registration_work =
-                                command.may_change_push_registration_work();
                             match command {
                                 AccountWorkerCommand::CatchUp { respond } => {
                                     handle_account_worker_catch_up(
@@ -1174,6 +1479,15 @@ async fn run_app_runtime_account_worker(
                                             account_id_hex: &account_id_hex,
                                             account_label: &account_label,
                                             shared: &shared,
+                                            pending_work_schedulers: Some(
+                                                AccountWorkerPendingWorkSchedulers {
+                                                    convergence: &mut scheduled_convergence,
+                                                    runtime_group_subscription_refresh:
+                                                        &mut scheduled_runtime_group_subscription_refresh,
+                                                    push_retry: &mut scheduled_push_retry,
+                                                    commands: &command_tx,
+                                                },
+                                            ),
                                         },
                                     )
                                     .await;
@@ -1191,11 +1505,29 @@ async fn run_app_runtime_account_worker(
                                             account_label: &account_label,
                                             shared: &shared,
                                             media_http: &media_http,
+                                            pending_work_schedulers: Some(
+                                                AccountWorkerPendingWorkSchedulers {
+                                                    convergence: &mut scheduled_convergence,
+                                                    runtime_group_subscription_refresh:
+                                                        &mut scheduled_runtime_group_subscription_refresh,
+                                                    push_retry: &mut scheduled_push_retry,
+                                                    commands: &command_tx,
+                                                },
+                                            ),
                                         },
                                     )
                                     .await;
                                 }
                             }
+                            let _ = publish_pending_checkpointed_sync_summary(
+                                &mut client,
+                                &events,
+                                &account_id_hex,
+                                &account_label,
+                                &shared,
+                                "command_fallback",
+                            )
+                            .await;
                             schedule_pending_convergence_groups(
                                 &mut scheduled_convergence,
                                 &mut client,
@@ -1204,12 +1536,10 @@ async fn run_app_runtime_account_worker(
                                 client.has_pending_runtime_group_subscription_refresh(),
                                 &command_tx,
                             );
-                            if may_change_push_registration_work {
-                                scheduled_push_retry.observe_pending(
-                                    client.has_pending_push_registration_work(),
-                                    &command_tx,
-                                );
-                            }
+                            scheduled_push_retry.observe_pending(
+                                client.has_pending_push_registration_work(),
+                                &command_tx,
+                            );
                         }
                     }
                     None => return,
@@ -1269,7 +1599,14 @@ async fn run_app_runtime_account_worker(
                 match result {
                     Ok(summary) => {
                         reconnect_backoff.reset();
-                        publish_app_runtime_summary(&events, &account_id_hex, &account_label, &summary);
+                        publish_sync_summary_with_audit(
+                            &events,
+                            &account_id_hex,
+                            &account_label,
+                            &summary,
+                            &shared,
+                            "receive",
+                        );
                         start_post_join_history_after_visibility(
                             &mut client,
                             &summary,
@@ -1278,13 +1615,13 @@ async fn run_app_runtime_account_worker(
                             &account_label,
                         )
                         .await;
-                        scheduled_runtime_group_subscription_refresh.observe_pending(
-                            client.has_pending_runtime_group_subscription_refresh(),
-                            &command_tx,
-                        );
                         schedule_pending_convergence_groups(
                             &mut scheduled_convergence,
                             &mut client,
+                        );
+                        scheduled_runtime_group_subscription_refresh.observe_pending(
+                            client.has_pending_runtime_group_subscription_refresh(),
+                            &command_tx,
                         );
                         if !overflow_recovery_incomplete {
                             let _ = run_pending_epoch_backfill_reporting_arm(
@@ -1300,26 +1637,82 @@ async fn run_app_runtime_account_worker(
                         if sync_summary_triggers_audit_tracker_update(&summary) {
                             shared.schedule_audit_log_tracker_update("receive");
                         }
+                        schedule_pending_convergence_groups(
+                            &mut scheduled_convergence,
+                            &mut client,
+                        );
+                        scheduled_runtime_group_subscription_refresh.observe_pending(
+                            client.has_pending_runtime_group_subscription_refresh(),
+                            &command_tx,
+                        );
                         if !summary.joined_groups.is_empty() {
-                            let pending = client
-                                .retry_pending_push_registration_shares_best_effort()
-                                .await;
+                            let pending = retry_pending_push_registration_shares_with_visibility(
+                                &mut client,
+                                &events,
+                                &account_id_hex,
+                                &account_label,
+                                &shared,
+                            )
+                            .await;
                             scheduled_push_retry.schedule_after_attempt(pending, &command_tx);
                             publish_client_pending_applied_summary(
                                 &mut client,
                                 &events,
                                 &account_id_hex,
                                 &account_label,
+                                &shared,
                             );
                         }
+                        scheduled_runtime_group_subscription_refresh.observe_pending(
+                            client.has_pending_runtime_group_subscription_refresh(),
+                            &command_tx,
+                        );
+                        scheduled_push_retry.observe_pending(
+                            client.has_pending_push_registration_work(),
+                            &command_tx,
+                        );
                     }
                     Err(err) => {
+                        let published_visibility =
+                            publish_pending_checkpointed_sync_summary_handoff(
+                            &mut client,
+                            &events,
+                            &account_id_hex,
+                            &account_label,
+                            &shared,
+                            "receive_error_fallback",
+                        );
+                        if published_visibility.is_some() {
+                            schedule_pending_convergence_groups(
+                                &mut scheduled_convergence,
+                                &mut client,
+                            );
+                            scheduled_runtime_group_subscription_refresh.observe_pending(
+                                client.has_pending_runtime_group_subscription_refresh(),
+                                &command_tx,
+                            );
+                            scheduled_push_retry.observe_pending(
+                                client.has_pending_push_registration_work(),
+                                &command_tx,
+                            );
+                        }
                         publish_app_runtime_account_error(
                             &events,
                             &account_id_hex,
                             &account_label,
                             account_error_message("runtime receive failed", &err),
                         );
+                        if let Some(summary) = published_visibility.as_ref() {
+                            finish_sync_summary_followups(
+                                &mut client,
+                                summary,
+                                &events,
+                                &account_id_hex,
+                                &account_label,
+                                &shared,
+                            )
+                            .await;
+                        }
                         // The account-session ownership guard is held by
                         // `AppClient`. Destroy the failed engine before the
                         // backoff as well as before hydrating its replacement;
@@ -1395,6 +1788,15 @@ async fn run_app_runtime_account_worker(
                                     // mid-session reconnect (mdk#1161).
                                     if let Err(err) = drain_deferred_hydration(&mut reopened).await
                                     {
+                                        let _ = publish_pending_checkpointed_sync_summary(
+                                            &mut reopened,
+                                            &events,
+                                            &account_id_hex,
+                                            &account_label,
+                                            &shared,
+                                            "reconnect_hydration_fallback",
+                                        )
+                                        .await;
                                         publish_app_runtime_account_error(
                                             &events,
                                             &account_id_hex,
@@ -1420,6 +1822,15 @@ async fn run_app_runtime_account_worker(
                                         result = reopened.prepare_transport_with_telemetry(Some(&telemetry)) => result,
                                     };
                                     if let Err(transport_err) = prepare_transport {
+                                        let _ = publish_pending_checkpointed_sync_summary(
+                                            &mut reopened,
+                                            &events,
+                                            &account_id_hex,
+                                            &account_label,
+                                            &shared,
+                                            "reconnect_transport_fallback",
+                                        )
+                                        .await;
                                         publish_app_runtime_account_error(
                                             &events,
                                             &account_id_hex,
@@ -1436,11 +1847,13 @@ async fn run_app_runtime_account_worker(
                                         .await;
                                     match reopened.drain_pending_session_events().await {
                                         Ok(summary) => {
-                                            publish_app_runtime_summary(
+                                            publish_sync_summary_with_audit(
                                                 &events,
                                                 &account_id_hex,
                                                 &account_label,
                                                 &summary,
+                                                &shared,
+                                                "reconnect_queued_work",
                                             );
                                             start_post_join_history_after_visibility(
                                                 &mut reopened,
@@ -1452,6 +1865,15 @@ async fn run_app_runtime_account_worker(
                                             .await;
                                         }
                                         Err(error) => {
+                                            let _ = publish_pending_checkpointed_sync_summary(
+                                                &mut reopened,
+                                                &events,
+                                                &account_id_hex,
+                                                &account_label,
+                                                &shared,
+                                                "reconnect_queued_work_fallback",
+                                            )
+                                            .await;
                                             publish_app_runtime_account_error(
                                                 &events,
                                                 &account_id_hex,
@@ -1463,8 +1885,14 @@ async fn run_app_runtime_account_worker(
                                             );
                                         }
                                     }
-                                    let pending = reopened
-                                        .retry_pending_push_registration_shares_best_effort()
+                                    let pending =
+                                        retry_pending_push_registration_shares_with_visibility(
+                                            &mut reopened,
+                                            &events,
+                                            &account_id_hex,
+                                            &account_label,
+                                            &shared,
+                                        )
                                         .await;
                                     scheduled_push_retry
                                         .schedule_after_attempt(pending, &command_tx);
@@ -1473,6 +1901,7 @@ async fn run_app_runtime_account_worker(
                                         &events,
                                         &account_id_hex,
                                         &account_label,
+                                        &shared,
                                     );
                                     break reopened;
                                 }
@@ -1486,6 +1915,10 @@ async fn run_app_runtime_account_worker(
                                 }
                             }
                         };
+                        scheduled_runtime_group_subscription_refresh.observe_pending(
+                            client.has_pending_runtime_group_subscription_refresh(),
+                            &command_tx,
+                        );
                         schedule_pending_convergence_groups(
                             &mut scheduled_convergence,
                             &mut client,
@@ -1512,16 +1945,18 @@ async fn run_app_runtime_account_worker(
                 if client.key_package_maintenance_requires_catch_up() {
                     match timeout(
                         Duration::from_secs(15),
-                        client.sync_with_partial_progress(),
+                        client.sync_with_classified_partial_progress(),
                     )
-                    .await
+                        .await
                     {
                         Ok(Ok(summary)) => {
-                            publish_app_runtime_summary(
+                            publish_sync_summary_with_audit(
                                 &events,
                                 &account_id_hex,
                                 &account_label,
                                 &summary,
+                                &shared,
+                                "key_package_maintenance_catch_up",
                             );
                             start_post_join_history_after_visibility(
                                 &mut client,
@@ -1531,6 +1966,26 @@ async fn run_app_runtime_account_worker(
                                 &account_label,
                             )
                             .await;
+                            if !summary.joined_groups.is_empty() {
+                                let pending =
+                                    retry_pending_push_registration_shares_with_visibility(
+                                        &mut client,
+                                        &events,
+                                        &account_id_hex,
+                                        &account_label,
+                                        &shared,
+                                    )
+                                    .await;
+                                scheduled_push_retry
+                                    .schedule_after_attempt(pending, &command_tx);
+                                publish_client_pending_applied_summary(
+                                    &mut client,
+                                    &events,
+                                    &account_id_hex,
+                                    &account_label,
+                                    &shared,
+                                );
+                            }
                             publish_client_pending_projection_updates(
                                 &mut client,
                                 &events,
@@ -1559,6 +2014,26 @@ async fn run_app_runtime_account_worker(
                                 &account_label,
                             )
                             .await;
+                            if !failure.partial_summary.joined_groups.is_empty() {
+                                let pending =
+                                    retry_pending_push_registration_shares_with_visibility(
+                                        &mut client,
+                                        &events,
+                                        &account_id_hex,
+                                        &account_label,
+                                        &shared,
+                                    )
+                                    .await;
+                                scheduled_push_retry
+                                    .schedule_after_attempt(pending, &command_tx);
+                                publish_client_pending_applied_summary(
+                                    &mut client,
+                                    &events,
+                                    &account_id_hex,
+                                    &account_label,
+                                    &shared,
+                                );
+                            }
                             publish_app_runtime_account_error(
                                 &events,
                                 &account_id_hex,
@@ -1578,6 +2053,25 @@ async fn run_app_runtime_account_worker(
                         }
                     }
                 }
+                if publish_pending_checkpointed_sync_summary(
+                    &mut client,
+                    &events,
+                    &account_id_hex,
+                    &account_label,
+                    &shared,
+                    "maintenance_timeout_fallback",
+                )
+                .await
+                {
+                    schedule_pending_convergence_groups(
+                        &mut scheduled_convergence,
+                        &mut client,
+                    );
+                    scheduled_push_retry.observe_pending(
+                        client.has_pending_push_registration_work(),
+                        &command_tx,
+                    );
+                }
                 scheduled_runtime_group_subscription_refresh.observe_pending(
                     client.has_pending_runtime_group_subscription_refresh(),
                     &command_tx,
@@ -1591,6 +2085,18 @@ async fn run_app_runtime_account_worker(
                     EpochBackfillExecutionSeam::Maintenance,
                 )
                 .await;
+                schedule_pending_convergence_groups(
+                    &mut scheduled_convergence,
+                    &mut client,
+                );
+                scheduled_runtime_group_subscription_refresh.observe_pending(
+                    client.has_pending_runtime_group_subscription_refresh(),
+                    &command_tx,
+                );
+                scheduled_push_retry.observe_pending(
+                    client.has_pending_push_registration_work(),
+                    &command_tx,
+                );
                 if let Err(err) = client.advance_post_join_maintenance_subscriptions().await {
                     publish_app_runtime_account_error(
                         &events,
@@ -1599,36 +2105,140 @@ async fn run_app_runtime_account_worker(
                         account_error_message("post-join maintenance subscription failed", &err),
                     );
                 }
-                match client.run_due_maintenance().await {
-                    Ok(summary) => {
-                        let _ = summary;
-                        publish_client_pending_projection_updates(
-                            &mut client,
+                let mut maintenance_visibility = None::<SyncSummary>;
+                let maintenance_result = client
+                    .run_due_maintenance_with_intermediate_handoff(|_client, summary| {
+                        // The tick may now cross a post-delete relay repair.
+                        // Broadcast/audit its already-checkpointed V2 before
+                        // that await so forced shutdown cannot erase it.
+                        publish_sync_summary_with_audit(
                             &events,
                             &account_id_hex,
                             &account_label,
+                            &summary,
+                            &shared,
+                            "scheduled_maintenance",
                         );
-                        publish_client_pending_applied_summary(
-                            &mut client,
-                            &events,
-                            &account_id_hex,
-                            &account_label,
-                        );
-                        schedule_pending_convergence_groups(
-                            &mut scheduled_convergence,
-                            &mut client,
-                        );
-                    }
-                    Err(err) => {
-                        publish_app_runtime_account_error(
-                            &events,
-                            &account_id_hex,
-                            &account_label,
-                            account_error_message("scheduled maintenance failed", &err),
-                        );
-                    }
+                        match &mut maintenance_visibility {
+                            Some(retained) => retained.merge(summary),
+                            None => maintenance_visibility = Some(summary),
+                        }
+                    })
+                    .await;
+                // The account tick hands one-shot effects to AppClient before
+                // its post-delete relay repair. Publish those staged effects
+                // whether that later repair succeeded or failed, and always
+                // before the corresponding AccountError.
+                publish_client_pending_projection_updates(
+                    &mut client,
+                    &events,
+                    &account_id_hex,
+                    &account_label,
+                );
+                publish_client_pending_applied_summary(
+                    &mut client,
+                    &events,
+                    &account_id_hex,
+                    &account_label,
+                    &shared,
+                );
+                publish_pending_welcome_delivery_events(
+                    &events,
+                    &account_id_hex,
+                    &account_label,
+                    &mut client,
+                );
+                schedule_pending_convergence_groups(
+                    &mut scheduled_convergence,
+                    &mut client,
+                );
+                scheduled_runtime_group_subscription_refresh.observe_pending(
+                    client.has_pending_runtime_group_subscription_refresh(),
+                    &command_tx,
+                );
+                scheduled_push_retry.observe_pending(
+                    client.has_pending_push_registration_work(),
+                    &command_tx,
+                );
+                let error_visibility = if maintenance_result.is_err() {
+                    publish_pending_checkpointed_sync_summary_handoff(
+                        &mut client,
+                        &events,
+                        &account_id_hex,
+                        &account_label,
+                        &shared,
+                        "scheduled_maintenance_error_fallback",
+                    )
+                } else {
+                    None
+                };
+                if let Err(err) = maintenance_result {
+                    publish_app_runtime_account_error(
+                        &events,
+                        &account_id_hex,
+                        &account_label,
+                        account_error_message("scheduled maintenance failed", &err),
+                    );
                 }
+                if let Some(summary) = maintenance_visibility.as_ref() {
+                    finish_sync_summary_followups(
+                        &mut client,
+                        summary,
+                        &events,
+                        &account_id_hex,
+                        &account_label,
+                        &shared,
+                    )
+                    .await;
+                }
+                if let Some(summary) = error_visibility.as_ref() {
+                    finish_sync_summary_followups(
+                        &mut client,
+                        summary,
+                        &events,
+                        &account_id_hex,
+                        &account_label,
+                        &shared,
+                    )
+                    .await;
+                }
+                // Either follow-up can perform a final push-gossip send that
+                // folds route-changing peer commits or leaves durable push
+                // work behind. Re-observe unconditionally after both network
+                // seams; the summary handoff was already consumed, so the
+                // generic fallback below may otherwise have nothing to key on.
+                schedule_pending_convergence_groups(
+                    &mut scheduled_convergence,
+                    &mut client,
+                );
+                observe_scheduled_maintenance_followup_retries(
+                    &mut scheduled_runtime_group_subscription_refresh,
+                    client.has_pending_runtime_group_subscription_refresh(),
+                    &mut scheduled_push_retry,
+                    client.has_pending_push_registration_work(),
+                    &command_tx,
+                );
+                #[cfg(test)]
+                shared.notify_maintenance_tick_completed_for_test(&account_label);
             }
+        }
+        if publish_pending_checkpointed_sync_summary(
+            &mut client,
+            &events,
+            &account_id_hex,
+            &account_label,
+            &shared,
+            "worker_fallback",
+        )
+        .await
+        {
+            schedule_pending_convergence_groups(&mut scheduled_convergence, &mut client);
+            scheduled_runtime_group_subscription_refresh.observe_pending(
+                client.has_pending_runtime_group_subscription_refresh(),
+                &command_tx,
+            );
+            scheduled_push_retry
+                .observe_pending(client.has_pending_push_registration_work(), &command_tx);
         }
     }
 }
@@ -1640,12 +2250,53 @@ async fn run_app_runtime_account_worker(
 /// later reads remain behind it to preserve worker FIFO semantics.
 /// Additional catch-up requests received before such a command coalesce onto
 /// the in-flight sync.
+struct AccountWorkerPendingWorkSchedulers<'a> {
+    convergence: &'a mut ScheduledConvergence,
+    runtime_group_subscription_refresh: &'a mut ScheduledRuntimeGroupSubscriptionRefresh,
+    push_retry: &'a mut ScheduledPushRegistrationRetry,
+    commands: &'a mpsc::Sender<AccountWorkerCommand>,
+}
+
+impl AccountWorkerPendingWorkSchedulers<'_> {
+    fn observe(&mut self, client: &mut AppClient) {
+        schedule_pending_convergence_groups(self.convergence, client);
+        self.runtime_group_subscription_refresh.observe_pending(
+            client.has_pending_runtime_group_subscription_refresh(),
+            self.commands,
+        );
+        self.push_retry
+            .observe_pending(client.has_pending_push_registration_work(), self.commands);
+    }
+}
+
+fn observe_scheduled_maintenance_followup_retries(
+    runtime_group_subscription_refresh: &mut ScheduledRuntimeGroupSubscriptionRefresh,
+    runtime_group_subscription_refresh_pending: bool,
+    push_retry: &mut ScheduledPushRegistrationRetry,
+    push_retry_pending: bool,
+    commands: &mpsc::Sender<AccountWorkerCommand>,
+) {
+    runtime_group_subscription_refresh
+        .observe_pending(runtime_group_subscription_refresh_pending, commands);
+    push_retry.observe_pending(push_retry_pending, commands);
+}
+
+fn observe_pending_worker_work(
+    schedulers: &mut Option<AccountWorkerPendingWorkSchedulers<'_>>,
+    client: &mut AppClient,
+) {
+    if let Some(schedulers) = schedulers.as_mut() {
+        schedulers.observe(client);
+    }
+}
+
 struct AccountWorkerCatchUpContext<'a> {
     app: &'a MarmotApp,
     events: &'a broadcast::Sender<MarmotAppEvent>,
     account_id_hex: &'a str,
     account_label: &'a str,
     shared: &'a RuntimeSharedServices,
+    pending_work_schedulers: Option<AccountWorkerPendingWorkSchedulers<'a>>,
 }
 
 async fn handle_account_worker_catch_up(
@@ -1653,7 +2304,7 @@ async fn handle_account_worker_catch_up(
     respond: oneshot::Sender<Result<(), AccountCatchUpFailure>>,
     commands: &mut mpsc::Receiver<AccountWorkerCommand>,
     pending: &mut VecDeque<AccountWorkerCommand>,
-    context: AccountWorkerCatchUpContext<'_>,
+    mut context: AccountWorkerCatchUpContext<'_>,
 ) {
     let read_snapshot = match client.group_read_snapshot() {
         Ok(snapshot) => Some(snapshot),
@@ -1761,14 +2412,18 @@ async fn handle_account_worker_catch_up(
             }
         }
     };
-    let result = match sync_result {
+    let (result, joined_group_visible) = match sync_result {
         Ok(summary) => {
-            publish_app_runtime_summary(
+            let joined_group_visible = !summary.joined_groups.is_empty();
+            publish_sync_summary_with_audit(
                 context.events,
                 context.account_id_hex,
                 context.account_label,
                 &summary,
+                context.shared,
+                "catch_up",
             );
+            observe_pending_worker_work(&mut context.pending_work_schedulers, client);
             start_post_join_history_after_visibility(
                 client,
                 &summary,
@@ -1777,6 +2432,7 @@ async fn handle_account_worker_catch_up(
                 context.account_label,
             )
             .await;
+            observe_pending_worker_work(&mut context.pending_work_schedulers, client);
             let backfill_result = run_pending_epoch_backfill_reporting_arm(
                 client,
                 context.events,
@@ -1786,12 +2442,10 @@ async fn handle_account_worker_catch_up(
                 EpochBackfillExecutionSeam::ExplicitCatchUp,
             )
             .await;
-            if sync_summary_triggers_audit_tracker_update(&summary) {
-                context.shared.schedule_audit_log_tracker_update("catch_up");
-            }
-            backfill_result
+            (backfill_result, joined_group_visible)
         }
         Err(failure) => {
+            let joined_group_visible = !failure.partial_summary.joined_groups.is_empty();
             publish_sync_summary_with_audit(
                 context.events,
                 context.account_id_hex,
@@ -1799,6 +2453,14 @@ async fn handle_account_worker_catch_up(
                 &failure.partial_summary,
                 context.shared,
                 "catch_up",
+            );
+            observe_pending_worker_work(&mut context.pending_work_schedulers, client);
+            let message = account_error_message("runtime catch-up failed", &failure.source);
+            publish_app_runtime_account_error(
+                context.events,
+                context.account_id_hex,
+                context.account_label,
+                message.clone(),
             );
             start_post_join_history_after_visibility(
                 client,
@@ -1808,19 +2470,16 @@ async fn handle_account_worker_catch_up(
                 context.account_label,
             )
             .await;
-            let message = account_error_message("runtime catch-up failed", &failure.source);
-            publish_app_runtime_account_error(
-                context.events,
-                context.account_id_hex,
-                context.account_label,
-                message.clone(),
-            );
-            Err(AccountCatchUpFailure::new(
-                message,
-                failure.classification(),
-            ))
+            (
+                Err(AccountCatchUpFailure::new(
+                    message,
+                    failure.classification(),
+                )),
+                joined_group_visible,
+            )
         }
     };
+    observe_pending_worker_work(&mut context.pending_work_schedulers, client);
     context
         .shared
         .app_performance_telemetry()
@@ -1832,15 +2491,21 @@ async fn handle_account_worker_catch_up(
                 .err()
                 .map(AccountCatchUpFailure::classification),
         );
-    let retry_after_response = result.is_ok();
+    let retry_after_response = result.is_ok() || joined_group_visible;
     for respond in catch_up_responders {
         let _ = respond.send(result.clone());
     }
     pending.append(&mut deferred);
     if retry_after_response {
-        client
-            .retry_pending_push_registration_shares_best_effort()
-            .await;
+        retry_pending_push_registration_shares_with_visibility(
+            client,
+            context.events,
+            context.account_id_hex,
+            context.account_label,
+            context.shared,
+        )
+        .await;
+        observe_pending_worker_work(&mut context.pending_work_schedulers, client);
     }
 }
 
@@ -2034,6 +2699,7 @@ async fn run_startup_hydration_pipeline(
                                 events,
                                 account_id_hex,
                                 account_label,
+                                shared,
                                 setup_key_package_result,
                             )
                             .await;
@@ -2055,6 +2721,7 @@ async fn run_startup_hydration_pipeline(
                         events,
                         account_id_hex,
                         account_label,
+                        shared,
                         setup_key_package_result,
                     )
                     .await;
@@ -2092,7 +2759,14 @@ async fn run_startup_hydration_pipeline(
         // hydration quarantines, restored leave requests) exactly as a live
         // drain would, so the projection updates incrementally.
         if let Ok(summary) = client.drain_pending_session_events().await {
-            publish_app_runtime_summary(events, account_id_hex, account_label, &summary);
+            publish_sync_summary_with_audit(
+                events,
+                account_id_hex,
+                account_label,
+                &summary,
+                shared,
+                "startup_hydration",
+            );
         }
         if progress.remaining == 0 {
             break;
@@ -2143,6 +2817,7 @@ async fn drain_deferred_hydration(client: &mut AppClient) -> Result<(), AppError
 /// subscribers through their `GroupHydrationQuarantined` events. Invite
 /// acceptance also runs live; everything else joins the startup deferral in
 /// arrival order.
+#[allow(clippy::too_many_arguments)]
 async fn handle_startup_hydration_command(
     client: &mut AppClient,
     command: AccountWorkerCommand,
@@ -2150,6 +2825,7 @@ async fn handle_startup_hydration_command(
     events: &broadcast::Sender<MarmotAppEvent>,
     account_id_hex: &str,
     account_label: &str,
+    shared: &RuntimeSharedServices,
     setup_key_package_result: &mut Option<Result<usize, AppError>>,
 ) {
     match command {
@@ -2193,9 +2869,14 @@ async fn handle_startup_hydration_command(
             let retry_after_response = result.is_ok();
             let _ = respond.send(result);
             if retry_after_response {
-                client
-                    .retry_pending_push_registration_shares_best_effort()
-                    .await;
+                retry_pending_push_registration_shares_with_visibility(
+                    client,
+                    events,
+                    account_id_hex,
+                    account_label,
+                    shared,
+                )
+                .await;
             }
         }
         #[cfg(test)]
@@ -2529,6 +3210,7 @@ struct AccountWorkerCommandContext<'a> {
     account_label: &'a str,
     shared: &'a RuntimeSharedServices,
     media_http: &'a MediaHttpContext,
+    pending_work_schedulers: Option<AccountWorkerPendingWorkSchedulers<'a>>,
 }
 
 /// Commands that arrived while a previous handler held `&mut client` stay in
@@ -2550,6 +3232,7 @@ async fn handle_account_worker_command(
         account_label,
         shared,
         media_http,
+        mut pending_work_schedulers,
     } = context;
     match command {
         AccountWorkerCommand::NetworkStartupSettled { respond } => {
@@ -2586,9 +3269,30 @@ async fn handle_account_worker_command(
         }
         AccountWorkerCommand::CatchUp { respond } => {
             let sync_started_at = Instant::now();
-            let result = match client.sync_with_classified_partial_progress().await {
+            let (result, joined_group_visible) = match client
+                .sync_with_classified_partial_progress()
+                .await
+            {
                 Ok(summary) => {
-                    publish_app_runtime_summary(events, account_id_hex, account_label, &summary);
+                    let joined_group_visible = !summary.joined_groups.is_empty();
+                    publish_sync_summary_with_audit(
+                        events,
+                        account_id_hex,
+                        account_label,
+                        &summary,
+                        shared,
+                        "catch_up",
+                    );
+                    observe_pending_worker_work(&mut pending_work_schedulers, client);
+                    start_post_join_history_after_visibility(
+                        client,
+                        &summary,
+                        events,
+                        account_id_hex,
+                        account_label,
+                    )
+                    .await;
+                    observe_pending_worker_work(&mut pending_work_schedulers, client);
                     let backfill_result = run_pending_epoch_backfill_reporting_arm(
                         client,
                         events,
@@ -2598,12 +3302,10 @@ async fn handle_account_worker_command(
                         EpochBackfillExecutionSeam::ExplicitCatchUp,
                     )
                     .await;
-                    if sync_summary_triggers_audit_tracker_update(&summary) {
-                        shared.schedule_audit_log_tracker_update("catch_up");
-                    }
-                    backfill_result
+                    (backfill_result, joined_group_visible)
                 }
                 Err(failure) => {
+                    let joined_group_visible = !failure.partial_summary.joined_groups.is_empty();
                     publish_sync_summary_with_audit(
                         events,
                         account_id_hex,
@@ -2612,6 +3314,7 @@ async fn handle_account_worker_command(
                         shared,
                         "catch_up",
                     );
+                    observe_pending_worker_work(&mut pending_work_schedulers, client);
                     let message = account_error_message("runtime catch-up failed", &failure.source);
                     publish_app_runtime_account_error(
                         events,
@@ -2619,12 +3322,24 @@ async fn handle_account_worker_command(
                         account_label,
                         message.clone(),
                     );
-                    Err(AccountCatchUpFailure::new(
-                        message,
-                        failure.classification(),
-                    ))
+                    start_post_join_history_after_visibility(
+                        client,
+                        &failure.partial_summary,
+                        events,
+                        account_id_hex,
+                        account_label,
+                    )
+                    .await;
+                    (
+                        Err(AccountCatchUpFailure::new(
+                            message,
+                            failure.classification(),
+                        )),
+                        joined_group_visible,
+                    )
                 }
             };
+            observe_pending_worker_work(&mut pending_work_schedulers, client);
             shared.app_performance_telemetry().record_sync_result(
                 AppPerformanceOperation::AccountSync,
                 sync_started_at.elapsed(),
@@ -2633,23 +3348,168 @@ async fn handle_account_worker_command(
                     .err()
                     .map(AccountCatchUpFailure::classification),
             );
-            let retry_after_response = result.is_ok();
+            let retry_after_response = result.is_ok() || joined_group_visible;
             let _ = respond.send(result);
             if retry_after_response {
-                client
-                    .retry_pending_push_registration_shares_best_effort()
-                    .await;
+                retry_pending_push_registration_shares_with_visibility(
+                    client,
+                    events,
+                    account_id_hex,
+                    account_label,
+                    shared,
+                )
+                .await;
+                observe_pending_worker_work(&mut pending_work_schedulers, client);
+            }
+        }
+        AccountWorkerCommand::SyncWithPartialProgress { respond } => {
+            let sync_started_at = Instant::now();
+            let mut failure_classification = None;
+            let (result, joined_group_visible) =
+                match client.sync_with_classified_partial_progress().await {
+                    Ok(summary) => {
+                        publish_sync_summary_with_audit(
+                            events,
+                            account_id_hex,
+                            account_label,
+                            &summary,
+                            shared,
+                            "sync_with_partial_progress",
+                        );
+                        observe_pending_worker_work(&mut pending_work_schedulers, client);
+                        start_post_join_history_after_visibility(
+                            client,
+                            &summary,
+                            events,
+                            account_id_hex,
+                            account_label,
+                        )
+                        .await;
+                        let joined_group_visible = !summary.joined_groups.is_empty();
+                        (Ok(summary), joined_group_visible)
+                    }
+                    Err(failure) => {
+                        failure_classification = Some(failure.classification());
+                        publish_sync_summary_with_audit(
+                            events,
+                            account_id_hex,
+                            account_label,
+                            &failure.partial_summary,
+                            shared,
+                            "sync_with_partial_progress",
+                        );
+                        observe_pending_worker_work(&mut pending_work_schedulers, client);
+                        publish_app_runtime_account_error(
+                            events,
+                            account_id_hex,
+                            account_label,
+                            account_error_message("runtime sync failed", &failure.source),
+                        );
+                        start_post_join_history_after_visibility(
+                            client,
+                            &failure.partial_summary,
+                            events,
+                            account_id_hex,
+                            account_label,
+                        )
+                        .await;
+                        let joined_group_visible =
+                            !failure.partial_summary.joined_groups.is_empty();
+                        (Err(SyncFailure::from(failure)), joined_group_visible)
+                    }
+                };
+            observe_pending_worker_work(&mut pending_work_schedulers, client);
+            // The classified sync detector can arm a full-history replay while
+            // ingesting either a successful batch or a partial-progress
+            // failure. Execute/report that durable intent at this explicit sync
+            // seam instead of waiting for unrelated receive or maintenance;
+            // preserve the primary SyncFailure response contract if replay also
+            // fails (the helper emits its own typed AccountError).
+            let _ = run_pending_epoch_backfill_reporting_arm(
+                client,
+                events,
+                account_id_hex,
+                account_label,
+                shared,
+                EpochBackfillExecutionSeam::ExplicitCatchUp,
+            )
+            .await;
+            shared.app_performance_telemetry().record_sync_result(
+                AppPerformanceOperation::AccountSync,
+                sync_started_at.elapsed(),
+                failure_classification,
+            );
+            let retry_after_response = result.is_ok() || joined_group_visible;
+            let _ = respond.send(result);
+            if retry_after_response {
+                retry_pending_push_registration_shares_with_visibility(
+                    client,
+                    events,
+                    account_id_hex,
+                    account_label,
+                    shared,
+                )
+                .await;
+                observe_pending_worker_work(&mut pending_work_schedulers, client);
             }
         }
         AccountWorkerCommand::RepairFullHistory { respond } => {
             let sync_started_at = Instant::now();
-            let result = match client.repair_full_history().await {
+            let mut intermediate_summary = SyncSummary::default();
+            let repair = client
+                .repair_full_history_with_intermediate_handoff(|client, summary| {
+                    // An unconfirmed detector replay can still have committed a
+                    // visible prefix. Publish it synchronously before explicit
+                    // repair starts its second, unfloored relay pass; retaining
+                    // it in this future would lose V2 on forced worker abort.
+                    publish_sync_summary_with_audit(
+                        events,
+                        account_id_hex,
+                        account_label,
+                        &summary,
+                        shared,
+                        "repair_full_history_intermediate",
+                    );
+                    intermediate_summary.merge(summary);
+                    observe_pending_worker_work(&mut pending_work_schedulers, client);
+                })
+                .await;
+            let intermediate_joined_visible = !intermediate_summary.joined_groups.is_empty();
+            let (result, joined_group_visible) = match repair {
                 Ok(summary) => {
-                    publish_app_runtime_summary(events, account_id_hex, account_label, &summary);
-                    if sync_summary_triggers_audit_tracker_update(&summary) {
-                        shared.schedule_audit_log_tracker_update("repair_full_history");
+                    publish_sync_summary_with_audit(
+                        events,
+                        account_id_hex,
+                        account_label,
+                        &summary,
+                        shared,
+                        "repair_full_history",
+                    );
+                    observe_pending_worker_work(&mut pending_work_schedulers, client);
+                    if intermediate_summary != SyncSummary::default() {
+                        start_post_join_history_after_visibility(
+                            client,
+                            &intermediate_summary,
+                            events,
+                            account_id_hex,
+                            account_label,
+                        )
+                        .await;
+                        observe_pending_worker_work(&mut pending_work_schedulers, client);
                     }
-                    Ok(())
+                    start_post_join_history_after_visibility(
+                        client,
+                        &summary,
+                        events,
+                        account_id_hex,
+                        account_label,
+                    )
+                    .await;
+                    observe_pending_worker_work(&mut pending_work_schedulers, client);
+                    (
+                        Ok(()),
+                        intermediate_joined_visible || !summary.joined_groups.is_empty(),
+                    )
                 }
                 Err(failure) => {
                     publish_sync_summary_with_audit(
@@ -2660,6 +3520,9 @@ async fn handle_account_worker_command(
                         shared,
                         "repair_full_history",
                     );
+                    observe_pending_worker_work(&mut pending_work_schedulers, client);
+                    let joined_group_visible = intermediate_joined_visible
+                        || !failure.partial_summary.joined_groups.is_empty();
                     let message =
                         account_error_message("full-history repair failed", &failure.source);
                     publish_app_runtime_account_error(
@@ -2668,10 +3531,33 @@ async fn handle_account_worker_command(
                         account_label,
                         message.clone(),
                     );
-                    Err(AccountCatchUpFailure::new(
-                        message,
-                        failure.classification(),
-                    ))
+                    if intermediate_summary != SyncSummary::default() {
+                        start_post_join_history_after_visibility(
+                            client,
+                            &intermediate_summary,
+                            events,
+                            account_id_hex,
+                            account_label,
+                        )
+                        .await;
+                        observe_pending_worker_work(&mut pending_work_schedulers, client);
+                    }
+                    start_post_join_history_after_visibility(
+                        client,
+                        &failure.partial_summary,
+                        events,
+                        account_id_hex,
+                        account_label,
+                    )
+                    .await;
+                    observe_pending_worker_work(&mut pending_work_schedulers, client);
+                    (
+                        Err(AccountCatchUpFailure::new(
+                            message,
+                            failure.classification(),
+                        )),
+                        joined_group_visible,
+                    )
                 }
             };
             shared.app_performance_telemetry().record_sync_result(
@@ -2683,6 +3569,17 @@ async fn handle_account_worker_command(
                     .map(AccountCatchUpFailure::classification),
             );
             let _ = respond.send(result);
+            if joined_group_visible {
+                retry_pending_push_registration_shares_with_visibility(
+                    client,
+                    events,
+                    account_id_hex,
+                    account_label,
+                    shared,
+                )
+                .await;
+                observe_pending_worker_work(&mut pending_work_schedulers, client);
+            }
         }
         AccountWorkerCommand::CreateGroup {
             queued_at,
@@ -2787,9 +3684,14 @@ async fn handle_account_worker_command(
                                 "confirmed group creation could not refresh subscriptions immediately"
                             );
                         }
-                        client
-                            .retry_pending_push_registration_shares_best_effort()
-                            .await;
+                        retry_pending_push_registration_shares_with_visibility(
+                            client,
+                            events,
+                            account_id_hex,
+                            account_label,
+                            shared,
+                        )
+                        .await;
                     },
                     commands,
                     pending,
@@ -2959,9 +3861,14 @@ async fn handle_account_worker_command(
                 // consumers refresh and the group leaves the recovery
                 // surface and reappears as a normal chat.
                 match client.drain_pending_session_events().await {
-                    Ok(summary) => {
-                        publish_app_runtime_summary(events, account_id_hex, account_label, &summary)
-                    }
+                    Ok(summary) => publish_sync_summary_with_audit(
+                        events,
+                        account_id_hex,
+                        account_label,
+                        &summary,
+                        shared,
+                        "retry_hydration",
+                    ),
                     Err(err) => publish_app_runtime_account_error(
                         events,
                         account_id_hex,
@@ -3169,7 +4076,19 @@ async fn handle_account_worker_command(
             let _ = respond.send(result);
         }
         AccountWorkerCommand::LeaveGroup { group_id, respond } => {
-            let result = client.leave_group(&group_id).await;
+            let mut handoff = |client: &mut AppClient| {
+                publish_client_pending_applied_summary(
+                    client,
+                    events,
+                    account_id_hex,
+                    account_label,
+                    shared,
+                );
+                observe_pending_worker_work(&mut pending_work_schedulers, client);
+            };
+            let result = client
+                .leave_group_with_handoff(&group_id, &mut handoff)
+                .await;
             // Drain the kind-1210 "member left" row this commit queued. Sibling
             // mutators (invite/remove/profile) already flush
             // `pending_projection_updates`; without this the live timeline stays
@@ -3196,7 +4115,19 @@ async fn handle_account_worker_command(
             let _ = respond.send(result);
         }
         AccountWorkerCommand::DeleteGroupLocal { group_id, respond } => {
-            let result = client.delete_group_local(&group_id).await;
+            let mut handoff = |client: &mut AppClient| {
+                publish_client_pending_applied_summary(
+                    client,
+                    events,
+                    account_id_hex,
+                    account_label,
+                    shared,
+                );
+                observe_pending_worker_work(&mut pending_work_schedulers, client);
+            };
+            let result = client
+                .delete_group_local_with_handoff(&group_id, &mut handoff)
+                .await;
             if matches!(result, Ok(true)) {
                 publish_app_runtime_group_state_updated(
                     events,
@@ -3220,13 +4151,30 @@ async fn handle_account_worker_command(
             let retry_after_response = result.is_ok();
             let _ = respond.send(result);
             if retry_after_response {
-                client
-                    .retry_pending_push_registration_shares_best_effort()
-                    .await;
+                retry_pending_push_registration_shares_with_visibility(
+                    client,
+                    events,
+                    account_id_hex,
+                    account_label,
+                    shared,
+                )
+                .await;
             }
         }
         AccountWorkerCommand::DeclineGroupInvite { group_id, respond } => {
-            let result = client.decline_group_invite(&group_id).await;
+            let mut handoff = |client: &mut AppClient| {
+                publish_client_pending_applied_summary(
+                    client,
+                    events,
+                    account_id_hex,
+                    account_label,
+                    shared,
+                );
+                observe_pending_worker_work(&mut pending_work_schedulers, client);
+            };
+            let result = client
+                .decline_group_invite_with_handoff(&group_id, &mut handoff)
+                .await;
             if result.is_ok() {
                 publish_client_pending_projection_updates(
                     client,
@@ -3598,14 +4546,18 @@ async fn handle_account_worker_command(
             let _ = respond.send(result);
         }
         AccountWorkerCommand::RetryGroupConvergence { group_id, respond } => {
-            let result = client.retry_group_convergence(&group_id).await;
+            let result = client
+                .retry_group_convergence_with_deferred_notification(&group_id)
+                .await;
+            // Finalization updates are one-shot: publish the completed prefix
+            // on errors too, before the response can trigger later work.
+            publish_client_pending_projection_updates(
+                client,
+                events,
+                account_id_hex,
+                account_label,
+            );
             if result.is_ok() {
-                publish_client_pending_projection_updates(
-                    client,
-                    events,
-                    account_id_hex,
-                    account_label,
-                );
                 publish_app_runtime_group_state_updated(
                     events,
                     account_id_hex,
@@ -3624,6 +4576,51 @@ async fn handle_account_worker_command(
             respond,
         } => {
             let result = client.redeliver_welcome(&message_id_hex).await;
+            let _ = respond.send(result);
+        }
+        AccountWorkerCommand::DeleteKeyPackageRevision {
+            event_id,
+            endpoints,
+            respond,
+        } => {
+            let result = client
+                .delete_key_package_revision_durably(&event_id, endpoints)
+                .await;
+            let _ = respond.send(result);
+        }
+        AccountWorkerCommand::PublishNip65RelaySet {
+            read_relays,
+            write_relays,
+            bootstrap_relays,
+            respond,
+        } => {
+            let result = client
+                .publish_account_nip65_relay_set(read_relays, write_relays, bootstrap_relays)
+                .await;
+            let _ = respond.send(result);
+        }
+        AccountWorkerCommand::SetNip65Relays {
+            relays,
+            bootstrap_relays,
+            respond,
+        } => {
+            let result = client
+                .set_account_nip65_relays(relays, bootstrap_relays)
+                .await;
+            let _ = respond.send(result);
+        }
+        AccountWorkerCommand::PublishInboxRelayList {
+            relays,
+            bootstrap_relays,
+            respond,
+        } => {
+            let result = client
+                .publish_account_inbox_relays(relays, bootstrap_relays)
+                .await;
+            let _ = respond.send(result);
+        }
+        AccountWorkerCommand::IngestSelfNip65RelayEvent { record, respond } => {
+            let result = client.ingest_self_nip65_relay_event(record).await;
             let _ = respond.send(result);
         }
         AccountWorkerCommand::PublishKeyPackage { respond } => {
@@ -3684,18 +4681,29 @@ async fn handle_account_worker_command(
         }
         AccountWorkerCommand::RunDueMaintenance { respond } => {
             let result = client.run_due_maintenance().await;
-            if result.is_ok() {
-                publish_client_pending_projection_updates(
+            publish_client_pending_projection_updates(
+                client,
+                events,
+                account_id_hex,
+                account_label,
+            );
+            publish_pending_welcome_delivery_events(events, account_id_hex, account_label, client);
+            let _ = respond.send(result);
+        }
+        AccountWorkerCommand::SharePushRegistration { respond } => {
+            let mut handoff = |client: &mut AppClient| {
+                publish_client_pending_applied_summary(
                     client,
                     events,
                     account_id_hex,
                     account_label,
+                    shared,
                 );
-            }
-            let _ = respond.send(result);
-        }
-        AccountWorkerCommand::SharePushRegistration { respond } => {
-            let result = client.share_push_registration().await;
+                observe_pending_worker_work(&mut pending_work_schedulers, client);
+            };
+            let result = client
+                .share_push_registration_with_handoff(&mut handoff)
+                .await;
             let _ = respond.send(result);
         }
         AccountWorkerCommand::UpsertPushRegistration {
@@ -3705,18 +4713,41 @@ async fn handle_account_worker_command(
             relay_hint,
             respond,
         } => {
+            let mut handoff = |client: &mut AppClient| {
+                publish_client_pending_applied_summary(
+                    client,
+                    events,
+                    account_id_hex,
+                    account_label,
+                    shared,
+                );
+                observe_pending_worker_work(&mut pending_work_schedulers, client);
+            };
             let result = client
-                .upsert_and_share_push_registration(
+                .upsert_and_share_push_registration_with_handoff(
                     platform,
                     &raw_token,
                     &server_pubkey_hex,
                     relay_hint,
+                    &mut handoff,
                 )
                 .await;
             let _ = respond.send(result);
         }
         AccountWorkerCommand::ClearPushRegistration { respond } => {
-            let result = client.clear_and_share_push_registration().await;
+            let mut handoff = |client: &mut AppClient| {
+                publish_client_pending_applied_summary(
+                    client,
+                    events,
+                    account_id_hex,
+                    account_label,
+                    shared,
+                );
+                observe_pending_worker_work(&mut pending_work_schedulers, client);
+            };
+            let result = client
+                .clear_and_share_push_registration_with_handoff(&mut handoff)
+                .await;
             let _ = respond.send(result);
         }
         AccountWorkerCommand::SetNativePushEnabled { enabled, respond } => {
@@ -3726,22 +4757,44 @@ async fn handle_account_worker_command(
             let should_retry = result.is_ok();
             let _ = respond.send(result);
             if should_retry {
-                client
-                    .retry_pending_push_registration_shares_best_effort()
-                    .await;
+                retry_pending_push_registration_shares_with_visibility(
+                    client,
+                    events,
+                    account_id_hex,
+                    account_label,
+                    shared,
+                )
+                .await;
             }
         }
         AccountWorkerCommand::RemovePushRegistration {
             registration,
             respond,
         } => {
-            let result = client.remove_push_registration(registration).await;
+            let mut handoff = |client: &mut AppClient| {
+                publish_client_pending_applied_summary(
+                    client,
+                    events,
+                    account_id_hex,
+                    account_label,
+                    shared,
+                );
+                observe_pending_worker_work(&mut pending_work_schedulers, client);
+            };
+            let result = client
+                .remove_push_registration_with_handoff(registration, &mut handoff)
+                .await;
             let _ = respond.send(result);
         }
         AccountWorkerCommand::RetryPushRegistration { respond } => {
-            let pending = client
-                .retry_pending_push_registration_shares_best_effort()
-                .await;
+            let pending = retry_pending_push_registration_shares_with_visibility(
+                client,
+                events,
+                account_id_hex,
+                account_label,
+                shared,
+            )
+            .await;
             let _ = respond.send(pending);
         }
         AccountWorkerCommand::DeleteAuditLog { path, respond } => {
@@ -3756,7 +4809,15 @@ async fn handle_account_worker_command(
     // Publishing from this seam — rather than inside each send arm — keeps
     // every command path covered; the summary is empty for commands that
     // applied nothing.
-    publish_client_pending_applied_summary(client, events, account_id_hex, account_label);
+    publish_client_pending_applied_summary(client, events, account_id_hex, account_label, shared);
+    observe_pending_worker_work(&mut pending_work_schedulers, client);
+    // A send records its notification intent before returning from the client
+    // method. The applied summary above must reach subscribers first; only then
+    // cross the notification network await. Cancellation leaves the group in
+    // the client-owned set for the next worker seam.
+    client
+        .publish_pending_new_message_notifications_best_effort()
+        .await;
 }
 
 pub(super) fn group_roster_after_hydration(
@@ -4354,6 +5415,145 @@ fn publish_sync_summary_with_audit(
     }
 }
 
+/// Publish the visibility handoff before any network follow-up, then perform
+/// the durable join obligations that every summary-producing seam shares.
+/// Returning whether a join was visible lets callers arm their local retry
+/// schedulers without re-inspecting a summary after the awaits.
+async fn publish_sync_summary_with_followups(
+    client: &mut AppClient,
+    events: &broadcast::Sender<MarmotAppEvent>,
+    account_id_hex: &str,
+    account_label: &str,
+    summary: &SyncSummary,
+    shared: &RuntimeSharedServices,
+    audit_trigger: &'static str,
+) -> bool {
+    publish_sync_summary_with_audit(
+        events,
+        account_id_hex,
+        account_label,
+        summary,
+        shared,
+        audit_trigger,
+    );
+    finish_sync_summary_followups(
+        client,
+        summary,
+        events,
+        account_id_hex,
+        account_label,
+        shared,
+    )
+    .await
+}
+
+async fn finish_sync_summary_followups(
+    client: &mut AppClient,
+    summary: &SyncSummary,
+    events: &broadcast::Sender<MarmotAppEvent>,
+    account_id_hex: &str,
+    account_label: &str,
+    shared: &RuntimeSharedServices,
+) -> bool {
+    start_post_join_history_after_visibility(
+        client,
+        summary,
+        events,
+        account_id_hex,
+        account_label,
+    )
+    .await;
+    let joined_group_visible = !summary.joined_groups.is_empty();
+    if joined_group_visible {
+        retry_pending_push_registration_shares_with_visibility(
+            client,
+            events,
+            account_id_hex,
+            account_label,
+            shared,
+        )
+        .await;
+    }
+    publish_client_pending_applied_summary(client, events, account_id_hex, account_label, shared);
+    client
+        .publish_pending_new_message_notifications_best_effort()
+        .await;
+    joined_group_visible
+}
+
+/// Synchronously checkpoint/take/publish a retained V1/V2 prefix. Error paths
+/// use this before emitting their AccountError or arming schedulers, then may
+/// run [`finish_sync_summary_followups`] afterward. This keeps best-effort
+/// network awaits from delaying the primary visibility/error ordering.
+fn publish_pending_checkpointed_sync_summary_handoff(
+    client: &mut AppClient,
+    events: &broadcast::Sender<MarmotAppEvent>,
+    account_id_hex: &str,
+    account_label: &str,
+    shared: &RuntimeSharedServices,
+    audit_trigger: &'static str,
+) -> Option<SyncSummary> {
+    if let Err(error) = client.checkpoint_pending_sync_visibility() {
+        publish_app_runtime_account_error(
+            events,
+            account_id_hex,
+            account_label,
+            account_error_message("pending sync visibility checkpoint failed", &error),
+        );
+    }
+    let summary = client.take_pending_checkpointed_sync_summary()?;
+    publish_sync_summary_with_audit(
+        events,
+        account_id_hex,
+        account_label,
+        &summary,
+        shared,
+        audit_trigger,
+    );
+    Some(summary)
+}
+
+/// Checkpoint any cancellation-retained V1 batch, then hand off V2 from the
+/// owning [`AppClient`]. The take happens before the first follow-up await so a
+/// second fallback seam cannot attempt to publish the same batch. Broadcast is
+/// deliberately at-most-once; subscribers that lag must resnapshot durable
+/// projections. `Some(default)` remains meaningful occupancy: publishing it is
+/// a no-op, but the caller still needs to schedule convergence/backfill and
+/// subscription work retained on the client.
+fn publish_pending_checkpointed_sync_summary<'a>(
+    client: &'a mut AppClient,
+    events: &'a broadcast::Sender<MarmotAppEvent>,
+    account_id_hex: &'a str,
+    account_label: &'a str,
+    shared: &'a RuntimeSharedServices,
+    audit_trigger: &'static str,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send + 'a>> {
+    Box::pin(async move {
+        if let Err(error) = client.checkpoint_pending_sync_visibility() {
+            publish_app_runtime_account_error(
+                events,
+                account_id_hex,
+                account_label,
+                account_error_message("pending sync visibility checkpoint failed", &error),
+            );
+        }
+        let Some(summary) = client.take_pending_checkpointed_sync_summary() else {
+            return false;
+        };
+        publish_sync_summary_with_followups(
+            client,
+            events,
+            account_id_hex,
+            account_label,
+            &summary,
+            shared,
+            audit_trigger,
+        )
+        .await;
+        true
+    })
+}
+
 /// Run any pending epoch-gap backfill and push its arm evidence to the audit
 /// tracker. The arm state is captured *before* the replay drains it, and the
 /// tracker is scheduled unconditionally on the replay outcome: the
@@ -4377,6 +5577,9 @@ async fn run_pending_epoch_backfill_reporting_arm(
     seam: EpochBackfillExecutionSeam,
 ) -> Result<(), AccountCatchUpFailure> {
     let backfill_armed = client.has_pending_epoch_backfill();
+    if backfill_armed {
+        shared.schedule_audit_log_tracker_update("epoch_backfill_armed");
+    }
     let mut result = match client.run_pending_epoch_backfill(seam).await {
         // An incomplete replay published the same real summary: it ingested
         // whatever it reached before the relays failed to confirm they had
@@ -4386,18 +5589,46 @@ async fn run_pending_epoch_backfill_reporting_arm(
             EpochBackfillRunOutcome::Completed(summary)
             | EpochBackfillRunOutcome::Incomplete(summary),
         ) => {
-            publish_app_runtime_summary(events, account_id_hex, account_label, &summary);
+            publish_sync_summary_with_followups(
+                client,
+                events,
+                account_id_hex,
+                account_label,
+                &summary,
+                shared,
+                "epoch_backfill",
+            )
+            .await;
             Ok(())
         }
         Ok(EpochBackfillRunOutcome::Deferred | EpochBackfillRunOutcome::NotPending) => Ok(()),
         Err(error) => {
             let message = account_error_message("epoch-gap backfill failed", &error);
+            let published_visibility = publish_pending_checkpointed_sync_summary_handoff(
+                client,
+                events,
+                account_id_hex,
+                account_label,
+                shared,
+                "epoch_backfill_error_fallback",
+            );
             publish_app_runtime_account_error(
                 events,
                 account_id_hex,
                 account_label,
                 message.clone(),
             );
+            if let Some(summary) = published_visibility.as_ref() {
+                finish_sync_summary_followups(
+                    client,
+                    summary,
+                    events,
+                    account_id_hex,
+                    account_label,
+                    shared,
+                )
+                .await;
+            }
             // run_pending_epoch_backfill returns only AppError, after several
             // distinct sync boundaries. Preserve its typed broad cause but do
             // not derive a stage from that cause.
@@ -4407,9 +5638,6 @@ async fn run_pending_epoch_backfill_reporting_arm(
             ))
         }
     };
-    if backfill_armed {
-        shared.schedule_audit_log_tracker_update("epoch_backfill_armed");
-    }
     // An epoch replay is itself a large relay burst and can discover the
     // bounded account queue's overflow record. Resolve that distinct durable
     // gap immediately instead of waiting for unrelated later traffic to wake
@@ -4538,9 +5766,38 @@ fn publish_client_pending_applied_summary(
     events: &broadcast::Sender<MarmotAppEvent>,
     account_id_hex: &str,
     account_label: &str,
+    shared: &RuntimeSharedServices,
 ) {
     let summary = client.take_pending_applied_sync_summary();
-    publish_app_runtime_summary(events, account_id_hex, account_label, &summary);
+    publish_sync_summary_with_audit(
+        events,
+        account_id_hex,
+        account_label,
+        &summary,
+        shared,
+        "send_applied",
+    );
+}
+
+async fn retry_pending_push_registration_shares_with_visibility(
+    client: &mut AppClient,
+    events: &broadcast::Sender<MarmotAppEvent>,
+    account_id_hex: &str,
+    account_label: &str,
+    shared: &RuntimeSharedServices,
+) -> bool {
+    let mut handoff = |client: &mut AppClient| {
+        publish_client_pending_applied_summary(
+            client,
+            events,
+            account_id_hex,
+            account_label,
+            shared,
+        );
+    };
+    client
+        .retry_pending_push_registration_shares_best_effort_with_handoff(&mut handoff)
+        .await
 }
 
 pub(crate) fn publish_app_runtime_group_state_updated(
@@ -4604,20 +5861,29 @@ enum SetupKeyPackagePriority {
     Skip,
 }
 
-fn setup_key_package_priority(
+fn setup_key_package_priority<F>(
     state: Result<Option<AccountSetupState>, AccountHomeError>,
-) -> Result<SetupKeyPackagePriority, AppError> {
-    let publish = state?.is_some_and(|state| {
-        state.kind == AccountSetupKind::GeneratedIdentity
-            && matches!(
-                state.phase,
-                AccountSetupPhase::LocalReady
-                    | AccountSetupPhase::BootstrapPublicationStarted
-                    | AccountSetupPhase::BootstrapPublicationConfirmed
-                    | AccountSetupPhase::KeyPackagePublicationStarted
-            )
-    });
-    Ok(if publish {
+    load_generated_context: F,
+) -> Result<SetupKeyPackagePriority, AppError>
+where
+    F: FnOnce() -> Result<GeneratedAccountSetupContext, AppError>,
+{
+    let Some(state) = state? else {
+        return Ok(SetupKeyPackagePriority::Skip);
+    };
+    let eligible_phase = state.kind == AccountSetupKind::GeneratedIdentity
+        && matches!(
+            state.phase,
+            AccountSetupPhase::LocalReady
+                | AccountSetupPhase::BootstrapPublicationStarted
+                | AccountSetupPhase::BootstrapPublicationConfirmed
+                | AccountSetupPhase::KeyPackagePublicationStarted
+        );
+    if !eligible_phase {
+        return Ok(SetupKeyPackagePriority::Skip);
+    }
+    let context = load_generated_context()?;
+    Ok(if context.publish_initial_key_package() {
         SetupKeyPackagePriority::PublishExactDurableInitial
     } else {
         SetupKeyPackagePriority::Skip
@@ -4680,6 +5946,48 @@ mod tests {
         }
     }
 
+    fn generated_setup_context(publish_initial_key_package: bool) -> GeneratedAccountSetupContext {
+        GeneratedAccountSetupContext::from_request(&crate::runtime::AccountSetupRequest {
+            publish_initial_key_package,
+            ..crate::runtime::AccountSetupRequest::default()
+        })
+    }
+
+    #[tokio::test]
+    async fn shutdown_can_drop_a_queued_key_package_delete_before_durable_admission() {
+        let lifecycle = RuntimeLifecycle::new();
+        let mut lifecycle_shutdown = lifecycle.subscribe_shutdown();
+        let (commands_tx, mut commands) = mpsc::channel(1);
+        let (respond, response) = oneshot::channel();
+        commands_tx
+            .send(AccountWorkerCommand::DeleteKeyPackageRevision {
+                event_id: MessageId::new(vec![0x11; 32]),
+                endpoints: vec![cgka_traits::TransportEndpoint(
+                    "wss://relay.example".to_owned(),
+                )],
+                respond,
+            })
+            .await
+            .expect("queue delete command while worker is live");
+        lifecycle.begin_shutdown();
+
+        // Mirrors the steady-state worker's biased control ordering. A
+        // successful mpsc send is volatile admission: when stop and command
+        // are both ready, stop wins before the durable deletion handler runs.
+        let command_was_dequeued = tokio::select! {
+            biased;
+            _ = wait_for_runtime_shutdown(&mut lifecycle_shutdown) => false,
+            command = commands.recv() => command.is_some(),
+        };
+
+        assert!(!command_was_dequeued);
+        drop(commands);
+        assert!(
+            response.await.is_err(),
+            "no success response may imply durable admission for a command the stop branch dropped"
+        );
+    }
+
     #[test]
     fn generated_setup_priority_selects_the_exact_durable_initial_key_package() {
         for phase in [
@@ -4689,13 +5997,39 @@ mod tests {
             AccountSetupPhase::KeyPackagePublicationStarted,
         ] {
             assert_eq!(
-                setup_key_package_priority(Ok(Some(setup_state(
-                    AccountSetupKind::GeneratedIdentity,
-                    phase,
-                ))))
+                setup_key_package_priority(
+                    Ok(Some(setup_state(
+                        AccountSetupKind::GeneratedIdentity,
+                        phase,
+                    ))),
+                    || Ok(generated_setup_context(true))
+                )
                 .unwrap(),
                 SetupKeyPackagePriority::PublishExactDurableInitial,
                 "phase {phase:?} must select the lifecycle-owned initial KeyPackage"
+            );
+        }
+    }
+
+    #[test]
+    fn generated_setup_priority_honors_the_durable_publication_opt_out() {
+        for phase in [
+            AccountSetupPhase::LocalReady,
+            AccountSetupPhase::BootstrapPublicationStarted,
+            AccountSetupPhase::BootstrapPublicationConfirmed,
+            AccountSetupPhase::KeyPackagePublicationStarted,
+        ] {
+            assert_eq!(
+                setup_key_package_priority(
+                    Ok(Some(setup_state(
+                        AccountSetupKind::GeneratedIdentity,
+                        phase
+                    ))),
+                    || Ok(generated_setup_context(false)),
+                )
+                .unwrap(),
+                SetupKeyPackagePriority::Skip,
+                "phase {phase:?} must retain the durable KeyPackage publication opt-out"
             );
         }
     }
@@ -4709,10 +6043,12 @@ mod tests {
             AccountSetupPhase::KeyPackagePublicationStarted,
         ] {
             assert_eq!(
-                setup_key_package_priority(Ok(Some(setup_state(
-                    AccountSetupKind::ImportedIdentity,
-                    phase,
-                ))))
+                setup_key_package_priority(
+                    Ok(Some(
+                        setup_state(AccountSetupKind::ImportedIdentity, phase,)
+                    )),
+                    || panic!("imported setup must not load generated context")
+                )
                 .unwrap(),
                 SetupKeyPackagePriority::Skip
             );
@@ -4722,23 +6058,32 @@ mod tests {
             AccountSetupPhase::KeyPackagePublicationConfirmed,
         ] {
             assert_eq!(
-                setup_key_package_priority(Ok(Some(setup_state(
-                    AccountSetupKind::GeneratedIdentity,
-                    phase,
-                ))))
+                setup_key_package_priority(
+                    Ok(Some(setup_state(
+                        AccountSetupKind::GeneratedIdentity,
+                        phase,
+                    ))),
+                    || panic!("ineligible phase must not load generated context")
+                )
                 .unwrap(),
                 SetupKeyPackagePriority::Skip
             );
         }
         assert_eq!(
-            setup_key_package_priority(Ok(None)).unwrap(),
+            setup_key_package_priority(Ok(None), || {
+                panic!("absent setup must not load generated context")
+            })
+            .unwrap(),
             SetupKeyPackagePriority::Skip
         );
     }
 
     #[test]
     fn setup_state_lookup_failure_never_enters_the_publication_lane() {
-        let error = setup_key_package_priority(Err(AccountHomeError::AccountSetupStateMissing))
+        let error =
+            setup_key_package_priority(Err(AccountHomeError::AccountSetupStateMissing), || {
+                panic!("failed setup lookup must not load generated context")
+            })
             .expect_err("lookup failure must be surfaced");
 
         assert!(matches!(error, AppError::AccountHome(_)));
@@ -5002,12 +6347,14 @@ mod tests {
             .await
             .unwrap();
         let stalled_epoch = client.group_mls_state(&group_id).unwrap().epoch;
-        client.apply_backfill_decision(
-            &group_id,
-            stalled_epoch,
-            BackfillDecision::Arm,
-            EpochStallBackfillTrigger::UndecryptableThreshold,
-        );
+        client
+            .apply_backfill_decision(
+                &group_id,
+                stalled_epoch,
+                BackfillDecision::Arm,
+                EpochStallBackfillTrigger::UndecryptableThreshold,
+            )
+            .unwrap();
 
         let (events, _subscriber) = broadcast::channel(4);
         let shared = RuntimeSharedServices::default();
@@ -5091,12 +6438,14 @@ mod tests {
             .await
             .unwrap();
         let stalled_epoch = client.group_mls_state(&group_id).unwrap().epoch;
-        client.apply_backfill_decision(
-            &group_id,
-            stalled_epoch,
-            BackfillDecision::Arm,
-            EpochStallBackfillTrigger::UndecryptableThreshold,
-        );
+        client
+            .apply_backfill_decision(
+                &group_id,
+                stalled_epoch,
+                BackfillDecision::Arm,
+                EpochStallBackfillTrigger::UndecryptableThreshold,
+            )
+            .unwrap();
 
         let (events, mut subscriber) = broadcast::channel(4);
         let shared = RuntimeSharedServices::default();
@@ -5232,12 +6581,14 @@ mod tests {
             .await
             .unwrap();
         let stalled_epoch = client.group_mls_state(&group_id).unwrap().epoch;
-        client.apply_backfill_decision(
-            &group_id,
-            stalled_epoch,
-            BackfillDecision::Arm,
-            EpochStallBackfillTrigger::UndecryptableThreshold,
-        );
+        client
+            .apply_backfill_decision(
+                &group_id,
+                stalled_epoch,
+                BackfillDecision::Arm,
+                EpochStallBackfillTrigger::UndecryptableThreshold,
+            )
+            .unwrap();
 
         let (events, _subscriber) = broadcast::channel(4);
         let shared = RuntimeSharedServices::default();
@@ -5249,6 +6600,7 @@ mod tests {
             shared: &shared,
             account_id_hex: "account-id",
             account_label: "alice",
+            pending_work_schedulers: None,
         };
         let (respond, response) = oneshot::channel();
 
@@ -5282,12 +6634,14 @@ mod tests {
             .await
             .unwrap();
         let stalled_epoch = client.group_mls_state(&group_id).unwrap().epoch;
-        client.apply_backfill_decision(
-            &group_id,
-            stalled_epoch,
-            BackfillDecision::Arm,
-            EpochStallBackfillTrigger::UndecryptableThreshold,
-        );
+        client
+            .apply_backfill_decision(
+                &group_id,
+                stalled_epoch,
+                BackfillDecision::Arm,
+                EpochStallBackfillTrigger::UndecryptableThreshold,
+            )
+            .unwrap();
         client
             .pending_epoch_backfill
             .as_mut()
@@ -5309,6 +6663,7 @@ mod tests {
             shared: &shared,
             account_id_hex: "account-id",
             account_label: "alice",
+            pending_work_schedulers: None,
         };
         let (respond, response) = oneshot::channel();
 
@@ -5339,6 +6694,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn detailed_sync_command_returns_its_exact_worker_summary() {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(relay.clone());
+        let _eose = scripted_eose_pump(app.relay_plane.clone(), relay.clone(), every_subscription);
+        let mut client = client_on_app_relay_plane(&app, "alice").await;
+        let subscriptions_before = relay.subscription_count();
+
+        let (events, _subscriber) = broadcast::channel(4);
+        let shared = RuntimeSharedServices::default();
+        let (respond, response) = oneshot::channel();
+        let (media_http_tx, _media_http_rx) = mpsc::unbounded_channel();
+        let (media_http_worker_lifetime, _) = watch::channel(());
+        let media_http = MediaHttpContext {
+            tx: media_http_tx,
+            permits: Arc::new(Semaphore::new(MEDIA_HTTP_IN_FLIGHT_LIMIT)),
+            prepared_group_image_uploads: Arc::new(Mutex::new(HashSet::new())),
+            worker_lifetime: media_http_worker_lifetime,
+        };
+        let (mut unused_commands, mut unused_pending) = unused_account_worker_command_io();
+        handle_account_worker_command(
+            &mut client,
+            AccountWorkerCommand::SyncWithPartialProgress { respond },
+            AccountWorkerCommandContext {
+                commands: &mut unused_commands,
+                pending: &mut unused_pending,
+                app: &app,
+                events: &events,
+                account_id_hex: "account-id",
+                account_label: "alice",
+                shared: &shared,
+                media_http: &media_http,
+                pending_work_schedulers: None,
+            },
+        )
+        .await;
+
+        let summary = response
+            .await
+            .unwrap()
+            .expect("detailed worker sync must return its own summary");
+        assert_eq!(summary, SyncSummary::default());
+        assert!(
+            relay.subscription_count() > subscriptions_before,
+            "the detailed result must come from a real worker-owned transport sync"
+        );
+    }
+
+    #[tokio::test]
     async fn full_history_repair_consumes_prearmed_backfill_without_replaying_twice() {
         let dir = tempfile::tempdir().unwrap();
         AccountHome::open(dir.path())
@@ -5358,12 +6766,14 @@ mod tests {
             .await
             .unwrap();
         let stalled_epoch = client.group_mls_state(&group_id).unwrap().epoch;
-        client.apply_backfill_decision(
-            &group_id,
-            stalled_epoch,
-            BackfillDecision::Arm,
-            EpochStallBackfillTrigger::UndecryptableThreshold,
-        );
+        client
+            .apply_backfill_decision(
+                &group_id,
+                stalled_epoch,
+                BackfillDecision::Arm,
+                EpochStallBackfillTrigger::UndecryptableThreshold,
+            )
+            .unwrap();
         let subscriptions_before_repair = relay.subscription_count();
 
         let (events, _subscriber) = broadcast::channel(4);
@@ -5390,6 +6800,7 @@ mod tests {
                 account_label: "alice",
                 shared: &shared,
                 media_http: &media_http,
+                pending_work_schedulers: None,
             },
         )
         .await;
@@ -5426,12 +6837,14 @@ mod tests {
             .await
             .unwrap();
         let stalled_epoch = client.group_mls_state(&group_id).unwrap().epoch;
-        client.apply_backfill_decision(
-            &group_id,
-            stalled_epoch,
-            BackfillDecision::Arm,
-            EpochStallBackfillTrigger::UndecryptableThreshold,
-        );
+        client
+            .apply_backfill_decision(
+                &group_id,
+                stalled_epoch,
+                BackfillDecision::Arm,
+                EpochStallBackfillTrigger::UndecryptableThreshold,
+            )
+            .unwrap();
         let marker_token = 7;
         app.account_storage("alice")
             .unwrap()
@@ -5529,12 +6942,14 @@ mod tests {
             .await
             .unwrap();
         let stalled_epoch = client.group_mls_state(&group_id).unwrap().epoch;
-        client.apply_backfill_decision(
-            &group_id,
-            stalled_epoch,
-            BackfillDecision::Arm,
-            EpochStallBackfillTrigger::UndecryptableThreshold,
-        );
+        client
+            .apply_backfill_decision(
+                &group_id,
+                stalled_epoch,
+                BackfillDecision::Arm,
+                EpochStallBackfillTrigger::UndecryptableThreshold,
+            )
+            .unwrap();
         client
             .pending_epoch_backfill
             .as_mut()
@@ -5581,31 +6996,38 @@ mod tests {
         let group_b = client.create_group("queued repair b", &[]).await.unwrap();
 
         let stalled_epoch_a = client.group_mls_state(&group_a).unwrap().epoch;
-        client.apply_backfill_decision(
-            &group_a,
-            stalled_epoch_a,
-            BackfillDecision::Arm,
-            EpochStallBackfillTrigger::UndecryptableThreshold,
-        );
+        client
+            .apply_backfill_decision(
+                &group_a,
+                stalled_epoch_a,
+                BackfillDecision::Arm,
+                EpochStallBackfillTrigger::UndecryptableThreshold,
+            )
+            .unwrap();
         let execution = client
             .begin_epoch_backfill_execution(EpochBackfillExecutionSeam::Maintenance)
+            .expect("persist first intent execution")
             .expect("first intent must begin");
         let operation_a = execution.pending.attempt_id.clone();
 
         let stalled_epoch_b = client.group_mls_state(&group_b).unwrap().epoch;
-        client.apply_backfill_decision(
-            &group_b,
-            stalled_epoch_b,
-            BackfillDecision::Arm,
-            EpochStallBackfillTrigger::UndecryptableThreshold,
-        );
+        client
+            .apply_backfill_decision(
+                &group_b,
+                stalled_epoch_b,
+                BackfillDecision::Arm,
+                EpochStallBackfillTrigger::UndecryptableThreshold,
+            )
+            .unwrap();
         let operation_b = client
             .pending_epoch_backfill
             .as_ref()
             .expect("second intent must arm in flight")
             .attempt_id
             .clone();
-        client.test_finish_epoch_backfill_execution(execution, false);
+        client
+            .test_finish_epoch_backfill_execution(execution, false)
+            .unwrap();
         client
             .pending_epoch_backfill
             .as_mut()
@@ -5756,24 +7178,28 @@ mod tests {
         assert!(!scheduled.is_armed());
     }
 
-    #[test]
-    fn push_registration_retry_observation_is_scoped_to_relevant_commands() {
-        let (share_respond, _share_response) = oneshot::channel();
-        assert!(
-            AccountWorkerCommand::SharePushRegistration {
-                respond: share_respond
-            }
-            .may_change_push_registration_work()
+    #[tokio::test]
+    async fn scheduled_maintenance_followup_reobserves_new_route_and_push_work() {
+        let (commands, _received_commands) = mpsc::channel(2);
+        let mut runtime_group_subscription_refresh =
+            ScheduledRuntimeGroupSubscriptionRefresh::new();
+        let mut push_retry = ScheduledPushRegistrationRetry::new();
+
+        observe_scheduled_maintenance_followup_retries(
+            &mut runtime_group_subscription_refresh,
+            true,
+            &mut push_retry,
+            true,
+            &commands,
         );
 
-        let (convergence_respond, _convergence_response) = oneshot::channel();
         assert!(
-            !AccountWorkerCommand::RetryGroupConvergence {
-                group_id: test_group_id(1),
-                respond: convergence_respond,
-            }
-            .may_change_push_registration_work(),
-            "unrelated convergence commands must not arm push maintenance"
+            runtime_group_subscription_refresh.is_armed(),
+            "a route change produced by the final follow-up send must arm its worker retry"
+        );
+        assert!(
+            push_retry.is_armed(),
+            "durable push work left by the final follow-up send must arm its worker retry"
         );
     }
 

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -27,6 +27,7 @@ use crate::{
     MediaDownloadResult, MediaUploadRequest, MediaUploadResult, NotificationSettings,
     PendingWelcomeDelivery, PushPlatform, PushRegistration, PushRegistrationShareOutcome,
     PushRegistrationSyncResult, RetentionSweepReport, SecureDeleteExpiredResult, SendSummary,
+    SyncFailure, SyncSummary,
 };
 
 impl AccountManager {
@@ -155,6 +156,28 @@ impl AccountManager {
             .await
             .map_err(|_| AppError::TransportClosed)?;
         long_account_worker_catch_up_response(response).await
+    }
+
+    /// Run one caller-visible sync through the selected account's owning
+    /// worker, preserving the exact applied prefix when a later stage fails.
+    pub async fn sync_with_partial_progress(
+        &self,
+        account_ref: &str,
+    ) -> Result<SyncSummary, SyncFailure> {
+        let command = self
+            .worker_commands(account_ref)
+            .await
+            .map_err(SyncFailure::from)?;
+        let (respond, response) = oneshot::channel();
+        command
+            .send(AccountWorkerCommand::SyncWithPartialProgress { respond })
+            .await
+            .map_err(|_| SyncFailure::from(AppError::TransportClosed))?;
+        match tokio::time::timeout(super::APP_RUNTIME_LONG_WORKER_RESPONSE_WAIT, response).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(_)) => Err(SyncFailure::from(AppError::TransportClosed)),
+            Err(_) => Err(SyncFailure::from(AppError::AccountWorkerResponseTimedOut)),
+        }
     }
 
     /// Create the group and return its canonical id. Invitation delivery is

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -3,7 +3,7 @@ use zeroize::Zeroizing;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{
     Arc, Mutex as StdMutex,
-    atomic::{AtomicBool, AtomicUsize, Ordering},
+    atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
 };
 use std::time::{Duration, Instant};
 
@@ -12,7 +12,9 @@ use cgka_traits::app_event::MarmotAppEvent as MarmotInnerEvent;
 use cgka_traits::engine::GroupEvent;
 use cgka_traits::storage::{KeyPackageBundleStorage, MaintenanceStorage};
 use cgka_traits::transport_adapter::TransportEndpointRejectionCategory;
-use cgka_traits::{GroupId, SecretBytes, TransportAdapterError, TransportEndpoint};
+use cgka_traits::{
+    GroupId, MemberId, SecretBytes, TransportAdapter, TransportAdapterError, TransportEndpoint,
+};
 use marmot_account::{
     AccountHome, AccountHomeError, AccountSetupKind, AccountSetupPhase, AccountSummary,
     NostrAccountImport,
@@ -63,6 +65,10 @@ mod audit_tracker;
 mod commands;
 mod event_routing;
 mod subscriptions;
+
+/// Detached sign-out/wipe operations retained concurrently by one runtime.
+/// Completed operations retain no handle or identity key.
+const ACCOUNT_TEARDOWN_TASK_LIMIT: usize = 64;
 
 // Re-export the public surface so `crate::runtime::Item` and the
 // `marmot_app::...` paths in `lib.rs` resolve unchanged after the split.
@@ -125,6 +131,10 @@ pub struct MarmotAppRuntime {
     #[cfg(test)]
     shutdown_test_hook: Arc<StdMutex<Option<ShutdownTestHook>>>,
     #[cfg(test)]
+    wipe_before_teardown_test_hook: Arc<StdMutex<Option<WipeBeforeTeardownTestHook>>>,
+    #[cfg(test)]
+    generated_setup_handoff_test_hook: Arc<StdMutex<Option<GeneratedSetupHandoffTestHook>>>,
+    #[cfg(test)]
     shutdown_grace_wait_for_test: Arc<StdMutex<Duration>>,
 }
 
@@ -144,6 +154,20 @@ pub(crate) enum ShutdownTestPhase {
 #[derive(Clone)]
 struct ShutdownTestHook {
     phase: ShutdownTestPhase,
+    entered: Arc<Semaphore>,
+    release: Arc<Semaphore>,
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+struct WipeBeforeTeardownTestHook {
+    entered: Arc<Semaphore>,
+    release: Arc<Semaphore>,
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+struct GeneratedSetupHandoffTestHook {
     entered: Arc<Semaphore>,
     release: Arc<Semaphore>,
 }
@@ -173,6 +197,27 @@ impl ShutdownTestStall {
     }
 }
 
+#[cfg(test)]
+pub(crate) struct GeneratedSetupHandoffTestStall {
+    entered: Arc<Semaphore>,
+    release: Arc<Semaphore>,
+}
+
+#[cfg(test)]
+impl GeneratedSetupHandoffTestStall {
+    pub(crate) async fn wait_until_entered(&self) {
+        self.entered
+            .acquire()
+            .await
+            .expect("generated-setup handoff test hook semaphore must stay open")
+            .forget();
+    }
+
+    pub(crate) fn release(&self) {
+        self.release.add_permits(1);
+    }
+}
+
 #[derive(Clone)]
 pub struct AccountManager {
     app: MarmotApp,
@@ -180,12 +225,79 @@ pub struct AccountManager {
     shared: RuntimeSharedServices,
     workers: Arc<Mutex<HashMap<String, ManagedAccountWorker>>>,
     tearing_down: Arc<StdMutex<HashSet<String>>>,
+    // Setup admission is account-scoped: tearing down one account must not
+    // invalidate unrelated setup work. Generations are process-unique so a
+    // wiped identity cannot suffer an ABA if it is imported again while an
+    // older setup future is still unwinding.
+    next_setup_admission_generation: Arc<AtomicU64>,
+    setup_admission_generations: Arc<StdMutex<HashMap<String, u64>>>,
     worker_transactions: Arc<Mutex<()>>,
     generated_setup_local_transaction: Arc<Mutex<()>>,
     #[cfg(test)]
     reconcile_rollback_waiters: Arc<StdMutex<Vec<std::sync::mpsc::Sender<()>>>>,
     invite_catch_up_tasks: Arc<StdMutex<InviteCatchUpTasks>>,
     generated_setup_tasks: Arc<StdMutex<GeneratedSetupTasks>>,
+    teardown_tasks: Arc<StdMutex<AccountTeardownTasks>>,
+    teardown_task_activity: watch::Sender<usize>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct AccountSetupAdmission {
+    generation: u64,
+    started_signed_out: bool,
+}
+
+/// Cloneable proof passed only to setup-owned publishers. It binds the final
+/// route-locked relay boundary to the exact account/setup generation and
+/// signed-out state without granting general worker or session admission.
+#[derive(Clone)]
+pub(crate) struct AccountSetupPublicationAdmission {
+    account_id_hex: String,
+    generation: u64,
+    started_signed_out: bool,
+    setup_admission_generations: Arc<StdMutex<HashMap<String, u64>>>,
+    tearing_down: Arc<StdMutex<HashSet<String>>>,
+}
+
+impl AccountSetupPublicationAdmission {
+    pub(crate) fn account_id_hex(&self) -> &str {
+        &self.account_id_hex
+    }
+
+    pub(crate) fn is_current(&self) -> bool {
+        let tearing_down = self
+            .tearing_down
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .contains(&self.account_id_hex);
+        if tearing_down {
+            return false;
+        }
+        self.setup_admission_generations
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(&self.account_id_hex)
+            .is_some_and(|generation| *generation == self.generation)
+    }
+
+    pub(crate) fn started_signed_out(&self) -> bool {
+        self.started_signed_out
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test(account_id_hex: &str) -> Self {
+        let generation = 1;
+        Self {
+            account_id_hex: account_id_hex.to_owned(),
+            generation,
+            started_signed_out: false,
+            setup_admission_generations: Arc::new(StdMutex::new(HashMap::from([(
+                account_id_hex.to_owned(),
+                generation,
+            )]))),
+            tearing_down: Arc::new(StdMutex::new(HashSet::new())),
+        }
+    }
 }
 
 struct InviteCatchUpTasks {
@@ -195,8 +307,69 @@ struct InviteCatchUpTasks {
 
 struct GeneratedSetupTasks {
     accepting: bool,
-    active_accounts: HashSet<String>,
-    handles: Vec<JoinHandle<()>>,
+    handles: HashMap<String, JoinHandle<()>>,
+}
+
+struct AccountTeardownTasks {
+    accepting: bool,
+    active: usize,
+}
+
+/// Registers one runtime-owned sign-out/wipe operation with shutdown.
+///
+/// The task itself may be detached from its caller, but this guard keeps it in
+/// the runtime's bounded active-task count until every relay/local cleanup
+/// boundary has settled. No per-account handle or completed-task history is
+/// retained.
+struct AccountTeardownTaskGuard {
+    tasks: Arc<StdMutex<AccountTeardownTasks>>,
+    activity: watch::Sender<usize>,
+}
+
+impl Drop for AccountTeardownTaskGuard {
+    fn drop(&mut self) {
+        let mut tasks = self
+            .tasks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        tasks.active = tasks.active.saturating_sub(1);
+        self.activity.send_replace(tasks.active);
+    }
+}
+
+/// Holds worker admission closed for one account across network-bound teardown.
+///
+/// The global worker transaction is used only while the existing worker is
+/// stopped. This account-scoped marker then remains live through relay cleanup,
+/// so unrelated accounts can still reconcile while this account cannot be
+/// restarted. Dropping the barrier reliably reopens admission on every exit.
+struct AccountTeardownBarrier {
+    account_label: String,
+    account_id_hex: String,
+    app: MarmotApp,
+    cleanup_admission: Option<crate::AccountTeardownSessionAdmissionToken>,
+    tearing_down: Arc<StdMutex<HashSet<String>>>,
+}
+
+impl AccountTeardownBarrier {
+    fn cleanup_admission(&self) -> Result<&crate::AccountTeardownSessionAdmissionToken, AppError> {
+        self.cleanup_admission
+            .as_ref()
+            .ok_or(AppError::AccountWorkerBusy)
+    }
+}
+
+impl Drop for AccountTeardownBarrier {
+    fn drop(&mut self) {
+        if let Some(admission) = self.cleanup_admission.as_ref() {
+            self.app
+                .close_account_teardown_session_admission(&self.account_label, admission);
+        }
+        self.tearing_down
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&self.account_id_hex);
+    }
 }
 
 const GENERATED_SETUP_BACKGROUND_MAX_ATTEMPTS: usize = 3;
@@ -218,6 +391,11 @@ pub struct RuntimeSharedServices {
     /// scheduler timing. Consulted only with the `test-policy-overrides`
     /// feature; always `None` in production.
     create_group_catch_up_barrier: Arc<StdMutex<Option<Arc<tokio::sync::Notify>>>>,
+    /// Account-specific unit-test observation points for worker maintenance
+    /// ticks. Counting permits let a test wait after a tick has already
+    /// completed without one account consuming another account's signal.
+    #[cfg(test)]
+    maintenance_ticks_completed: Arc<StdMutex<HashMap<String, Arc<Semaphore>>>>,
 }
 
 const MESSAGE_SUBSCRIPTION_SEEN_ID_LIMIT: usize = MAX_SEEN_EVENT_IDS;
@@ -296,6 +474,8 @@ impl Default for RuntimeSharedServices {
             service_endpoints: MarmotServiceEndpoints::default(),
             audit_log_tracker_uploader: None,
             create_group_catch_up_barrier: Arc::new(StdMutex::new(None)),
+            #[cfg(test)]
+            maintenance_ticks_completed: Arc::new(StdMutex::new(HashMap::new())),
         }
     }
 }
@@ -322,6 +502,8 @@ impl RuntimeSharedServices {
             service_endpoints: app.service_endpoints().clone(),
             audit_log_tracker_uploader: Some(audit_log_tracker_uploader),
             create_group_catch_up_barrier: Arc::new(StdMutex::new(None)),
+            #[cfg(test)]
+            maintenance_ticks_completed: Arc::new(StdMutex::new(HashMap::new())),
         }
     }
 
@@ -348,6 +530,34 @@ impl RuntimeSharedServices {
 
     fn create_group_catch_up_barrier(&self) -> Option<Arc<tokio::sync::Notify>> {
         self.create_group_catch_up_barrier.lock().unwrap().clone()
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn wait_for_maintenance_tick_for_test(&self, account_label: &str) {
+        let completed = self
+            .maintenance_ticks_completed
+            .lock()
+            .unwrap()
+            .entry(account_label.to_owned())
+            .or_insert_with(|| Arc::new(Semaphore::new(0)))
+            .clone();
+        completed
+            .acquire()
+            .await
+            .expect("maintenance-tick test semaphore remains open")
+            .forget();
+    }
+
+    #[cfg(test)]
+    fn notify_maintenance_tick_completed_for_test(&self, account_label: &str) {
+        let completed = self
+            .maintenance_ticks_completed
+            .lock()
+            .unwrap()
+            .entry(account_label.to_owned())
+            .or_insert_with(|| Arc::new(Semaphore::new(0)))
+            .clone();
+        completed.add_permits(1);
     }
 
     pub(crate) fn lifecycle(&self) -> RuntimeLifecycle {
@@ -663,11 +873,11 @@ pub struct ManagedAccount {
 /// Structured outcome of [`MarmotAppRuntime::sign_out_and_wipe`].
 ///
 /// Every stage of the destructive sign-out is reported independently so the
-/// app can render progress and a partial-failure sheet. The network-bound
-/// stages (group leave, KeyPackage deletion) are best-effort and may report
-/// per-target failures without aborting the wipe; the local-cleanup stage is
-/// all-or-nothing (see the type-level invariant on
-/// [`MarmotAppRuntime::sign_out_and_wipe`]).
+/// app can render progress and a partial-failure sheet. Group-leave failures do
+/// not abort the wipe. KeyPackage cleanup failures retain the local account and
+/// its durable recovery journal so a later retry can finish relay cleanup
+/// before removal. The local-cleanup stage is all-or-nothing (see the
+/// type-level invariant on [`MarmotAppRuntime::sign_out_and_wipe`]).
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WipeOutcome {
     /// Number of active MLS groups this account successfully left.
@@ -676,7 +886,8 @@ pub struct WipeOutcome {
     pub group_leave_failures: Vec<GroupLeaveFailure>,
     /// Number of relay-published KeyPackage events successfully deleted.
     pub key_packages_deleted: u32,
-    /// Per-relay KeyPackage deletion failures. Best-effort.
+    /// Per-relay KeyPackage deletion failures. Any such failure retains local
+    /// recovery state instead of removing the account.
     pub key_package_failures: Vec<RelayFailure>,
     /// Whether the local cleanup stage (MLS DB, media cache, SQL account row,
     /// secret-store nsec, ephemeral relay/subscription state) completed.
@@ -691,6 +902,23 @@ pub struct WipeOutcome {
 pub struct GroupLeaveFailure {
     pub group_id_hex: String,
     pub reason: String,
+}
+
+impl GroupLeaveFailure {
+    /// Build the account-wide failure emitted when a quiesced wipe cannot
+    /// deactivate its transport. Kept as one constructor so every app/FFI
+    /// surface receives a fixed privacy-safe category rather than a transport
+    /// error whose text may contain relay or account identifiers.
+    #[doc(hidden)]
+    pub fn from_transport_deactivation_error(error: TransportAdapterError) -> Self {
+        Self {
+            group_id_hex: String::new(),
+            reason: format!(
+                "quiesced group-leave transport deactivation failed: {}",
+                wipe_failure_reason(&AppError::Transport(error))
+            ),
+        }
+    }
 }
 
 /// A failed relay-side operation (currently KeyPackage deletion) during the
@@ -760,8 +988,9 @@ pub struct SignOutOutcome {
     /// `0` when `delete_key_packages` was `false`.
     pub key_packages_deleted: u32,
     /// Per-relay KeyPackage deletion (or discovery) failures. Best-effort: a
-    /// failure here never blocks local cleanup. No durable remote-deletion
-    /// retry is implied by this outcome.
+    /// failure here never blocks local cleanup. Superseded revision obligations
+    /// remain durable, and deletion of a live revision forces reauthoring on
+    /// the next activation.
     pub key_package_failures: Vec<RelayFailure>,
     /// Result of the always-run local teardown (worker shutdown, subscription
     /// deactivation, in-memory cache eviction). Unlike a wipe this never
@@ -839,8 +1068,17 @@ fn relay_failures_from_key_package_deletion_results(
     let mut deleted = 0;
     let mut failures = Vec::new();
     for result in results {
+        let partial_failure = !result.failed_endpoints.is_empty();
         match result.result {
-            Ok(accepted) if accepted > 0 => deleted += 1,
+            Ok(accepted) if accepted > 0 => {
+                deleted += 1;
+                if partial_failure {
+                    failures.push(RelayFailure {
+                        event_id_hex: result.event_id_hex,
+                        reason: "one or more relay deletions remain retryable".to_owned(),
+                    });
+                }
+            }
             Ok(_) => failures.push(RelayFailure {
                 event_id_hex: result.event_id_hex,
                 reason: "relay publish failed".to_owned(),
@@ -852,6 +1090,57 @@ fn relay_failures_from_key_package_deletion_results(
         }
     }
     (deleted, failures)
+}
+
+fn merge_key_package_deletion_results(
+    results: Vec<KeyPackageDeletionResult>,
+) -> Vec<KeyPackageDeletionResult> {
+    let mut merged = Vec::<KeyPackageDeletionResult>::new();
+    for mut result in results {
+        if let Some(existing) = merged
+            .iter_mut()
+            .find(|existing| existing.event_id_hex == result.event_id_hex)
+        {
+            existing
+                .accepted_endpoints
+                .append(&mut result.accepted_endpoints);
+            existing
+                .confirmed_absent_endpoints
+                .append(&mut result.confirmed_absent_endpoints);
+            existing
+                .failed_endpoints
+                .append(&mut result.failed_endpoints);
+            if existing.result.is_ok() && result.result.is_err() {
+                existing.result = result.result;
+            }
+        } else {
+            merged.push(result);
+        }
+    }
+    for result in &mut merged {
+        result.accepted_endpoints.sort();
+        result.accepted_endpoints.dedup();
+        result.confirmed_absent_endpoints.sort();
+        result.confirmed_absent_endpoints.dedup();
+        result.failed_endpoints.sort();
+        result.failed_endpoints.dedup();
+        result.failed_endpoints.retain(|endpoint| {
+            !result.accepted_endpoints.contains(endpoint)
+                && !result.confirmed_absent_endpoints.contains(endpoint)
+        });
+        let terminal = result
+            .accepted_endpoints
+            .len()
+            .saturating_add(result.confirmed_absent_endpoints.len());
+        if result.failed_endpoints.is_empty() && terminal > 0 {
+            result.result = Ok(terminal);
+        } else if result.result.is_ok() {
+            result.result = Err(AppError::Publish(
+                "one or more relay key package deletions remain retryable".to_owned(),
+            ));
+        }
+    }
+    merged
 }
 
 #[derive(Default, PartialEq, Eq)]
@@ -935,7 +1224,7 @@ pub enum AccountSetupReadiness {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-struct GeneratedAccountSetupContext {
+pub(crate) struct GeneratedAccountSetupContext {
     default_relays: Vec<String>,
     bootstrap_relays: Vec<String>,
     discovery_relays: Vec<String>,
@@ -943,8 +1232,20 @@ struct GeneratedAccountSetupContext {
     publish_initial_key_package: bool,
 }
 
+struct PreparedGeneratedAccountSetup {
+    result: AccountSetupResult,
+    context: GeneratedAccountSetupContext,
+    admission: AccountSetupAdmission,
+}
+
+#[derive(Clone, Debug)]
+struct ExpectedAccountSetupAdmission {
+    account_id_hex: String,
+    admission: AccountSetupAdmission,
+}
+
 impl GeneratedAccountSetupContext {
-    fn from_request(request: &AccountSetupRequest) -> Self {
+    pub(crate) fn from_request(request: &AccountSetupRequest) -> Self {
         Self {
             default_relays: request
                 .default_relays
@@ -966,7 +1267,7 @@ impl GeneratedAccountSetupContext {
         }
     }
 
-    fn request(&self) -> AccountSetupRequest {
+    pub(crate) fn request(&self) -> AccountSetupRequest {
         AccountSetupRequest {
             identity: None,
             import_nsec: None,
@@ -991,6 +1292,10 @@ impl GeneratedAccountSetupContext {
             publish_missing_relay_lists: self.publish_missing_relay_lists,
             publish_initial_key_package: self.publish_initial_key_package,
         }
+    }
+
+    pub(crate) fn publish_initial_key_package(&self) -> bool {
+        self.publish_initial_key_package
     }
 }
 
@@ -1120,6 +1425,10 @@ impl MarmotAppRuntime {
             initial_directory_sync: Arc::new(Mutex::new(None)),
             #[cfg(test)]
             shutdown_test_hook: Arc::new(StdMutex::new(None)),
+            #[cfg(test)]
+            wipe_before_teardown_test_hook: Arc::new(StdMutex::new(None)),
+            #[cfg(test)]
+            generated_setup_handoff_test_hook: Arc::new(StdMutex::new(None)),
             #[cfg(test)]
             shutdown_grace_wait_for_test: Arc::new(StdMutex::new(
                 APP_RUNTIME_ACCOUNT_SHUTDOWN_WAIT,
@@ -1292,6 +1601,7 @@ impl MarmotAppRuntime {
         let handle = DirectorySyncHandle::spawn(
             self.accounts.app.clone(),
             self.shared.relay_plane().clone(),
+            Some(self.accounts.clone()),
         );
         self.accounts
             .app
@@ -1321,6 +1631,15 @@ impl MarmotAppRuntime {
     /// aggregate per-pass work telemetry (mdk#1380).
     pub async fn catch_up_accounts_reporting(&self) -> Result<CatchUpAccountsSummary, AppError> {
         self.accounts.catch_up_accounts().await
+    }
+
+    /// Sync one selected account through its runtime-owned worker while
+    /// retaining the exact durably applied prefix on failure.
+    pub async fn sync_with_partial_progress(
+        &self,
+        account_ref: &str,
+    ) -> Result<crate::SyncSummary, crate::SyncFailure> {
+        self.accounts.sync_with_partial_progress(account_ref).await
     }
 
     /// Explicitly repair a potentially incomplete incremental history.
@@ -2768,50 +3087,544 @@ impl MarmotAppRuntime {
     async fn delete_relay_key_packages(
         &self,
         account_label: &str,
-        packages: Vec<AccountKeyPackageRecord>,
+        targets: Vec<KeyPackageDeletionTarget>,
+        teardown_barrier: &AccountTeardownBarrier,
     ) -> (u32, Vec<RelayFailure>) {
-        let targets = packages
-            .into_iter()
-            .filter(|package| package.relay)
-            .map(|package| KeyPackageDeletionTarget {
-                event_id_hex: package.key_package_event_id,
-                source_relays: package
-                    .source_relays
-                    .into_iter()
-                    .map(TransportEndpoint)
-                    .collect(),
-            })
-            .collect::<Vec<_>>();
         if targets.is_empty() {
             return (0, Vec::new());
         }
-        let event_ids = targets
-            .iter()
-            .map(|target| target.event_id_hex.clone())
-            .collect::<Vec<_>>();
-        let results = match self
-            .accounts
-            .app
-            .delete_key_package_events(account_label, targets)
-            .await
-        {
-            Ok(results) => results,
+        let cleanup_admission = match teardown_barrier.cleanup_admission() {
+            Ok(admission) => admission.clone(),
             Err(error) => {
                 let reason = wipe_failure_reason(&error);
                 return (
                     0,
-                    event_ids
+                    targets
                         .into_iter()
-                        .map(|event_id_hex| RelayFailure {
-                            event_id_hex,
+                        .map(|target| RelayFailure {
+                            event_id_hex: target.event_id_hex,
                             reason: reason.clone(),
                         })
                         .collect(),
                 );
             }
         };
+        let mut pending = targets;
+        let mut results = Vec::new();
+        loop {
+            let admission = match self
+                .accounts
+                .app
+                .prepare_quiesced_key_package_deletion_recovery(account_label, &pending)
+            {
+                Ok(admission) => admission,
+                Err(error) => {
+                    let reason = wipe_failure_reason(&error);
+                    results.extend(pending.into_iter().map(|target| KeyPackageDeletionResult {
+                        event_id_hex: target.event_id_hex,
+                        accepted_endpoints: Vec::new(),
+                        confirmed_absent_endpoints: Vec::new(),
+                        failed_endpoints: target.source_relays,
+                        result: Err(AppError::Publish(reason.clone())),
+                    }));
+                    break;
+                }
+            };
 
-        relay_failures_from_key_package_deletion_results(results)
+            results.extend(admission.invalid_targets.iter().map(|invalid| {
+                KeyPackageDeletionResult {
+                    event_id_hex: invalid.target.event_id_hex.clone(),
+                    accepted_endpoints: Vec::new(),
+                    confirmed_absent_endpoints: Vec::new(),
+                    failed_endpoints: invalid.target.source_relays.clone(),
+                    result: Err(AppError::Publish(invalid.reason.clone())),
+                }
+            }));
+            results.extend(admission.unsafe_targets.iter().map(|target| {
+                KeyPackageDeletionResult {
+                    event_id_hex: target.event_id_hex.clone(),
+                    accepted_endpoints: Vec::new(),
+                    confirmed_absent_endpoints: Vec::new(),
+                    failed_endpoints: target.source_relays.clone(),
+                    result: Err(AppError::Publish(
+                        "key package deletion endpoint failed safety validation and remains durable"
+                            .to_owned(),
+                    )),
+                }
+            }));
+
+            if admission.admitted.is_empty() {
+                results.extend(admission.deferred.into_iter().map(|target| {
+                    KeyPackageDeletionResult {
+                        event_id_hex: target.event_id_hex,
+                        accepted_endpoints: Vec::new(),
+                        confirmed_absent_endpoints: Vec::new(),
+                        failed_endpoints: target.source_relays,
+                        result: Err(AppError::Publish(
+                            "key package deletion deferred because the durable liability journal is full"
+                                .to_owned(),
+                        )),
+                    }
+                }));
+                break;
+            }
+
+            let admitted_for_failure = admission.admitted.clone();
+            let batch_results = match self
+                .accounts
+                .app
+                .delete_key_package_events(
+                    account_label,
+                    admission.admitted,
+                    crate::AccountSessionAdmission::Teardown(cleanup_admission.clone()),
+                )
+                .await
+            {
+                Ok(results) => results,
+                Err(error) => {
+                    let reason = wipe_failure_reason(&error);
+                    results.extend(admitted_for_failure.into_iter().map(|target| {
+                        KeyPackageDeletionResult {
+                            event_id_hex: target.event_id_hex,
+                            accepted_endpoints: Vec::new(),
+                            confirmed_absent_endpoints: Vec::new(),
+                            failed_endpoints: target.source_relays,
+                            result: Err(AppError::Publish(reason.clone())),
+                        }
+                    }));
+                    results.extend(admission.deferred.into_iter().map(|target| {
+                        KeyPackageDeletionResult {
+                            event_id_hex: target.event_id_hex,
+                            accepted_endpoints: Vec::new(),
+                            confirmed_absent_endpoints: Vec::new(),
+                            failed_endpoints: target.source_relays,
+                            result: Err(AppError::Publish(
+                                "key package deletion remains capacity-deferred".to_owned(),
+                            )),
+                        }
+                    }));
+                    break;
+                }
+            };
+
+            if let Err(error) = self
+                .accounts
+                .app
+                .acknowledge_retired_key_package_deletions(account_label, &batch_results)
+            {
+                let reason = wipe_failure_reason(&error);
+                results.extend(admitted_for_failure.into_iter().map(|target| {
+                    KeyPackageDeletionResult {
+                        event_id_hex: target.event_id_hex,
+                        accepted_endpoints: Vec::new(),
+                        confirmed_absent_endpoints: Vec::new(),
+                        failed_endpoints: target.source_relays,
+                        result: Err(AppError::Publish(reason.clone())),
+                    }
+                }));
+                results.extend(admission.deferred.into_iter().map(|target| {
+                    KeyPackageDeletionResult {
+                        event_id_hex: target.event_id_hex,
+                        accepted_endpoints: Vec::new(),
+                        confirmed_absent_endpoints: Vec::new(),
+                        failed_endpoints: target.source_relays,
+                        result: Err(AppError::Publish(
+                            "key package deletion remains capacity-deferred".to_owned(),
+                        )),
+                    }
+                }));
+                break;
+            }
+
+            results.extend(batch_results);
+            if admission.deferred.is_empty() {
+                break;
+            }
+            // Terminal ACKs were committed above and may have opened journal
+            // capacity. Re-run admission only for previously unjournaled pairs;
+            // no endpoint already attempted in this call is retried here.
+            pending = admission.deferred;
+        }
+
+        relay_failures_from_key_package_deletion_results(merge_key_package_deletion_results(
+            results,
+        ))
+    }
+
+    /// Drain the crash frontier and every same-slot winner revealed by
+    /// teardown's exact deletions while the account worker remains quiesced.
+    /// This intentionally calls only the scan/admit/delete loop: the full open
+    /// maintenance path may author a replacement, which wipe would then need
+    /// to discover and delete again.
+    async fn peel_quiesced_key_package_history(
+        &self,
+        account: &AccountSummary,
+        teardown_barrier: &AccountTeardownBarrier,
+    ) -> Result<(), AppError> {
+        let app = self.accounts.app.clone();
+        let mut client = app
+            .local_teardown_cleanup_client_with_relay_plane(
+                &account.label,
+                &account.account_id_hex,
+                self.shared.relay_plane(),
+                teardown_barrier.cleanup_admission()?,
+            )
+            .await?;
+        client.prepare_teardown_transport().await?;
+        let cleanup_completed = {
+            let route_lock = app.key_package_route_lock(&account.label);
+            let _route_guard = route_lock.lock().await;
+            client
+                .runtime
+                .set_key_package_cutover_publication_blocked(true)?;
+            app.retire_relay_non_current_key_packages_for_teardown(
+                &account.label,
+                &mut client.runtime,
+            )
+            .await
+        };
+        let account_id = MemberId::new(
+            hex::decode(&account.account_id_hex).map_err(|_| AppError::IdentityKeyMismatch)?,
+        );
+        client
+            .adapter
+            .deactivate_account(&account_id)
+            .await
+            .map_err(AppError::from)?;
+        if cleanup_completed {
+            Ok(())
+        } else {
+            Err(AppError::Publish(
+                "relay KeyPackage history peeling remains incomplete".into(),
+            ))
+        }
+    }
+
+    async fn finish_sign_out_after_teardown(
+        &self,
+        account_ref: &str,
+        account: &AccountSummary,
+        options: SignOutOptions,
+        mut outcome: SignOutOutcome,
+        teardown_barrier: AccountTeardownBarrier,
+    ) -> SignOutOutcome {
+        if options.delete_key_packages {
+            let cleanup_armed = match self
+                .accounts
+                .app
+                .mark_key_package_teardown_cleanup_pending(&account.label)
+            {
+                Ok(()) => true,
+                Err(error) => {
+                    outcome.key_package_failures.push(RelayFailure {
+                        event_id_hex: String::new(),
+                        reason: format!(
+                            "key package cleanup could not be armed: {}",
+                            wipe_failure_reason(&error)
+                        ),
+                    });
+                    false
+                }
+            };
+            if cleanup_armed {
+                match self
+                    .accounts
+                    .account_key_packages_for_teardown(account_ref, Vec::new())
+                    .await
+                {
+                    Ok((targets, discovery_error)) => {
+                        let (deleted, failures) = self
+                            .delete_relay_key_packages(&account.label, targets, &teardown_barrier)
+                            .await;
+                        outcome.key_packages_deleted += deleted;
+                        outcome.key_package_failures.extend(failures);
+                        if let Some(error) = discovery_error {
+                            outcome.key_package_failures.push(RelayFailure {
+                                event_id_hex: String::new(),
+                                reason: format!(
+                                    "key package discovery failed: {}",
+                                    wipe_failure_reason(&error)
+                                ),
+                            });
+                        }
+                    }
+                    Err(error) => outcome.key_package_failures.push(RelayFailure {
+                        event_id_hex: String::new(),
+                        reason: format!(
+                            "key package discovery failed: {}",
+                            wipe_failure_reason(&error)
+                        ),
+                    }),
+                }
+                if let Err(error) = self
+                    .peel_quiesced_key_package_history(account, &teardown_barrier)
+                    .await
+                {
+                    outcome.key_package_failures.push(RelayFailure {
+                        event_id_hex: String::new(),
+                        reason: format!(
+                            "key package history cleanup failed: {}",
+                            wipe_failure_reason(&error)
+                        ),
+                    });
+                }
+            }
+        }
+
+        // Discovery may reopen the SQLCipher handle that teardown evicted.
+        // Close it again before the barrier is released.
+        self.accounts.app.drop_account_caches(&account.label);
+        outcome
+    }
+
+    async fn finish_wipe_after_teardown(
+        &self,
+        account_ref: &str,
+        account: &AccountSummary,
+        mut outcome: WipeOutcome,
+        teardown_barrier: AccountTeardownBarrier,
+    ) -> WipeOutcome {
+        let cleanup_armed = match self
+            .accounts
+            .app
+            .mark_key_package_teardown_cleanup_pending(&account.label)
+        {
+            Ok(()) => true,
+            Err(error) => {
+                outcome.key_package_failures.push(RelayFailure {
+                    event_id_hex: String::new(),
+                    reason: format!(
+                        "key package cleanup could not be armed: {}",
+                        wipe_failure_reason(&error)
+                    ),
+                });
+                false
+            }
+        };
+        if cleanup_armed {
+            match self
+                .accounts
+                .account_key_packages_for_teardown(account_ref, Vec::new())
+                .await
+            {
+                Ok((targets, discovery_error)) => {
+                    let (deleted, failures) = self
+                        .delete_relay_key_packages(&account.label, targets, &teardown_barrier)
+                        .await;
+                    outcome.key_packages_deleted += deleted;
+                    outcome.key_package_failures.extend(failures);
+                    if let Some(error) = discovery_error {
+                        outcome.key_package_failures.push(RelayFailure {
+                            event_id_hex: String::new(),
+                            reason: format!(
+                                "key package discovery failed: {}",
+                                wipe_failure_reason(&error)
+                            ),
+                        });
+                    }
+                }
+                Err(error) => outcome.key_package_failures.push(RelayFailure {
+                    event_id_hex: String::new(),
+                    reason: format!(
+                        "key package discovery failed: {}",
+                        wipe_failure_reason(&error)
+                    ),
+                }),
+            }
+        }
+
+        let history_cleanup = if cleanup_armed {
+            self.peel_quiesced_key_package_history(account, &teardown_barrier)
+                .await
+        } else {
+            Err(AppError::Publish(
+                "destructive KeyPackage cleanup was not durably armed".into(),
+            ))
+        };
+        if let Err(error) = &history_cleanup {
+            outcome.key_package_failures.push(RelayFailure {
+                event_id_hex: String::new(),
+                reason: format!(
+                    "key package history cleanup failed: {}",
+                    wipe_failure_reason(error)
+                ),
+            });
+        }
+
+        let cleanup = history_cleanup.and_then(|()| {
+            if outcome.key_package_failures.is_empty() {
+                self.accounts.remove_quiesced_account(account)
+            } else {
+                Err(AppError::Publish(
+                    "relay KeyPackage cleanup is incomplete; local recovery state was retained"
+                        .into(),
+                ))
+            }
+        });
+        match cleanup {
+            Ok(()) => {
+                outcome.local_cleanup = LocalCleanupReport {
+                    completed: true,
+                    reason: None,
+                };
+            }
+            Err(error) => {
+                outcome.local_cleanup = LocalCleanupReport {
+                    completed: false,
+                    reason: Some(wipe_failure_reason(&error)),
+                };
+            }
+        }
+        outcome
+    }
+
+    /// Leave every locally joined group after the managed worker has released
+    /// its exclusive account session.
+    ///
+    /// An admitted wipe must survive both caller cancellation and a concurrent
+    /// runtime shutdown. The global lifecycle latch deliberately stops managed
+    /// workers, so Stage 1 cannot safely depend on a worker sender after the
+    /// wipe has registered. Instead it uses one teardown-owned client without
+    /// lifecycle admission; shutdown keeps account storage and the shared relay
+    /// plane live until the teardown-task guard drains.
+    async fn leave_groups_for_quiesced_wipe(
+        &self,
+        account: &AccountSummary,
+        teardown_barrier: &AccountTeardownBarrier,
+        outcome: &mut WipeOutcome,
+    ) {
+        let groups = match self.accounts.app.groups(&account.label) {
+            Ok(groups) => groups,
+            Err(err) => {
+                outcome.group_leave_failures.push(GroupLeaveFailure {
+                    group_id_hex: String::new(),
+                    reason: format!("group discovery failed: {}", wipe_failure_reason(&err)),
+                });
+                return;
+            }
+        };
+        let groups = groups
+            .into_iter()
+            .filter_map(|group| match hex::decode(&group.group_id_hex) {
+                Ok(bytes) => Some((group.group_id_hex, GroupId::new(bytes))),
+                Err(_) => {
+                    outcome.group_leave_failures.push(GroupLeaveFailure {
+                        group_id_hex: group.group_id_hex,
+                        reason: "invalid group id".to_owned(),
+                    });
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        if groups.is_empty() {
+            return;
+        }
+
+        let cleanup_admission =
+            match teardown_barrier.cleanup_admission() {
+                Ok(admission) => admission,
+                Err(error) => {
+                    let reason = format!(
+                        "quiesced group-leave admission failed: {}",
+                        wipe_failure_reason(&error)
+                    );
+                    outcome.group_leave_failures.extend(groups.into_iter().map(
+                        |(group_id_hex, _)| GroupLeaveFailure {
+                            group_id_hex,
+                            reason: reason.clone(),
+                        },
+                    ));
+                    return;
+                }
+            };
+
+        let mut client =
+            match self
+                .accounts
+                .app
+                .local_teardown_cleanup_client_with_relay_plane(
+                    &account.label,
+                    &account.account_id_hex,
+                    self.shared.relay_plane(),
+                    cleanup_admission,
+                )
+                .await
+            {
+                Ok(client) => client,
+                Err(error) => {
+                    let reason = format!(
+                        "quiesced group-leave client open failed: {}",
+                        wipe_failure_reason(&error)
+                    );
+                    outcome.group_leave_failures.extend(groups.into_iter().map(
+                        |(group_id_hex, _)| GroupLeaveFailure {
+                            group_id_hex,
+                            reason: reason.clone(),
+                        },
+                    ));
+                    return;
+                }
+            };
+        if let Err(error) = client.prepare_teardown_transport().await {
+            let reason = format!(
+                "quiesced group-leave transport activation failed: {}",
+                wipe_failure_reason(&error)
+            );
+            outcome
+                .group_leave_failures
+                .extend(
+                    groups
+                        .into_iter()
+                        .map(|(group_id_hex, _)| GroupLeaveFailure {
+                            group_id_hex,
+                            reason: reason.clone(),
+                        }),
+                );
+            self.deactivate_quiesced_wipe_transport(&client, account, outcome)
+                .await;
+            drop(client);
+            return;
+        }
+
+        for (group_id_hex, group_id) in groups {
+            match client.leave_group_for_teardown(&group_id).await {
+                Ok(_) => outcome.groups_left += 1,
+                Err(err) => outcome.group_leave_failures.push(GroupLeaveFailure {
+                    group_id_hex,
+                    reason: wipe_failure_reason(&err),
+                }),
+            }
+        }
+        self.deactivate_quiesced_wipe_transport(&client, account, outcome)
+            .await;
+        // Release the exclusive account-session guard before KeyPackage
+        // discovery reopens storage and before the removal commit renames it.
+        drop(client);
+    }
+
+    async fn deactivate_quiesced_wipe_transport(
+        &self,
+        client: &crate::AppClient,
+        account: &AccountSummary,
+        outcome: &mut WipeOutcome,
+    ) {
+        match hex::decode(&account.account_id_hex) {
+            Ok(account_id) => {
+                if let Err(error) = client
+                    .adapter
+                    .deactivate_account(&MemberId::new(account_id))
+                    .await
+                {
+                    outcome
+                        .group_leave_failures
+                        .push(GroupLeaveFailure::from_transport_deactivation_error(error));
+                }
+            }
+            Err(_) => outcome.group_leave_failures.push(GroupLeaveFailure {
+                group_id_hex: String::new(),
+                reason: "invalid account id during group-leave transport deactivation".to_owned(),
+            }),
+        }
     }
 
     /// Non-destructive sign-out: deactivate the account on this device and
@@ -2823,16 +3636,18 @@ impl MarmotAppRuntime {
     /// mdk#477 / parent mdk-android#347.
     ///
     /// Steps:
-    /// 1. **Local teardown (always).** Shut the managed account worker down
-    ///    (which deactivates its transport subscriptions) and evict the
-    ///    account's in-memory storage/directory caches. This mirrors what
-    ///    today's logout already does. It does **NOT** call `remove_account`,
+    /// 1. **Local teardown (always).** Persist the signed-out marker, shut the
+    ///    managed account worker down (which deactivates its transport
+    ///    subscriptions), and evict the account's in-memory storage/directory
+    ///    caches. This mirrors what today's logout already does. It does
+    ///    **NOT** call `remove_account`,
     ///    so the SQLCipher session database (MLS state + projections), the
     ///    cached media/source-epoch secrets, the on-disk KeyPackage material,
     ///    the SQL account record, and the secret-store nsec all stay on disk.
     ///    The account remains a live record in the picker and can be
     ///    re-activated with its groups, message history, and drafts intact.
-    /// 2. **KeyPackage hygiene (when `delete_key_packages`).** Enumerate every
+    /// 2. **KeyPackage hygiene (when `delete_key_packages`).** After the worker
+    ///    is fully stopped, enumerate every
     ///    relay-published KeyPackage for this account and publish a kind:5
     ///    deletion to each one's source relays, mirroring the
     ///    [`delete_key_package`](Self::delete_key_package) path. This stops
@@ -2844,13 +3659,19 @@ impl MarmotAppRuntime {
     ///   resume" contract.
     /// - KeyPackage cleanup is best-effort and per-relay: a failure is recorded
     ///   in [`SignOutOutcome::key_package_failures`] and never blocks the local
-    ///   teardown. The runtime does not persist a remote-deletion retry queue.
+    ///   teardown. Superseded exact revisions retain durable endpoint cleanup
+    ///   obligations; any deleted live revision is reauthored on activation.
     /// - A discovery failure (could not enumerate KeyPackages) is recorded as a
     ///   single failure with an empty `event_id_hex`, not silently treated as
     ///   "no KeyPackages".
-    /// - The KeyPackage step runs **before** the worker teardown so it can use
-    ///   the account's live state; neither step depends on a running worker for
-    ///   the publish itself.
+    /// - Worker teardown runs **before** KeyPackage discovery and deletion.
+    ///   This serializes sign-out against managed publication/retry: once a
+    ///   deletion is sent, no worker can re-author or republish a KeyPackage
+    ///   behind it. Discovery and deletion use durable account state directly
+    ///   and do not depend on a running worker. An account-scoped teardown
+    ///   barrier stays live through relay cleanup, so a concurrent explicit
+    ///   sign-in is rejected as retryable busy while unrelated accounts remain
+    ///   free to reconcile.
     /// - The account ref stays valid after this returns (unlike a wipe).
     /// - Every account that can sign — local or external-signer — can sign
     ///   out. Only tracked-only (npub) accounts are rejected.
@@ -2873,60 +3694,68 @@ impl MarmotAppRuntime {
             return Err(AccountHomeError::SecretNotFound(account.account_id_hex).into());
         }
 
-        let mut outcome = SignOutOutcome::default();
-
-        // Step 1 (KeyPackage hygiene): delete every relay-published KeyPackage
-        // before tearing the worker down, while the account is still fully
-        // live. Discovery itself is network-bound; a discovery failure is
-        // recorded as a single failure (no event id) and must not abort the
-        // sign-out. This mirrors stage 2 of `sign_out_and_wipe`.
-        if options.delete_key_packages {
-            match self.account_key_packages(account_ref, Vec::new()).await {
-                Ok(packages) => {
-                    let (deleted, failures) = self
-                        .delete_relay_key_packages(&account.label, packages)
-                        .await;
-                    outcome.key_packages_deleted += deleted;
-                    outcome.key_package_failures.extend(failures);
+        // The spawned task starts before the first teardown await and owns the
+        // whole operation: setup/worker reap, barrier, relay deletion, and
+        // cache closure. Caller cancellation at any boundary cannot truncate
+        // the requested sign-out after admission has closed.
+        let teardown_task = self.accounts.register_account_teardown_task()?;
+        let runtime = self.clone();
+        let account_ref = account_ref.to_owned();
+        tokio::spawn(async move {
+            let _teardown_task = teardown_task;
+            let mut outcome = SignOutOutcome::default();
+            match runtime
+                .accounts
+                .begin_admitted_account_teardown(&account_ref, true)
+                .await
+            {
+                Ok((quiesced_account, teardown_barrier)) => {
+                    outcome.local_cleanup = LocalCleanupReport {
+                        completed: true,
+                        reason: None,
+                    };
+                    runtime
+                        .finish_sign_out_after_teardown(
+                            &account_ref,
+                            &quiesced_account,
+                            options,
+                            outcome,
+                            teardown_barrier,
+                        )
+                        .await
                 }
-                Err(err) => outcome.key_package_failures.push(RelayFailure {
-                    event_id_hex: String::new(),
-                    reason: format!(
-                        "key package discovery failed: {}",
-                        wipe_failure_reason(&err)
-                    ),
-                }),
+                Err(error) => {
+                    outcome.local_cleanup = LocalCleanupReport {
+                        completed: false,
+                        reason: Some(wipe_failure_reason(&error)),
+                    };
+                    if options.delete_key_packages {
+                        outcome.key_package_failures.push(RelayFailure {
+                            event_id_hex: String::new(),
+                            reason:
+                                "key package cleanup skipped because account worker teardown failed"
+                                    .to_owned(),
+                        });
+                    }
+                    outcome
+                }
             }
-        }
-
-        // Step 2 (local teardown): shut the worker down (deactivating its
-        // subscriptions) and drop in-memory caches. Crucially this does NOT
-        // remove the account directory, so all on-disk state survives for a
-        // later sign-in. Teardown is treated as completed whenever it runs; the
-        // rare error path records a privacy-safe reason without aborting.
-        match self.accounts.deactivate_account(account_ref).await {
-            Ok(()) => {
-                outcome.local_cleanup = LocalCleanupReport {
-                    completed: true,
-                    reason: None,
-                };
-            }
-            Err(err) => {
-                outcome.local_cleanup = LocalCleanupReport {
-                    completed: false,
-                    reason: Some(wipe_failure_reason(&err)),
-                };
-            }
-        }
-
-        Ok(outcome)
+        })
+        .await
+        .map_err(|error| AppError::BlockingTask(format!("sign-out cleanup task failed: {error}")))
     }
 
     /// Destructive sign-out: fully remove the account's footprint from this
     /// device and from the relays the engine controls publishing to.
     ///
-    /// Stages run in the order the spec (mdk#478) mandates:
-    /// 1. Best-effort leave for every active MLS group. Failures are collected
+    /// Stages run in the order the spec (mdk#478) mandates, with the managed
+    /// worker quiesced before network cleanup so an admitted wipe can survive
+    /// a concurrent runtime shutdown:
+    /// 1. Quiesce the account: persist signed-out state, tear down the managed
+    ///    worker and wait for it to release its session. This prevents a live
+    ///    worker from racing either group leave or KeyPackage deletion.
+    /// 2. Best-effort leave for every active MLS group through one dedicated,
+    ///    teardown-owned client. Failures are collected
     ///    per group and do not abort the wipe. This MUST happen while MLS state
     ///    still exists — once the session DB is wiped the engine can no longer
     ///    sign leave messages. "Active" here means *locally MLS-joined*, which
@@ -2935,11 +3764,11 @@ impl MarmotAppRuntime {
     ///    pending invite is a real committed membership this device must leave
     ///    (the decline path leaves such groups too). Group-enumeration failures
     ///    are surfaced as a recorded failure rather than silently dropped.
-    /// 2. Best-effort delete of every relay-published KeyPackage event, always
-    ///    (no toggle), mirroring the `delete_key_package` path.
-    /// 3. Local cleanup (stages 3-5 of the spec): tear down the managed worker
-    ///    and in-memory caches, then remove the account directory. In mdk
-    ///    `remove_account` first **atomically renames** the live account
+    /// 3. Delete every relay-published KeyPackage event, always (no toggle),
+    ///    mirroring the `delete_key_package` path. Per-target failures are
+    ///    reported and retain the local recovery state for a later retry.
+    /// 4. Local cleanup (stages 3-5 of the spec): remove the account directory.
+    ///    In mdk `remove_account` first **atomically renames** the live account
     ///    directory out of the active namespace and only then deletes the
     ///    tombstoned bytes (the SQLCipher session database holding MLS state,
     ///    projections, and cached media/source-epoch secrets, the on-disk
@@ -2948,7 +3777,7 @@ impl MarmotAppRuntime {
     ///    just shut down.
     ///
     /// # Invariants
-    /// - Stage 3 (local MLS-DB wipe) is all-or-nothing: `remove_account`
+    /// - Stage 4 (local MLS-DB wipe) is all-or-nothing: `remove_account`
     ///   atomically renames the account directory out of the live namespace as
     ///   its single commit point, so the MLS database is never observably left
     ///   partially wiped — a live account either still fully exists (rename not
@@ -2958,14 +3787,15 @@ impl MarmotAppRuntime {
     ///   bytes later fails.
     /// - After a successful wipe the `account_ref` is no longer valid for any
     ///   further runtime/FFI call.
-    /// - Stages 1 and 2 are network-bound; their per-target failures are
-    ///   surfaced for the app's partial-failure sheet and never block local
-    ///   cleanup.
+    /// - Stages 2 and 3 are network-bound and surface per-target failures for
+    ///   the app's partial-failure sheet. Group-leave failures do not block
+    ///   local cleanup; KeyPackage cleanup failures intentionally do, retaining
+    ///   the signing identity and lifecycle journal needed to retry safely.
     /// - Every account that can sign — local or external-signer — can be
     ///   wiped. Only tracked-only (npub) accounts are rejected. An external
-    ///   signer that is unavailable at wipe time degrades stages 1 and 2 to
-    ///   recorded failures; the local wipe still completes, so a device is
-    ///   never stuck holding an account it cannot remove.
+    ///   signer that is unavailable at wipe time produces recorded network
+    ///   failures and retains local recovery state until relay KeyPackage
+    ///   cleanup can be retried with the signer available.
     pub async fn sign_out_and_wipe(&self, account_ref: &str) -> Result<WipeOutcome, AppError> {
         self.shared.lifecycle().ensure_running()?;
         let account = self.accounts.resolve(account_ref)?;
@@ -2975,99 +3805,100 @@ impl MarmotAppRuntime {
             // from this device, so there is nothing device-side to tear down.
             // External-signer accounts have both and are wiped like local ones;
             // stages 1 and 2 sign through the account's registered external
-            // signer, and an unavailable signer degrades to a recorded
-            // best-effort failure instead of blocking the local wipe. Surface
-            // the same error the worker path uses.
+            // signer. If that signer is unavailable, KeyPackage cleanup keeps
+            // the local recovery state for retry. Surface the same error the
+            // worker path uses.
             return Err(AccountHomeError::SecretNotFound(account.account_id_hex).into());
         }
 
-        let mut outcome = WipeOutcome::default();
-
-        // Stage 1: best-effort leave for every active MLS group. We read the
-        // group set directly from the in-memory account state (no relay round
-        // trip). We attempt the leave for *every* group with local MLS
-        // membership, including ones still marked `pending_confirmation`: in
-        // mdk an incoming Welcome auto-joins MLS state while the app
-        // keeps the invite pending until the user accepts, so a
-        // pending-confirmation group is already a committed MLS member this
-        // device can — and must — leave before its state is wiped (mirroring
-        // `decline_group_invite`, which leaves the group before archiving). If
-        // we skipped them, signing out before accepting an invite would wipe
-        // the local MLS state without ever publishing a leave, and the engine
-        // could never sign one afterwards. A failure to enumerate groups is a
-        // recorded failure, not a silent "no groups" — it must not let the wipe
-        // skip remote leaves without surfacing why.
-        let groups = match self.accounts.app.groups(&account.label) {
-            Ok(groups) => groups,
-            Err(err) => {
-                outcome.group_leave_failures.push(GroupLeaveFailure {
-                    group_id_hex: String::new(),
-                    reason: format!("group discovery failed: {}", wipe_failure_reason(&err)),
-                });
-                Vec::new()
-            }
-        };
-        for group in groups {
-            let group_id_hex = group.group_id_hex.clone();
-            let group_id = match hex::decode(&group_id_hex) {
-                Ok(bytes) => GroupId::new(bytes),
-                Err(_) => {
-                    outcome.group_leave_failures.push(GroupLeaveFailure {
-                        group_id_hex,
-                        reason: "invalid group id".to_owned(),
-                    });
-                    continue;
-                }
+        // Register runtime ownership before the first teardown/network await.
+        // A host/FFI caller can be cancelled while a leave publish is in
+        // flight; the wipe must still quiesce the worker, finish every remaining
+        // leave, clean relays, and reach the durable local-cleanup decision.
+        // Shutdown drains these registered tasks before closing storage or the
+        // relay plane.
+        let teardown_task = self.accounts.register_account_teardown_task()?;
+        let runtime = self.clone();
+        let account_ref = account_ref.to_owned();
+        tokio::spawn(async move {
+            let _teardown_task = teardown_task;
+            let mut outcome = WipeOutcome::default();
+            #[cfg(test)]
+            let wipe_before_teardown_test_hook = {
+                runtime
+                    .wipe_before_teardown_test_hook
+                    .lock()
+                    .expect("wipe pre-teardown test-hook lock poisoned")
+                    .take()
             };
-            match self.leave_group(account_ref, &group_id).await {
-                Ok(_) => outcome.groups_left += 1,
-                Err(err) => outcome.group_leave_failures.push(GroupLeaveFailure {
-                    group_id_hex,
-                    reason: wipe_failure_reason(&err),
-                }),
+            #[cfg(test)]
+            if let Some(hook) = wipe_before_teardown_test_hook {
+                hook.entered.add_permits(1);
+                hook.release
+                    .acquire()
+                    .await
+                    .expect("wipe pre-teardown test-hook release dropped")
+                    .forget();
             }
-        }
-
-        // Stage 2: delete every relay-published KeyPackage. Discovery itself is
-        // network-bound; a discovery failure is recorded as a single failure
-        // (no event id) and must not abort the wipe.
-        match self.account_key_packages(account_ref, Vec::new()).await {
-            Ok(packages) => {
-                let (deleted, failures) = self
-                    .delete_relay_key_packages(&account.label, packages)
-                    .await;
-                outcome.key_packages_deleted += deleted;
-                outcome.key_package_failures.extend(failures);
+            // Stage 1: persist signed-out state and fully stop the worker.
+            // The admitted path intentionally crosses a concurrent shutdown
+            // latch; shutdown is already waiting for this registered task.
+            match runtime
+                .accounts
+                .begin_admitted_account_teardown(&account_ref, true)
+                .await
+            {
+                Ok((quiesced_account, teardown_barrier)) => {
+                    // Stage 2: use the still-live MLS state and relay plane to
+                    // leave every locally joined group. Pending-confirmation
+                    // groups are included because Welcome ingest has already
+                    // committed their MLS membership.
+                    runtime
+                        .leave_groups_for_quiesced_wipe(
+                            &quiesced_account,
+                            &teardown_barrier,
+                            &mut outcome,
+                        )
+                        .await;
+                    runtime
+                        .finish_wipe_after_teardown(
+                            &account_ref,
+                            &quiesced_account,
+                            outcome,
+                            teardown_barrier,
+                        )
+                        .await
+                }
+                Err(error) => {
+                    outcome.key_package_failures.push(RelayFailure {
+                        event_id_hex: String::new(),
+                        reason: format!(
+                            "key package cleanup skipped because account worker teardown failed: {}",
+                            wipe_failure_reason(&error)
+                        ),
+                    });
+                    match runtime.accounts.remove_account(&account_ref).await {
+                        Ok(()) => {
+                            outcome.local_cleanup = LocalCleanupReport {
+                                completed: true,
+                                reason: None,
+                            };
+                        }
+                        Err(error) => {
+                            outcome.local_cleanup = LocalCleanupReport {
+                                completed: false,
+                                reason: Some(wipe_failure_reason(&error)),
+                            };
+                        }
+                    }
+                    outcome
+                }
             }
-            Err(err) => outcome.key_package_failures.push(RelayFailure {
-                event_id_hex: String::new(),
-                reason: format!(
-                    "key package discovery failed: {}",
-                    wipe_failure_reason(&err)
-                ),
-            }),
-        }
-
-        // Stages 3-5: local cleanup. `remove_account` shuts the worker down,
-        // drops in-memory caches, and removes the account directory (MLS DB,
-        // media, KeyPackage material, SQL row) plus the secret-store nsec in a
-        // single all-or-nothing step.
-        match self.accounts.remove_account(account_ref).await {
-            Ok(()) => {
-                outcome.local_cleanup = LocalCleanupReport {
-                    completed: true,
-                    reason: None,
-                };
-            }
-            Err(err) => {
-                outcome.local_cleanup = LocalCleanupReport {
-                    completed: false,
-                    reason: Some(wipe_failure_reason(&err)),
-                };
-            }
-        }
-
-        Ok(outcome)
+        })
+        .await
+        .map_err(|error| {
+            AppError::BlockingTask(format!("account wipe cleanup task failed: {error}"))
+        })
     }
 
     /// Read the selected account's current published kind-0 profile through the
@@ -3391,9 +4222,47 @@ impl MarmotAppRuntime {
         bootstrap_relays: Vec<TransportEndpoint>,
     ) -> Result<AccountRelayListStatus, AppError> {
         let account = self.accounts.resolve(account_ref)?;
+        if relay_type == "nip65" {
+            return self
+                .accounts
+                .publish_nip65_relay_set(&account.label, relays.clone(), relays, bootstrap_relays)
+                .await;
+        }
+        if relay_type != "inbox" {
+            return Err(AppError::RelayDirectory(format!(
+                "unsupported relay list type: {relay_type}"
+            )));
+        }
         self.accounts
-            .app
-            .publish_account_relay_list_kind(&account.label, relay_type, relays, bootstrap_relays)
+            .publish_inbox_relay_list(&account.label, relays, bootstrap_relays)
+            .await
+    }
+
+    /// Publish the account's ordinary NIP-65 and Marmot inbox relay lists.
+    ///
+    /// Both records route through the active account worker. Even the inbox
+    /// record is signed account metadata, so it shares the route-locked session
+    /// proof and cannot publish or recache after sign-out.
+    pub async fn publish_account_relay_lists(
+        &self,
+        account_ref: &str,
+        bootstrap: AccountRelayListBootstrap,
+    ) -> Result<AccountRelayListStatus, AppError> {
+        let account = self.accounts.resolve(account_ref)?;
+        self.accounts
+            .publish_nip65_relay_set(
+                &account.label,
+                bootstrap.default_relays.clone(),
+                bootstrap.default_relays.clone(),
+                bootstrap.bootstrap_relays.clone(),
+            )
+            .await?;
+        self.accounts
+            .publish_inbox_relay_list(
+                &account.label,
+                bootstrap.default_relays,
+                bootstrap.bootstrap_relays,
+            )
             .await
     }
 
@@ -3404,15 +4273,8 @@ impl MarmotAppRuntime {
         write_relays: Vec<TransportEndpoint>,
         bootstrap_relays: Vec<TransportEndpoint>,
     ) -> Result<AccountRelayListStatus, AppError> {
-        let account = self.accounts.resolve(account_ref)?;
         self.accounts
-            .app
-            .publish_account_nip65_relay_set(
-                &account.label,
-                read_relays,
-                write_relays,
-                bootstrap_relays,
-            )
+            .publish_nip65_relay_set(account_ref, read_relays, write_relays, bootstrap_relays)
             .await
     }
 
@@ -3432,10 +4294,8 @@ impl MarmotAppRuntime {
         relays: Vec<TransportEndpoint>,
         bootstrap_relays: Vec<TransportEndpoint>,
     ) -> Result<AccountRelayListStatus, AppError> {
-        let account = self.accounts.resolve(account_ref)?;
         self.accounts
-            .app
-            .set_account_nip65_relays(&account.label, relays, bootstrap_relays)
+            .set_nip65_relays(account_ref, relays, bootstrap_relays)
             .await
     }
 
@@ -3447,8 +4307,7 @@ impl MarmotAppRuntime {
     ) -> Result<AccountRelayListStatus, AppError> {
         let account = self.accounts.resolve(account_ref)?;
         self.accounts
-            .app
-            .set_account_inbox_relays(&account.label, relays, bootstrap_relays)
+            .publish_inbox_relay_list(&account.label, relays, bootstrap_relays)
             .await
     }
 
@@ -3897,8 +4756,7 @@ impl MarmotAppRuntime {
     ) -> Result<AccountSetupResult, AppError> {
         validate_account_setup_request(&request, AccountSetupOperation::CreateIdentityOnly)?;
         request.identity = None;
-        self.create_generated_account_local_ready(request, true)
-            .await
+        self.create_generated_account_local_ready(request).await
     }
 
     pub async fn login(
@@ -3949,7 +4807,8 @@ impl MarmotAppRuntime {
         if request.identity.is_none() && request.import_nsec.is_none() {
             return self.create_generated_account_network_ready(request).await;
         }
-        self.create_or_import_account_network_ready(request).await
+        self.create_or_import_account_network_ready(request, None)
+            .await
     }
 
     pub fn account_setup_readiness(
@@ -4010,7 +4869,7 @@ impl MarmotAppRuntime {
             }
         };
         if let Err(error) = self
-            .create_generated_account_local_ready(context.request(), true)
+            .create_generated_account_local_ready(context.request())
             .await
         {
             self.report_generated_setup_resume_deferred(&account, error.privacy_safe_kind());
@@ -4038,11 +4897,10 @@ impl MarmotAppRuntime {
             }));
     }
 
-    async fn create_generated_account_local_ready(
+    async fn prepare_generated_account_local_ready(
         &self,
         request: AccountSetupRequest,
-        schedule_background: bool,
-    ) -> Result<AccountSetupResult, AppError> {
+    ) -> Result<PreparedGeneratedAccountSetup, AppError> {
         self.shared.lifecycle().ensure_running()?;
         let _generated_setup_transaction =
             self.accounts.generated_setup_local_transaction.lock().await;
@@ -4089,6 +4947,38 @@ impl MarmotAppRuntime {
             identity_result.is_ok(),
         );
         let (account, _) = identity_result?;
+        // Close the record-visible pre-preparation window immediately. On
+        // resume, an already-durable lifecycle plus an absent hold proves that
+        // explicit publication consent won earlier, so this never resurrects
+        // a cleared hold.
+        self.accounts
+            .app
+            .ensure_generated_initial_key_package_publication_hold_before_preparation(
+                &account.label,
+            )?;
+        let admission = {
+            let _worker_transaction = self.accounts.worker_transactions.lock().await;
+            self.shared.lifecycle().ensure_running()?;
+            let current = self
+                .accounts
+                .app
+                .account_home()
+                .account(&account.account_id_hex)
+                .map_err(|error| match error {
+                    AccountHomeError::UnknownAccount(_) => AppError::AccountWorkerBusy,
+                    error => error.into(),
+                })?;
+            let admission = self
+                .accounts
+                .account_setup_admission(&current.account_id_hex)?;
+            // Automatic generated-setup resume is not an explicit sign-in. If
+            // the user signed this incomplete account out, leave it sealed until
+            // they deliberately sign back in through the normal login surface.
+            if admission.started_signed_out {
+                return Err(AppError::AccountWorkerBusy);
+            }
+            admission
+        };
         if self
             .accounts
             .app
@@ -4096,11 +4986,22 @@ impl MarmotAppRuntime {
             .account_setup_context(&account.label)?
             .is_none()
         {
+            let _root_mutation = self
+                .accounts
+                .app
+                .begin_root_mutation("generated account setup context")?;
             self.accounts
                 .app
                 .account_home()
                 .set_account_setup_context(&account.label, &serde_json::to_vec(&context)?)?;
         }
+        let phase = self
+            .accounts
+            .app
+            .account_home()
+            .account_setup_state(&account.label)?
+            .map(|state| state.phase)
+            .ok_or(AppError::AccountSetupRetryRequired)?;
         let storage_started = Instant::now();
         let storage_result = self.accounts.app.account_storage(&account.label);
         self.shared.app_performance_telemetry().record(
@@ -4109,14 +5010,6 @@ impl MarmotAppRuntime {
             storage_result.is_ok(),
         );
         storage_result?;
-        let phase = self
-            .accounts
-            .app
-            .account_home()
-            .account_setup_state(&account.label)?
-            .map(|state| state.phase)
-            .ok_or(AppError::AccountSetupRetryRequired)?;
-
         let profile_started = Instant::now();
         let profile_result = (|| {
             if let Some(profile) = self
@@ -4148,8 +5041,8 @@ impl MarmotAppRuntime {
         let profile = profile_result?;
 
         let key_package_started = Instant::now();
-        let key_package_result = async {
-            if phase == AccountSetupPhase::LocalStateCreated {
+        let key_package_result: Result<usize, AppError> = async {
+            let key_package_bytes = if phase == AccountSetupPhase::LocalStateCreated {
                 let mut client = self
                     .accounts
                     .app
@@ -4164,11 +5057,7 @@ impl MarmotAppRuntime {
                     .await?;
                 let bytes = key_package.bytes().len();
                 drop(client);
-                self.accounts
-                    .app
-                    .account_home()
-                    .set_account_setup_phase(&account.label, AccountSetupPhase::LocalReady)?;
-                Ok(bytes)
+                bytes
             } else {
                 let lifecycle = self
                     .accounts
@@ -4186,8 +5075,58 @@ impl MarmotAppRuntime {
                             .as_ref()
                             .map(|key_package| key_package.bytes().len())
                     })
-                    .ok_or(AppError::AccountSetupRetryRequired)
+                    .ok_or(AppError::AccountSetupRetryRequired)?
+            };
+
+            // Route authority is locally signed and durable before LocalReady,
+            // but no relay I/O occurs here. Worker startup can therefore
+            // recover the exact requested NIP-65 event before publishing the
+            // exact prepared KeyPackage without falling back to app defaults.
+            let route_intent_exists = self
+                .accounts
+                .app
+                .pending_nip65_route_mutation(&account.label);
+            let route_generation_exists = if route_intent_exists {
+                false
+            } else {
+                self.accounts
+                    .app
+                    .read_nip65_route_generation_for_authoring(&account.label)?
+                    .is_some()
+            };
+            if phase == AccountSetupPhase::LocalStateCreated
+                || (!route_intent_exists && !route_generation_exists)
+            {
+                self.accounts
+                    .app
+                    .stage_generated_account_nip65_route_mutation(&account.label, &bootstrap)
+                    .await?;
             }
+            // The lifecycle exists now. Mirror only when the durable hold is
+            // still present, under the same route lock as explicit release;
+            // absence means user consent already won and must not be undone.
+            if phase == AccountSetupPhase::LocalStateCreated {
+                // Mirror precedes the LocalReady phase write. Every resumable
+                // phase therefore already proves this step completed; repeating
+                // it could queue a converging caller behind the first attempt's
+                // route-locked network publication or resurrect cleared
+                // explicit-consent state.
+                self.accounts
+                    .app
+                    .mirror_generated_initial_key_package_publication_hold_into_lifecycle(
+                        &account.label,
+                    )
+                    .await?;
+                let _root_mutation = self
+                    .accounts
+                    .app
+                    .begin_root_mutation("generated account setup phase")?;
+                self.accounts
+                    .app
+                    .account_home()
+                    .set_account_setup_phase(&account.label, AccountSetupPhase::LocalReady)?;
+            }
+            Ok(key_package_bytes)
         }
         .await;
         self.shared.app_performance_telemetry().record(
@@ -4202,48 +5141,77 @@ impl MarmotAppRuntime {
             .app
             .account_relay_list_status(&account.label)?;
         let readiness = self.account_setup_readiness(&account.label)?;
-        if schedule_background {
-            let handoff_started_at = Instant::now();
-            let handoff_result = self.accounts.reconcile().await;
-            self.shared.app_performance_telemetry().record(
-                AppPerformanceOperation::AccountSetupLocalReadyHandoff,
-                handoff_started_at.elapsed(),
-                handoff_result.is_ok(),
-            );
-            handoff_result?;
-            self.schedule_generated_account_setup(account.clone(), context);
-        }
-        Ok(AccountSetupResult {
-            account,
-            relay_lists,
-            key_package_bytes: effective_request
-                .publish_initial_key_package
-                .then_some(key_package_bytes),
-            profile: Some(profile),
-            readiness,
+        Ok(PreparedGeneratedAccountSetup {
+            result: AccountSetupResult {
+                account,
+                relay_lists,
+                key_package_bytes: effective_request
+                    .publish_initial_key_package
+                    .then_some(key_package_bytes),
+                profile: Some(profile),
+                readiness,
+            },
+            context,
+            admission,
         })
+    }
+
+    async fn create_generated_account_local_ready(
+        &self,
+        request: AccountSetupRequest,
+    ) -> Result<AccountSetupResult, AppError> {
+        let prepared = self.prepare_generated_account_local_ready(request).await?;
+        #[cfg(test)]
+        self.stall_generated_setup_handoff_for_test().await;
+
+        let handoff_started_at = Instant::now();
+        let handoff_result = async {
+            // Validation, worker reconciliation, and background-task
+            // registration share teardown's transaction. A sign-out therefore
+            // either supersedes this token before handoff or observes and reaps
+            // the registered task; there is no untracked gap between them.
+            let _worker_transaction = self.accounts.worker_transactions.lock().await;
+            self.shared.lifecycle().ensure_running()?;
+            self.accounts.ensure_expected_setup_admission(
+                &prepared.result.account.account_id_hex,
+                prepared.admission,
+            )?;
+            self.accounts.reconcile_locked().await?;
+            self.schedule_generated_account_setup(
+                prepared.result.account.clone(),
+                prepared.context.clone(),
+                prepared.admission,
+            );
+            Ok::<_, AppError>(())
+        }
+        .await;
+        self.shared.app_performance_telemetry().record(
+            AppPerformanceOperation::AccountSetupLocalReadyHandoff,
+            handoff_started_at.elapsed(),
+            handoff_result.is_ok(),
+        );
+        handoff_result?;
+        Ok(prepared.result)
     }
 
     async fn create_generated_account_network_ready(
         &self,
         request: AccountSetupRequest,
     ) -> Result<AccountSetupResult, AppError> {
-        let local = self
-            .create_generated_account_local_ready(request, false)
-            .await?;
-        let context = self
-            .accounts
-            .app
-            .account_home()
-            .account_setup_context(&local.account.label)?
-            .ok_or(AppError::AccountSetupRetryRequired)
-            .and_then(|bytes| {
-                serde_json::from_slice::<GeneratedAccountSetupContext>(&bytes)
-                    .map_err(AppError::from)
-            })?;
+        let prepared = self.prepare_generated_account_local_ready(request).await?;
+        #[cfg(test)]
+        self.stall_generated_setup_handoff_for_test().await;
+
+        let expected_admission = ExpectedAccountSetupAdmission {
+            account_id_hex: prepared.result.account.account_id_hex.clone(),
+            admission: prepared.admission,
+        };
         let started_at = Instant::now();
         let result = self
-            .create_or_import_account_network_ready(context.request())
+            .create_or_import_account_network_ready(
+                prepared.context.request(),
+                Some(expected_admission),
+            )
             .await;
         self.shared.app_performance_telemetry().record(
             AppPerformanceOperation::AccountSetupNetworkReady,
@@ -4252,7 +5220,7 @@ impl MarmotAppRuntime {
         );
         let mut result = result?;
         if result.profile.is_none() {
-            result.profile = local.profile;
+            result.profile = prepared.result.profile;
         }
         Ok(result)
     }
@@ -4261,14 +5229,20 @@ impl MarmotAppRuntime {
         &self,
         account: AccountSummary,
         context: GeneratedAccountSetupContext,
+        admission: AccountSetupAdmission,
     ) {
         let mut tasks = self
             .accounts
             .generated_setup_tasks
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        tasks.handles.retain(|handle| !handle.is_finished());
-        if !tasks.accepting || !tasks.active_accounts.insert(account.account_id_hex.clone()) {
+        tasks.handles.retain(|_, handle| !handle.is_finished());
+        if !tasks.accepting
+            || tasks.handles.contains_key(&account.account_id_hex)
+            || self
+                .accounts
+                .account_is_tearing_down(&account.account_id_hex)
+        {
             return;
         }
         let manager = self.clone();
@@ -4279,7 +5253,13 @@ impl MarmotAppRuntime {
             for attempt in 0..GENERATED_SETUP_BACKGROUND_MAX_ATTEMPTS {
                 let started_at = Instant::now();
                 let result = manager
-                    .create_or_import_account_network_ready(context.request())
+                    .create_or_import_account_network_ready(
+                        context.request(),
+                        Some(ExpectedAccountSetupAdmission {
+                            account_id_hex: account_id_hex.clone(),
+                            admission,
+                        }),
+                    )
                     .await;
                 manager.shared.app_performance_telemetry().record(
                     AppPerformanceOperation::AccountSetupNetworkReady,
@@ -4321,17 +5301,20 @@ impl MarmotAppRuntime {
             active
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .active_accounts
+                .handles
                 .remove(&account_id_hex);
         });
-        tasks.handles.push(handle);
+        tasks.handles.insert(account.account_id_hex, handle);
     }
 
     async fn create_or_import_account_network_ready(
         &self,
         request: AccountSetupRequest,
+        expected_admission: Option<ExpectedAccountSetupAdmission>,
     ) -> Result<AccountSetupResult, AppError> {
-        self.accounts.create_or_import_account(request).await
+        self.accounts
+            .create_or_import_account_with_admission(request, expected_admission)
+            .await
     }
 
     pub async fn reset_incomplete_account_setup(
@@ -4381,6 +5364,41 @@ impl MarmotAppRuntime {
             release: release.clone(),
         });
         ShutdownTestStall { entered, release }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn install_generated_setup_handoff_stall_for_test(
+        &self,
+    ) -> GeneratedSetupHandoffTestStall {
+        let entered = Arc::new(Semaphore::new(0));
+        let release = Arc::new(Semaphore::new(0));
+        *self
+            .generated_setup_handoff_test_hook
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) =
+            Some(GeneratedSetupHandoffTestHook {
+                entered: entered.clone(),
+                release: release.clone(),
+            });
+        GeneratedSetupHandoffTestStall { entered, release }
+    }
+
+    #[cfg(test)]
+    async fn stall_generated_setup_handoff_for_test(&self) {
+        let hook = self
+            .generated_setup_handoff_test_hook
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        let Some(hook) = hook else {
+            return;
+        };
+        hook.entered.add_permits(1);
+        hook.release
+            .acquire()
+            .await
+            .expect("generated-setup handoff test-hook release dropped")
+            .forget();
     }
 
     #[cfg(test)]
@@ -4440,19 +5458,17 @@ impl MarmotAppRuntime {
             let _ = initial_directory_sync.await;
         }
         self.accounts.app.set_directory_sync_handle(None);
-        let accounts = async {
-            #[cfg(test)]
-            self.stall_shutdown_phase_for_test(ShutdownTestPhase::AccountWorkers)
-                .await;
-            self.accounts.shutdown().await;
-        };
-        let relay_plane = async {
-            #[cfg(test)]
-            self.stall_shutdown_phase_for_test(ShutdownTestPhase::RelayPlane)
-                .await;
-            self.shared.relay_plane.shutdown().await;
-        };
-        tokio::join!(accounts, relay_plane);
+        #[cfg(test)]
+        self.stall_shutdown_phase_for_test(ShutdownTestPhase::AccountWorkers)
+            .await;
+        // Account shutdown drains every admitted sign-out/wipe operation.
+        // Keep the relay plane alive until their kind-5 requests and durable
+        // acknowledgements have settled.
+        self.accounts.shutdown().await;
+        #[cfg(test)]
+        self.stall_shutdown_phase_for_test(ShutdownTestPhase::RelayPlane)
+            .await;
+        self.shared.relay_plane.shutdown().await;
         #[cfg(test)]
         self.stall_shutdown_phase_for_test(ShutdownTestPhase::AuditTracker)
             .await;
@@ -4490,10 +5506,12 @@ impl MarmotAppRuntime {
     /// Group container).
     ///
     /// Ordering is the point of this method: the lifecycle stop latch closes
-    /// admission first, then storage closure takes priority over graceful
-    /// draining. This is deliberately different from [`Self::shutdown`]. A
-    /// host suspension deadline cannot safely sit behind directory, worker,
-    /// relay, or audit cleanup that may be awaiting network or task progress.
+    /// admission first. Already-admitted sign-out/wipe work gets the same
+    /// bounded graceful budget as the rest of shutdown, but a stalled relay or
+    /// group leave can never postpone storage closure past that budget. After
+    /// the budget expires, storage closure takes priority over every graceful
+    /// operation. This is deliberately different from [`Self::shutdown`]. A
+    /// host suspension deadline cannot safely sit behind network cleanup.
     /// SQLite completes the statement holding a connection guard and rolls an
     /// uncommitted transaction back on close; later work sees `Closed` and
     /// cannot reopen storage.
@@ -4508,9 +5526,12 @@ impl MarmotAppRuntime {
     /// Safe to call twice, safe to call concurrently, and safe to call with or
     /// without a preceding [`Self::shutdown`]. The terminal operation runs in a
     /// runtime-owned task, so cancelling the caller (including a host-side FFI
-    /// future) cannot cancel storage closure. Graceful draining is bounded by
-    /// `APP_RUNTIME_ACCOUNT_SHUTDOWN_WAIT`; the close itself waits only for an
-    /// already-admitted database open or SQLite statement.
+    /// future) cannot cancel storage closure. All graceful draining, including
+    /// admitted teardown, shares `APP_RUNTIME_ACCOUNT_SHUTDOWN_WAIT`; the close
+    /// itself waits only for an already-admitted database open or SQLite
+    /// statement. Graceful cleanup that exceeds the host-facing budget remains
+    /// runtime-owned and continues after this method returns, against the
+    /// already-closed storage graph.
     pub async fn shutdown_and_close(&self) -> Result<(), AppError> {
         let runtime = self.clone();
         tokio::spawn(async move { runtime.run_terminal_shutdown_and_close().await })
@@ -4522,6 +5543,29 @@ impl MarmotAppRuntime {
 
     async fn run_terminal_shutdown_and_close(self) -> Result<(), AppError> {
         self.shared.lifecycle().begin_shutdown();
+        let graceful_wait = self.shutdown_grace_wait();
+        let graceful_started_at = Instant::now();
+        // Give caller-independent teardown a bounded chance to settle while
+        // storage and the relay plane remain live. The task-count cap controls
+        // memory only; this timeout is the load-bearing suspension bound when a
+        // relay or group leave never completes.
+        self.accounts.close_teardown_admission();
+        // Generated setup owns AccountHome phase/context/rollback commits, not
+        // just SQL work. Reap it before the root lease can transfer; teardown
+        // tasks are cancellation-independent and instead use bounded root
+        // mutation admission at their final local commits.
+        self.accounts.abort_generated_setup_tasks().await;
+        if timeout(graceful_wait, self.accounts.drain_teardown_tasks())
+            .await
+            .is_err()
+        {
+            tracing::warn!(
+                target: "marmot_app::runtime",
+                method = "shutdown_and_close",
+                graceful_wait_ms = graceful_wait.as_millis() as u64,
+                "account teardown exceeded the terminal shutdown budget; closing storage",
+            );
+        }
         #[cfg(test)]
         self.stall_shutdown_phase_for_test(ShutdownTestPhase::StorageClose)
             .await;
@@ -4532,14 +5576,27 @@ impl MarmotAppRuntime {
         let app = self.accounts.app.clone();
         let close_result = blocking_app_task(move || app.close_storage()).await;
 
-        let graceful_wait = self.shutdown_grace_wait();
-        if timeout(graceful_wait, self.shutdown()).await.is_err() {
-            tracing::warn!(
+        let remaining_grace = graceful_wait.saturating_sub(graceful_started_at.elapsed());
+        // The wait is bounded, but the cleanup is runtime-owned. Timing out
+        // this JoinHandle detaches it instead of cancelling `shutdown`, so
+        // relay/audit/worker cleanup can still finish after storage and the
+        // root lease have met the host's suspension deadline.
+        let runtime = self.clone();
+        let graceful_shutdown = tokio::spawn(async move { runtime.shutdown().await });
+        match timeout(remaining_grace, graceful_shutdown).await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => tracing::warn!(
                 target: "marmot_app::runtime",
                 method = "shutdown_and_close",
-                graceful_wait_ms = graceful_wait.as_millis() as u64,
-                "graceful runtime shutdown exceeded its budget after storage was closed",
-            );
+                error_kind = if error.is_panic() { "panic" } else { "cancelled" },
+                "runtime-owned graceful shutdown task failed after storage close",
+            ),
+            Err(_) => tracing::warn!(
+                target: "marmot_app::runtime",
+                method = "shutdown_and_close",
+                graceful_wait_ms = remaining_grace.as_millis() as u64,
+                "graceful runtime shutdown exceeded its budget after storage was closed and remains detached",
+            ),
         }
         close_result
     }
@@ -4566,12 +5623,15 @@ impl AccountManager {
         events: broadcast::Sender<MarmotAppEvent>,
         shared: RuntimeSharedServices,
     ) -> Self {
+        let (teardown_task_activity, _) = watch::channel(0);
         Self {
             app,
             events,
             shared,
             workers: Arc::new(Mutex::new(HashMap::new())),
             tearing_down: Arc::new(StdMutex::new(HashSet::new())),
+            next_setup_admission_generation: Arc::new(AtomicU64::new(0)),
+            setup_admission_generations: Arc::new(StdMutex::new(HashMap::new())),
             worker_transactions: Arc::new(Mutex::new(())),
             generated_setup_local_transaction: Arc::new(Mutex::new(())),
             #[cfg(test)]
@@ -4582,9 +5642,13 @@ impl AccountManager {
             })),
             generated_setup_tasks: Arc::new(StdMutex::new(GeneratedSetupTasks {
                 accepting: true,
-                active_accounts: HashSet::new(),
-                handles: Vec::new(),
+                handles: HashMap::new(),
             })),
+            teardown_tasks: Arc::new(StdMutex::new(AccountTeardownTasks {
+                accepting: true,
+                active: 0,
+            })),
+            teardown_task_activity,
         }
     }
 
@@ -4607,16 +5671,11 @@ impl AccountManager {
         }
     }
 
-    fn set_account_tearing_down(&self, account_id_hex: &str, tearing_down: bool) {
-        let mut accounts = self
-            .tearing_down
+    fn try_begin_account_teardown(&self, account_id_hex: &str) -> bool {
+        self.tearing_down
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if tearing_down {
-            accounts.insert(account_id_hex.to_owned());
-        } else {
-            accounts.remove(account_id_hex);
-        }
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(account_id_hex.to_owned())
     }
 
     fn account_is_tearing_down(&self, account_id_hex: &str) -> bool {
@@ -4624,6 +5683,188 @@ impl AccountManager {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .contains(account_id_hex)
+    }
+
+    fn register_account_teardown_task(&self) -> Result<AccountTeardownTaskGuard, AppError> {
+        {
+            let mut tasks = self
+                .teardown_tasks
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if !tasks.accepting {
+                return Err(AppError::RuntimeStopping);
+            }
+            if tasks.active >= ACCOUNT_TEARDOWN_TASK_LIMIT {
+                return Err(AppError::AccountWorkerBusy);
+            }
+            tasks.active = tasks.active.saturating_add(1);
+            self.teardown_task_activity.send_replace(tasks.active);
+        }
+        Ok(AccountTeardownTaskGuard {
+            tasks: self.teardown_tasks.clone(),
+            activity: self.teardown_task_activity.clone(),
+        })
+    }
+
+    fn close_teardown_admission(&self) {
+        {
+            let mut tasks = self
+                .teardown_tasks
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            tasks.accepting = false;
+            self.teardown_task_activity.send_replace(tasks.active);
+        }
+    }
+
+    async fn drain_teardown_tasks(&self) {
+        let mut activity = self.teardown_task_activity.subscribe();
+        while *activity.borrow_and_update() != 0 {
+            if activity.changed().await.is_err() {
+                break;
+            }
+        }
+    }
+
+    async fn abort_generated_setup_tasks(&self) {
+        let generated_setup_tasks = {
+            let mut tasks = self
+                .generated_setup_tasks
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            tasks.accepting = false;
+            std::mem::take(&mut tasks.handles)
+                .into_values()
+                .collect::<Vec<_>>()
+        };
+        for task in generated_setup_tasks {
+            task.abort();
+            let _ = task.await;
+        }
+    }
+
+    fn next_setup_admission_generation(&self) -> u64 {
+        self.next_setup_admission_generation
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |generation| {
+                Some(generation.saturating_add(1))
+            })
+            .expect("setup admission generation update must not be rejected")
+            .saturating_add(1)
+    }
+
+    fn setup_admission_generation(&self, account_id_hex: &str) -> u64 {
+        let mut generations = self
+            .setup_admission_generations
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *generations
+            .entry(account_id_hex.to_owned())
+            .or_insert_with(|| self.next_setup_admission_generation())
+    }
+
+    fn advance_setup_admission_generation(&self, account_id_hex: &str) {
+        let generation = self.next_setup_admission_generation();
+        self.setup_admission_generations
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(account_id_hex.to_owned(), generation);
+    }
+
+    fn local_account_for_account_id(
+        &self,
+        account_id_hex: &str,
+    ) -> Result<Option<AccountSummary>, AppError> {
+        Ok(self
+            .app
+            .account_home()
+            .accounts()?
+            .into_iter()
+            .find(|account| account.account_id_hex == account_id_hex))
+    }
+
+    fn forget_setup_admission_generation(&self, account_id_hex: &str) {
+        self.setup_admission_generations
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(account_id_hex);
+    }
+
+    /// Snapshot setup admission while `worker_transactions` excludes teardown.
+    fn account_setup_admission(
+        &self,
+        account_id_hex: &str,
+    ) -> Result<AccountSetupAdmission, AppError> {
+        if self.account_is_tearing_down(account_id_hex) {
+            return Err(AppError::AccountWorkerBusy);
+        }
+        let started_signed_out = self
+            .local_account_for_account_id(account_id_hex)?
+            .is_some_and(|account| account.signed_out);
+        Ok(AccountSetupAdmission {
+            generation: self.setup_admission_generation(account_id_hex),
+            started_signed_out,
+        })
+    }
+
+    fn setup_admission_is_current(
+        &self,
+        account_id_hex: &str,
+        admission: AccountSetupAdmission,
+    ) -> bool {
+        !self.account_is_tearing_down(account_id_hex)
+            && self.setup_admission_generation(account_id_hex) == admission.generation
+    }
+
+    /// Validate a previously admitted setup while `worker_transactions`
+    /// excludes teardown. A signed-out transition that began after admission is
+    /// stale work, not permission to treat the old caller as an explicit login.
+    fn ensure_expected_setup_admission(
+        &self,
+        account_id_hex: &str,
+        admission: AccountSetupAdmission,
+    ) -> Result<AccountSummary, AppError> {
+        if !self.setup_admission_is_current(account_id_hex, admission) {
+            return Err(AppError::AccountWorkerBusy);
+        }
+        let current = self
+            .local_account_for_account_id(account_id_hex)?
+            .ok_or(AppError::AccountWorkerBusy)?;
+        if current.signed_out && !admission.started_signed_out {
+            return Err(AppError::AccountWorkerBusy);
+        }
+        Ok(current)
+    }
+
+    fn account_setup_publication_admission(
+        &self,
+        account_id_hex: &str,
+        admission: AccountSetupAdmission,
+    ) -> Result<AccountSetupPublicationAdmission, AppError> {
+        self.ensure_expected_setup_admission(account_id_hex, admission)?;
+        Ok(AccountSetupPublicationAdmission {
+            account_id_hex: account_id_hex.to_owned(),
+            generation: admission.generation,
+            started_signed_out: admission.started_signed_out,
+            setup_admission_generations: self.setup_admission_generations.clone(),
+            tearing_down: self.tearing_down.clone(),
+        })
+    }
+
+    async fn shutdown_generated_setup_for_account(&self, account_id_hex: &str) {
+        let task = self
+            .generated_setup_tasks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .handles
+            .remove(account_id_hex);
+        if let Some(task) = task {
+            task.abort();
+            // Reaping is the teardown boundary: a cancelled setup future may
+            // already have cleared signed-out state or entered reconcile.
+            // Await its destructors before persisting the marker and removing
+            // the worker so none of that work can escape behind relay cleanup.
+            let _ = task.await;
+        }
     }
 
     async fn shutdown_workers_for_account_ids(&self, account_ids: &[String]) {
@@ -4677,36 +5918,190 @@ impl AccountManager {
         self.shared.schedule_audit_log_tracker_update(trigger);
     }
 
-    pub async fn remove_account(&self, account_ref: &str) -> Result<(), AppError> {
-        let _worker_transaction = self.worker_transactions.lock().await;
-        self.shared.lifecycle().ensure_running()?;
+    async fn begin_account_teardown(
+        &self,
+        account_ref: &str,
+        persist_signed_out: bool,
+    ) -> Result<(AccountSummary, AccountTeardownBarrier), AppError> {
+        self.begin_account_teardown_inner(account_ref, persist_signed_out, true)
+            .await
+    }
+
+    /// Complete a sign-out/wipe that registered before shutdown closed task
+    /// admission. Runtime shutdown waits for this operation, so it may cross
+    /// the lifecycle stop latch without admitting any new external work.
+    async fn begin_admitted_account_teardown(
+        &self,
+        account_ref: &str,
+        persist_signed_out: bool,
+    ) -> Result<(AccountSummary, AccountTeardownBarrier), AppError> {
+        self.begin_account_teardown_inner(account_ref, persist_signed_out, false)
+            .await
+    }
+
+    async fn begin_account_teardown_inner(
+        &self,
+        account_ref: &str,
+        persist_signed_out: bool,
+        require_running: bool,
+    ) -> Result<(AccountSummary, AccountTeardownBarrier), AppError> {
+        if require_running {
+            self.shared.lifecycle().ensure_running()?;
+        }
         let account = self.app.account_home().account(account_ref)?;
-        self.set_account_tearing_down(&account.account_id_hex, true);
-        let result = async {
-            let worker = self.workers.lock().await.remove(&account.account_id_hex);
+        if !self.try_begin_account_teardown(&account.account_id_hex) {
+            return Err(AppError::AccountWorkerBusy);
+        }
+        // This is the process-local linearization point for every session
+        // capability, including an unabortable open that has not registered
+        // its adapter yet. It must happen before the first await; sign-in may
+        // later open a distinct generation, but can never revive this one.
+        self.app
+            .close_account_session_admission(&account.label, &account.account_id_hex);
+        self.advance_setup_admission_generation(&account.account_id_hex);
+        let mut barrier = AccountTeardownBarrier {
+            account_label: account.label.clone(),
+            account_id_hex: account.account_id_hex.clone(),
+            app: self.app.clone(),
+            cleanup_admission: None,
+            tearing_down: self.tearing_down.clone(),
+        };
+        let manager = self.clone();
+        let teardown = tokio::spawn(async move {
+            // The account-scoped barrier moved into this runtime-owned task
+            // before the first await. If the host cancels sign-out while the
+            // worker transaction or either child task is being reaped,
+            // dropping this JoinHandle detaches the teardown instead of
+            // reopening worker/setup admission prematurely.
+            let worker_transaction = manager.worker_transactions.clone().lock_owned().await;
+            let _worker_transaction = worker_transaction;
+            manager
+                .shutdown_generated_setup_for_account(&account.account_id_hex)
+                .await;
+            let worker = manager.workers.lock().await.remove(&account.account_id_hex);
             if let Some(worker) = worker {
                 worker.shutdown().await;
             }
-            // Evict every in-memory handle and warm flag for this label BEFORE
-            // the account directory is deleted. Otherwise the cached account
-            // storage connection (and directory cache) keeps pointing at the
-            // unlinked inode and a later re-import silently splits writes
-            // across a stale handle.
-            self.app.drop_account_caches(&account.label);
-            self.app
-                .remove_account_key_package_artifacts(&account.label)?;
-            self.app.account_home().remove_account(&account.label)?;
-            // The account no longer exists on this device, so the host callback
-            // handle it registered must not outlive it. This runs only after
-            // the removal commit point: a removal that failed leaves the
-            // account live, and a live external-signer account still needs its
-            // signer to reconcile.
-            self.app.forget_external_signer(&account.account_id_hex);
-            Ok(())
-        }
-        .await;
-        self.set_account_tearing_down(&account.account_id_hex, false);
-        result
+
+            // A setup admitted before the first close may have been queued on
+            // `worker_transactions` and attempted to reopen ordinary session
+            // admission while teardown waited to acquire the transaction.
+            // Re-close after every setup/worker task is reaped, then mint the
+            // distinct teardown-only capability used by relay cleanup.
+            manager
+                .app
+                .close_account_session_admission(&account.label, &account.account_id_hex);
+            barrier.cleanup_admission = Some(manager.app.open_account_teardown_session_admission(
+                &account.label,
+                &account.account_id_hex,
+            )?);
+
+            // The managed worker has been reaped and worker admission remains
+            // closed by `_worker_transaction`. Linearize the durable teardown
+            // boundary with every direct AppClient's final kind-30443 send:
+            // an in-flight publisher finishes before this marker, while any
+            // queued or future publisher observes the marker under the same
+            // route lock and fails before reopening account storage or doing
+            // relay I/O. Destructive removal uses the signed-out bit as an
+            // interim publication fence until the account directory is
+            // atomically renamed out of the live namespace.
+            let route_lock = manager.app.key_package_route_lock(&account.label);
+            {
+                let _route_guard = route_lock.lock().await;
+                let live_account = manager.app.account_home().account(&account.label)?;
+                if live_account.account_id_hex != account.account_id_hex
+                    || live_account.can_sign() != account.can_sign()
+                {
+                    return Err(AppError::IdentityKeyMismatch);
+                }
+                // Tracked-only npub records cannot sign or publish a
+                // KeyPackage, and AccountHome intentionally rejects a
+                // signed-out marker for them. They still pass through the
+                // route barrier, but need no durable publication fence.
+                if account.can_sign() {
+                    let _root_mutation =
+                        manager.app.begin_root_mutation(if persist_signed_out {
+                            "account signed-out marker"
+                        } else {
+                            "account removal publication fence"
+                        })?;
+                    manager
+                        .app
+                        .account_home()
+                        .set_account_signed_out(&account.label, true)?;
+                }
+            }
+            let account_id = MemberId::new(
+                hex::decode(&account.account_id_hex).map_err(|_| AppError::IdentityKeyMismatch)?,
+            );
+            if let Some(adapter) = manager.app.account_session_adapter(&account.label)
+                && adapter.deactivate_account(&account_id).await.is_err()
+            {
+                tracing::warn!(
+                    target: "marmot_app::runtime",
+                    method = "begin_account_teardown",
+                    "standalone account-session relay deactivation failed after local teardown",
+                );
+            }
+            if manager
+                .shared
+                .relay_plane()
+                .deactivate_account(&account_id)
+                .await
+                .is_err()
+            {
+                tracing::warn!(
+                    target: "marmot_app::runtime",
+                    method = "begin_account_teardown",
+                    "relay-side account unsubscribe failed after local teardown deactivation",
+                );
+            }
+            manager.app.drop_account_caches(&account.label);
+            Ok::<_, AppError>((account, barrier))
+        });
+
+        teardown.await.map_err(|error| {
+            AppError::BlockingTask(format!(
+                "account teardown task {}",
+                if error.is_cancelled() {
+                    "was cancelled"
+                } else {
+                    "failed"
+                }
+            ))
+        })?
+    }
+
+    fn remove_quiesced_account(&self, account: &AccountSummary) -> Result<(), AppError> {
+        let _root_mutation = self.app.begin_root_mutation("account removal")?;
+        // Commit the immutable local stable-slot retirement before deleting
+        // either the compatibility record that can recover that slot or the
+        // AccountHome directory that owns its private MLS material. Failure to
+        // publish this marker aborts destructive removal.
+        self.app
+            .persist_removed_local_key_package_tombstone(account)?;
+        // Evict every in-memory handle and warm flag for this label BEFORE the
+        // account directory is deleted. Otherwise the cached account storage
+        // connection (and directory cache) keeps pointing at the unlinked
+        // inode and a later re-import silently splits writes across a stale
+        // handle.
+        self.app.drop_account_caches(&account.label);
+        self.app
+            .remove_account_key_package_artifacts(&account.label)?;
+        self.app.account_home().remove_account(&account.label)?;
+        self.forget_setup_admission_generation(&account.account_id_hex);
+        // The account no longer exists on this device, so the host callback
+        // handle it registered must not outlive it. This runs only after the
+        // removal commit point: a removal that failed leaves the account live,
+        // and a live external-signer account still needs its signer to
+        // reconcile.
+        self.app.forget_external_signer(&account.account_id_hex);
+        Ok(())
+    }
+
+    pub async fn remove_account(&self, account_ref: &str) -> Result<(), AppError> {
+        let (account, _barrier) = self.begin_account_teardown(account_ref, false).await?;
+        self.remove_quiesced_account(&account)
     }
 
     /// Explicit recovery for an account created before durable setup journals.
@@ -4722,7 +6117,7 @@ impl AccountManager {
         nsec: &str,
         acknowledge_possible_key_package_orphan: bool,
     ) -> Result<(), AppError> {
-        let _worker_transaction = self.worker_transactions.lock().await;
+        let worker_transaction = self.worker_transactions.clone().lock_owned().await;
         self.shared.lifecycle().ensure_running()?;
         if !acknowledge_possible_key_package_orphan {
             return Err(AppError::AccountSetupRecoveryRequired);
@@ -4762,22 +6157,55 @@ impl AccountManager {
             return Err(AppError::AccountSetupKeyPackageRecoveryAvailable);
         }
 
-        self.set_account_tearing_down(&account.account_id_hex, true);
-        let result = async {
-            if let Some(worker) = self.workers.lock().await.remove(&account.account_id_hex) {
+        if !self.try_begin_account_teardown(&account.account_id_hex) {
+            return Err(AppError::AccountWorkerBusy);
+        }
+        self.app
+            .close_account_session_admission(&account.label, &account.account_id_hex);
+        self.advance_setup_admission_generation(&account.account_id_hex);
+        let barrier = AccountTeardownBarrier {
+            account_label: account.label.clone(),
+            account_id_hex: account.account_id_hex.clone(),
+            app: self.app.clone(),
+            cleanup_admission: None,
+            tearing_down: self.tearing_down.clone(),
+        };
+        let manager = self.clone();
+        let reset = tokio::spawn(async move {
+            let _worker_transaction = worker_transaction;
+            let _barrier = barrier;
+            manager
+                .shutdown_generated_setup_for_account(&account.account_id_hex)
+                .await;
+            if let Some(worker) = manager.workers.lock().await.remove(&account.account_id_hex) {
                 worker.shutdown().await;
             }
-            self.app.drop_account_caches(&account.label);
-            self.app
+            manager
+                .app
+                .close_account_session_admission(&account.label, &account.account_id_hex);
+            let _root_mutation = manager
+                .app
+                .begin_root_mutation("incomplete account setup reset")?;
+            manager.app.drop_account_caches(&account.label);
+            manager
+                .app
                 .remove_account_key_package_artifacts(&account.label)?;
-            self.app
+            manager
+                .app
                 .account_home()
                 .reset_incomplete_setup_preserving_credential(&account.label)?;
-            Ok(())
-        }
-        .await;
-        self.set_account_tearing_down(&account.account_id_hex, false);
-        result
+            Ok::<_, AppError>(())
+        });
+        reset.await.map_err(|error| {
+            AppError::BlockingTask(format!(
+                "account setup reset task {}",
+                if error.is_cancelled() {
+                    "was cancelled"
+                } else {
+                    "failed"
+                }
+            ))
+        })?
     }
 
     /// Non-destructive deactivation of an account on this device: persist a
@@ -4798,24 +6226,8 @@ impl AccountManager {
     /// Dropping the in-memory caches is harmless when the directory is kept: a
     /// later sign-in simply re-warms them from the unchanged on-disk database.
     pub async fn deactivate_account(&self, account_ref: &str) -> Result<(), AppError> {
-        let _worker_transaction = self.worker_transactions.lock().await;
-        self.shared.lifecycle().ensure_running()?;
-        let account = self.app.account_home().account(account_ref)?;
-        self.set_account_tearing_down(&account.account_id_hex, true);
-        let result = async {
-            self.app
-                .account_home()
-                .set_account_signed_out(&account.label, true)?;
-            let worker = self.workers.lock().await.remove(&account.account_id_hex);
-            if let Some(worker) = worker {
-                worker.shutdown().await;
-            }
-            self.app.drop_account_caches(&account.label);
-            Ok(())
-        }
-        .await;
-        self.set_account_tearing_down(&account.account_id_hex, false);
-        result
+        let (_account, _barrier) = self.begin_account_teardown(account_ref, true).await?;
+        Ok(())
     }
 
     async fn restore_signed_out_after_key_package_failure(&self, account_ref: &str) {
@@ -4829,15 +6241,223 @@ impl AccountManager {
         }
     }
 
+    fn rollback_account_session_reactivation(
+        &self,
+        account: &AccountSummary,
+    ) -> Result<(), AppError> {
+        // Close the process-local capability before the durable rollback. A
+        // queued final publisher therefore fails closed even if persisting the
+        // marker itself encounters an error.
+        self.app
+            .close_account_session_admission(&account.label, &account.account_id_hex);
+        let _root_mutation = self
+            .app
+            .begin_root_mutation("account session reactivation rollback")?;
+        self.app
+            .account_home()
+            .set_account_signed_out(&account.label, true)?;
+        Ok(())
+    }
+
+    async fn reactivate_account_for_setup(
+        &self,
+        account: &AccountSummary,
+        admission: AccountSetupAdmission,
+    ) -> Result<AccountSummary, AppError> {
+        let _worker_transaction = self.worker_transactions.lock().await;
+        self.shared.lifecycle().ensure_running()?;
+        if !self.setup_admission_is_current(&account.account_id_hex, admission) {
+            return Err(AppError::AccountWorkerBusy);
+        }
+        let current = self.app.account_home().account(&account.label)?;
+        if current.signed_out && !admission.started_signed_out {
+            return Err(AppError::AccountWorkerBusy);
+        }
+        let opened_from_signed_out = current.signed_out;
+        let reactivated = if current.signed_out {
+            let _root_mutation = self.app.begin_root_mutation("account setup reactivation")?;
+            self.app
+                .account_home()
+                .set_account_signed_out(&account.label, false)?
+        } else {
+            current
+        };
+        if opened_from_signed_out
+            && let Err(error) = self
+                .app
+                .open_account_session_admission(&reactivated.label, &reactivated.account_id_hex)
+        {
+            self.rollback_account_session_reactivation(&reactivated)?;
+            return Err(error);
+        }
+        Ok(reactivated)
+    }
+
+    /// Linearize setup completion against account teardown.
+    ///
+    /// A teardown that starts anywhere after setup admission advances a
+    /// process-wide generation. Even after its active marker has cleared, that
+    /// generation prevents an older foreground setup from reactivating an
+    /// account or returning a false `NetworkReady` result. Conservatively,
+    /// teardown of one account also supersedes in-flight setup for another.
+    async fn complete_account_setup_if_admitted(
+        &self,
+        account: &AccountSummary,
+        admission: AccountSetupAdmission,
+    ) -> Result<AccountSummary, AppError> {
+        let _worker_transaction = self.worker_transactions.lock().await;
+        self.shared.lifecycle().ensure_running()?;
+        if !self.setup_admission_is_current(&account.account_id_hex, admission) {
+            return Err(AppError::AccountWorkerBusy);
+        }
+
+        let mut current = self.app.account_home().account(&account.label)?;
+        let mut opened_session_admission = false;
+        if current.signed_out {
+            if !admission.started_signed_out {
+                return Err(AppError::AccountWorkerBusy);
+            }
+            current = {
+                let _root_mutation = self
+                    .app
+                    .begin_root_mutation("account setup signed-out marker")?;
+                self.app
+                    .account_home()
+                    .set_account_signed_out(&account.label, false)?
+            };
+            if let Err(error) = self
+                .app
+                .open_account_session_admission(&current.label, &current.account_id_hex)
+            {
+                self.rollback_account_session_reactivation(&current)?;
+                return Err(error);
+            }
+            opened_session_admission = true;
+        }
+        if let Err(error) = self.reconcile_locked().await {
+            if admission.started_signed_out || opened_session_admission {
+                self.rollback_account_session_reactivation(&current)?;
+            }
+            return Err(error);
+        }
+        let clear_cutover_replacement = self
+            .app
+            .key_package_cutover_has_fresh_account_proof(&current.label)
+            && self
+                .app
+                .account_storage(&current.label)?
+                .key_package_lifecycle()?
+                .as_ref()
+                .is_some_and(|lifecycle| {
+                    self.app.key_package_lifecycle_has_current_cutover_revision(
+                        &current.label,
+                        lifecycle,
+                    )
+                });
+        if current.can_sign()
+            && !self
+                .workers
+                .lock()
+                .await
+                .contains_key(&current.account_id_hex)
+        {
+            return Err(AppError::AccountWorkerBusy);
+        }
+
+        // Setup relay publishers validate their generation only after taking
+        // this route lock. Drain any publisher that already crossed that
+        // boundary, then consume this generation while still holding the lock
+        // so a sibling setup cannot publish after NetworkReady completes.
+        let route_lock = self.app.key_package_route_lock(&current.label);
+        let _route_guard = route_lock.lock().await;
+        let tearing_down = self
+            .tearing_down
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut setup_admission_generations = self
+            .setup_admission_generations
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if tearing_down.contains(&current.account_id_hex)
+            || setup_admission_generations.get(&current.account_id_hex)
+                != Some(&admission.generation)
+        {
+            return Err(AppError::AccountWorkerBusy);
+        }
+        current = self.app.account_home().account(&current.label)?;
+        if current.account_id_hex != account.account_id_hex
+            || (current.signed_out && !admission.started_signed_out)
+        {
+            return Err(AppError::AccountWorkerBusy);
+        }
+        {
+            let _root_mutation = self.app.begin_root_mutation("account setup completion")?;
+            if clear_cutover_replacement {
+                // A generated identity persists its no-prior-publication proof
+                // before the first session opens. Once setup has an acknowledged
+                // current signed revision, no upgrade replacement remains to be
+                // scheduled; exact predecessor liabilities created by any retry
+                // reauthoring stay independently durable in the lifecycle journal.
+                self.app
+                    .clear_key_package_cutover_replacement_pending(&current.label)?;
+            }
+            self.app
+                .account_home()
+                .complete_account_setup(&current.label)?;
+        }
+        setup_admission_generations.insert(
+            current.account_id_hex.clone(),
+            self.next_setup_admission_generation(),
+        );
+        drop(setup_admission_generations);
+        drop(tearing_down);
+        current = self.app.account_home().account(&current.label)?;
+        Ok(current)
+    }
+
     /// Explicitly re-activate a reversibly signed-out local account.
     pub async fn sign_in_account(&self, account_ref: &str) -> Result<ManagedAccount, AppError> {
         let _worker_transaction = self.worker_transactions.lock().await;
         self.shared.lifecycle().ensure_running()?;
-        let account = self
-            .app
-            .account_home()
-            .set_account_signed_out(account_ref, false)?;
-        self.reconcile_locked().await?;
+        let current = self.app.account_home().account(account_ref)?;
+        if self.account_is_tearing_down(&current.account_id_hex) {
+            // Sign-out keeps this account-scoped marker through relay cleanup.
+            // Reject rather than queue an explicit sign-in that could publish a
+            // replacement KeyPackage immediately after deletion completes.
+            return Err(AppError::AccountWorkerBusy);
+        }
+        let reactivation_required = current.signed_out
+            || !self
+                .app
+                .account_session_admission_is_open(&current.label, &current.account_id_hex);
+        if reactivation_required {
+            // Invalidate quiesced/setup-owned relay publishers before changing
+            // the durable signed-out bit. A failed sign-in may restore that bit,
+            // but must never revive a pre-sign-in publication capability (ABA).
+            self.advance_setup_admission_generation(&current.account_id_hex);
+        }
+        let account = if current.signed_out {
+            let _root_mutation = self.app.begin_root_mutation("account sign-in marker")?;
+            self.app
+                .account_home()
+                .set_account_signed_out(account_ref, false)?
+        } else {
+            current
+        };
+        if reactivation_required
+            && let Err(error) = self
+                .app
+                .open_account_session_admission(&account.label, &account.account_id_hex)
+        {
+            self.rollback_account_session_reactivation(&account)?;
+            return Err(error);
+        }
+        if let Err(error) = self.reconcile_locked().await {
+            if reactivation_required {
+                self.rollback_account_session_reactivation(&account)?;
+            }
+            return Err(error);
+        }
         let running = self
             .workers
             .lock()
@@ -5186,16 +6806,219 @@ impl AccountManager {
             .await
     }
 
+    /// Collect teardown obligations without letting a directory outage discard
+    /// exact event ids and relay targets already owned by durable lifecycle
+    /// state. Remote discovery remains additive and its failure stays visible
+    /// to the caller.
+    async fn account_key_packages_for_teardown(
+        &self,
+        account_ref: &str,
+        bootstrap_relays: Vec<TransportEndpoint>,
+    ) -> Result<(Vec<KeyPackageDeletionTarget>, Option<AppError>), AppError> {
+        let account = self.resolve(account_ref)?;
+        let owned = cgka_engine::key_package::durably_owned_key_packages(
+            &self.app.account_storage(&account.label)?,
+            cgka_traits::group::ProtocolProfile::Current,
+        )
+        .map_err(cgka_session::SessionError::from)?;
+        let local = self
+            .app
+            .local_key_package_records(&account.label, owned.clone())?;
+        let mut durable_targets = key_package_deletion_targets(local);
+        durable_targets.extend(
+            self.app
+                .durable_key_package_deletion_targets(&account.label)?,
+        );
+        match self
+            .app
+            .account_key_package_records(&account.label, bootstrap_relays, owned)
+            .await
+        {
+            Ok(records) => {
+                durable_targets.extend(key_package_deletion_targets(records));
+                Ok((merge_key_package_deletion_targets(durable_targets), None))
+            }
+            Err(error) => Ok((
+                merge_key_package_deletion_targets(durable_targets),
+                Some(error),
+            )),
+        }
+    }
+
     pub async fn delete_key_package(
         &self,
         account_ref: &str,
         event_id_hex: &str,
         relays: Vec<TransportEndpoint>,
     ) -> Result<usize, AppError> {
-        let account = self.resolve(account_ref)?;
-        self.app
-            .delete_key_package_event(&account.label, event_id_hex, relays)
+        let event_id_hex =
+            crate::key_package_records::parse_key_package_event_id_hex(event_id_hex)?;
+        let event_id = cgka_traits::MessageId::new(
+            hex::decode(&event_id_hex)
+                .map_err(|_| AppError::Publish("invalid key package event id".to_owned()))?,
+        );
+
+        // The account worker serializes intent persistence, network I/O, and
+        // endpoint-level receipt commit. Queue admission itself is not durable:
+        // dropping this caller normally leaves the live worker to continue,
+        // but a concurrent runtime stop may win the worker's biased shutdown
+        // branch before it dequeues the command. Cancellation safety begins
+        // when `delete_key_package_revision_durably` records the exact durable
+        // liability, before its first relay side effect. A caller cancelled
+        // before receiving the response may retry this idempotent operation.
+        let command = self.worker_commands(account_ref).await?;
+        let (respond, response) = oneshot::channel();
+        command
+            .send(AccountWorkerCommand::DeleteKeyPackageRevision {
+                event_id,
+                endpoints: relays,
+                respond,
+            })
             .await
+            .map_err(|_| AppError::TransportClosed)?;
+        account_worker_response(response).await
+    }
+
+    async fn publish_nip65_relay_set(
+        &self,
+        account_ref: &str,
+        read_relays: Vec<TransportEndpoint>,
+        write_relays: Vec<TransportEndpoint>,
+        bootstrap_relays: Vec<TransportEndpoint>,
+    ) -> Result<AccountRelayListStatus, AppError> {
+        let account = self.resolve(account_ref)?;
+        let command = self.worker_commands(&account.label).await?;
+        let (respond, response) = oneshot::channel();
+        command
+            .send(AccountWorkerCommand::PublishNip65RelaySet {
+                read_relays,
+                write_relays,
+                bootstrap_relays,
+                respond,
+            })
+            .await
+            .map_err(|_| AppError::TransportClosed)?;
+        account_worker_response(response).await
+    }
+
+    async fn set_nip65_relays(
+        &self,
+        account_ref: &str,
+        relays: Vec<TransportEndpoint>,
+        bootstrap_relays: Vec<TransportEndpoint>,
+    ) -> Result<AccountRelayListStatus, AppError> {
+        let command = self.worker_commands(account_ref).await?;
+        let (respond, response) = oneshot::channel();
+        command
+            .send(AccountWorkerCommand::SetNip65Relays {
+                relays,
+                bootstrap_relays,
+                respond,
+            })
+            .await
+            .map_err(|_| AppError::TransportClosed)?;
+        account_worker_response(response).await
+    }
+
+    async fn publish_inbox_relay_list(
+        &self,
+        account_ref: &str,
+        relays: Vec<TransportEndpoint>,
+        bootstrap_relays: Vec<TransportEndpoint>,
+    ) -> Result<AccountRelayListStatus, AppError> {
+        let command = self.worker_commands(account_ref).await?;
+        let (respond, response) = oneshot::channel();
+        command
+            .send(AccountWorkerCommand::PublishInboxRelayList {
+                relays,
+                bootstrap_relays,
+                respond,
+            })
+            .await
+            .map_err(|_| AppError::TransportClosed)?;
+        account_worker_response(response).await
+    }
+
+    /// Install an exact setup-discovered self kind-10002 without allowing a
+    /// session to open before its durable intent and SQL publication gate.
+    ///
+    /// A normal new import has no worker yet and takes the short quiesced app
+    /// path under `worker_transactions`. A resumed setup may already have a
+    /// worker; in that case use its route-serialized command lane, then recheck
+    /// setup admission before the caller can advance toward KeyPackage I/O.
+    async fn install_setup_nip65_authority(
+        &self,
+        account_id_hex: &str,
+        admission: AccountSetupAdmission,
+        record: crate::relay_plane::DirectoryRelayEventRecord,
+    ) -> Result<AccountRelayListStatus, AppError> {
+        let worker_commands = {
+            let _worker_transaction = self.worker_transactions.lock().await;
+            self.shared.lifecycle().ensure_running()?;
+            let account = self.ensure_expected_setup_admission(account_id_hex, admission)?;
+            if !account.can_sign() {
+                return Err(AccountHomeError::SecretNotFound(account.account_id_hex).into());
+            }
+            let worker_commands = self
+                .workers
+                .lock()
+                .await
+                .get(account_id_hex)
+                .map(|worker| worker.commands.clone());
+            if worker_commands.is_none() {
+                // No worker can appear while the transaction is held. Once
+                // the route lock is acquired, ingest performs only synchronous
+                // durable mutations, so caller cancellation cannot split the
+                // intent/gate/generation commit.
+                return self
+                    .app
+                    .ingest_local_nip65_relay_event_serialized(&account.label, record)
+                    .await;
+            }
+            worker_commands
+        }
+        .expect("running setup worker command sender was checked above");
+
+        let (respond, response) = oneshot::channel();
+        worker_commands
+            .send(AccountWorkerCommand::IngestSelfNip65RelayEvent { record, respond })
+            .await
+            .map_err(|_| AppError::TransportClosed)?;
+        let status = account_worker_response(response).await?;
+        {
+            let _worker_transaction = self.worker_transactions.lock().await;
+            self.shared.lifecycle().ensure_running()?;
+            self.ensure_expected_setup_admission(account_id_hex, admission)?;
+        }
+        Ok(status)
+    }
+
+    pub(crate) async fn ingest_directory_relay_event(
+        &self,
+        record: crate::relay_plane::DirectoryRelayEventRecord,
+    ) -> Result<(), AppError> {
+        if record.event.kind == crate::KIND_NIP65_RELAY_LIST
+            && let Some(label) = self.app.local_account_label_for_id(&record.event.pubkey)
+        {
+            let account = self.resolve(&label)?;
+            if account.signed_out {
+                // Directory sync is observation, not setup admission. A late
+                // self event must not reopen signed-out account storage or
+                // install new routing authority after teardown; setup uses the
+                // capability-bearing install_setup_nip65_authority path.
+                return Ok(());
+            }
+            let command = self.worker_commands(&label).await?;
+            let (respond, response) = oneshot::channel();
+            command
+                .send(AccountWorkerCommand::IngestSelfNip65RelayEvent { record, respond })
+                .await
+                .map_err(|_| AppError::TransportClosed)?;
+            account_worker_response(response).await?;
+            return Ok(());
+        }
+        let app = self.app.clone();
+        blocking_app_task(move || app.ingest_directory_relay_event(record)).await
     }
 
     async fn worker_commands(
@@ -5226,30 +7049,111 @@ impl AccountManager {
         &self,
         request: AccountSetupRequest,
     ) -> Result<AccountSetupResult, AppError> {
+        self.create_or_import_account_with_admission(request, None)
+            .await
+    }
+
+    async fn create_or_import_account_with_admission(
+        &self,
+        request: AccountSetupRequest,
+        expected_admission: Option<ExpectedAccountSetupAdmission>,
+    ) -> Result<AccountSetupResult, AppError> {
         self.shared.lifecycle().ensure_running()?;
         validate_account_setup_request(&request, AccountSetupOperation::CreateOrImport)?;
         let imports_private_key = request.import_nsec.is_some();
         let creates_new_private_key = request.identity.is_none() && request.import_nsec.is_none();
         let directory_bootstrap_relays = directory_bootstrap_relays_for_setup(&request);
-        if let Some(nsec) = request.import_nsec.as_deref()
-            && self.legacy_incomplete_account_for_import(nsec)?
-        {
-            return Err(AppError::AccountSetupRecoveryRequired);
-        }
-        let identity_key: Option<&str> = request
-            .import_nsec
-            .as_ref()
-            .map(|value| value.as_str())
-            .or(request.identity.as_deref());
-        let (mut account, private_key_import) = if let Some(identity) = identity_key {
-            match self.signed_out_account_for_identity(identity)? {
-                Some(account) => (account, None),
-                None => self.create_nostr_account_from_setup(&request)?,
-            }
-        } else {
-            self.create_nostr_account_from_setup(&request)?
+        // The request field, not the key's textual encoding, determines how
+        // setup resolves its account id. `AccountHome` accepts compatible
+        // secret formats such as hex in addition to NIP-19 `nsec`; treating a
+        // hex secret as a public identity would bind teardown admission to the
+        // wrong account before the actual import derives its public key.
+        let known_account_id = match request.import_nsec.as_deref() {
+            Some(secret) => Some(AccountHome::account_id_for_secret(secret)?),
+            None => request
+                .identity
+                .as_deref()
+                .map(AccountHome::account_id_for_public_key)
+                .transpose()?,
         };
-        let reactivating_existing = account.signed_out;
+        let (mut account, private_key_import, admission) = {
+            let _worker_transaction = self.worker_transactions.lock().await;
+            self.shared.lifecycle().ensure_running()?;
+            if let Some(nsec) = request.import_nsec.as_deref()
+                && self.legacy_incomplete_account_for_import(nsec)?
+            {
+                return Err(AppError::AccountSetupRecoveryRequired);
+            }
+            let (account, private_key_import, admission) = if let Some(expected) =
+                expected_admission.as_ref()
+            {
+                if known_account_id
+                    .as_deref()
+                    .is_some_and(|account_id| account_id != expected.account_id_hex)
+                {
+                    return Err(AppError::AccountWorkerBusy);
+                }
+                let account = self.ensure_expected_setup_admission(
+                    &expected.account_id_hex,
+                    expected.admission,
+                )?;
+                (account, None, expected.admission)
+            } else {
+                let known_admission = known_account_id
+                    .as_deref()
+                    .map(|account_id| self.account_setup_admission(account_id))
+                    .transpose()?;
+                let (account, private_key_import) = if let Some(account_id) = &known_account_id {
+                    match self.signed_out_local_account_for_account_id(account_id)? {
+                        Some(account) => (account, None),
+                        None => self.create_nostr_account_from_setup(&request)?,
+                    }
+                } else {
+                    self.create_nostr_account_from_setup(&request)?
+                };
+                let admission = match known_admission {
+                    Some(admission) => admission,
+                    None => self.account_setup_admission(&account.account_id_hex)?,
+                };
+                (account, private_key_import, admission)
+            };
+            let account =
+                self.ensure_expected_setup_admission(&account.account_id_hex, admission)?;
+            // A credential-preserving incomplete-setup reset leaves the
+            // previous identity's process-local gate closed. This setup owns a
+            // current admission under `worker_transactions`, so it may open a
+            // fresh generation before its worker/session is reconciled.
+            if !account.signed_out
+                && !self
+                    .app
+                    .account_session_admission_is_open(&account.label, &account.account_id_hex)
+            {
+                self.app
+                    .open_account_session_admission(&account.label, &account.account_id_hex)?;
+            }
+            (account, private_key_import, admission)
+        };
+        let reactivating_existing = admission.started_signed_out;
+        let directory_discovery_relays = directory_discovery_relays_for_setup(&request);
+        let binds_existing_signing_authority =
+            account.can_sign() && (imports_private_key || reactivating_existing);
+        if binds_existing_signing_authority
+            && let Err(err) = self
+                .establish_setup_nip65_authority(&account, admission, &directory_discovery_relays)
+                .await
+        {
+            if self.setup_failure_can_roll_back(&account, admission, reactivating_existing)? {
+                return self
+                    .rollback_import_after_setup_failure(
+                        &account,
+                        private_key_import.as_ref(),
+                        admission,
+                        err,
+                    )
+                    .await;
+            }
+            return Err(err);
+        }
         let recent_relay_lists =
             if imports_private_key || reactivating_existing || !account.local_signing {
                 // Resolve a pre-existing identity's profile from public indexers, not
@@ -5264,7 +7168,7 @@ impl AccountManager {
                     "import_directory_preflight",
                     self.preflight_existing_account_directory(
                         &account.account_id_hex,
-                        directory_discovery_relays_for_setup(&request),
+                        directory_discovery_relays,
                     ),
                 )
                 .await
@@ -5272,20 +7176,52 @@ impl AccountManager {
             } else {
                 None
             };
+        let recent_relay_lists = if binds_existing_signing_authority {
+            match self.bind_setup_relay_lists_to_nip65_authority(&account.label, recent_relay_lists)
+            {
+                Ok(status) => Some(status),
+                Err(err) => {
+                    if self.setup_failure_can_roll_back(
+                        &account,
+                        admission,
+                        reactivating_existing,
+                    )? {
+                        return self
+                            .rollback_import_after_setup_failure(
+                                &account,
+                                private_key_import.as_ref(),
+                                admission,
+                                err,
+                            )
+                            .await;
+                    }
+                    return Err(err);
+                }
+            }
+        } else {
+            recent_relay_lists
+        };
 
         let (relay_lists, profile) = if creates_new_private_key && account.local_signing {
             match self
-                .setup_generated_account_bootstrap(&account, &request)
+                .setup_generated_account_bootstrap(&account, &request, admission)
                 .await
             {
                 Ok(result) => result,
                 Err(err) => {
-                    if self.setup_failure_can_roll_back(&account, reactivating_existing)? {
-                        return self.rollback_import_after_setup_failure(
-                            &account,
-                            private_key_import.as_ref(),
-                            err,
-                        );
+                    if self.setup_failure_can_roll_back(
+                        &account,
+                        admission,
+                        reactivating_existing,
+                    )? {
+                        return self
+                            .rollback_import_after_setup_failure(
+                                &account,
+                                private_key_import.as_ref(),
+                                admission,
+                                err,
+                            )
+                            .await;
                     }
                     // Once the helper records publication intent, a relay may
                     // hold one replaceable bootstrap record. Retain the
@@ -5298,6 +7234,7 @@ impl AccountManager {
                 .setup_relay_lists_for_account(
                     &account,
                     &request,
+                    admission,
                     imports_private_key,
                     creates_new_private_key,
                     recent_relay_lists,
@@ -5306,12 +7243,19 @@ impl AccountManager {
             {
                 Ok(relay_lists) => relay_lists,
                 Err(err) => {
-                    if self.setup_failure_can_roll_back(&account, reactivating_existing)? {
-                        return self.rollback_import_after_setup_failure(
-                            &account,
-                            private_key_import.as_ref(),
-                            err,
-                        );
+                    if self.setup_failure_can_roll_back(
+                        &account,
+                        admission,
+                        reactivating_existing,
+                    )? {
+                        return self
+                            .rollback_import_after_setup_failure(
+                                &account,
+                                private_key_import.as_ref(),
+                                admission,
+                                err,
+                            )
+                            .await;
                     }
                     return Err(err);
                 }
@@ -5335,31 +7279,46 @@ impl AccountManager {
                 Some(bytes)
             } else {
                 self.shared.lifecycle().ensure_running()?;
-                if setup_phase.is_some()
-                    && let Err(err) = self.app.account_home().set_account_setup_phase(
-                        &account.label,
-                        AccountSetupPhase::KeyPackagePublicationStarted,
-                    )
-                {
-                    if self.setup_failure_can_roll_back(&account, reactivating_existing)? {
-                        return self.rollback_import_after_setup_failure(
+                if setup_phase.is_some() {
+                    let phase_result = {
+                        let _root_mutation = self
+                            .app
+                            .begin_root_mutation("account KeyPackage setup start")?;
+                        self.app.account_home().set_account_setup_phase(
+                            &account.label,
+                            AccountSetupPhase::KeyPackagePublicationStarted,
+                        )
+                    };
+                    if let Err(err) = phase_result {
+                        if self.setup_failure_can_roll_back(
                             &account,
-                            private_key_import.as_ref(),
-                            err.into(),
-                        );
+                            admission,
+                            reactivating_existing,
+                        )? {
+                            return self
+                                .rollback_import_after_setup_failure(
+                                    &account,
+                                    private_key_import.as_ref(),
+                                    admission,
+                                    err.into(),
+                                )
+                                .await;
+                        }
+                        return Err(err.into());
                     }
-                    return Err(err.into());
                 }
                 if account.signed_out {
                     account = self
-                        .app
-                        .account_home()
-                        .set_account_signed_out(&account.label, false)?;
+                        .reactivate_account_for_setup(&account, admission)
+                        .await?;
                 }
                 let publication = self.publish_initial_key_package_for_account(&account).await;
                 match publication {
                     Ok(bytes) => {
                         if setup_phase.is_some() {
+                            let _root_mutation = self
+                                .app
+                                .begin_root_mutation("account KeyPackage setup confirmation")?;
                             self.app.account_home().set_account_setup_phase(
                                 &account.label,
                                 AccountSetupPhase::KeyPackagePublicationConfirmed,
@@ -5368,14 +7327,17 @@ impl AccountManager {
                         Some(bytes)
                     }
                     Err(err) => {
-                        // Publication-started state plus the SQLCipher lifecycle
-                        // is sufficient to retry safely after any ordinary error
-                        // or task cancellation. Never delete possibly exposed
-                        // exact bytes/private material here.
+                        // Publication-started state plus the SQLCipher
+                        // lifecycle is sufficient to retry safely after any
+                        // ordinary error or task cancellation. Never delete
+                        // possibly exposed lifecycle/private material here;
+                        // retries remain exact within the current signed
+                        // revision, while bounded-age policy may first persist
+                        // a newer revision at the same coordinate.
                         // A reactivation has no setup journal, so restore its
                         // durable signed-out state and stop the just-started
-                        // worker. The same nsec can then resume this exact
-                        // lifecycle attempt instead of failing AccountExists.
+                        // worker. The same nsec can then resume this durable
+                        // lifecycle instead of failing AccountExists.
                         if reactivating_existing {
                             self.restore_signed_out_after_key_package_failure(&account.label)
                                 .await;
@@ -5404,16 +7366,9 @@ impl AccountManager {
             )
             .await;
         }
-        if account.signed_out {
-            account = self
-                .app
-                .account_home()
-                .set_account_signed_out(&account.label, false)?;
-        }
-        self.reconcile().await?;
-        self.app
-            .account_home()
-            .complete_account_setup(&account.label)?;
+        account = self
+            .complete_account_setup_if_admitted(&account, admission)
+            .await?;
 
         Ok(AccountSetupResult {
             account,
@@ -5461,30 +7416,47 @@ impl AccountManager {
         if signer_public_key.to_hex() != account_id_hex {
             return Err(AppError::ExternalSignerMismatch);
         }
-        let existing_account = self.app.account_home().account(&account_id_hex).ok();
-        let created_account = existing_account.is_none();
-        // add_external_signer_account below promotes a pre-existing tracked
-        // (public) account to external_signing, so a later setup failure must
-        // revert that promotion — not skip cleanup and leave a torn account.
-        // Created accounts are deleted, already-external accounts are left as-is.
-        let upgraded_public_account = existing_account
-            .is_some_and(|account| !account.external_signing && !account.local_signing);
-        let mut account = self
-            .app
-            .account_home()
-            .add_external_signer_account(&public_key)?;
-        let reactivating_existing = account.signed_out;
+        let (mut account, created_account, upgraded_public_account, admission) = {
+            let _worker_transaction = self.worker_transactions.lock().await;
+            self.shared.lifecycle().ensure_running()?;
+            let admission = self.account_setup_admission(&account_id_hex)?;
+            let existing_account = match self.app.account_home().account(&account_id_hex) {
+                Ok(account) => Some(account),
+                Err(AccountHomeError::UnknownAccount(_)) => None,
+                Err(error) => return Err(error.into()),
+            };
+            let created_account = existing_account.is_none();
+            // add_external_signer_account below promotes a pre-existing tracked
+            // (public) account to external_signing, so a later setup failure must
+            // revert that promotion — not skip cleanup and leave a torn account.
+            // Created accounts are deleted, already-external accounts are left as-is.
+            let upgraded_public_account = existing_account
+                .is_some_and(|account| !account.external_signing && !account.local_signing);
+            let account = {
+                let _root_mutation = self
+                    .app
+                    .begin_root_mutation("external signer account registration")?;
+                self.app
+                    .account_home()
+                    .add_external_signer_account(&public_key)?
+            };
+            (account, created_account, upgraded_public_account, admission)
+        };
+        let reactivating_existing = admission.started_signed_out;
         if let Err(err) = self
             .app
             .register_external_signer(&account.account_id_hex, signer)
             .await
         {
-            return self.rollback_external_signer_setup(
-                &account.label,
-                created_account,
-                upgraded_public_account,
-                err,
-            );
+            return self
+                .rollback_external_signer_setup(
+                    &account,
+                    created_account,
+                    upgraded_public_account,
+                    admission,
+                    err,
+                )
+                .await;
         }
         if self
             .app
@@ -5492,6 +7464,9 @@ impl AccountManager {
             .account_setup_state(&account.label)?
             .is_none()
         {
+            let _root_mutation = self
+                .app
+                .begin_root_mutation("external signer setup journal")?;
             self.app.account_home().begin_account_setup_with(
                 &account,
                 false,
@@ -5500,6 +7475,24 @@ impl AccountManager {
             )?;
         }
         let directory_bootstrap_relays = directory_bootstrap_relays_for_setup(&request);
+        let directory_discovery_relays = directory_discovery_relays_for_setup(&request);
+        if let Err(err) = self
+            .establish_setup_nip65_authority(&account, admission, &directory_discovery_relays)
+            .await
+        {
+            if !self.setup_failure_can_roll_back(&account, admission, reactivating_existing)? {
+                return Err(err);
+            }
+            return self
+                .rollback_external_signer_setup(
+                    &account,
+                    created_account,
+                    upgraded_public_account,
+                    admission,
+                    err,
+                )
+                .await;
+        }
         // An external-signer account is pre-existing by definition, so resolve
         // its profile from public indexers (its outbox metadata does not live on
         // the app's messaging relays). Runs before the relay-list setup so
@@ -5512,43 +7505,79 @@ impl AccountManager {
             "login_directory_preflight",
             self.preflight_existing_account_directory(
                 &account.account_id_hex,
-                directory_discovery_relays_for_setup(&request),
+                directory_discovery_relays,
             ),
         )
         .await
         .flatten();
+        let recent_relay_lists = match self
+            .bind_setup_relay_lists_to_nip65_authority(&account.label, recent_relay_lists)
+        {
+            Ok(status) => Some(status),
+            Err(err) => {
+                if !self.setup_failure_can_roll_back(&account, admission, reactivating_existing)? {
+                    return Err(err);
+                }
+                return self
+                    .rollback_external_signer_setup(
+                        &account,
+                        created_account,
+                        upgraded_public_account,
+                        admission,
+                        err,
+                    )
+                    .await;
+            }
+        };
 
         let relay_lists = match self
-            .setup_relay_lists_for_account(&account, &request, true, false, recent_relay_lists)
+            .setup_relay_lists_for_account(
+                &account,
+                &request,
+                admission,
+                true,
+                false,
+                recent_relay_lists,
+            )
             .await
         {
             Ok(relay_lists) => relay_lists,
             Err(err) => {
-                if !self.setup_failure_can_roll_back(&account, account.signed_out)? {
+                if !self.setup_failure_can_roll_back(&account, admission, reactivating_existing)? {
                     return Err(err);
                 }
-                return self.rollback_external_signer_setup(
-                    &account.label,
-                    created_account,
-                    upgraded_public_account,
-                    err,
-                );
+                return self
+                    .rollback_external_signer_setup(
+                        &account,
+                        created_account,
+                        upgraded_public_account,
+                        admission,
+                        err,
+                    )
+                    .await;
             }
         };
 
         let key_package_bytes = if request.publish_initial_key_package {
             if account.signed_out {
                 account = self
-                    .app
-                    .account_home()
-                    .set_account_signed_out(&account.label, false)?;
+                    .reactivate_account_for_setup(&account, admission)
+                    .await?;
             }
-            self.app.account_home().set_account_setup_phase(
-                &account.label,
-                AccountSetupPhase::KeyPackagePublicationStarted,
-            )?;
+            {
+                let _root_mutation = self
+                    .app
+                    .begin_root_mutation("external signer KeyPackage setup start")?;
+                self.app.account_home().set_account_setup_phase(
+                    &account.label,
+                    AccountSetupPhase::KeyPackagePublicationStarted,
+                )?;
+            }
             match self.publish_initial_key_package_for_account(&account).await {
                 Ok(bytes) => {
+                    let _root_mutation = self
+                        .app
+                        .begin_root_mutation("external signer KeyPackage setup confirmation")?;
                     self.app.account_home().set_account_setup_phase(
                         &account.label,
                         AccountSetupPhase::KeyPackagePublicationConfirmed,
@@ -5556,11 +7585,14 @@ impl AccountManager {
                     Some(bytes)
                 }
                 Err(err) => {
-                    // Session lifecycle state owns exact signed bytes and
-                    // private material before network exposure. Once
+                    // Session lifecycle state owns the current signed revision
+                    // and private material before network exposure. Once
                     // KeyPackage setup has started, deleting a freshly-added
                     // external account could orphan an ambiguously accepted
-                    // publication; keep it for an exact-byte retry instead.
+                    // publication; retain the durable lifecycle for
+                    // restart-safe publication instead. Retries are exact
+                    // within a revision, while bounded-age policy may first
+                    // persist a newer revision at the same coordinate.
                     // A previously signed-out account is different: restore
                     // that durable state while retaining its setup journal.
                     if reactivating_existing {
@@ -5585,16 +7617,9 @@ impl AccountManager {
             ),
         )
         .await;
-        if account.signed_out {
-            account = self
-                .app
-                .account_home()
-                .set_account_signed_out(&account.label, false)?;
-        }
-        self.reconcile().await?;
-        self.app
-            .account_home()
-            .complete_account_setup(&account.label)?;
+        account = self
+            .complete_account_setup_if_admitted(&account, admission)
+            .await?;
 
         Ok(AccountSetupResult {
             account,
@@ -5642,8 +7667,16 @@ impl AccountManager {
             }
         };
 
-        let profile_relays = status
-            .nip65
+        // A generic aggregate fetch is only an inbox/profile projection for a
+        // local identity. When setup has already bound an exact kind-10002
+        // generation, route the profile refresh through that durable state
+        // rather than through the aggregate fetch's possibly stale copy.
+        let profile_nip65 = self
+            .app
+            .account_relay_list_status_for_account_id(account_id_hex)
+            .map(|local| local.nip65)
+            .unwrap_or_else(|_| status.nip65.clone());
+        let profile_relays = profile_nip65
             .relays
             .iter()
             .cloned()
@@ -5668,10 +7701,81 @@ impl AccountManager {
         Some(status)
     }
 
+    /// Establish setup-time route authority from an exact, completion-proven
+    /// self kind-10002 event. Existing exact generations are already the local
+    /// high-water and make retries network-independent.
+    async fn establish_setup_nip65_authority(
+        &self,
+        account: &AccountSummary,
+        admission: AccountSetupAdmission,
+        discovery_relays: &[TransportEndpoint],
+    ) -> Result<(), AppError> {
+        {
+            let _worker_transaction = self.worker_transactions.lock().await;
+            self.shared.lifecycle().ensure_running()?;
+            self.ensure_expected_setup_admission(&account.account_id_hex, admission)?;
+            if self
+                .app
+                .read_nip65_route_generation_for_authoring(&account.label)?
+                .is_some()
+            {
+                return Ok(());
+            }
+        }
+
+        // Keep relay I/O outside `worker_transactions`: teardown must be able
+        // to supersede a stalled import/login. The strict fetch has its own
+        // finite all-relay EOSE contract and never mutates local state.
+        let discovered = self
+            .app
+            .fetch_exact_self_nip65_event_strict(&account.account_id_hex, discovery_relays)
+            .await;
+
+        // Admission changed while the network was in flight takes precedence
+        // over the fetch result. Stale setup work must not install authority or
+        // report an unrelated relay failure after sign-out/wipe won.
+        {
+            let _worker_transaction = self.worker_transactions.lock().await;
+            self.shared.lifecycle().ensure_running()?;
+            self.ensure_expected_setup_admission(&account.account_id_hex, admission)?;
+        }
+        let Some(record) = discovered? else {
+            // Complete absence is deliberately distinct from incomplete
+            // discovery. The relay-list setup below may author a fresh route
+            // only when the caller explicitly enabled publish-missing.
+            return Ok(());
+        };
+        self.install_setup_nip65_authority(&account.account_id_hex, admission, record)
+            .await?;
+        Ok(())
+    }
+
+    /// Combine advisory inbox/bootstrap observations with the exact local
+    /// NIP-65 authority. When no authority exists after a completed-empty
+    /// strict scan, force NIP-65 missing so an aggregate cache row cannot make
+    /// setup skip the explicit publish-missing/error decision.
+    fn bind_setup_relay_lists_to_nip65_authority(
+        &self,
+        label: &str,
+        observed: Option<AccountRelayListStatus>,
+    ) -> Result<AccountRelayListStatus, AppError> {
+        let mut status = match observed {
+            Some(status) => status,
+            None => self.app.account_relay_list_status(label)?,
+        };
+        match self.app.read_nip65_route_generation_for_authoring(label)? {
+            Some(generation) => status.nip65 = generation.nip65,
+            None => status.nip65 = AccountRelayListStatus::empty().nip65,
+        }
+        status.refresh();
+        Ok(status)
+    }
+
     async fn setup_generated_account_bootstrap(
         &self,
         account: &AccountSummary,
         request: &AccountSetupRequest,
+        admission: AccountSetupAdmission,
     ) -> Result<(AccountRelayListStatus, Option<UserProfileMetadata>), AppError> {
         let mut profile = if let Some(cached) = self
             .app
@@ -5700,12 +7804,33 @@ impl AccountManager {
         }
         self.app
             .validate_account_relay_list_declarations(&bootstrap, None)?;
-        let phase = self
-            .app
-            .account_home()
-            .account_setup_state(&account.label)?
-            .map(|state| state.phase)
-            .ok_or(AppError::AccountSetupRetryRequired)?;
+        let (phase, publication_admission) = {
+            let _worker_transaction = self.worker_transactions.lock().await;
+            self.shared.lifecycle().ensure_running()?;
+            let current =
+                self.ensure_expected_setup_admission(&account.account_id_hex, admission)?;
+            if !current.is_active_signing() || current.account_id_hex != account.account_id_hex {
+                return Err(AppError::AccountWorkerBusy);
+            }
+            let phase = self
+                .app
+                .account_home()
+                .account_setup_state(&account.label)?
+                .map(|state| state.phase)
+                .ok_or(AppError::AccountSetupRetryRequired)?;
+            let publication_admission =
+                self.account_setup_publication_admission(&account.account_id_hex, admission)?;
+            if phase == AccountSetupPhase::LocalReady {
+                let _root_mutation = self
+                    .app
+                    .begin_root_mutation("generated account bootstrap start")?;
+                self.app.account_home().set_account_setup_phase(
+                    &account.label,
+                    AccountSetupPhase::BootstrapPublicationStarted,
+                )?;
+            }
+            (phase, publication_admission)
+        };
         if matches!(
             phase,
             AccountSetupPhase::BootstrapPublicationConfirmed
@@ -5731,17 +7856,16 @@ impl AccountManager {
         if phase == AccountSetupPhase::LocalStateCreated {
             return Err(AppError::AccountSetupRetryRequired);
         }
-        if phase == AccountSetupPhase::LocalReady {
-            self.app.account_home().set_account_setup_phase(
-                &account.label,
-                AccountSetupPhase::BootstrapPublicationStarted,
-            )?;
-        }
         self.shared.lifecycle().ensure_running()?;
         let publish_started_at = Instant::now();
         let publication = match self
             .app
-            .publish_generated_account_bootstrap(&account.label, bootstrap, &profile)
+            .publish_generated_account_bootstrap_admitted(
+                &account.label,
+                bootstrap,
+                &profile,
+                &publication_admission,
+            )
             .await
         {
             Ok(publication) => {
@@ -5779,8 +7903,12 @@ impl AccountManager {
     fn setup_failure_can_roll_back(
         &self,
         account: &AccountSummary,
+        admission: AccountSetupAdmission,
         reactivating_existing: bool,
     ) -> Result<bool, AppError> {
+        if !self.setup_admission_is_current(&account.account_id_hex, admission) {
+            return Err(AppError::AccountWorkerBusy);
+        }
         if reactivating_existing {
             return Ok(false);
         }
@@ -5795,11 +7923,20 @@ impl AccountManager {
         &self,
         account: &AccountSummary,
         request: &AccountSetupRequest,
+        admission: AccountSetupAdmission,
         imports_private_key: bool,
         creates_new_private_key: bool,
         recent_relay_lists: Option<AccountRelayListStatus>,
     ) -> Result<AccountRelayListStatus, AppError> {
         if account.can_sign() {
+            // Advisory discovery above deliberately runs outside the worker
+            // transaction. Re-prove the exact setup after it settles, then
+            // carry that capability through the final route-locked relay send.
+            let publication_admission = {
+                let _worker_transaction = self.worker_transactions.lock().await;
+                self.shared.lifecycle().ensure_running()?;
+                self.account_setup_publication_admission(&account.account_id_hex, admission)?
+            };
             if creates_new_private_key && request.default_relays.is_empty() {
                 return Err(AppError::MissingDefaultRelays);
             }
@@ -5854,10 +7991,11 @@ impl AccountManager {
                     self.mark_bootstrap_publication_started(&account.label)?;
                     let status = self
                         .app
-                        .publish_missing_account_relay_lists_from_status(
+                        .publish_missing_account_relay_lists_from_status_for_setup(
                             &account.label,
                             bootstrap,
                             current_status,
+                            &publication_admission,
                         )
                         .await?;
                     self.mark_bootstrap_publication_confirmed(&account.label)?;
@@ -5875,7 +8013,11 @@ impl AccountManager {
                 }
                 self.mark_bootstrap_publication_started(&account.label)?;
                 let status = self
-                    .publish_relay_lists_for_new_account(&account.label, request)
+                    .publish_relay_lists_for_new_account(
+                        &account.label,
+                        request,
+                        &publication_admission,
+                    )
                     .await?;
                 self.mark_bootstrap_publication_confirmed(&account.label)?;
                 Ok(status)
@@ -5895,6 +8037,9 @@ impl AccountManager {
     }
 
     fn mark_bootstrap_publication_started(&self, label: &str) -> Result<(), AppError> {
+        let _root_mutation = self
+            .app
+            .begin_root_mutation("account bootstrap publication start")?;
         if self
             .app
             .account_home()
@@ -5909,6 +8054,9 @@ impl AccountManager {
     }
 
     fn mark_bootstrap_publication_confirmed(&self, label: &str) -> Result<(), AppError> {
+        let _root_mutation = self
+            .app
+            .begin_root_mutation("account bootstrap publication confirmation")?;
         if self
             .app
             .account_home()
@@ -5938,6 +8086,7 @@ impl AccountManager {
         &self,
         label: &str,
         request: &AccountSetupRequest,
+        publication_admission: &AccountSetupPublicationAdmission,
     ) -> Result<AccountRelayListStatus, AppError> {
         if request.default_relays.is_empty() && request.bootstrap_relays.is_empty() {
             return self.app.account_relay_list_status(label);
@@ -5946,12 +8095,13 @@ impl AccountManager {
             return Err(AppError::MissingDefaultRelays);
         }
         self.app
-            .publish_account_relay_lists(
+            .publish_account_relay_lists_for_setup(
                 label,
                 AccountRelayListBootstrap::new(
                     request.default_relays.clone(),
                     request.bootstrap_relays.clone(),
                 ),
+                publication_admission,
             )
             .await
     }
@@ -5964,6 +8114,9 @@ impl AccountManager {
             .app
             .legacy_incomplete_setup_requires_recovery(&account.label)?
         {
+            let _root_mutation = self
+                .app
+                .begin_root_mutation("legacy account setup recovery marker")?;
             let _ = self
                 .app
                 .mark_key_package_cutover_replacement_pending(&account.label);
@@ -5984,21 +8137,13 @@ impl AccountManager {
             .map(|key_package| key_package.bytes().len()))
     }
 
-    fn signed_out_account_for_identity(
+    fn signed_out_local_account_for_account_id(
         &self,
-        identity: &str,
+        account_id: &str,
     ) -> Result<Option<AccountSummary>, AppError> {
-        let account_id = if crate::is_nostr_secret(identity) {
-            AccountHome::account_id_for_secret(identity)?
-        } else {
-            AccountHome::account_id_for_public_key(identity)?
-        };
-        match self.app.account_home().account(&account_id) {
-            Ok(account) if account.local_signing && account.signed_out => Ok(Some(account)),
-            Ok(_) => Ok(None),
-            Err(AccountHomeError::UnknownAccount(_)) => Ok(None),
-            Err(err) => Err(err.into()),
-        }
+        Ok(self
+            .local_account_for_account_id(account_id)?
+            .filter(|account| account.local_signing && account.signed_out))
     }
 
     fn legacy_incomplete_account_for_import(&self, nsec: &str) -> Result<bool, AppError> {
@@ -6034,6 +8179,9 @@ impl AccountManager {
             {
                 return Err(AppError::IdentityKeyMismatch);
             }
+            let _root_mutation = self
+                .app
+                .begin_root_mutation("legacy imported account setup journal")?;
             self.app.account_home().begin_account_setup_with(
                 &account,
                 false,
@@ -6048,6 +8196,9 @@ impl AccountManager {
         {
             return Ok(false);
         }
+        let _root_mutation = self
+            .app
+            .begin_root_mutation("legacy account setup recovery marker")?;
         let _ = self
             .app
             .mark_key_package_cutover_replacement_pending(&account.label);
@@ -6058,6 +8209,9 @@ impl AccountManager {
         &self,
         request: &AccountSetupRequest,
     ) -> Result<(AccountSummary, Option<NostrAccountImport>), AppError> {
+        let _root_mutation = self
+            .app
+            .begin_root_mutation("account setup identity creation")?;
         let account_home = self.app.account_home();
         if let Some(nsec) = request.import_nsec.as_deref() {
             let imported = account_home.import_nostr_account_idempotent(nsec)?;
@@ -6079,7 +8233,28 @@ impl AccountManager {
             }
             None => {
                 let account = match account_home.resumable_generated_account_setup()? {
-                    Some(account) => account,
+                    Some(account) => {
+                        let setup = account_home
+                            .account_setup_state(&account.label)?
+                            .ok_or(AppError::AccountSetupRetryRequired)?;
+                        // The original fresh-account proof was written before
+                        // the first session open. Older builds did not fsync its
+                        // parent entry, so a crash in that pre-session window
+                        // can leave the generated setup journal but lose only
+                        // the marker. LocalStateCreated is the durable boundary
+                        // proving no setup session has yet completed its local
+                        // handoff; restore the proof before opening one now.
+                        if setup.kind == AccountSetupKind::GeneratedIdentity
+                            && setup.phase == AccountSetupPhase::LocalStateCreated
+                            && !self
+                                .app
+                                .key_package_cutover_has_fresh_account_proof(&account.label)
+                        {
+                            self.app
+                                .mark_key_package_cutover_scan_complete(&account.label)?;
+                        }
+                        account
+                    }
                     None => {
                         let account = account_home.create_nostr_account_for_setup()?;
                         // This identity did not exist before this process and
@@ -6110,22 +8285,33 @@ impl AccountManager {
     /// then surface the original error. Without this, a failed public→external
     /// login leaves a torn account: the promotion applied, but the relay-list and
     /// KeyPackage setup that should follow it did not.
-    fn rollback_external_signer_setup<T>(
+    async fn rollback_external_signer_setup<T>(
         &self,
-        label: &str,
+        account: &AccountSummary,
         created_account: bool,
         upgraded_public_account: bool,
+        admission: AccountSetupAdmission,
         err: AppError,
     ) -> Result<T, AppError> {
+        let _worker_transaction = self.worker_transactions.lock().await;
+        if !self.setup_admission_is_current(&account.account_id_hex, admission) {
+            return Err(AppError::AccountWorkerBusy);
+        }
         if created_account {
-            return self.rollback_account_after_setup_failure(label, err);
+            return self.rollback_account_after_setup_failure(&account.label, err);
         }
         if upgraded_public_account {
-            let _ = self.app.account_home().complete_account_setup(label);
+            let _root_mutation = self
+                .app
+                .begin_root_mutation("external signer setup rollback")?;
             let _ = self
                 .app
                 .account_home()
-                .revert_external_signer_upgrade(label);
+                .complete_account_setup(&account.label);
+            let _ = self
+                .app
+                .account_home()
+                .revert_external_signer_upgrade(&account.label);
         }
         Err(err)
     }
@@ -6135,6 +8321,14 @@ impl AccountManager {
         account: &str,
         source: AppError,
     ) -> Result<T, AppError> {
+        let account_summary = self.app.account_home().account(account).ok();
+        if let Some(account_summary) = account_summary.as_ref() {
+            self.app.close_account_session_admission(
+                &account_summary.label,
+                &account_summary.account_id_hex,
+            );
+        }
+        let _root_mutation = self.app.begin_root_mutation("account setup rollback")?;
         // Setup probes (e.g. `status()`) may have already cached this account's
         // storage/directory handles. Evict them before the directory is deleted
         // so a later re-import does not reuse a handle bound to the now-unlinked
@@ -6145,24 +8339,40 @@ impl AccountManager {
                 "failed to roll back account after setup failure: {source}; rollback error: {rollback}"
             )));
         }
+        let account_id_hex = account_summary.map(|account| account.account_id_hex);
         match self.app.account_home().remove_account(account) {
-            Ok(()) => Err(source),
+            Ok(()) => {
+                if let Some(account_id_hex) = account_id_hex {
+                    self.forget_setup_admission_generation(&account_id_hex);
+                }
+                Err(source)
+            }
             Err(rollback) => Err(AppError::RelayDirectory(format!(
                 "failed to roll back account after setup failure: {source}; rollback error: {rollback}"
             ))),
         }
     }
 
-    fn rollback_import_after_setup_failure<T>(
+    async fn rollback_import_after_setup_failure<T>(
         &self,
         account: &AccountSummary,
         private_key_import: Option<&NostrAccountImport>,
+        admission: AccountSetupAdmission,
         source: AppError,
     ) -> Result<T, AppError> {
+        let _worker_transaction = self.worker_transactions.lock().await;
+        if !self.setup_admission_is_current(&account.account_id_hex, admission) {
+            return Err(AppError::AccountWorkerBusy);
+        }
         let Some(imported) = private_key_import else {
             return self.rollback_account_after_setup_failure(&account.label, source);
         };
 
+        let _root_mutation = self
+            .app
+            .begin_root_mutation("imported account setup rollback")?;
+        self.app
+            .close_account_session_admission(&account.label, &account.account_id_hex);
         self.app.drop_account_caches(&account.label);
         if let Err(rollback) = self
             .app
@@ -6212,19 +8422,11 @@ impl AccountManager {
 
     pub async fn shutdown(&self) {
         self.shared.lifecycle().begin_shutdown();
-        let generated_setup_tasks = {
-            let mut tasks = self
-                .generated_setup_tasks
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            tasks.accepting = false;
-            tasks.active_accounts.clear();
-            std::mem::take(&mut tasks.handles)
-        };
-        for task in generated_setup_tasks {
-            task.abort();
-            let _ = task.await;
-        }
+        // Stop admitting new detached sign-out/wipe work immediately. Existing
+        // generated setup tasks are aborted below before we wait, so an
+        // admitted teardown cannot deadlock shutdown while reaping one.
+        self.close_teardown_admission();
+        self.abort_generated_setup_tasks().await;
         let invite_catch_up_tasks = {
             let mut tasks = self
                 .invite_catch_up_tasks
@@ -6243,6 +8445,9 @@ impl AccountManager {
         for task in invite_catch_up_tasks {
             let _ = task.await;
         }
+        // Keep account storage and the relay plane live until every admitted
+        // sign-out/wipe operation has completed relay and local cleanup.
+        self.drain_teardown_tasks().await;
         let _worker_transaction = self.worker_transactions.lock().await;
         let workers = {
             let mut workers = self.workers.lock().await;
@@ -6259,6 +8464,54 @@ impl AccountManager {
         }
         while shutdowns.join_next().await.is_some() {}
     }
+}
+
+fn key_package_deletion_targets(
+    packages: Vec<AccountKeyPackageRecord>,
+) -> Vec<KeyPackageDeletionTarget> {
+    merge_key_package_deletion_targets(
+        packages
+            .into_iter()
+            // A locally-authored event can have crossed the transport boundary
+            // even when a subsequent relay discovery snapshot did not observe it.
+            // Its durable event id is therefore a deletion obligation in its own
+            // right; `relay` is positive discovery evidence, not an admission gate.
+            .filter(|package| !package.key_package_event_id.is_empty())
+            .map(|package| KeyPackageDeletionTarget {
+                event_id_hex: package.key_package_event_id,
+                source_relays: package
+                    .source_relays
+                    .into_iter()
+                    .map(TransportEndpoint)
+                    .collect(),
+            })
+            .collect(),
+    )
+}
+
+fn merge_key_package_deletion_targets(
+    targets: Vec<KeyPackageDeletionTarget>,
+) -> Vec<KeyPackageDeletionTarget> {
+    let mut merged = Vec::<KeyPackageDeletionTarget>::new();
+    for mut target in targets {
+        if target.event_id_hex.is_empty() {
+            continue;
+        }
+        target.source_relays.sort();
+        target.source_relays.dedup();
+        if let Some(existing) = merged
+            .iter_mut()
+            .find(|existing| existing.event_id_hex == target.event_id_hex)
+        {
+            existing.source_relays.extend(target.source_relays);
+            existing.source_relays.sort();
+            existing.source_relays.dedup();
+        } else {
+            merged.push(target);
+        }
+    }
+    merged.sort_by(|left, right| left.event_id_hex.cmp(&right.event_id_hex));
+    merged
 }
 
 fn debug_identity_field(identity: &Option<String>) -> Option<&str> {

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -7033,6 +7033,14 @@ impl AccountManager {
         if account.signed_out {
             return Err(AppError::RelayDirectory("account is signed out".into()));
         }
+        if account.external_signing
+            && !account.local_signing
+            && !self.app.has_external_signer(&account.account_id_hex)
+        {
+            return Err(AppError::ExternalSignerUnavailable(
+                account.account_id_hex.clone(),
+            ));
+        }
         self.reconcile().await?;
         let workers = self.workers.lock().await;
         workers

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -973,12 +973,36 @@ impl SqliteAccountStorage {
         frontiers_to_clear: &[(String, u64)],
         application_event_ids_to_ack: &[MessageId],
     ) -> StorageResult<()> {
+        self.save_account_projection_state_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
+            state,
+            max_seen_events,
+            max_future_skew_secs,
+            frontiers_to_clear,
+            application_event_ids_to_ack,
+            &[],
+        )
+    }
+
+    /// Persist the complete account projection and atomically transfer both
+    /// engine application events and lower account-visibility rows into app
+    /// ownership. A crash therefore replays the rows or observes their fully
+    /// committed projection, never an engine state advance with neither.
+    pub fn save_account_projection_state_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
+        &self,
+        state: &StoredAccountState,
+        max_seen_events: usize,
+        max_future_skew_secs: u64,
+        frontiers_to_clear: &[(String, u64)],
+        application_event_ids_to_ack: &[MessageId],
+        visibility_batch_ids_to_ack: &[Vec<u8>],
+    ) -> StorageResult<()> {
         self.save_account_projection(
             state,
             max_seen_events,
             max_future_skew_secs,
             frontiers_to_clear,
             application_event_ids_to_ack,
+            visibility_batch_ids_to_ack,
             true,
         )
     }
@@ -1001,16 +1025,38 @@ impl SqliteAccountStorage {
         frontiers_to_clear: &[(String, u64)],
         application_event_ids_to_ack: &[MessageId],
     ) -> StorageResult<()> {
+        self.save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
+            state,
+            max_seen_events,
+            max_future_skew_secs,
+            frontiers_to_clear,
+            application_event_ids_to_ack,
+            &[],
+        )
+    }
+
+    /// Delta counterpart to the full-snapshot visibility transfer above.
+    pub fn save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
+        &self,
+        state: &StoredAccountState,
+        max_seen_events: usize,
+        max_future_skew_secs: u64,
+        frontiers_to_clear: &[(String, u64)],
+        application_event_ids_to_ack: &[MessageId],
+        visibility_batch_ids_to_ack: &[Vec<u8>],
+    ) -> StorageResult<()> {
         self.save_account_projection(
             state,
             max_seen_events,
             max_future_skew_secs,
             frontiers_to_clear,
             application_event_ids_to_ack,
+            visibility_batch_ids_to_ack,
             false,
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn save_account_projection(
         &self,
         state: &StoredAccountState,
@@ -1018,6 +1064,7 @@ impl SqliteAccountStorage {
         max_future_skew_secs: u64,
         frontiers_to_clear: &[(String, u64)],
         application_event_ids_to_ack: &[MessageId],
+        visibility_batch_ids_to_ack: &[Vec<u8>],
         replace_group_snapshot: bool,
     ) -> StorageResult<()> {
         let now = unix_now_seconds();
@@ -1268,6 +1315,13 @@ impl SqliteAccountStorage {
                     "DELETE FROM pending_application_events WHERE message_id = ?1",
                     params![message_id.as_slice()],
                 )
+                    .storage()?;
+            }
+            for batch_id in visibility_batch_ids_to_ack {
+                conn.execute(
+                    "DELETE FROM account_visibility_journal WHERE batch_id = ?1",
+                    params![batch_id],
+                )
                 .storage()?;
             }
             Ok(())
@@ -1407,6 +1461,13 @@ impl SqliteAccountStorage {
                 deleted = deleted.saturating_add(
                     tx.execute(
                         "DELETE FROM pending_application_events WHERE group_id = ?1",
+                        params![&group_id],
+                    )
+                    .storage()?,
+                );
+                deleted = deleted.saturating_add(
+                    tx.execute(
+                        "DELETE FROM app_epoch_backfill_intents WHERE group_id = ?1",
                         params![&group_id],
                     )
                     .storage()?,

--- a/crates/storage-sqlite/src/account_projection/tests.rs
+++ b/crates/storage-sqlite/src/account_projection/tests.rs
@@ -2855,6 +2855,78 @@ fn failed_resurrection_projection_save_retains_local_deletion_frontier() {
 }
 
 #[test]
+fn visibility_batch_ack_is_atomic_with_projection_delta() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let operation_id = b"visibility-operation";
+    let batch_id = b"visibility-batch".to_vec();
+    store
+        .upsert_account_visibility_journal(operation_id, 1, &batch_id, b"opaque-effects")
+        .unwrap();
+    store
+        .lock()
+        .unwrap()
+        .execute_batch(
+            "CREATE TRIGGER fail_visibility_projection
+             BEFORE INSERT ON account_groups
+             BEGIN
+                 SELECT RAISE(ABORT, 'injected visibility projection failure');
+             END;",
+        )
+        .unwrap();
+    let state = StoredAccountState {
+        label: "alice".to_owned(),
+        seen_events: vec!["visible-event".to_owned()],
+        last_transport_timestamp: None,
+        groups: vec![group("aa", "visible group")],
+    };
+
+    let result = store
+        .save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
+            &state,
+            16,
+            MAX_FUTURE_SKEW_SECS,
+            &[],
+            &[],
+            std::slice::from_ref(&batch_id),
+        );
+
+    assert!(result.is_err());
+    assert_eq!(store.load_account_visibility_journal().unwrap().len(), 1);
+    assert!(
+        store
+            .load_account_projection_state("alice", 16)
+            .unwrap()
+            .groups
+            .is_empty(),
+        "a failed projection must not expose state while keeping the lower row",
+    );
+
+    store
+        .lock()
+        .unwrap()
+        .execute_batch("DROP TRIGGER fail_visibility_projection")
+        .unwrap();
+    store
+        .save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
+            &state,
+            16,
+            MAX_FUTURE_SKEW_SECS,
+            &[],
+            &[],
+            std::slice::from_ref(&batch_id),
+        )
+        .unwrap();
+    assert!(store.load_account_visibility_journal().unwrap().is_empty());
+    assert_eq!(
+        store
+            .load_account_projection_state("alice", 16)
+            .unwrap()
+            .groups,
+        state.groups,
+    );
+}
+
+#[test]
 fn repeated_local_group_delete_advances_frontier_past_buffered_messages() {
     let store = SqliteAccountStorage::in_memory().unwrap();
     insert_protocol_group_marker(&store, &[0xaa]);

--- a/crates/storage-sqlite/src/account_visibility_journal.rs
+++ b/crates/storage-sqlite/src/account_visibility_journal.rs
@@ -1,0 +1,294 @@
+use crate::connection::retry_on_busy;
+use crate::{SqliteAccountStorage, SqliteResultExt, i64_to_u64, u64_to_i64};
+use cgka_traits::storage::{StorageError, StorageResult};
+use rusqlite::{OptionalExtension, params};
+
+/// One ordered opaque account-runtime visibility record.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AccountVisibilityJournalRow {
+    pub sequence: u64,
+    pub operation_id: Vec<u8>,
+    pub ordinal: u64,
+    pub batch_id: Vec<u8>,
+    pub record: Vec<u8>,
+}
+
+/// One opaque record to insert or replace as part of an atomic visibility
+/// checkpoint.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AccountVisibilityJournalUpsert {
+    pub operation_id: Vec<u8>,
+    pub ordinal: u64,
+    pub batch_id: Vec<u8>,
+    pub record: Vec<u8>,
+}
+
+impl SqliteAccountStorage {
+    /// Load every unacknowledged visibility record in insertion order.
+    pub fn load_account_visibility_journal(
+        &self,
+    ) -> StorageResult<Vec<AccountVisibilityJournalRow>> {
+        let connection = self.lock()?;
+        let mut statement = connection
+            .prepare(
+                "SELECT sequence, operation_id, ordinal, batch_id, record
+                 FROM account_visibility_journal
+                 ORDER BY sequence",
+            )
+            .storage()?;
+        let rows = statement
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, Vec<u8>>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, Vec<u8>>(3)?,
+                    row.get::<_, Vec<u8>>(4)?,
+                ))
+            })
+            .storage()?
+            .collect::<Result<Vec<_>, _>>()
+            .storage()?;
+        rows.into_iter()
+            .map(|(sequence, operation_id, ordinal, batch_id, record)| {
+                Ok(AccountVisibilityJournalRow {
+                    sequence: i64_to_u64(sequence)?,
+                    operation_id,
+                    ordinal: i64_to_u64(ordinal)?,
+                    batch_id,
+                    record,
+                })
+            })
+            .collect()
+    }
+
+    /// Insert a new stable operation/ordinal record or replace its opaque bytes.
+    /// Existing rows retain their original global `sequence`.
+    pub fn upsert_account_visibility_journal(
+        &self,
+        operation_id: &[u8],
+        ordinal: u64,
+        batch_id: &[u8],
+        record: &[u8],
+    ) -> StorageResult<u64> {
+        let mut sequences =
+            self.upsert_account_visibility_journal_records(&[AccountVisibilityJournalUpsert {
+                operation_id: operation_id.to_vec(),
+                ordinal,
+                batch_id: batch_id.to_vec(),
+                record: record.to_vec(),
+            }])?;
+        Ok(sequences.pop().expect("one input produces one sequence"))
+    }
+
+    /// Atomically insert or replace a complete visibility checkpoint. If any
+    /// entry is invalid or conflicts, none of the rows are changed.
+    pub fn upsert_account_visibility_journal_records(
+        &self,
+        records: &[AccountVisibilityJournalUpsert],
+    ) -> StorageResult<Vec<u64>> {
+        let validated = records
+            .iter()
+            .map(|record| {
+                if record.operation_id.is_empty() || record.batch_id.is_empty() {
+                    return Err(StorageError::Backend(
+                        "account visibility operation and batch ids must be non-empty".into(),
+                    ));
+                }
+                Ok((record, u64_to_i64(record.ordinal)?))
+            })
+            .collect::<StorageResult<Vec<_>>>()?;
+        self.write_account_visibility_journal(|| {
+            self.connection.with_transaction(|| {
+                let connection = self.lock()?;
+                let mut sequences = Vec::with_capacity(validated.len());
+                for (record, ordinal) in &validated {
+                    connection
+                        .execute(
+                            "INSERT INTO account_visibility_journal
+                                (operation_id, ordinal, batch_id, record)
+                             VALUES (?1, ?2, ?3, ?4)
+                             ON CONFLICT(operation_id, ordinal) DO UPDATE SET
+                                record = excluded.record
+                             WHERE account_visibility_journal.batch_id = excluded.batch_id",
+                            params![
+                                &record.operation_id,
+                                ordinal,
+                                &record.batch_id,
+                                &record.record,
+                            ],
+                        )
+                        .storage()?;
+                    let sequence = connection
+                        .query_row(
+                            "SELECT sequence FROM account_visibility_journal
+                             WHERE operation_id = ?1 AND ordinal = ?2 AND batch_id = ?3",
+                            params![&record.operation_id, ordinal, &record.batch_id],
+                            |row| row.get::<_, i64>(0),
+                        )
+                        .optional()
+                        .storage()?
+                        .ok_or_else(|| {
+                            StorageError::Backend(
+                                "account visibility operation/ordinal reused with another batch id"
+                                    .into(),
+                            )
+                        })?;
+                    sequences.push(i64_to_u64(sequence)?);
+                }
+                Ok(sequences)
+            })
+        })
+    }
+
+    /// Atomically delete exactly the acknowledged stable batch ids.
+    pub fn delete_account_visibility_journal_batches(
+        &self,
+        batch_ids: &[Vec<u8>],
+    ) -> StorageResult<usize> {
+        self.write_account_visibility_journal(|| {
+            self.connection.with_transaction(|| {
+                let connection = self.lock()?;
+                let mut deleted = 0_usize;
+                for batch_id in batch_ids {
+                    deleted = deleted.saturating_add(
+                        connection
+                            .execute(
+                                "DELETE FROM account_visibility_journal WHERE batch_id = ?1",
+                                params![batch_id],
+                            )
+                            .storage()?,
+                    );
+                }
+                Ok(deleted)
+            })
+        })
+    }
+
+    fn write_account_visibility_journal<T>(
+        &self,
+        op: impl Fn() -> StorageResult<T>,
+    ) -> StorageResult<T> {
+        if self.connection.is_current_thread_transaction_owner() {
+            op()
+        } else {
+            retry_on_busy(op)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn journal_orders_exact_bytes_upserts_in_place_and_deletes_atomically() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let operation_a = [0_u8, 0xff, 0x80];
+        let operation_b = [2_u8, 0, 3];
+        let batch_a = [4_u8, 0xff, 5];
+        let batch_b = [6_u8, 0, 7];
+        let first = [8_u8, 0xff, 9, 0];
+        let second = [10_u8, 0, 11];
+        let replacement = [12_u8, 0xff, 13, 0];
+
+        let sequence_a = store
+            .upsert_account_visibility_journal(&operation_a, 0, &batch_a, &first)
+            .unwrap();
+        let sequence_b = store
+            .upsert_account_visibility_journal(&operation_b, 9, &batch_b, &second)
+            .unwrap();
+        assert!(sequence_a < sequence_b);
+        assert_eq!(
+            store
+                .upsert_account_visibility_journal(&operation_a, 0, &batch_a, &replacement,)
+                .unwrap(),
+            sequence_a,
+            "upsert must preserve global order"
+        );
+
+        assert_eq!(
+            store.load_account_visibility_journal().unwrap(),
+            vec![
+                AccountVisibilityJournalRow {
+                    sequence: sequence_a,
+                    operation_id: operation_a.to_vec(),
+                    ordinal: 0,
+                    batch_id: batch_a.to_vec(),
+                    record: replacement.to_vec(),
+                },
+                AccountVisibilityJournalRow {
+                    sequence: sequence_b,
+                    operation_id: operation_b.to_vec(),
+                    ordinal: 9,
+                    batch_id: batch_b.to_vec(),
+                    record: second.to_vec(),
+                },
+            ]
+        );
+
+        assert_eq!(
+            store
+                .delete_account_visibility_journal_batches(&[batch_b.to_vec(), batch_a.to_vec(),])
+                .unwrap(),
+            2
+        );
+        assert!(store.load_account_visibility_journal().unwrap().is_empty());
+    }
+
+    #[test]
+    fn upsert_rejects_operation_ordinal_or_batch_id_aba() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store
+            .upsert_account_visibility_journal(b"operation-a", 3, b"batch-a", b"first")
+            .unwrap();
+        assert!(
+            store
+                .upsert_account_visibility_journal(b"operation-a", 3, b"batch-b", b"other")
+                .is_err()
+        );
+        assert!(
+            store
+                .upsert_account_visibility_journal(b"operation-b", 4, b"batch-a", b"other")
+                .is_err()
+        );
+        assert_eq!(
+            store.load_account_visibility_journal().unwrap()[0].record,
+            b"first"
+        );
+    }
+
+    #[test]
+    fn bulk_upsert_rolls_back_every_row_when_one_entry_conflicts() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store
+            .upsert_account_visibility_journal(b"operation-a", 1, b"batch-a", b"original")
+            .unwrap();
+
+        let result = store.upsert_account_visibility_journal_records(&[
+            AccountVisibilityJournalUpsert {
+                operation_id: b"operation-b".to_vec(),
+                ordinal: 2,
+                batch_id: b"batch-b".to_vec(),
+                record: vec![0, 0xff, 0x80],
+            },
+            AccountVisibilityJournalUpsert {
+                operation_id: b"operation-a".to_vec(),
+                ordinal: 1,
+                batch_id: b"wrong-batch".to_vec(),
+                record: b"must-not-replace".to_vec(),
+            },
+        ]);
+        assert!(result.is_err());
+        assert_eq!(
+            store.load_account_visibility_journal().unwrap(),
+            vec![AccountVisibilityJournalRow {
+                sequence: 1,
+                operation_id: b"operation-a".to_vec(),
+                ordinal: 1,
+                batch_id: b"batch-a".to_vec(),
+                record: b"original".to_vec(),
+            }]
+        );
+    }
+}

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -14,7 +14,7 @@ use cgka_traits::app_event::{
     GROUP_SYSTEM_TYPE_MEMBER_LEFT, GROUP_SYSTEM_TYPE_MEMBER_REMOVED, GROUP_SYSTEM_TYPE_TAG,
     MARMOT_APP_EVENT_KIND_CHAT, MARMOT_APP_EVENT_KIND_GROUP_SYSTEM,
 };
-use cgka_traits::storage::StorageResult;
+use cgka_traits::storage::{StorageError, StorageResult};
 use rusqlite::{Connection, OptionalExtension, Params, params};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -717,24 +717,60 @@ impl SqliteAccountStorage {
         group_id_hex: &str,
         mention_classifier: &MentionClassifier<'_>,
     ) -> StorageResult<Option<ChatListRow>> {
+        self.save_account_projection_delta_and_refresh_chat_list_row_acking_application_events_and_visibility_batches(
+            state,
+            max_seen_events,
+            max_future_skew_secs,
+            frontiers_to_clear,
+            application_event_ids_to_ack,
+            &[],
+            local_account_id_hex,
+            group_id_hex,
+            mention_classifier,
+        )
+    }
+
+    /// Persist an exact account-projection delta, acknowledge both engine
+    /// application events and lower account-visibility batches, and materialize
+    /// one chat-list row in the same SQLCipher transaction.
+    ///
+    /// This is the visibility-aware created-group boundary. A failed row refresh
+    /// rolls back the projection, frontier clears, and both outbox transfers;
+    /// success returns the row committed with all of them.
+    #[allow(clippy::too_many_arguments)]
+    pub fn save_account_projection_delta_and_refresh_chat_list_row_acking_application_events_and_visibility_batches(
+        &self,
+        state: &StoredAccountState,
+        max_seen_events: usize,
+        max_future_skew_secs: u64,
+        frontiers_to_clear: &[(String, u64)],
+        application_event_ids_to_ack: &[cgka_traits::MessageId],
+        visibility_batch_ids_to_ack: &[Vec<u8>],
+        local_account_id_hex: &str,
+        group_id_hex: &str,
+        mention_classifier: &MentionClassifier<'_>,
+    ) -> StorageResult<Option<ChatListRow>> {
         self.connection.with_transaction(|| {
             // `with_transaction` is intentionally nestable on the owning
             // thread, so the projection helper participates in this outer
             // transaction and cannot commit before the chat-list row exists.
-            self.save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events(
+            self.save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events_and_visibility_batches(
                 state,
                 max_seen_events,
                 max_future_skew_secs,
                 frontiers_to_clear,
                 application_event_ids_to_ack,
+                visibility_batch_ids_to_ack,
             )?;
             let conn = self.lock()?;
-            refresh_chat_list_row_tx(
+            let row = refresh_chat_list_row_tx(
                 &conn,
                 local_account_id_hex,
                 group_id_hex,
                 mention_classifier,
-            )
+            )?
+            .ok_or(StorageError::NotFound)?;
+            Ok(Some(row))
         })
     }
 

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -15,7 +15,7 @@ use cgka_traits::app_event::{
     MARMOT_APP_EVENT_KIND_GROUP_SYSTEM, MARMOT_APP_EVENT_KIND_REACTION,
 };
 use cgka_traits::storage::{GroupStorage, LeaveRequest, LeaveRequestStorage};
-use cgka_traits::types::{EpochId, GroupId};
+use cgka_traits::types::{EpochId, GroupId, MessageId};
 
 const LOCAL: &str = "aa";
 const REMOTE: &str = "bb";
@@ -231,6 +231,243 @@ fn created_group_projection_and_chat_list_row_commit_atomically() {
         .unwrap()
         .expect("created chat-list row");
     assert_eq!(store.chat_list_row(GROUP).unwrap(), Some(committed));
+}
+
+#[test]
+fn created_group_visibility_transfer_and_chat_list_row_commit_atomically() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let deletion_frontier = 7_u64;
+    let application_event_id = MessageId::new(vec![0x42; 32]);
+    let operation_id = b"created-chat-visibility-operation";
+    let acknowledged_batch_id = b"created-chat-acknowledged-batch".to_vec();
+    let retained_batch_id = b"created-chat-retained-batch".to_vec();
+    {
+        let connection = store.lock().unwrap();
+        connection
+            .execute(
+                "INSERT INTO local_group_deletion_frontiers
+                    (group_id_hex, message_insert_order, prior_nostr_routes_json)
+                 VALUES (?1, ?2, '[]')",
+                params![GROUP, i64::try_from(deletion_frontier).unwrap()],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO pending_application_events
+                    (message_id, group_id, message_insert_order, record)
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    application_event_id.as_slice(),
+                    &[0x11_u8],
+                    i64::try_from(deletion_frontier + 1).unwrap(),
+                    b"opaque-pending-application-event",
+                ],
+            )
+            .unwrap();
+    }
+    store
+        .upsert_account_visibility_journal(
+            operation_id,
+            1,
+            &acknowledged_batch_id,
+            b"created-chat-effects",
+        )
+        .unwrap();
+    store
+        .upsert_account_visibility_journal(
+            operation_id,
+            2,
+            &retained_batch_id,
+            b"unrelated-effects",
+        )
+        .unwrap();
+    store
+        .lock()
+        .unwrap()
+        .execute_batch(
+            "CREATE TRIGGER fail_created_chat_list_visibility_row
+             BEFORE INSERT ON chat_list_rows
+             BEGIN
+                 SELECT RAISE(ABORT, 'injected created visibility row failure');
+             END;",
+        )
+        .unwrap();
+    let state = StoredAccountState {
+        label: "alice".to_owned(),
+        groups: vec![group()],
+        ..StoredAccountState::default()
+    };
+    let save = || {
+        store.save_account_projection_delta_and_refresh_chat_list_row_acking_application_events_and_visibility_batches(
+            &state,
+            256,
+            MAX_FUTURE_SKEW_SECS,
+            &[(GROUP.to_owned(), deletion_frontier)],
+            std::slice::from_ref(&application_event_id),
+            std::slice::from_ref(&acknowledged_batch_id),
+            LOCAL,
+            GROUP,
+            &no_mentions,
+        )
+    };
+    let pending_application_event_count = || {
+        store
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT COUNT(*) FROM pending_application_events WHERE message_id = ?1",
+                params![application_event_id.as_slice()],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap()
+    };
+    let visibility_batch_ids = || {
+        store
+            .load_account_visibility_journal()
+            .unwrap()
+            .into_iter()
+            .map(|row| row.batch_id)
+            .collect::<Vec<_>>()
+    };
+
+    save().expect_err("the chat-list failure must roll back the visibility transfer");
+    assert!(
+        store
+            .load_account_projection_state("alice", 256)
+            .unwrap()
+            .groups
+            .is_empty(),
+        "the failed outer transaction must roll back the projection delta",
+    );
+    assert_eq!(store.chat_list_row(GROUP).unwrap(), None);
+    assert_eq!(
+        store.local_group_deletion_frontier(GROUP).unwrap(),
+        Some(deletion_frontier),
+        "the failed row refresh must roll back the frontier clear",
+    );
+    assert_eq!(
+        pending_application_event_count(),
+        1,
+        "the failed row refresh must roll back the application-event acknowledgement",
+    );
+    assert_eq!(
+        visibility_batch_ids(),
+        vec![acknowledged_batch_id.clone(), retained_batch_id.clone()],
+        "the failed row refresh must retain every lower visibility batch",
+    );
+
+    store
+        .lock()
+        .unwrap()
+        .execute_batch("DROP TRIGGER fail_created_chat_list_visibility_row")
+        .unwrap();
+    let committed = save().unwrap().expect("created chat-list row");
+
+    assert_eq!(store.chat_list_row(GROUP).unwrap(), Some(committed));
+    assert_eq!(
+        store
+            .load_account_projection_state("alice", 256)
+            .unwrap()
+            .groups,
+        state.groups,
+    );
+    assert_eq!(store.local_group_deletion_frontier(GROUP).unwrap(), None);
+    assert_eq!(
+        pending_application_event_count(),
+        0,
+        "success must acknowledge the application event with the created row",
+    );
+    assert_eq!(
+        visibility_batch_ids(),
+        vec![retained_batch_id],
+        "success must delete exactly the passed visibility batch",
+    );
+}
+
+#[test]
+fn missing_created_chat_list_row_rolls_back_projection_and_outbox_acks() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let missing_group_id_hex = "22";
+    let application_event_id = MessageId::new(vec![0x43; 32]);
+    let visibility_batch_id = b"missing-created-chat-visibility-batch".to_vec();
+    store
+        .lock()
+        .unwrap()
+        .execute(
+            "INSERT INTO pending_application_events
+                (message_id, group_id, message_insert_order, record)
+             VALUES (?1, ?2, 1, ?3)",
+            params![
+                application_event_id.as_slice(),
+                &[0x22_u8],
+                b"opaque-pending-application-event",
+            ],
+        )
+        .unwrap();
+    store
+        .upsert_account_visibility_journal(
+            b"missing-created-chat-operation",
+            1,
+            &visibility_batch_id,
+            b"missing-created-chat-effects",
+        )
+        .unwrap();
+    let state = StoredAccountState {
+        label: "alice".to_owned(),
+        groups: vec![group()],
+        ..StoredAccountState::default()
+    };
+
+    let error = store
+        .save_account_projection_delta_and_refresh_chat_list_row_acking_application_events_and_visibility_batches(
+            &state,
+            256,
+            MAX_FUTURE_SKEW_SECS,
+            &[],
+            std::slice::from_ref(&application_event_id),
+            std::slice::from_ref(&visibility_batch_id),
+            LOCAL,
+            missing_group_id_hex,
+            &no_mentions,
+        )
+        .expect_err("a missing created-chat row must abort its enclosing transaction");
+
+    assert!(matches!(
+        error,
+        cgka_traits::storage::StorageError::NotFound
+    ));
+    assert!(
+        store
+            .load_account_projection_state("alice", 256)
+            .unwrap()
+            .groups
+            .is_empty(),
+        "the missing-row error must roll back the projection delta",
+    );
+    assert_eq!(store.chat_list_row(GROUP).unwrap(), None);
+    assert_eq!(
+        store
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT COUNT(*) FROM pending_application_events WHERE message_id = ?1",
+                params![application_event_id.as_slice()],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+        1,
+        "the missing-row error must roll back the application-event acknowledgement",
+    );
+    assert_eq!(
+        store
+            .load_account_visibility_journal()
+            .unwrap()
+            .into_iter()
+            .map(|row| row.batch_id)
+            .collect::<Vec<_>>(),
+        vec![visibility_batch_id],
+        "the missing-row error must roll back the visibility-batch deletion",
+    );
 }
 
 /// Operational mdk#1487 benchmark for the post-canonical app-local tail.
@@ -3519,6 +3756,7 @@ fn chat_list_rows_report_the_durable_leave_request_at_read_time() {
             group_id: group_id.clone(),
             requested_at_ms: 1_700_000_000_123,
             last_proposed_epoch: Some(EpochId(3)),
+            last_proposed_message_id: None,
         })
         .unwrap();
 

--- a/crates/storage-sqlite/src/epoch_backfill_intent_journal.rs
+++ b/crates/storage-sqlite/src/epoch_backfill_intent_journal.rs
@@ -1,0 +1,105 @@
+use crate::connection::retry_on_busy;
+use crate::{SqliteAccountStorage, SqliteResultExt};
+use cgka_traits::storage::StorageResult;
+use rusqlite::{OptionalExtension, params};
+
+impl SqliteAccountStorage {
+    /// Load the opaque, account-wide epoch-backfill intent journal.
+    ///
+    /// Serialization belongs to the app layer so storage-format changes do not
+    /// require this crate to understand the queued intent envelope.
+    pub fn load_epoch_backfill_intent_journal(&self) -> StorageResult<Option<Vec<u8>>> {
+        self.lock()?
+            .query_row(
+                "SELECT record FROM app_epoch_backfill_intent_journal WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .optional()
+            .storage()
+    }
+
+    /// Atomically replace the opaque, account-wide epoch-backfill intent
+    /// journal.
+    pub fn store_epoch_backfill_intent_journal(&self, record: &[u8]) -> StorageResult<()> {
+        self.write_epoch_backfill_intent_journal(|| {
+            self.lock()?
+                .execute(
+                    "INSERT INTO app_epoch_backfill_intent_journal (singleton, record)
+                     VALUES (1, ?1)
+                     ON CONFLICT(singleton) DO UPDATE SET record = excluded.record",
+                    params![record],
+                )
+                .storage()?;
+            Ok(())
+        })
+    }
+
+    /// Clear the account-wide epoch-backfill intent journal, if present.
+    pub fn clear_epoch_backfill_intent_journal(&self) -> StorageResult<()> {
+        self.write_epoch_backfill_intent_journal(|| {
+            self.lock()?
+                .execute(
+                    "DELETE FROM app_epoch_backfill_intent_journal WHERE singleton = 1",
+                    [],
+                )
+                .storage()?;
+            Ok(())
+        })
+    }
+
+    fn write_epoch_backfill_intent_journal<T>(
+        &self,
+        op: impl Fn() -> StorageResult<T>,
+    ) -> StorageResult<T> {
+        if self.connection.is_current_thread_transaction_owner() {
+            op()
+        } else {
+            retry_on_busy(op)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn journal_round_trips_overwrites_and_clears_opaque_bytes() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        assert_eq!(store.load_epoch_backfill_intent_journal().unwrap(), None);
+
+        let first = [0_u8, 0xff, 0x80, 0x00, b'{'];
+        store.store_epoch_backfill_intent_journal(&first).unwrap();
+        assert_eq!(
+            store.load_epoch_backfill_intent_journal().unwrap(),
+            Some(first.to_vec())
+        );
+
+        let replacement = [9_u8, 8, 7];
+        store
+            .store_epoch_backfill_intent_journal(&replacement)
+            .unwrap();
+        assert_eq!(
+            store.load_epoch_backfill_intent_journal().unwrap(),
+            Some(replacement.to_vec()),
+            "the singleton upsert must replace, not append to, the journal"
+        );
+
+        store.clear_epoch_backfill_intent_journal().unwrap();
+        assert_eq!(store.load_epoch_backfill_intent_journal().unwrap(), None);
+        store.clear_epoch_backfill_intent_journal().unwrap();
+    }
+
+    #[test]
+    fn journal_preserves_an_explicit_empty_blob() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store.store_epoch_backfill_intent_journal(&[]).unwrap();
+
+        assert_eq!(
+            store.load_epoch_backfill_intent_journal().unwrap(),
+            Some(Vec::new()),
+            "an empty opaque record is occupied state, not an absent journal"
+        );
+    }
+}

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -6,11 +6,13 @@
 //! layers.
 
 mod account_projection;
+mod account_visibility_journal;
 mod agent_stream_sequences;
 mod chat_list;
 mod codec;
 mod connection;
 mod encrypted_media_secrets;
+mod epoch_backfill_intent_journal;
 mod message_drafts;
 mod migrations;
 mod openmls_storage;
@@ -29,6 +31,7 @@ pub use account_projection::{
     StoredAppMessageQuery, StoredAppMessageRecord, StoredEpochBackfillIntent,
     StoredEpochStallEvidence, StoredNostrRoute, clamp_to_max_future_skew,
 };
+pub use account_visibility_journal::{AccountVisibilityJournalRow, AccountVisibilityJournalUpsert};
 pub use chat_list::{
     AccountUnreadTotal, ChatConversationKind, ChatListAttachmentKind, ChatListAvatar,
     ChatListMessageDeliveryState, ChatListMessagePreview, ChatListQuery, ChatListRow, ChatPinError,

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -108,6 +108,12 @@ mod migration_0053_account_delivery_recovery;
 mod migration_0054_transport_reconciliation_items;
 #[path = "migrations/0055_epoch_stall_evidence.rs"]
 mod migration_0055_epoch_stall_evidence;
+#[path = "migrations/0056_key_package_lifecycle_privacy_journal.rs"]
+mod migration_0056_key_package_lifecycle_privacy_journal;
+#[path = "migrations/0057_epoch_backfill_intent_journal.rs"]
+mod migration_0057_epoch_backfill_intent_journal;
+#[path = "migrations/0058_account_visibility_journal.rs"]
+mod migration_0058_account_visibility_journal;
 #[cfg(test)]
 #[path = "migrations/test_support.rs"]
 mod test_support;
@@ -398,6 +404,21 @@ const MIGRATIONS: &[Migration] = &[
         name: "0055_epoch_stall_evidence",
         apply: migration_0055_epoch_stall_evidence::apply,
     },
+    Migration {
+        version: 56,
+        name: "0056_key_package_lifecycle_privacy_journal",
+        apply: migration_0056_key_package_lifecycle_privacy_journal::apply,
+    },
+    Migration {
+        version: 57,
+        name: "0057_epoch_backfill_intent_journal",
+        apply: migration_0057_epoch_backfill_intent_journal::apply,
+    },
+    Migration {
+        version: 58,
+        name: "0058_account_visibility_journal",
+        apply: migration_0058_account_visibility_journal::apply,
+    },
 ];
 
 pub(crate) fn run_all(connection: &mut Connection) -> StorageResult<()> {
@@ -604,8 +625,9 @@ mod tests {
         SqlCipherHardening, SqlCipherKey, SqliteAccountStorage, epoch_to_i64, message_state_to_i64,
         open_hardened_sqlcipher, serialize,
     };
+    use cgka_traits::maintenance::KeyPackageLifecycleState;
     use cgka_traits::message::{MessageRecord, MessageState, StoredMessagePayload};
-    use cgka_traits::storage::{GroupStorage, MessageStorage};
+    use cgka_traits::storage::{GroupStorage, MaintenanceStorage, MessageStorage};
     use cgka_traits::transport::{Timestamp, TransportEnvelope, TransportMessage, TransportSource};
     use std::io::{Read, Write};
     use std::path::Path;
@@ -621,6 +643,10 @@ mod tests {
     const TEST_DATABASE_KEY: &str = "storage format migration crash key";
     const V0_9_12_FIXTURE_KEY: &str = "mdk storage v1 fixture key";
     const V0_9_12_FIXTURE: &[u8] = include_bytes!("../fixtures/storage-v1-v0.9.12.bin");
+    const KEY_PACKAGE_PRIVACY_JOURNAL_TRIGGERS: [&str; 2] = [
+        "cgka_key_package_lifecycle_privacy_journal_insert",
+        "cgka_key_package_lifecycle_privacy_journal_update",
+    ];
 
     fn applied_migrations(store: &SqliteAccountStorage) -> Vec<(i64, String)> {
         let conn = store.lock().unwrap();
@@ -690,6 +716,58 @@ mod tests {
             .collect();
         drop(connection);
         messages
+    }
+
+    fn schema_51_key_package_lifecycle_record() -> Vec<u8> {
+        let mut record =
+            serde_json::to_value(KeyPackageLifecycleState::slot_only("slot".into())).unwrap();
+        let fields = record.as_object_mut().unwrap();
+        fields.remove("cutover_publication_blocked");
+        fields.remove("deleted_live_revision_event_ids");
+        fields.remove("deletion_overflow_owner_event_id");
+        fields.remove("retired_publications_pending_deletion");
+        fields.remove("consumed_key_package_refs");
+        serde_json::to_vec(&record).unwrap()
+    }
+
+    fn seed_file_backed_schema_51_key_package_lifecycle(path: &Path) -> Vec<u8> {
+        let mut connection = keyed_connection(path);
+        run(&mut connection, &MIGRATIONS[..51]).unwrap();
+        let record = schema_51_key_package_lifecycle_record();
+        connection
+            .execute(
+                "INSERT INTO cgka_key_package_lifecycle (singleton, record) VALUES (1, ?1)",
+                params![record.as_slice()],
+            )
+            .unwrap();
+        connection
+            .execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")
+            .unwrap();
+        drop(connection);
+        record
+    }
+
+    fn key_package_privacy_journal_triggers(connection: &rusqlite::Connection) -> Vec<String> {
+        let mut statement = connection
+            .prepare(
+                "SELECT name
+                   FROM sqlite_schema
+                  WHERE type = 'trigger'
+                    AND name IN (?1, ?2)
+                  ORDER BY name",
+            )
+            .unwrap();
+        statement
+            .query_map(
+                params![
+                    KEY_PACKAGE_PRIVACY_JOURNAL_TRIGGERS[0],
+                    KEY_PACKAGE_PRIVACY_JOURNAL_TRIGGERS[1]
+                ],
+                |row| row.get(0),
+            )
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
     }
 
     fn benchmark_message_id(index: usize) -> cgka_traits::MessageId {
@@ -902,6 +980,36 @@ mod tests {
     }
 
     #[test]
+    fn key_package_privacy_journal_migration_refuses_schema_51_writer() {
+        let mut connection = rusqlite::Connection::open_in_memory().unwrap();
+        run(&mut connection, &MIGRATIONS[..56]).unwrap();
+        let privacy_journal = br#"{"stable_slot_id":"slot","cutover_publication_blocked":true,"deleted_live_revision_event_ids":[[1,2,3]],"deletion_overflow_owner_event_id":[4,5,6],"retired_publications_pending_deletion":[{"event_id":[4,5,6]}],"consumed_key_package_refs":[[7,8,9]]}"#;
+        connection
+            .execute(
+                "INSERT INTO cgka_key_package_lifecycle (singleton, record) VALUES (1, ?1)",
+                params![privacy_journal.as_slice()],
+            )
+            .unwrap();
+
+        let error = run(&mut connection, &MIGRATIONS[..55]).unwrap_err();
+        assert!(matches!(
+            error,
+            StorageError::UnsupportedSchemaVersion {
+                found: 56,
+                latest_supported: 55,
+            }
+        ));
+        let retained: Vec<u8> = connection
+            .query_row(
+                "SELECT record FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(retained, privacy_journal);
+    }
+
+    #[test]
     fn file_backed_v1_database_upgrades_once_and_refuses_downgrade() {
         let directory = tempfile::tempdir().unwrap();
         let database = directory.path().join("v1-upgrade.sqlite3");
@@ -922,13 +1030,19 @@ mod tests {
             .query_row("SELECT count(*) FROM cgka_messages", [], |row| row.get(0))
             .unwrap();
         let error = run(&mut older_connection, &MIGRATIONS[..46]).unwrap_err();
-        assert!(matches!(
-            error,
+        match error {
             StorageError::UnsupportedSchemaVersion {
-                found: 55,
+                found,
                 latest_supported: 46,
-            }
-        ));
+            } => assert_eq!(
+                found,
+                MIGRATIONS
+                    .last()
+                    .expect("migration registry is nonempty")
+                    .version
+            ),
+            other => panic!("expected downgrade refusal, got {other:?}"),
+        }
         let after: i64 = older_connection
             .query_row("SELECT count(*) FROM cgka_messages", [], |row| row.get(0))
             .unwrap();
@@ -978,13 +1092,19 @@ mod tests {
             connection
         };
         let error = run(&mut older_connection, &MIGRATIONS[..46]).unwrap_err();
-        assert!(matches!(
-            error,
+        match error {
             StorageError::UnsupportedSchemaVersion {
-                found: 55,
+                found,
                 latest_supported: 46,
-            }
-        ));
+            } => assert_eq!(
+                found,
+                MIGRATIONS
+                    .last()
+                    .expect("migration registry is nonempty")
+                    .version
+            ),
+            other => panic!("expected downgrade refusal, got {other:?}"),
+        }
     }
 
     #[test]
@@ -1138,6 +1258,114 @@ mod tests {
     }
 
     #[test]
+    fn process_kill_mid_key_package_privacy_migration_retries_fail_closed() {
+        let directory = tempfile::tempdir().unwrap();
+        let database = directory
+            .path()
+            .join("key-package-privacy-migration-kill.sqlite3");
+        let schema_51_record = seed_file_backed_schema_51_key_package_lifecycle(&database);
+
+        kill_child_at(
+            "migrations::tests::storage_format_migration_crash_child",
+            "migration",
+            "MDK_STORAGE_TEST_MIGRATION_CRASH_VERSION",
+            "56",
+            &database,
+            "migration-56",
+        );
+
+        let connection = keyed_connection(&database);
+        assert_eq!(applied_name(&connection, 56).unwrap(), None);
+        let rolled_back_record: Vec<u8> = connection
+            .query_row(
+                "SELECT record FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(rolled_back_record, schema_51_record);
+        let rolled_back_json: serde_json::Value =
+            serde_json::from_slice(&rolled_back_record).unwrap();
+        for field in [
+            "cutover_publication_blocked",
+            "deleted_live_revision_event_ids",
+            "deletion_overflow_owner_event_id",
+            "retired_publications_pending_deletion",
+            "consumed_key_package_refs",
+        ] {
+            assert!(
+                rolled_back_json.get(field).is_none(),
+                "killed migration must roll back the {field} backfill"
+            );
+        }
+        assert!(key_package_privacy_journal_triggers(&connection).is_empty());
+        drop(connection);
+
+        let key = SqlCipherKey::new(TEST_DATABASE_KEY).unwrap();
+        let store = SqliteAccountStorage::open_encrypted(&database, &key).unwrap();
+        let lifecycle = store.key_package_lifecycle().unwrap().unwrap();
+        assert!(
+            lifecycle.cutover_publication_blocked,
+            "an upgraded schema-51 lifecycle must remain fail-closed until relay cutover completes"
+        );
+        assert!(lifecycle.deleted_live_revision_event_ids.is_empty());
+        assert!(lifecycle.deletion_overflow_owner_event_id.is_none());
+        assert!(lifecycle.retired_publications_pending_deletion.is_empty());
+        assert!(lifecycle.consumed_key_package_refs.is_empty());
+
+        let connection = store.lock().unwrap();
+        assert_eq!(
+            applied_name(&connection, 56).unwrap().as_deref(),
+            Some("0056_key_package_lifecycle_privacy_journal")
+        );
+        let migration_count: i64 = connection
+            .query_row(
+                "SELECT count(*) FROM cgka_schema_migrations WHERE version = 56",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(migration_count, 1);
+        assert_eq!(
+            key_package_privacy_journal_triggers(&connection),
+            KEY_PACKAGE_PRIVACY_JOURNAL_TRIGGERS.map(str::to_owned)
+        );
+        let storage_type: String = connection
+            .query_row(
+                "SELECT typeof(record) FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(storage_type, "blob");
+        let upgraded_record: Vec<u8> = connection
+            .query_row(
+                "SELECT record FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let upgraded_json: serde_json::Value = serde_json::from_slice(&upgraded_record).unwrap();
+        assert_eq!(
+            upgraded_json.get("cutover_publication_blocked"),
+            Some(&serde_json::json!(true))
+        );
+        for field in [
+            "deleted_live_revision_event_ids",
+            "deletion_overflow_owner_event_id",
+            "retired_publications_pending_deletion",
+            "consumed_key_package_refs",
+        ] {
+            let expected = if field == "deletion_overflow_owner_event_id" {
+                serde_json::Value::Null
+            } else {
+                serde_json::json!([])
+            };
+            assert_eq!(upgraded_json.get(field), Some(&expected));
+        }
+    }
+
+    #[test]
     fn process_kill_mid_promotion_rolls_back_and_retry_converges() {
         let directory = tempfile::tempdir().unwrap();
         let database = directory.path().join("promotion-kill.sqlite3");
@@ -1282,13 +1510,19 @@ mod tests {
         run(&mut connection, MIGRATIONS).unwrap();
 
         let error = run(&mut connection, &MIGRATIONS[..46]).unwrap_err();
-        assert!(matches!(
-            error,
+        match error {
             StorageError::UnsupportedSchemaVersion {
-                found: 55,
+                found,
                 latest_supported: 46,
-            }
-        ));
+            } => assert_eq!(
+                found,
+                MIGRATIONS
+                    .last()
+                    .expect("migration registry is nonempty")
+                    .version
+            ),
+            other => panic!("expected downgrade refusal, got {other:?}"),
+        }
         assert_eq!(
             applied_migrations_from_connection(&connection),
             expected_migrations(),

--- a/crates/storage-sqlite/src/migrations/0056_key_package_lifecycle_privacy_journal.rs
+++ b/crates/storage-sqlite/src/migrations/0056_key_package_lifecycle_privacy_journal.rs
@@ -1,0 +1,264 @@
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+/// Compatibility fence for privacy-critical fields added to the serialized
+/// `cgka_key_package_lifecycle.record` value.
+///
+/// Schema-51 readers deserialize that JSON permissively and would discard the
+/// exact deletion, overflow-owner, and multi-consumption journals on their
+/// next write. The
+/// migration-runner version check rejects an older binary that opens after this
+/// migration. These triggers additionally reject a schema-51 writer that was
+/// already connected while a newer process applied the migration.
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+UPDATE cgka_key_package_lifecycle
+SET record = CAST(
+    json_set(
+        json_insert(
+            CAST(record AS TEXT),
+            '$.deleted_live_revision_event_ids', json('[]'),
+            '$.deletion_overflow_owner_event_id', json('null'),
+            '$.retired_publications_pending_deletion', json('[]'),
+            '$.consumed_key_package_refs', json('[]')
+        ),
+        -- Every schema-51 row predates the relay cutover proof, including a
+        -- development/backport row that already serialized `false`. Force the
+        -- gate closed while preserving any journals it already carries.
+        '$.cutover_publication_blocked', json('true')
+    ) AS BLOB
+)
+WHERE singleton = 1;
+
+CREATE TRIGGER cgka_key_package_lifecycle_privacy_journal_insert
+BEFORE INSERT ON cgka_key_package_lifecycle
+WHEN CASE
+    WHEN json_valid(CAST(NEW.record AS TEXT)) = 0 THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$') IS NOT 'object' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.cutover_publication_blocked') IS NOT 'false'
+         AND json_type(CAST(NEW.record AS TEXT), '$.cutover_publication_blocked') IS NOT 'true' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.deleted_live_revision_event_ids') IS NOT 'array' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.deletion_overflow_owner_event_id') IS NOT 'null'
+         AND json_type(CAST(NEW.record AS TEXT), '$.deletion_overflow_owner_event_id') IS NOT 'array' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.retired_publications_pending_deletion') IS NOT 'array' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.consumed_key_package_refs') IS NOT 'array' THEN 1
+    ELSE 0
+END
+BEGIN
+    SELECT RAISE(ABORT, 'key package lifecycle privacy journals are required');
+END;
+
+CREATE TRIGGER cgka_key_package_lifecycle_privacy_journal_update
+BEFORE UPDATE OF record ON cgka_key_package_lifecycle
+WHEN CASE
+    WHEN json_valid(CAST(NEW.record AS TEXT)) = 0 THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$') IS NOT 'object' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.cutover_publication_blocked') IS NOT 'false'
+         AND json_type(CAST(NEW.record AS TEXT), '$.cutover_publication_blocked') IS NOT 'true' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.deleted_live_revision_event_ids') IS NOT 'array' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.deletion_overflow_owner_event_id') IS NOT 'null'
+         AND json_type(CAST(NEW.record AS TEXT), '$.deletion_overflow_owner_event_id') IS NOT 'array' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.retired_publications_pending_deletion') IS NOT 'array' THEN 1
+    WHEN json_type(CAST(NEW.record AS TEXT), '$.consumed_key_package_refs') IS NOT 'array' THEN 1
+    ELSE 0
+END
+BEGIN
+    SELECT RAISE(ABORT, 'key package lifecycle privacy journals are required');
+END;
+
+-- Validate the upgraded row through the same guard. This is deliberately an
+-- identity update: valid existing bytes stay byte-for-byte unchanged.
+UPDATE cgka_key_package_lifecycle
+SET record = record
+WHERE singleton = 1;
+"#,
+    )
+    .storage()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::migrations::{MIGRATIONS, run};
+    use cgka_traits::{
+        KeyPackageLifecycleState, MessageId, RetiredKeyPackagePublication, Timestamp,
+    };
+    use rusqlite::{Connection, OptionalExtension, params};
+
+    fn schema_51_lifecycle_record() -> Vec<u8> {
+        let mut record = serde_json::to_value(KeyPackageLifecycleState::slot_only("slot".into()))
+            .expect("serialize lifecycle fixture");
+        let fields = record.as_object_mut().expect("lifecycle is an object");
+        fields.remove("cutover_publication_blocked");
+        fields.remove("deleted_live_revision_event_ids");
+        fields.remove("deletion_overflow_owner_event_id");
+        fields.remove("retired_publications_pending_deletion");
+        fields.remove("consumed_key_package_refs");
+        serde_json::to_vec(&record).expect("serialize schema-51 lifecycle fixture")
+    }
+
+    fn privacy_journal_lifecycle_record() -> Vec<u8> {
+        let mut lifecycle = KeyPackageLifecycleState::slot_only("slot".into());
+        lifecycle.cutover_publication_blocked = true;
+        lifecycle
+            .deleted_live_revision_event_ids
+            .push(MessageId::new(vec![1, 2, 3]));
+        lifecycle.deletion_overflow_owner_event_id = Some(MessageId::new(vec![4, 5, 6]));
+        lifecycle
+            .retired_publications_pending_deletion
+            .push(RetiredKeyPackagePublication {
+                event_id: MessageId::new(vec![4, 5, 6]),
+                authored_created_at: Timestamp(7),
+                key_package_ref: Some(vec![8]),
+                package_not_after: Some(Timestamp(9)),
+                delete_without_successor: true,
+                deletion_targets: Vec::new(),
+            });
+        lifecycle.consumed_key_package_refs.push(vec![10, 11]);
+        serde_json::to_vec(&lifecycle).expect("serialize lifecycle privacy journal fixture")
+    }
+
+    #[test]
+    fn migration_forces_an_existing_false_gate_without_replacing_privacy_journals() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        run(&mut connection, &MIGRATIONS[..51]).unwrap();
+        let mut before: serde_json::Value =
+            serde_json::from_slice(&privacy_journal_lifecycle_record()).unwrap();
+        before["cutover_publication_blocked"] = serde_json::json!(false);
+        let before_bytes = serde_json::to_vec(&before).unwrap();
+        connection
+            .execute(
+                "INSERT INTO cgka_key_package_lifecycle (singleton, record) VALUES (1, ?1)",
+                params![before_bytes],
+            )
+            .unwrap();
+
+        run(&mut connection, MIGRATIONS).unwrap();
+        let after: Vec<u8> = connection
+            .query_row(
+                "SELECT record FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let after: serde_json::Value = serde_json::from_slice(&after).unwrap();
+        assert_eq!(
+            after.get("cutover_publication_blocked"),
+            Some(&serde_json::json!(true))
+        );
+        for field in [
+            "deleted_live_revision_event_ids",
+            "deletion_overflow_owner_event_id",
+            "retired_publications_pending_deletion",
+            "consumed_key_package_refs",
+        ] {
+            assert_eq!(
+                after.get(field),
+                before.get(field),
+                "{field} must be preserved"
+            );
+        }
+    }
+
+    #[test]
+    fn migration_guards_blob_json_from_already_open_schema_51_writer() {
+        let directory = tempfile::tempdir().unwrap();
+        let database = directory.path().join("schema-51-open-writer.sqlite3");
+        let mut old_writer = Connection::open(&database).unwrap();
+        run(&mut old_writer, &MIGRATIONS[..51]).unwrap();
+        old_writer
+            .execute(
+                "INSERT INTO cgka_key_package_lifecycle (singleton, record) VALUES (1, ?1)",
+                params![schema_51_lifecycle_record()],
+            )
+            .unwrap();
+
+        let mut new_writer = Connection::open(&database).unwrap();
+        run(&mut new_writer, MIGRATIONS).unwrap();
+        let upgraded: Vec<u8> = new_writer
+            .query_row(
+                "SELECT record FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            new_writer
+                .query_row(
+                    "SELECT typeof(record) FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                    [],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "blob",
+            "JSON1 backfill must preserve the encrypted table's BLOB representation"
+        );
+        let upgraded: serde_json::Value = serde_json::from_slice(&upgraded).unwrap();
+        for field in [
+            "cutover_publication_blocked",
+            "deleted_live_revision_event_ids",
+            "deletion_overflow_owner_event_id",
+            "retired_publications_pending_deletion",
+            "consumed_key_package_refs",
+        ] {
+            let expected = match field {
+                "cutover_publication_blocked" => serde_json::json!(true),
+                "deletion_overflow_owner_event_id" => serde_json::Value::Null,
+                _ => serde_json::json!([]),
+            };
+            assert_eq!(upgraded.get(field), Some(&expected));
+        }
+
+        let privacy_record = privacy_journal_lifecycle_record();
+        new_writer
+            .execute(
+                "UPDATE cgka_key_package_lifecycle SET record = ?1 WHERE singleton = 1",
+                params![privacy_record.as_slice()],
+            )
+            .unwrap();
+
+        let error = old_writer
+            .execute(
+                "INSERT INTO cgka_key_package_lifecycle (singleton, record) VALUES (1, ?1)
+                 ON CONFLICT(singleton) DO UPDATE SET record = excluded.record",
+                params![schema_51_lifecycle_record()],
+            )
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("key package lifecycle privacy journals are required")
+        );
+        let retained: Vec<u8> = new_writer
+            .query_row(
+                "SELECT record FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(retained, privacy_record);
+
+        new_writer
+            .execute("DELETE FROM cgka_key_package_lifecycle", [])
+            .unwrap();
+        assert!(
+            old_writer
+                .execute(
+                    "INSERT INTO cgka_key_package_lifecycle (singleton, record) VALUES (1, ?1)",
+                    params![schema_51_lifecycle_record()],
+                )
+                .is_err(),
+            "the insert guard must reject an old-shaped row too"
+        );
+        let absent: Option<Vec<u8>> = new_writer
+            .query_row(
+                "SELECT record FROM cgka_key_package_lifecycle WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .optional()
+            .unwrap();
+        assert!(absent.is_none());
+    }
+}

--- a/crates/storage-sqlite/src/migrations/0057_epoch_backfill_intent_journal.rs
+++ b/crates/storage-sqlite/src/migrations/0057_epoch_backfill_intent_journal.rs
@@ -1,0 +1,111 @@
+//! Migration 0057: durable per-account epoch-backfill intent state.
+
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE TABLE app_epoch_backfill_intent_journal (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    record BLOB NOT NULL
+);
+"#,
+    )
+    .storage()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::migrations::{MIGRATIONS, run};
+    use cgka_traits::storage::StorageError;
+    use rusqlite::{Connection, OptionalExtension, params};
+
+    #[test]
+    fn migration_adds_an_empty_singleton_blob_journal_after_schema_56() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        run(&mut connection, &MIGRATIONS[..56]).unwrap();
+        let absent: Option<String> = connection
+            .query_row(
+                "SELECT name FROM sqlite_schema
+                 WHERE type = 'table' AND name = 'app_epoch_backfill_intent_journal'",
+                [],
+                |row| row.get(0),
+            )
+            .optional()
+            .unwrap();
+        assert_eq!(absent, None);
+
+        run(&mut connection, &MIGRATIONS[..57]).unwrap();
+
+        let initial: Option<Vec<u8>> = connection
+            .query_row(
+                "SELECT record FROM app_epoch_backfill_intent_journal WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .optional()
+            .unwrap();
+        assert_eq!(initial, None, "migration must not synthesize an intent");
+
+        let opaque = [0_u8, 0xff, 0x80, 0x00];
+        connection
+            .execute(
+                "INSERT INTO app_epoch_backfill_intent_journal (singleton, record)
+                 VALUES (1, ?1)",
+                params![opaque.as_slice()],
+            )
+            .unwrap();
+        let stored: Vec<u8> = connection
+            .query_row(
+                "SELECT record FROM app_epoch_backfill_intent_journal WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored, opaque);
+
+        assert!(
+            connection
+                .execute(
+                    "INSERT INTO app_epoch_backfill_intent_journal (singleton, record)
+                     VALUES (2, ?1)",
+                    params![opaque.as_slice()],
+                )
+                .is_err(),
+            "the per-account journal must admit only its singleton row"
+        );
+    }
+
+    #[test]
+    fn schema_56_runner_refuses_a_journal_database_without_mutating_the_blob() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        run(&mut connection, &MIGRATIONS[..57]).unwrap();
+        let opaque = [0_u8, 0xff, 0x80, 0x00];
+        connection
+            .execute(
+                "INSERT INTO app_epoch_backfill_intent_journal (singleton, record)
+                 VALUES (1, ?1)",
+                params![opaque.as_slice()],
+            )
+            .unwrap();
+
+        let error = run(&mut connection, &MIGRATIONS[..56]).unwrap_err();
+        assert!(matches!(
+            error,
+            StorageError::UnsupportedSchemaVersion {
+                found: 57,
+                latest_supported: 56,
+            }
+        ));
+        let retained: Vec<u8> = connection
+            .query_row(
+                "SELECT record FROM app_epoch_backfill_intent_journal WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(retained, opaque);
+    }
+}

--- a/crates/storage-sqlite/src/migrations/0058_account_visibility_journal.rs
+++ b/crates/storage-sqlite/src/migrations/0058_account_visibility_journal.rs
@@ -1,0 +1,112 @@
+//! Migration 0058: durable ordered account-runtime visibility outbox.
+
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE TABLE account_visibility_journal (
+    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+    operation_id BLOB NOT NULL CHECK (length(operation_id) > 0),
+    ordinal INTEGER NOT NULL CHECK (ordinal >= 0),
+    batch_id BLOB NOT NULL UNIQUE CHECK (length(batch_id) > 0),
+    record BLOB NOT NULL,
+    UNIQUE (operation_id, ordinal)
+);
+"#,
+    )
+    .storage()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::migrations::{MIGRATIONS, run};
+    use cgka_traits::storage::StorageError;
+    use rusqlite::{Connection, OptionalExtension, params};
+
+    #[test]
+    fn migration_adds_an_empty_ordered_visibility_journal_after_schema_57() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        run(&mut connection, &MIGRATIONS[..57]).unwrap();
+        let absent: Option<String> = connection
+            .query_row(
+                "SELECT name FROM sqlite_schema
+                 WHERE type = 'table' AND name = 'account_visibility_journal'",
+                [],
+                |row| row.get(0),
+            )
+            .optional()
+            .unwrap();
+        assert_eq!(absent, None);
+
+        run(&mut connection, MIGRATIONS).unwrap();
+        let initial: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM account_visibility_journal",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(initial, 0, "migration must not synthesize visibility");
+
+        let operation = [0_u8, 0xff, 0x80];
+        let batch = [9_u8, 0, 8];
+        let record = [7_u8, 0xff, 6, 0];
+        connection
+            .execute(
+                "INSERT INTO account_visibility_journal
+                    (operation_id, ordinal, batch_id, record)
+                 VALUES (?1, 0, ?2, ?3)",
+                params![operation.as_slice(), batch.as_slice(), record.as_slice()],
+            )
+            .unwrap();
+        let stored: (Vec<u8>, i64, Vec<u8>, Vec<u8>) = connection
+            .query_row(
+                "SELECT operation_id, ordinal, batch_id, record
+                 FROM account_visibility_journal",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            stored,
+            (operation.to_vec(), 0, batch.to_vec(), record.to_vec())
+        );
+    }
+
+    #[test]
+    fn schema_57_runner_refuses_a_visibility_journal_database_without_mutating_rows() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        run(&mut connection, MIGRATIONS).unwrap();
+        let operation = [1_u8, 2, 3];
+        let batch = [4_u8, 5, 6];
+        let record = [0_u8, 0xff, 0x80, 0x00];
+        connection
+            .execute(
+                "INSERT INTO account_visibility_journal
+                    (operation_id, ordinal, batch_id, record)
+                 VALUES (?1, 0, ?2, ?3)",
+                params![operation.as_slice(), batch.as_slice(), record.as_slice()],
+            )
+            .unwrap();
+
+        let error = run(&mut connection, &MIGRATIONS[..57]).unwrap_err();
+        assert!(matches!(
+            error,
+            StorageError::UnsupportedSchemaVersion {
+                found: 58,
+                latest_supported: 57,
+            }
+        ));
+        let retained: Vec<u8> = connection
+            .query_row(
+                "SELECT record FROM account_visibility_journal WHERE batch_id = ?1",
+                params![batch.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(retained, record);
+    }
+}

--- a/crates/storage-sqlite/src/shared.rs
+++ b/crates/storage-sqlite/src/shared.rs
@@ -257,6 +257,33 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
         Ok(Some(record))
     }
 
+    /// Remove one exact cached KeyPackage projection without disturbing the
+    /// identity's public profile, relay lists, follow edges, or their generic
+    /// event provenance.
+    ///
+    /// `expected_key_package_json` makes this a compare-and-swap: a sibling
+    /// device may publish under a different NIP-33 `d` slot while a removed
+    /// local slot is being scrubbed, and that newer projection must survive.
+    pub fn clear_public_directory_key_package_if_matches(
+        &self,
+        account_id_hex: &str,
+        expected_key_package_json: &str,
+    ) -> StorageResult<bool> {
+        retry_on_busy(|| {
+            let conn = self.lock()?;
+            let changed = conn
+                .execute(
+                    "UPDATE directory_users
+                     SET key_package_json = NULL
+                     WHERE account_id_hex = ?1
+                       AND key_package_json = ?2",
+                    params![account_id_hex, expected_key_package_json],
+                )
+                .storage()?;
+            Ok(changed != 0)
+        })
+    }
+
     pub fn public_directory_users(&self) -> StorageResult<Vec<PublicDirectoryUserRecord>> {
         self.public_directory_users_capped(PUBLIC_DIRECTORY_USERS_MAX)
     }
@@ -620,6 +647,64 @@ mod tests {
                 .unwrap(),
             record
         );
+    }
+
+    #[test]
+    fn conditional_key_package_clear_preserves_public_identity_projection() {
+        let storage = SqliteSharedStorage::in_memory().unwrap();
+        let record = PublicDirectoryUserRecord {
+            account_id_hex: "aa".repeat(32),
+            npub: "npub1example".to_owned(),
+            profile_json: Some(r#"{"name":"Alice"}"#.to_owned()),
+            relay_lists_json: r#"{"nip65":["wss://relay.example"]}"#.to_owned(),
+            key_package_json: Some(r#"{"key_package_id":"removed-slot"}"#.to_owned()),
+            event_id_hex: Some("bb".repeat(32)),
+            // These columns describe the combined public-directory projection,
+            // not exclusively its KeyPackage. Use profile-like provenance so
+            // this regression catches a scrub that damages profile ordering.
+            event_kind: Some(0),
+            event_created_at: Some(1_700_000_000),
+            follows: vec!["cc".repeat(32)],
+        };
+        storage.put_public_directory_user(&record).unwrap();
+
+        assert!(
+            !storage
+                .clear_public_directory_key_package_if_matches(
+                    &record.account_id_hex,
+                    r#"{"key_package_id":"sibling-slot"}"#,
+                )
+                .unwrap(),
+            "a changed sibling-device projection must win the CAS"
+        );
+        assert_eq!(
+            storage
+                .public_directory_user(&record.account_id_hex)
+                .unwrap()
+                .unwrap(),
+            record
+        );
+
+        assert!(
+            storage
+                .clear_public_directory_key_package_if_matches(
+                    &record.account_id_hex,
+                    record.key_package_json.as_deref().unwrap(),
+                )
+                .unwrap()
+        );
+        let scrubbed = storage
+            .public_directory_user(&record.account_id_hex)
+            .unwrap()
+            .unwrap();
+        assert_eq!(scrubbed.npub, record.npub);
+        assert_eq!(scrubbed.profile_json, record.profile_json);
+        assert_eq!(scrubbed.relay_lists_json, record.relay_lists_json);
+        assert_eq!(scrubbed.follows, record.follows);
+        assert!(scrubbed.key_package_json.is_none());
+        assert_eq!(scrubbed.event_id_hex, record.event_id_hex);
+        assert_eq!(scrubbed.event_kind, record.event_kind);
+        assert_eq!(scrubbed.event_created_at, record.event_created_at);
     }
 
     #[test]

--- a/crates/storage-sqlite/src/storage/leave_requests.rs
+++ b/crates/storage-sqlite/src/storage/leave_requests.rs
@@ -104,6 +104,7 @@ mod tests {
             group_id: group.id.clone(),
             requested_at_ms: 42,
             last_proposed_epoch: Some(EpochId(3)),
+            last_proposed_message_id: None,
         };
         store.put_leave_request(&request).unwrap();
         assert_eq!(store.leave_request(&group.id).unwrap(), Some(request));

--- a/crates/traits/src/lib.rs
+++ b/crates/traits/src/lib.rs
@@ -87,10 +87,11 @@ pub use ingest::{
     ProposalRejectionCategory, StaleReason,
 };
 pub use maintenance::{
-    DurableGroupEvolution, DurableTransportFanout, GroupEvolutionPhase, GroupEvolutionSemantic,
-    GroupMaintenanceState, GroupMaintenanceStatus, KeyPackageLifecycleState, MaintenanceObligation,
-    MaintenancePhase, MaintenanceRandom, MaintenanceRunSummary, MaintenanceTrigger, MonotonicClock,
-    PendingKeyPackageReplacement, PeriodicMaintenancePolicy, RetainedKeyPackagePrivateMaterial,
+    ConsumedKeyPackageRefJournalFull, DurableGroupEvolution, DurableTransportFanout,
+    GroupEvolutionPhase, GroupEvolutionSemantic, GroupMaintenanceState, GroupMaintenanceStatus,
+    KeyPackageLifecycleState, MaintenanceObligation, MaintenancePhase, MaintenanceRandom,
+    MaintenanceRunSummary, MaintenanceTrigger, MonotonicClock, PendingKeyPackageReplacement,
+    PeriodicMaintenancePolicy, RetainedKeyPackagePrivateMaterial, RetiredKeyPackagePublication,
     SendMaintenanceDisposition, SignedPublicationArtifact, TransportFanoutAttemptState,
     TransportFanoutTarget, WallClock,
 };

--- a/crates/traits/src/maintenance.rs
+++ b/crates/traits/src/maintenance.rs
@@ -11,6 +11,36 @@ use crate::transport::{Timestamp, TransportMessage};
 use crate::transport_adapter::{TransportEndpoint, TransportPublishTarget};
 use crate::types::{EpochId, GroupId, MessageId};
 use serde::{Deserialize, Serialize};
+
+/// Maximum durable exact `(signed event id, relay endpoint)` liabilities held
+/// by one account-device KeyPackage lifecycle.
+pub const MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES: usize = 256;
+/// Additional exact endpoint liabilities reserved exclusively for atomically
+/// deleting one explicitly selected KeyPackage revision. An event id that is
+/// not projected as current/pending is still treated as potentially live for
+/// this purpose because the deletion API carries no stable-slot proof. The
+/// app's relay safety boundary caps one publication route at sixteen
+/// endpoints. Keeping the reserve separate means a full ordinary journal
+/// cannot force partial same-slot deletion, while discovery and new
+/// publication remain bound by
+/// [`MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES`].
+pub const MAX_KEY_PACKAGE_LIVE_DELETION_OVERFLOW_LIABILITIES: usize = 16;
+/// Absolute lifecycle bound while a live-revision deletion is in flight.
+pub const MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES_WITH_LIVE_DELETION_OVERFLOW: usize =
+    MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES
+        + MAX_KEY_PACKAGE_LIVE_DELETION_OVERFLOW_LIABILITIES;
+/// Maximum distinct consumed KeyPackage references awaiting account cleanup.
+/// The journal never evicts live evidence; a transaction that would exceed
+/// this cap fails closed before committing the Welcome.
+pub const MAX_CONSUMED_KEY_PACKAGE_REFS_PENDING_CLEANUP: usize = 256;
+
+/// The durable consumed-KeyPackage cleanup journal has no free slot.
+///
+/// Welcome processing must fail closed instead of evicting an older, still
+/// unswept consumption record.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+#[error("consumed KeyPackage cleanup journal is full")]
+pub struct ConsumedKeyPackageRefJournalFull;
 use std::time::Duration;
 
 pub const POST_JOIN_CONTENTION_JITTER_MAX_MS: u64 = 30_000;
@@ -219,8 +249,8 @@ pub struct DurableTransportFanout {
     pub bounded_until: Option<Timestamp>,
 }
 
-/// Transport-neutral exact signed artifact used for account-scoped
-/// replaceable events such as a KeyPackage publication.
+/// One exact signed revision of an account-scoped replaceable event such as a
+/// KeyPackage publication.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SignedPublicationArtifact {
     pub id: MessageId,
@@ -228,13 +258,45 @@ pub struct SignedPublicationArtifact {
     pub bytes: Vec<u8>,
 }
 
+/// A superseded signed KeyPackage revision that still has relay-side deletion
+/// work outstanding.
+///
+/// Reauthoring keeps the same replaceable-event coordinate, but a relay that
+/// accepted (or may ambiguously have accepted) the older event can retain that
+/// exact event id. Each endpoint remains listed until it explicitly
+/// acknowledges a deletion for `event_id`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RetiredKeyPackagePublication {
+    pub event_id: MessageId,
+    pub authored_created_at: Timestamp,
+    /// Reference of the semantic MLS KeyPackage carried by this signed
+    /// revision. This lets consumption make every older transport revision of
+    /// the same single-use package immediately eligible for deletion.
+    #[serde(default)]
+    pub key_package_ref: Option<Vec<u8>>,
+    /// MLS lifetime boundary for the semantic KeyPackage carried by this
+    /// revision. Once reached, the old event may be deleted even when no newer
+    /// revision reached that endpoint.
+    #[serde(default)]
+    pub package_not_after: Option<Timestamp>,
+    /// The underlying single-use KeyPackage is no longer usable locally (for
+    /// example because a Welcome consumed it), so successor acknowledgement is
+    /// not required before deleting this revision.
+    #[serde(default)]
+    pub delete_without_successor: bool,
+    #[serde(default)]
+    pub deletion_targets: Vec<TransportFanoutTarget>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PendingKeyPackageReplacement {
     pub key_package: KeyPackage,
     pub key_package_ref: Vec<u8>,
-    /// Transport authoring time selected before signing. The private bundle
-    /// and this enclosing lifecycle intent are persisted atomically; signing
-    /// may therefore resume safely after a crash.
+    /// Transport authoring time of the current pending signed revision. The
+    /// private bundle and this enclosing lifecycle intent are persisted
+    /// atomically; signing may therefore resume safely after a crash. A
+    /// bounded-age transport updates this field and `signed_event` together
+    /// before exposing a newer revision.
     pub authored_created_at: Timestamp,
     pub not_before: Timestamp,
     pub not_after: Timestamp,
@@ -260,17 +322,49 @@ pub struct KeyPackageLifecycleState {
     pub stable_slot_id: String,
     #[serde(default)]
     pub phase: MaintenancePhase,
+    /// Durable fail-closed gate for upgrade cutover discovery. While set, the
+    /// account may prepare local KeyPackage material and retry exact deletion
+    /// obligations, but it must not publish, republish, or fan out a kind
+    /// 30443 revision. The app clears this only after every authoritative
+    /// relay completed its scan and every discovered exact endpoint liability
+    /// was admitted durably.
+    #[serde(default)]
+    pub cutover_publication_blocked: bool,
     pub current_key_package: Option<KeyPackage>,
     pub current_key_package_ref: Option<Vec<u8>>,
     pub current_not_before: Option<Timestamp>,
     pub current_not_after: Option<Timestamp>,
     pub authored_event_id: Option<MessageId>,
+    /// Highest transport authoring time durably selected for this stable
+    /// replaceable-event slot. This normally describes the current artifact,
+    /// but remains above it when a newer pending artifact was consumed before
+    /// acknowledgement so the required fresh replacement sorts after both.
     pub authored_event_created_at: Option<Timestamp>,
-    /// Exact current replaceable event retained until its snapshotted fanout
-    /// finishes. Local lifecycle promotion still occurs on the first accepted
-    /// acknowledgement.
+    /// Current signed revision retained for restart-safe exact retries within
+    /// that revision. A bounded-age transport may atomically replace it with a
+    /// strictly newer revision at the same coordinate and reset every live
+    /// target before fanout continues. Local lifecycle promotion still occurs
+    /// on the first accepted acknowledgement.
     #[serde(default)]
     pub authored_signed_event: Option<SignedPublicationArtifact>,
+    /// Current or pending signed revision ids selected for relay deletion.
+    /// An artifact remains forbidden from exact republication while its id is
+    /// present; the marker follows that exact revision rather than leaking
+    /// onto a newly generated KeyPackage after expiry or promotion.
+    #[serde(default)]
+    pub deleted_live_revision_event_ids: Vec<MessageId>,
+    /// Exact deletion currently entitled to use the bounded liabilities above
+    /// [`MAX_KEY_PACKAGE_SIGNED_PUBLICATION_LIABILITIES`]. The owner remains
+    /// durable until every one of that event's deletion targets has a terminal
+    /// receipt, preventing two atomic exact-deletion sets from sharing the
+    /// overflow reserve across retries or process restarts.
+    #[serde(default)]
+    pub deletion_overflow_owner_event_id: Option<MessageId>,
+    /// Superseded signed revisions whose possible relay copies still require
+    /// explicit deletion acknowledgement. This is independent of MLS private
+    /// material retention and therefore survives package expiry and restart.
+    #[serde(default)]
+    pub retired_publications_pending_deletion: Vec<RetiredKeyPackagePublication>,
     #[serde(default)]
     pub publication_targets: Vec<TransportFanoutTarget>,
     pub refresh_at: Option<Timestamp>,
@@ -282,6 +376,12 @@ pub struct KeyPackageLifecycleState {
     pub last_consumed_key_package_ref: Option<Vec<u8>>,
     #[serde(default)]
     pub last_consumed_at: Option<Timestamp>,
+    /// Durable, deduplicated references of locally owned KeyPackages proven
+    /// consumed by successfully processed Welcomes. Only the account sweep
+    /// may remove evidence after it has handled the matching private material;
+    /// unmatched upgrade-era evidence is retained fail-closed.
+    #[serde(default)]
+    pub consumed_key_package_refs: Vec<Vec<u8>>,
     /// Prior, unconsumed packages remain decryptable until their MLS lifetime
     /// expires so an invite already in flight can still be processed.
     #[serde(default)]
@@ -297,6 +397,7 @@ impl KeyPackageLifecycleState {
         Self {
             stable_slot_id,
             phase: MaintenancePhase::Complete,
+            cutover_publication_blocked: false,
             current_key_package: None,
             current_key_package_ref: None,
             current_not_before: None,
@@ -304,13 +405,80 @@ impl KeyPackageLifecycleState {
             authored_event_id: None,
             authored_event_created_at: None,
             authored_signed_event: None,
+            deleted_live_revision_event_ids: Vec::new(),
+            deletion_overflow_owner_event_id: None,
+            retired_publications_pending_deletion: Vec::new(),
             publication_targets: Vec::new(),
             refresh_at: None,
             upgrade_rotation_recorded: false,
             last_consumed_key_package_ref: None,
             last_consumed_at: None,
+            consumed_key_package_refs: Vec::new(),
             retained_private_material: Vec::new(),
             pending_replacement: None,
+        }
+    }
+
+    /// Record a locally matched Welcome consumption without overwriting an
+    /// earlier still-live reference. The legacy `last_consumed_*` fields remain
+    /// the latest-consumption status projection.
+    pub fn record_consumed_key_package_ref(
+        &mut self,
+        key_package_ref: Vec<u8>,
+        consumed_at: Timestamp,
+    ) -> Result<(), ConsumedKeyPackageRefJournalFull> {
+        if !self.consumed_key_package_refs.contains(&key_package_ref) {
+            if self.consumed_key_package_refs.len() >= MAX_CONSUMED_KEY_PACKAGE_REFS_PENDING_CLEANUP
+            {
+                return Err(ConsumedKeyPackageRefJournalFull);
+            }
+            self.consumed_key_package_refs.push(key_package_ref.clone());
+        }
+        self.last_consumed_key_package_ref = Some(key_package_ref);
+        self.last_consumed_at = Some(consumed_at);
+        Ok(())
+    }
+
+    /// Import the legacy last-consumed marker and deduplicate without pruning.
+    /// Only the account sweep that actually handles matching private/lifecycle
+    /// material may clear consumption evidence; an upgrade row may not yet
+    /// project its still-owned OpenMLS bundle into these lifecycle fields.
+    pub fn reconcile_consumed_key_package_refs(&mut self) {
+        if let Some(last) = self.last_consumed_key_package_ref.as_ref()
+            && !self
+                .consumed_key_package_refs
+                .iter()
+                .any(|candidate| candidate == last)
+            && self.consumed_key_package_refs.len() < MAX_CONSUMED_KEY_PACKAGE_REFS_PENDING_CLEANUP
+        {
+            self.consumed_key_package_refs.push(last.clone());
+        }
+        let mut reconciled = Vec::with_capacity(self.consumed_key_package_refs.len());
+        for consumed in self.consumed_key_package_refs.drain(..) {
+            if !reconciled.iter().any(|candidate| candidate == &consumed) {
+                reconciled.push(consumed);
+            }
+        }
+        self.consumed_key_package_refs = reconciled;
+    }
+
+    /// Whether a still-live/private lifecycle reference has durable Welcome
+    /// consumption evidence. The legacy field is accepted for upgrade safety.
+    pub fn key_package_ref_is_consumed(&self, key_package_ref: &[u8]) -> bool {
+        self.consumed_key_package_refs
+            .iter()
+            .any(|candidate| candidate.as_slice() == key_package_ref)
+            || self.last_consumed_key_package_ref.as_deref() == Some(key_package_ref)
+    }
+
+    /// Clear one consumption marker only after the account sweep has handled
+    /// the matching current/pending/retained private material.
+    pub fn clear_consumed_key_package_ref(&mut self, key_package_ref: &[u8]) {
+        self.consumed_key_package_refs
+            .retain(|candidate| candidate.as_slice() != key_package_ref);
+        if self.last_consumed_key_package_ref.as_deref() == Some(key_package_ref) {
+            self.last_consumed_key_package_ref = self.consumed_key_package_refs.last().cloned();
+            self.last_consumed_at = None;
         }
     }
 }
@@ -359,7 +527,10 @@ pub struct GroupMaintenanceStatus {
 
 #[cfg(test)]
 mod tests {
-    use super::MaintenancePhase;
+    use super::{
+        KeyPackageLifecycleState, MAX_CONSUMED_KEY_PACKAGE_REFS_PENDING_CLEANUP, MaintenancePhase,
+    };
+    use crate::Timestamp;
 
     #[test]
     fn maintenance_phase_names_are_stable_snake_case() {
@@ -374,6 +545,73 @@ mod tests {
         assert_eq!(
             MaintenancePhase::ClockSkewBlocked.as_str(),
             "clock_skew_blocked"
+        );
+    }
+
+    #[test]
+    fn consumed_key_package_ref_journal_is_serde_defaulted_deduplicated_and_reconciled() {
+        let mut legacy_json =
+            serde_json::to_value(KeyPackageLifecycleState::slot_only("stable-slot".into()))
+                .unwrap();
+        legacy_json
+            .as_object_mut()
+            .unwrap()
+            .remove("consumed_key_package_refs");
+        legacy_json
+            .as_object_mut()
+            .unwrap()
+            .remove("cutover_publication_blocked");
+        legacy_json
+            .as_object_mut()
+            .unwrap()
+            .remove("deletion_overflow_owner_event_id");
+        let legacy: KeyPackageLifecycleState = serde_json::from_value(legacy_json).unwrap();
+        assert!(legacy.consumed_key_package_refs.is_empty());
+        assert!(!legacy.cutover_publication_blocked);
+        assert!(legacy.deletion_overflow_owner_event_id.is_none());
+
+        let mut lifecycle = KeyPackageLifecycleState::slot_only("stable-slot".into());
+        lifecycle.current_key_package_ref = Some(vec![1]);
+        lifecycle
+            .record_consumed_key_package_ref(vec![1], Timestamp(10))
+            .unwrap();
+        lifecycle
+            .record_consumed_key_package_ref(vec![1], Timestamp(11))
+            .unwrap();
+        assert_eq!(lifecycle.consumed_key_package_refs, vec![vec![1]]);
+        assert_eq!(lifecycle.last_consumed_at, Some(Timestamp(11)));
+
+        lifecycle.current_key_package_ref = Some(vec![2]);
+        lifecycle
+            .record_consumed_key_package_ref(vec![2], Timestamp(12))
+            .unwrap();
+        assert_eq!(
+            lifecycle.consumed_key_package_refs,
+            vec![vec![1], vec![2]],
+            "only the account sweep may clear older unswept evidence"
+        );
+        lifecycle.clear_consumed_key_package_ref(&[1]);
+        assert_eq!(lifecycle.consumed_key_package_refs, vec![vec![2]]);
+        lifecycle.current_key_package_ref = None;
+        lifecycle.clear_consumed_key_package_ref(&[2]);
+        assert!(lifecycle.consumed_key_package_refs.is_empty());
+        assert!(lifecycle.last_consumed_key_package_ref.is_none());
+        assert!(lifecycle.last_consumed_at.is_none());
+
+        let mut bounded = KeyPackageLifecycleState::slot_only(String::new());
+        for index in 0..MAX_CONSUMED_KEY_PACKAGE_REFS_PENDING_CLEANUP {
+            bounded
+                .record_consumed_key_package_ref(
+                    u64::try_from(index).unwrap().to_be_bytes().to_vec(),
+                    Timestamp(index as u64),
+                )
+                .unwrap();
+        }
+        assert!(
+            bounded
+                .record_consumed_key_package_ref(vec![0xff; 9], Timestamp(u64::MAX))
+                .is_err(),
+            "the journal fails closed rather than evicting unswept evidence"
         );
     }
 }

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -403,6 +403,11 @@ pub struct LeaveRequest {
     pub group_id: GroupId,
     pub requested_at_ms: u64,
     pub last_proposed_epoch: Option<EpochId>,
+    /// Exact engine message id of the most recently accepted SelfRemove.
+    /// Older records predate this attribution and hydrate it from the paired
+    /// durable sent-message row.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_proposed_message_id: Option<MessageId>,
 }
 
 pub trait LeaveRequestStorage {

--- a/crates/traits/src/transport_adapter.rs
+++ b/crates/traits/src/transport_adapter.rs
@@ -849,6 +849,16 @@ pub struct TransportEndpointFailure {
     pub rejection_category: Option<TransportEndpointRejectionCategory>,
 }
 
+impl TransportEndpointFailure {
+    /// Whether the adapter mapped an exact, stable relay response to terminal
+    /// target-absence evidence. The sentinel reason is adapter-authored and
+    /// privacy-safe; arbitrary relay suffix text is never retained here.
+    pub fn confirms_target_absence(&self) -> bool {
+        self.rejection_category == Some(TransportEndpointRejectionCategory::Invalid)
+            && self.reason == "relay rejected event (not-found)"
+    }
+}
+
 /// Publish failure surfaced by transport adapters.
 ///
 /// `summary` is safe for `Display`/logging. Per-endpoint diagnostics live in

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -92,6 +92,7 @@ pub use telemetry::{
 };
 
 const DELIVERY_BUFFER: usize = 1024;
+const GROUP_MAINTENANCE_SUBSCRIPTION_ID_PREFIX: &str = "marmot:group-maintenance:";
 
 fn unix_now_seconds() -> u64 {
     SystemTime::now()
@@ -672,12 +673,14 @@ impl NostrTransportAdapter {
         subscription: NostrSubscription,
     ) -> Result<(), TransportAdapterError> {
         let _subscription_guard = self.subscription_lock.lock().await;
-        self.relay_client.unsubscribe(subscription.clone()).await?;
+        // Local teardown is authoritative even when relay cleanup fails or is
+        // cancelled: once the caller removes this temporary subscription, a
+        // late raw relay copy must no longer be an account delivery path.
         self.state
             .write()
             .await
             .forget_subscription_starts(std::slice::from_ref(&subscription));
-        Ok(())
+        self.relay_client.unsubscribe(subscription).await
     }
 
     /// Resolve opaque relay indices to relay endpoints for the opt-in export
@@ -722,6 +725,37 @@ impl NostrTransportAdapter {
             .await
     }
 
+    /// Route a raw SDK relay copy only when it belongs to an active temporary
+    /// group-maintenance subscription.
+    ///
+    /// The SDK's database is shared by every local account. When another
+    /// account has already cached an event, a later full-history REQ emits only
+    /// the raw per-subscription copy; the SDK's ordinary deduplicated `Event`
+    /// notification is suppressed. Subscription ownership restores that replay
+    /// for the requesting account without turning ordinary raw copies into a
+    /// second, cross-account delivery path.
+    #[cfg(feature = "sdk")]
+    pub async fn handle_group_maintenance_replay(
+        &self,
+        relay_event: NostrRelayEvent,
+    ) -> Result<usize, TransportAdapterError> {
+        let Some(subscription_id) = relay_event.subscription_id.as_deref() else {
+            return Ok(0);
+        };
+        let account_id = self
+            .state
+            .read()
+            .await
+            .group_maintenance_accounts
+            .get(subscription_id)
+            .cloned();
+        let Some(account_id) = account_id else {
+            return Ok(0);
+        };
+        self.handle_relay_event_scoped(relay_event, Some(&account_id))
+            .await
+    }
+
     async fn handle_relay_event_scoped(
         &self,
         relay_event: NostrRelayEvent,
@@ -734,6 +768,27 @@ impl NostrTransportAdapter {
         let received_at = Timestamp(unix_now_seconds());
         let mut routes = {
             let state = self.state.read().await;
+            if let Some(subscription_id) = relay_event.subscription_id.as_deref()
+                && subscription_id.starts_with(GROUP_MAINTENANCE_SUBSCRIPTION_ID_PREFIX)
+                && state
+                    .group_maintenance_accounts
+                    .get(subscription_id)
+                    .is_none_or(|owner| account_id.is_some_and(|account_id| owner != account_id))
+            {
+                // nostr-relay-pool does not verify subscription existence by
+                // default. A relay can therefore race a queued EVENT behind
+                // CLOSE (or keep sending after failed remote teardown), and
+                // the SDK may surface that stale maintenance copy as its
+                // deduplicated Event. Once local ownership is gone, fail
+                // closed instead of letting the stale temporary REQ re-enter
+                // ordinary group routing.
+                tracing::debug!(
+                    target: "transport_nostr_adapter::adapter",
+                    method = "handle_relay_event_scoped",
+                    "ignored event for inactive maintenance subscription"
+                );
+                return Ok(0);
+            }
             state.routes_for(&message, &relay_event.endpoint)
         };
         if let Some(account_id) = account_id {
@@ -1296,6 +1351,15 @@ struct AdapterState {
     /// sync may append only missing pre-REQ routes while a subscribe batch is in
     /// flight; both success and failure rebuild the index before returning.
     by_transport_group: HashMap<Vec<u8>, Vec<GroupRouteEntry>>,
+    /// Account ownership for active full-history post-join subscriptions.
+    ///
+    /// `nostr-sdk` suppresses its deduplicated `Event` notification when a
+    /// relay replays an event already present in the shared SDK database, but
+    /// still emits the raw per-subscription copy. Keeping this ownership map
+    /// lets that raw maintenance replay use the ordinary signed-routing table
+    /// while remaining scoped to the account that requested it. Ordinary raw
+    /// subscription copies remain telemetry-only.
+    group_maintenance_accounts: HashMap<String, MemberId>,
     /// Unconfirmed relay unsubscribes retained until teardown succeeds.
     /// Routing state (`accounts`/`by_transport_group`) already reflects the
     /// removal; these are relay-side cleanups only, drained on later
@@ -1486,13 +1550,18 @@ impl AdapterState {
 
     fn record_subscription_starts(&mut self, subscriptions: &[NostrSubscription], now_ms: u64) {
         for subscription in subscriptions {
+            let subscription_id = subscription.subscription_id();
+            if let NostrSubscription::GroupMaintenance { account_id, .. } = subscription {
+                self.group_maintenance_accounts
+                    .insert(subscription_id.clone(), account_id.clone());
+            }
             let relays: Vec<RelayIndex> = subscription
                 .endpoints()
                 .iter()
                 .map(|endpoint| self.relay_index.index_for(endpoint))
                 .collect();
             self.sync
-                .record_subscription_start(&subscription.subscription_id(), &relays, now_ms);
+                .record_subscription_start(&subscription_id, &relays, now_ms);
         }
     }
 
@@ -1541,8 +1610,11 @@ impl AdapterState {
     /// telemetry map tracks live subscriptions rather than historical churn.
     fn forget_subscription_starts(&mut self, subscriptions: &[NostrSubscription]) {
         for subscription in subscriptions {
-            self.sync
-                .forget_subscription(&subscription.subscription_id());
+            let subscription_id = subscription.subscription_id();
+            self.sync.forget_subscription(&subscription_id);
+            if matches!(subscription, NostrSubscription::GroupMaintenance { .. }) {
+                self.group_maintenance_accounts.remove(&subscription_id);
+            }
         }
     }
 
@@ -1579,6 +1651,17 @@ impl AdapterState {
     fn forget_account_subscription_starts(&mut self, account_id: &MemberId) {
         for id in self.account_subscription_ids(account_id) {
             self.sync.forget_subscription(&id);
+        }
+        let maintenance_ids = self
+            .group_maintenance_accounts
+            .iter()
+            .filter_map(|(subscription_id, owner)| {
+                (owner == account_id).then_some(subscription_id.clone())
+            })
+            .collect::<Vec<_>>();
+        for subscription_id in maintenance_ids {
+            self.group_maintenance_accounts.remove(&subscription_id);
+            self.sync.forget_subscription(&subscription_id);
         }
     }
 

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -1037,14 +1037,19 @@ impl TransportAdapter for NostrTransportAdapter {
             subscriptions_removed = removed_count,
             "deactivating transport account"
         );
-        self.relay_client.unsubscribe_account(account_id).await?;
-        let mut state = self.state.write().await;
-        state.forget_account_subscription_starts(account_id);
-        // The blanket `unsubscribe_account` above supersedes any queued
-        // per-subscription unsubscribes for this account.
-        state.clear_pending_unsubscribes_for_account(account_id);
-        state.deactivate(account_id, removed_count);
-        Ok(())
+        // Commit the local teardown before the fallible/cancellable relay I/O.
+        // A signed-out or wiped account cannot remain an active delivery target
+        // merely because a relay is unavailable or this future is cancelled.
+        {
+            let mut state = self.state.write().await;
+            state.forget_account_subscription_starts(account_id);
+            // The blanket `unsubscribe_account` below supersedes queued
+            // per-subscription relay cleanup for this account.
+            state.clear_pending_unsubscribes_for_account(account_id);
+            state.deactivate(account_id, removed_count);
+        }
+
+        self.relay_client.unsubscribe_account(account_id).await
     }
 
     async fn publish(

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -478,23 +478,31 @@ impl NostrSdkRelayClient {
                                         event,
                                     },
                             } => {
-                                // Raw per-relay copy (not deduplicated): telemetry
-                                // only, so cross-relay spread sees every relay's
-                                // copy. Delivery happens on the deduplicated
-                                // `Event` notification above.
+                                // Raw per-relay copy (not deduplicated): always
+                                // retain it for telemetry, so cross-relay spread
+                                // sees every relay's copy. Normally delivery
+                                // happens on the deduplicated `Event`
+                                // notification above. One exception is an active
+                                // full-history group-maintenance subscription:
+                                // nostr-sdk suppresses `Event` when another local
+                                // account already cached the replayed event in
+                                // the shared database, while this verified raw
+                                // copy is still emitted. The adapter registry
+                                // scopes that replay to the requesting account.
                                 if let Ok(event) = NostrTransportEvent::from_nostr_event(&event) {
                                     tracing::trace!(
                                         target: "transport_nostr_adapter::sdk_client",
                                         method = "spawn_notification_forwarder",
                                         "observing per-relay event copy"
                                     );
-                                    adapter
-                                        .observe_relay_event(NostrRelayEvent {
-                                            endpoint: TransportEndpoint(relay_url.to_string()),
-                                            subscription_id: Some(subscription_id.to_string()),
-                                            event,
-                                        })
-                                        .await;
+                                    let relay_event = NostrRelayEvent {
+                                        endpoint: TransportEndpoint(relay_url.to_string()),
+                                        subscription_id: Some(subscription_id.to_string()),
+                                        event,
+                                    };
+                                    adapter.observe_relay_event(relay_event.clone()).await;
+                                    let _ =
+                                        adapter.handle_group_maintenance_replay(relay_event).await;
                                 }
                                 Ok(false)
                             }
@@ -1577,8 +1585,10 @@ fn relay_rejection_endpoint_failure(
 mod tests {
     use super::*;
     use crate::NostrKeyPackagePublication;
-    use cgka_traits::Timestamp;
     use cgka_traits::engine::KeyPackage;
+    use cgka_traits::{
+        Timestamp, TransportAccountActivation, TransportAdapter, TransportGroupSubscription,
+    };
     use futures::{SinkExt, StreamExt};
     use nostr_relay_builder::MockRelay;
     use nostr_sdk::prelude::{DatabaseEventStatus, EventBuilder, Keys, Kind, Tag};
@@ -1600,6 +1610,204 @@ mod tests {
             .sign_with_keys(&ephemeral)
             .expect("sign ephemeral 445");
         NostrTransportEvent::from_nostr_event(&signed).expect("dto from signed event")
+    }
+
+    #[tokio::test]
+    async fn shared_sdk_cache_replays_group_history_only_to_maintenance_owner() {
+        let relay = timeout(Duration::from_secs(5), MockRelay::run())
+            .await
+            .expect("local relay starts within the test budget")
+            .expect("start relay");
+        let endpoint = TransportEndpoint(relay.url().await.to_string());
+        let sdk = NostrSdkRelayClient::new(Client::builder().build());
+        let adapter = NostrTransportAdapter::new(Arc::new(sdk.clone()));
+        let forwarder = sdk.spawn_notification_forwarder(adapter.clone());
+        // Let the spawned task install its notification receiver before the
+        // first subscription can produce stored-event notifications.
+        tokio::task::yield_now().await;
+
+        let alice = MemberId::new(Keys::generate().public_key().to_bytes().to_vec());
+        let bob = MemberId::new(Keys::generate().public_key().to_bytes().to_vec());
+        let group = TransportGroupSubscription {
+            group_id: cgka_traits::GroupId::new(vec![0xAB; 32]),
+            transport_group_id: vec![0xCC; 32],
+            endpoints: vec![endpoint.clone()],
+        };
+        timeout(
+            Duration::from_secs(5),
+            adapter.activate_account(TransportAccountActivation {
+                account_id: alice.clone(),
+                inbox_endpoints: vec![endpoint.clone()],
+                group_subscriptions: vec![group.clone()],
+                since: None,
+            }),
+        )
+        .await
+        .expect("account A activation finishes within the test budget")
+        .expect("activate account A");
+
+        let event = signed_group_event_dto();
+        // Use a distinct client/database for the remote sender. Publishing
+        // through the recipient client would pre-cache the outgoing event and
+        // suppress A's initial deduplicated Event notification too, which is a
+        // different scenario from A caching a genuinely received event.
+        let publisher = NostrSdkRelayClient::new(Client::builder().build());
+        timeout(
+            Duration::from_secs(5),
+            publisher.publish_event(std::slice::from_ref(&endpoint), &event, 1),
+        )
+        .await
+        .expect("publish finishes within the test budget")
+        .expect("publish event for account A's live subscription");
+        let alice_delivery = timeout(Duration::from_secs(5), adapter.receive())
+            .await
+            .expect("account A receives the live event")
+            .expect("delivery queue remains open")
+            .expect("account A delivery exists");
+        assert_eq!(alice_delivery.account_id, alice);
+
+        // Account B shares the same nostr-sdk client/database. Its ordinary
+        // group REQ gets the relay's raw stored copy, but nostr-sdk suppresses
+        // the deduplicated Event notification because A already cached it.
+        timeout(
+            Duration::from_secs(5),
+            adapter.activate_account(TransportAccountActivation {
+                account_id: bob.clone(),
+                inbox_endpoints: vec![endpoint.clone()],
+                group_subscriptions: vec![group.clone()],
+                since: None,
+            }),
+        )
+        .await
+        .expect("account B activation finishes within the test budget")
+        .expect("activate account B");
+        assert!(
+            timeout(Duration::from_millis(250), adapter.receive())
+                .await
+                .is_err(),
+            "ordinary raw replays must remain telemetry-only"
+        );
+
+        let maintenance_id = timeout(
+            Duration::from_secs(5),
+            adapter.install_group_maintenance_subscription(&bob, &group),
+        )
+        .await
+        .expect("maintenance install finishes within the test budget")
+        .expect("install account B maintenance subscription");
+        let bob_delivery = timeout(Duration::from_secs(5), adapter.receive())
+            .await
+            .expect("maintenance REQ recovers the shared-cache event")
+            .expect("delivery queue remains open")
+            .expect("account B delivery exists");
+        assert_eq!(bob_delivery.account_id, bob);
+        assert_eq!(bob_delivery.group_id_hint, Some(group.group_id.clone()));
+        assert_eq!(
+            bob_delivery.source.subscription_id.as_deref(),
+            Some(maintenance_id.as_str())
+        );
+        assert!(
+            timeout(Duration::from_millis(250), adapter.receive())
+                .await
+                .is_err(),
+            "account B's maintenance replay must not fan out to account A"
+        );
+
+        let maintenance = NostrSubscription::GroupMaintenance {
+            account_id: bob.clone(),
+            group_id: group.group_id.clone(),
+            transport_group_id: group.transport_group_id.clone(),
+            endpoints: group.endpoints.clone(),
+        };
+        timeout(
+            Duration::from_secs(5),
+            adapter.remove_group_maintenance_subscription(maintenance.clone()),
+        )
+        .await
+        .expect("maintenance removal finishes within the test budget")
+        .expect("remove maintenance subscription");
+        let replay_after_remove = adapter
+            .handle_group_maintenance_replay(NostrRelayEvent {
+                endpoint: endpoint.clone(),
+                subscription_id: Some(maintenance_id.clone()),
+                event: event.clone(),
+            })
+            .await
+            .expect("removed replay is ignored");
+        assert_eq!(replay_after_remove, 0);
+
+        // Account teardown is also authoritative for an otherwise-live
+        // maintenance registration.
+        timeout(
+            Duration::from_secs(5),
+            adapter.install_group_maintenance_subscription(&bob, &group),
+        )
+        .await
+        .expect("maintenance reinstall finishes within the test budget")
+        .expect("reinstall maintenance subscription");
+        assert_eq!(
+            adapter
+                .state
+                .read()
+                .await
+                .group_maintenance_accounts
+                .get(&maintenance_id),
+            Some(&bob)
+        );
+        timeout(Duration::from_secs(5), adapter.deactivate_account(&bob))
+            .await
+            .expect("account B teardown finishes within the test budget")
+            .expect("deactivate account B");
+        assert!(
+            !adapter
+                .state
+                .read()
+                .await
+                .group_maintenance_accounts
+                .contains_key(&maintenance_id),
+            "account teardown must remove raw-replay ownership"
+        );
+
+        publisher.client().shutdown().await;
+        sdk.client().shutdown().await;
+        timeout(Duration::from_secs(5), forwarder)
+            .await
+            .expect("notification forwarder shuts down")
+            .expect("notification forwarder does not panic");
+    }
+
+    #[tokio::test]
+    async fn failed_maintenance_subscribe_rolls_back_raw_replay_scope() {
+        let sdk = NostrSdkRelayClient::new(Client::builder().build());
+        let adapter = NostrTransportAdapter::new(Arc::new(sdk));
+        let account_id = MemberId::new(Keys::generate().public_key().to_bytes().to_vec());
+        let group = TransportGroupSubscription {
+            group_id: cgka_traits::GroupId::new(vec![0x11; 32]),
+            transport_group_id: vec![0x22; 32],
+            endpoints: vec![TransportEndpoint("not a relay URL".into())],
+        };
+        let maintenance_id = NostrSubscription::GroupMaintenance {
+            account_id: account_id.clone(),
+            group_id: group.group_id.clone(),
+            transport_group_id: group.transport_group_id.clone(),
+            endpoints: group.endpoints.clone(),
+        }
+        .subscription_id();
+
+        adapter
+            .install_group_maintenance_subscription(&account_id, &group)
+            .await
+            .expect_err("invalid endpoint rejects the maintenance REQ");
+
+        assert!(
+            !adapter
+                .state
+                .read()
+                .await
+                .group_maintenance_accounts
+                .contains_key(&maintenance_id),
+            "failed subscribe must not leave raw-replay ownership active"
+        );
     }
 
     #[test]

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -1520,6 +1520,17 @@ fn relay_rejection_endpoint_failure(
     endpoint: TransportEndpoint,
     relay_message: &str,
 ) -> TransportEndpointFailure {
+    // Buzz relays currently expose deletion target absence through this exact
+    // stable rejection. Do not generalize the free-text suffix across other
+    // NIP-01 prefixes: only the observed full response is terminal evidence.
+    if relay_message == "invalid: target event not found" {
+        return TransportEndpointFailure {
+            endpoint,
+            reason: "relay rejected event (not-found)".to_owned(),
+            kind: TransportEndpointFailureKind::TerminalRejected,
+            rejection_category: Some(TransportEndpointRejectionCategory::Invalid),
+        };
+    }
     if let Some(prefix) = nostr::message::MachineReadablePrefix::parse(relay_message) {
         let category = map_relay_rejection_category(prefix);
         // nostr-sdk also uses the generic `error:` prefix for local SDK/send
@@ -1638,6 +1649,12 @@ mod tests {
                 "relay rejected event (invalid)",
             ),
             (
+                "invalid: target event not found",
+                TransportEndpointRejectionCategory::Invalid,
+                TransportEndpointFailureKind::TerminalRejected,
+                "relay rejected event (not-found)",
+            ),
+            (
                 "unsupported: kind 5",
                 TransportEndpointRejectionCategory::Unsupported,
                 TransportEndpointFailureKind::TerminalRejected,
@@ -1653,6 +1670,32 @@ mod tests {
             assert_eq!(failure.reason, summary);
             assert!(!failure.reason.contains("evil.example"));
             assert!(!failure.reason.contains("leaked event payload"));
+        }
+        assert!(
+            relay_rejection_endpoint_failure(
+                TransportEndpoint("wss://relay.example".into()),
+                "invalid: target event not found",
+            )
+            .confirms_target_absence()
+        );
+    }
+
+    #[test]
+    fn target_absence_requires_the_exact_known_relay_response() {
+        for message in [
+            "error: target event not found",
+            "blocked: target event not found",
+            "invalid: target event not found elsewhere",
+            "invalid: Target event not found",
+        ] {
+            let failure = relay_rejection_endpoint_failure(
+                TransportEndpoint("wss://relay.example".into()),
+                message,
+            );
+            assert!(
+                !failure.confirms_target_absence(),
+                "unrecognized free text must remain retryable: {message}"
+            );
         }
     }
 

--- a/crates/transport-nostr-adapter/tests/inbound_routing.rs
+++ b/crates/transport-nostr-adapter/tests/inbound_routing.rs
@@ -342,6 +342,9 @@ struct FlakyUnsubscribeRelayClient {
     unsubscribed: Mutex<Vec<transport_nostr_adapter::NostrSubscription>>,
     unsubscribed_accounts: Mutex<Vec<MemberId>>,
     fail_next_unsubscribes: AtomicUsize,
+    fail_next_account_unsubscribes: AtomicUsize,
+    block_account_unsubscribes: AtomicBool,
+    account_unsubscribe_entered: AtomicUsize,
 }
 
 #[async_trait]
@@ -377,6 +380,22 @@ impl NostrRelayClient for FlakyUnsubscribeRelayClient {
         &self,
         account_id: &MemberId,
     ) -> Result<(), cgka_traits::TransportAdapterError> {
+        if self.block_account_unsubscribes.load(Ordering::SeqCst) {
+            self.account_unsubscribe_entered
+                .fetch_add(1, Ordering::SeqCst);
+            std::future::pending::<()>().await;
+        }
+        if self
+            .fail_next_account_unsubscribes
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |armed| {
+                armed.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(cgka_traits::TransportAdapterError::Subscription(
+                "injected account unsubscribe failure".into(),
+            ));
+        }
         self.unsubscribed_accounts
             .lock()
             .unwrap()
@@ -2381,6 +2400,111 @@ async fn deactivate_account_clears_pending_unsubscribes() {
         std::slice::from_ref(&account_id)
     );
     assert_eq!(adapter.metrics().await.unsubscribe_retries_pending, 0);
+}
+
+#[tokio::test]
+async fn failed_account_unsubscribe_still_clears_local_account_routes() {
+    let relay = Arc::new(FlakyUnsubscribeRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay.clone());
+    let account_id = MemberId::new(vec![0xA1; 32]);
+
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://inbox.example".into())],
+            group_subscriptions: vec![],
+            since: None,
+        })
+        .await
+        .expect("activation succeeds");
+    assert_eq!(adapter.metrics().await.active_accounts, 1);
+
+    relay
+        .fail_next_account_unsubscribes
+        .store(1, Ordering::SeqCst);
+    adapter
+        .deactivate_account(&account_id)
+        .await
+        .expect_err("relay-side account unsubscribe is injected to fail");
+
+    assert_eq!(
+        adapter.metrics().await.active_accounts,
+        0,
+        "local routing must be inactive even when relay unsubscribe fails"
+    );
+    assert!(
+        relay.unsubscribed_accounts.lock().unwrap().is_empty(),
+        "the injected failure must not be recorded as a relay acknowledgement"
+    );
+}
+
+#[tokio::test]
+async fn cancelled_pending_account_unsubscribe_keeps_local_account_deactivated() {
+    let relay = Arc::new(FlakyUnsubscribeRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay.clone());
+    let account_id = MemberId::new(vec![0xA1; 32]);
+    let group = TransportGroupSubscription {
+        group_id: cgka_traits::GroupId::new(vec![0xB2; 32]),
+        transport_group_id: vec![0xC3; 32],
+        endpoints: vec![TransportEndpoint("wss://group.example".into())],
+    };
+
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://inbox.example".into())],
+            group_subscriptions: vec![group],
+            since: None,
+        })
+        .await
+        .expect("activation succeeds");
+    relay.fail_next_unsubscribes.store(1, Ordering::SeqCst);
+    adapter
+        .sync_account_groups(TransportGroupSync {
+            account_id: account_id.clone(),
+            group_subscriptions: vec![],
+            since: None,
+        })
+        .await
+        .expect("group removal commits despite failed relay cleanup");
+    assert_eq!(adapter.metrics().await.unsubscribe_retries_pending, 1);
+
+    relay
+        .block_account_unsubscribes
+        .store(true, Ordering::SeqCst);
+    let adapter_for_deactivation = adapter.clone();
+    let account_for_deactivation = account_id.clone();
+    let deactivation = tokio::spawn(async move {
+        adapter_for_deactivation
+            .deactivate_account(&account_for_deactivation)
+            .await
+    });
+    tokio::time::timeout(concurrent_subscribe_timeout(), async {
+        while relay.account_unsubscribe_entered.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("deactivation must reach the pending relay unsubscribe");
+
+    let metrics = adapter.metrics().await;
+    assert_eq!(metrics.active_accounts, 0);
+    assert_eq!(metrics.active_group_subscriptions, 0);
+    assert_eq!(
+        metrics.unsubscribe_retries_pending, 0,
+        "blanket account teardown must clear queued relay cleanup before awaiting"
+    );
+    assert_eq!(adapter.relay_sync().await.tracked_subscriptions, 0);
+
+    deactivation.abort();
+    let join_error = deactivation
+        .await
+        .expect_err("pending deactivation must be cancellable");
+    assert!(join_error.is_cancelled());
+
+    let metrics = adapter.metrics().await;
+    assert_eq!(metrics.active_accounts, 0);
+    assert_eq!(metrics.unsubscribe_retries_pending, 0);
 }
 
 #[tokio::test]

--- a/crates/transport-nostr-adapter/tests/inbound_routing.rs
+++ b/crates/transport-nostr-adapter/tests/inbound_routing.rs
@@ -704,6 +704,95 @@ async fn group_subscription_id_fans_out_to_matching_accounts_and_replays_route_a
 }
 
 #[tokio::test]
+async fn failed_maintenance_unsubscribe_blocks_late_deduplicated_event() {
+    let relay = Arc::new(FlakyUnsubscribeRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay.clone());
+    let account_id = MemberId::new(vec![0xA1; 32]);
+    let group_id = cgka_traits::GroupId::new(vec![0xB2; 32]);
+    let transport_group_id = vec![0xC3; 32];
+    let endpoint = TransportEndpoint("wss://group.example".into());
+    let group = TransportGroupSubscription {
+        group_id: group_id.clone(),
+        transport_group_id: transport_group_id.clone(),
+        endpoints: vec![endpoint.clone()],
+    };
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://inbox.example".into())],
+            group_subscriptions: vec![group.clone()],
+            since: None,
+        })
+        .await
+        .expect("activate account");
+
+    let maintenance_id = adapter
+        .install_group_maintenance_subscription(&account_id, &group)
+        .await
+        .expect("install maintenance subscription");
+    let maintenance = NostrSubscription::GroupMaintenance {
+        account_id: account_id.clone(),
+        group_id: group_id.clone(),
+        transport_group_id: transport_group_id.clone(),
+        endpoints: vec![endpoint.clone()],
+    };
+    let delivered = adapter
+        .handle_relay_event(NostrRelayEvent {
+            endpoint: endpoint.clone(),
+            subscription_id: Some(maintenance_id.clone()),
+            event: group_event("active-maintenance", &transport_group_id),
+        })
+        .await
+        .expect("active maintenance event remains routable");
+    assert_eq!(delivered, 1);
+    assert_eq!(
+        adapter.receive().await.unwrap().unwrap().account_id,
+        account_id
+    );
+
+    relay.fail_next_unsubscribes.store(1, Ordering::SeqCst);
+    adapter
+        .remove_group_maintenance_subscription(maintenance)
+        .await
+        .expect_err("inject relay-side unsubscribe failure");
+
+    let delivered = adapter
+        .handle_relay_event(NostrRelayEvent {
+            endpoint: endpoint.clone(),
+            subscription_id: Some(maintenance_id),
+            event: group_event("retired-maintenance", &transport_group_id),
+        })
+        .await
+        .expect("late maintenance event is handled fail-closed");
+    assert_eq!(
+        delivered, 0,
+        "a retired maintenance REQ must not re-enter ordinary group routing"
+    );
+
+    let ordinary_id = NostrSubscription::Group {
+        account_id: account_id.clone(),
+        group_id,
+        transport_group_id: transport_group_id.clone(),
+        endpoints: vec![endpoint.clone()],
+        since: None,
+    }
+    .subscription_id();
+    let delivered = adapter
+        .handle_relay_event(NostrRelayEvent {
+            endpoint,
+            subscription_id: Some(ordinary_id),
+            event: group_event("ordinary-live", &transport_group_id),
+        })
+        .await
+        .expect("ordinary group event remains routable");
+    assert_eq!(delivered, 1);
+    assert_eq!(
+        adapter.receive().await.unwrap().unwrap().account_id,
+        account_id
+    );
+}
+
+#[tokio::test]
 async fn reconciled_group_event_routes_only_to_the_compared_account() {
     let relay = Arc::new(FakeRelayClient::default());
     let adapter = NostrTransportAdapter::new(relay);

--- a/crates/transport-quic-broker/src/tests.rs
+++ b/crates/transport-quic-broker/src/tests.rs
@@ -3,6 +3,7 @@
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use cgka_traits::agent_text_stream::{
@@ -18,7 +19,8 @@ use tokio::sync::oneshot;
 use tokio::time::{sleep, timeout};
 use transport_quic_stream::{
     AgentTextStreamCrypto, AgentTextStreamReceiveLimitError, AgentTextStreamReceiveLimits,
-    EphemeralPublisherSequenceStore, stream_record_text,
+    EphemeralPublisherSequenceStore, PublisherSequenceReservation, PublisherSequenceSnapshot,
+    PublisherSequenceStore, prepare_text_stream_crypto_for_network_handoff, stream_record_text,
 };
 
 use crate::client::{
@@ -55,6 +57,55 @@ fn test_state(max_backlog: usize) -> BrokerState {
         DEFAULT_BROKER_MAX_BACKLOG_BYTES,
         MAX_BROKER_REPLAY_TTL,
     )
+}
+
+struct ClosablePublisherSequenceStore {
+    inner: EphemeralPublisherSequenceStore,
+    closed: AtomicBool,
+}
+
+impl ClosablePublisherSequenceStore {
+    fn new() -> Self {
+        Self {
+            inner: EphemeralPublisherSequenceStore::default(),
+            closed: AtomicBool::new(false),
+        }
+    }
+
+    fn close(&self) {
+        self.closed.store(true, Ordering::SeqCst);
+    }
+
+    fn ensure_open(&self) -> Result<(), String> {
+        if self.closed.load(Ordering::SeqCst) {
+            Err("publisher sequence backend is closed".to_owned())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl PublisherSequenceStore for ClosablePublisherSequenceStore {
+    fn load(&self, context_id: &[u8; 32]) -> Result<Option<PublisherSequenceSnapshot>, String> {
+        self.ensure_open()?;
+        self.inner.load(context_id)
+    }
+
+    fn reserve(
+        &self,
+        context_id: &[u8; 32],
+        initial_transcript_hash: &[u8; 32],
+        reservation: &PublisherSequenceReservation,
+    ) -> Result<(), String> {
+        self.ensure_open()?;
+        self.inner
+            .reserve(context_id, initial_transcript_hash, reservation)
+    }
+
+    fn confirm(&self, context_id: &[u8; 32], token: &[u8; 16]) -> Result<(), String> {
+        self.ensure_open()?;
+        self.inner.confirm(context_id, token)
+    }
 }
 
 #[tokio::test]
@@ -110,6 +161,84 @@ async fn broker_forwards_live_records_to_subscriber_with_same_transcript() {
     assert_eq!(received.chunk_count, 4);
     assert_eq!(sent.chunk_count, received.chunk_count);
     assert_eq!(sent.transcript_hash, received.transcript_hash);
+
+    let _ = shutdown_tx.send(());
+    broker_task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn broker_publishes_preconfirmed_range_after_sequence_backend_closes() {
+    let server = QuicBrokerServer::bind(QuicBrokerConfig {
+        bind_addr: LOCAL_SERVER_BIND,
+        ..QuicBrokerConfig::default()
+    })
+    .unwrap();
+    let broker_addr = server.local_addr().unwrap();
+    let server_cert = server.server_cert_der().to_vec();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let broker_task = tokio::spawn(server.run_until(async {
+        let _ = shutdown_rx.await;
+    }));
+
+    let stream_id = vec![0xa8; 32];
+    let start_event_id = MessageId::new(vec![0x18; 32]);
+    let stream_secret = SecretBytes::new(vec![0x28; 32]);
+    let context = AgentTextStreamKeyContextV1::new(
+        GroupId::new(vec![0x38; 32]),
+        stream_id.clone(),
+        EpochId(4),
+        MemberId::new(vec![0x48; 32]),
+        start_event_id.clone(),
+    );
+    let sequence_backend = Arc::new(ClosablePublisherSequenceStore::new());
+    let durable_crypto = AgentTextStreamCrypto::new(stream_secret.clone(), context.clone())
+        .with_publisher_sequence_store(sequence_backend.clone());
+    let text = "publish after root shutdown";
+    let detached_crypto = prepare_text_stream_crypto_for_network_handoff(
+        durable_crypto,
+        &stream_id,
+        &start_event_id,
+        text,
+        7,
+        None,
+    )
+    .expect("reserve and confirm the exact range before shutdown");
+    sequence_backend.close();
+
+    let receiver_crypto = AgentTextStreamCrypto::new(stream_secret, context);
+    let subscriber = tokio::spawn(subscribe_text_from_broker(SubscribeTextFromBroker {
+        broker_addr,
+        server_name: "localhost".to_owned(),
+        trust: BrokerServerTrust::CertificateDer(server_cert.clone()),
+        stream_id: stream_id.clone(),
+        start_event_id: start_event_id.clone(),
+        crypto: Some(receiver_crypto),
+    }));
+    sleep(Duration::from_millis(100)).await;
+
+    let sent = publish_text_to_broker(PublishTextToBroker {
+        broker_addr,
+        server_name: "localhost".to_owned(),
+        trust: BrokerServerTrust::CertificateDer(server_cert),
+        stream_id: stream_id.clone(),
+        start_event_id,
+        text: text.to_owned(),
+        max_chunk_bytes: 7,
+        chunk_delay: Duration::ZERO,
+        crypto: Some(detached_crypto),
+        max_plaintext_frame_len: None,
+    })
+    .await
+    .expect("publish must use only the detached one-shot capability");
+    let received = timeout(Duration::from_secs(5), subscriber)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(received.text, text);
+    assert_eq!(received.transcript_hash, sent.transcript_hash);
+    assert_eq!(received.chunk_count, sent.chunk_count);
 
     let _ = shutdown_tx.send(());
     broker_task.await.unwrap().unwrap();

--- a/crates/transport-quic-stream/src/lib.rs
+++ b/crates/transport-quic-stream/src/lib.rs
@@ -50,5 +50,6 @@ pub use receive::{
     QuicTextStreamReceiver, ReceivedTextChunk, ReceivedTextStream, ServerTrust, stream_record_text,
 };
 pub use send::{
-    SendTextStream, SentTextStream, random_stream_id, send_text_stream, split_text_deltas,
+    SendTextStream, SentTextStream, prepare_text_stream_crypto_for_network_handoff,
+    random_stream_id, send_text_stream, split_text_deltas,
 };

--- a/crates/transport-quic-stream/src/publisher_sequence.rs
+++ b/crates/transport-quic-stream/src/publisher_sequence.rs
@@ -42,15 +42,110 @@ pub struct ReservedPublisherRecords {
     pub transcript_hash: [u8; 32],
     pub chunk_count: u64,
     context_id: [u8; 32],
-    token: [u8; 16],
+    initial_transcript_hash: [u8; 32],
+    reservation: PublisherSequenceReservation,
     store: Arc<dyn PublisherSequenceStore>,
 }
 
 impl ReservedPublisherRecords {
     pub fn confirm(self) -> Result<(), QuicTextStreamError> {
         self.store
-            .confirm(&self.context_id, &self.token)
+            .confirm(&self.context_id, &self.reservation.token)
             .map_err(QuicTextStreamError::PublisherSequence)
+    }
+
+    pub(crate) fn confirm_and_detach_store(
+        self,
+    ) -> Result<Arc<dyn PublisherSequenceStore>, QuicTextStreamError> {
+        self.store
+            .confirm(&self.context_id, &self.reservation.token)
+            .map_err(QuicTextStreamError::PublisherSequence)?;
+        Ok(Arc::new(DetachedPublisherSequenceStore {
+            context_id: self.context_id,
+            initial_transcript_hash: self.initial_transcript_hash,
+            expected: self.reservation.expected,
+            resulting: self.reservation.resulting,
+            state: Mutex::new(DetachedPublisherSequenceState::Ready),
+        }))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DetachedPublisherSequenceState {
+    Ready,
+    Reserved([u8; 16]),
+    Exhausted,
+}
+
+/// One-shot capability for replaying one already-durable reservation after
+/// its SQLCipher store has been closed for a root-ownership handoff.
+struct DetachedPublisherSequenceStore {
+    context_id: [u8; 32],
+    initial_transcript_hash: [u8; 32],
+    expected: PublisherSequenceSnapshot,
+    resulting: PublisherSequenceSnapshot,
+    state: Mutex<DetachedPublisherSequenceState>,
+}
+
+impl PublisherSequenceStore for DetachedPublisherSequenceStore {
+    fn load(&self, context_id: &[u8; 32]) -> Result<Option<PublisherSequenceSnapshot>, String> {
+        if context_id != &self.context_id {
+            return Err("detached publisher context does not match".to_owned());
+        }
+        match *self
+            .state
+            .lock()
+            .map_err(|_| "detached publisher state lock poisoned")?
+        {
+            DetachedPublisherSequenceState::Ready => Ok(Some(self.expected)),
+            DetachedPublisherSequenceState::Reserved(_) => {
+                Err("publisher continuity is ambiguous".to_owned())
+            }
+            DetachedPublisherSequenceState::Exhausted => {
+                Err("detached publisher sequence capability is exhausted".to_owned())
+            }
+        }
+    }
+
+    fn reserve(
+        &self,
+        context_id: &[u8; 32],
+        initial_transcript_hash: &[u8; 32],
+        reservation: &PublisherSequenceReservation,
+    ) -> Result<(), String> {
+        if context_id != &self.context_id
+            || initial_transcript_hash != &self.initial_transcript_hash
+            || reservation.expected != self.expected
+            || reservation.resulting != self.resulting
+        {
+            return Err("detached publisher reservation does not match".to_owned());
+        }
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| "detached publisher state lock poisoned")?;
+        if *state != DetachedPublisherSequenceState::Ready {
+            return Err("detached publisher sequence capability is not available".to_owned());
+        }
+        *state = DetachedPublisherSequenceState::Reserved(reservation.token);
+        Ok(())
+    }
+
+    fn confirm(&self, context_id: &[u8; 32], token: &[u8; 16]) -> Result<(), String> {
+        if context_id != &self.context_id {
+            return Err("detached publisher context does not match".to_owned());
+        }
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| "detached publisher state lock poisoned")?;
+        match *state {
+            DetachedPublisherSequenceState::Reserved(current) if &current == token => {
+                *state = DetachedPublisherSequenceState::Exhausted;
+                Ok(())
+            }
+            _ => Err("detached publisher reservation is not current".to_owned()),
+        }
     }
 }
 
@@ -110,23 +205,21 @@ pub fn reserve_publisher_records(
         transcript_hash: transcript.hash(),
         chunk_count: transcript.chunk_count(),
     };
+    let reservation = PublisherSequenceReservation {
+        expected,
+        resulting,
+        token,
+    };
     store
-        .reserve(
-            &context_id,
-            &initial,
-            &PublisherSequenceReservation {
-                expected,
-                resulting,
-                token,
-            },
-        )
+        .reserve(&context_id, &initial, &reservation)
         .map_err(QuicTextStreamError::PublisherSequence)?;
     Ok(ReservedPublisherRecords {
         records,
         transcript_hash: resulting.transcript_hash,
         chunk_count: resulting.chunk_count,
         context_id,
-        token,
+        initial_transcript_hash: initial,
+        reservation,
         store,
     })
 }
@@ -260,6 +353,69 @@ mod tests {
                 &stream_id,
                 &start,
                 &[(AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, b"retry".to_vec())],
+            ),
+            Err(QuicTextStreamError::PublisherSequence(_))
+        ));
+    }
+
+    #[test]
+    fn confirmed_detached_capability_replays_exact_durable_range_once() {
+        let store = Arc::new(EphemeralPublisherSequenceStore::default());
+        let durable_crypto = crypto(store);
+        let stream_id = durable_crypto.context.stream_id.clone();
+        let start = durable_crypto.context.start_event_id.clone();
+        let detached_crypto = crate::prepare_text_stream_crypto_for_network_handoff(
+            durable_crypto.clone(),
+            &stream_id,
+            &start,
+            "detached",
+            1024,
+            None,
+        )
+        .unwrap();
+
+        let frames = vec![(AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, b"detached".to_vec())];
+        let detached = reserve_publisher_records(&detached_crypto, &stream_id, &start, &frames)
+            .expect("the exact preconfirmed range remains usable after storage closes");
+        assert_eq!(detached.records[0].seq, 1);
+        detached.confirm().unwrap();
+        assert!(matches!(
+            reserve_publisher_records(&detached_crypto, &stream_id, &start, &frames),
+            Err(QuicTextStreamError::PublisherSequence(_))
+        ));
+
+        let next = reserve_publisher_records(
+            &durable_crypto,
+            &stream_id,
+            &start,
+            &[(AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, b"next".to_vec())],
+        )
+        .expect("durable state advanced before the detached send");
+        assert_eq!(next.records[0].seq, 2);
+        next.confirm().unwrap();
+    }
+
+    #[test]
+    fn detached_capability_rejects_a_different_frame_set() {
+        let durable_crypto = crypto(Arc::new(EphemeralPublisherSequenceStore::default()));
+        let stream_id = durable_crypto.context.stream_id.clone();
+        let start = durable_crypto.context.start_event_id.clone();
+        let detached_crypto = crate::prepare_text_stream_crypto_for_network_handoff(
+            durable_crypto,
+            &stream_id,
+            &start,
+            "authorized",
+            1024,
+            None,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            reserve_publisher_records(
+                &detached_crypto,
+                &stream_id,
+                &start,
+                &[(AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, b"different".to_vec())],
             ),
             Err(QuicTextStreamError::PublisherSequence(_))
         ));

--- a/crates/transport-quic-stream/src/send.rs
+++ b/crates/transport-quic-stream/src/send.rs
@@ -47,20 +47,11 @@ pub struct SentTextStream {
 pub async fn send_text_stream(
     config: SendTextStream,
 ) -> Result<SentTextStream, QuicTextStreamError> {
-    if config.max_chunk_bytes == 0 {
-        return Err(QuicTextStreamError::EmptyChunkSize);
-    }
-    if config.max_chunk_bytes > AGENT_TEXT_STREAM_MAX_PLAINTEXT_FRAME_LEN as usize {
-        return Err(QuicTextStreamError::ChunkSizeTooLarge(
-            config.max_chunk_bytes,
-        ));
-    }
-    // Clamp the chunk size to the group policy cap when the caller supplied
-    // one. A plaintext within the cap always encrypts to a ciphertext within
-    // the record's `ciphertext<0..2^16-1>` field bound (cap + 16 <= 65535).
-    let max_chunk_bytes = config
-        .max_chunk_bytes
-        .min(effective_plaintext_cap(config.max_plaintext_frame_len));
+    let frames = text_delta_frames(
+        &config.text,
+        config.max_chunk_bytes,
+        config.max_plaintext_frame_len,
+    )?;
 
     let endpoint = client_endpoint(config.trust, config.server_addr)?;
     let connection = connect_with_timeout(
@@ -71,15 +62,6 @@ pub async fn send_text_stream(
     )
     .await?;
     let mut send = connection.open_uni().await?;
-    let frames = split_text_deltas(&config.text, max_chunk_bytes)
-        .into_iter()
-        .map(|chunk| {
-            (
-                cgka_traits::agent_text_stream::AGENT_TEXT_STREAM_RECORD_TEXT_DELTA,
-                chunk,
-            )
-        })
-        .collect::<Vec<_>>();
     let mut transcript =
         AgentTextStreamTranscriptV1::new(config.stream_id.clone(), config.start_event_id.clone());
     let reservation = config
@@ -138,6 +120,57 @@ pub async fn send_text_stream(
         transcript_hash,
         chunk_count,
     })
+}
+
+/// Persist and confirm exactly one bounded text-record range, then replace the
+/// crypto's SQL-backed sequence store with a one-shot in-memory capability for
+/// that same range. This is for hosts that must terminally close storage before
+/// network I/O to transfer exclusive root ownership.
+///
+/// A later network failure burns the confirmed range rather than risking nonce
+/// reuse. The returned capability rejects any different frame set and cannot be
+/// reused for another send.
+pub fn prepare_text_stream_crypto_for_network_handoff(
+    crypto: AgentTextStreamCrypto,
+    stream_id: &[u8],
+    start_event_id: &MessageId,
+    text: &str,
+    max_chunk_bytes: usize,
+    max_plaintext_frame_len: Option<u32>,
+) -> Result<AgentTextStreamCrypto, QuicTextStreamError> {
+    let frames = text_delta_frames(text, max_chunk_bytes, max_plaintext_frame_len)?;
+    if frames.is_empty() {
+        return Ok(crypto);
+    }
+    let detached_store = reserve_publisher_records(&crypto, stream_id, start_event_id, &frames)?
+        .confirm_and_detach_store()?;
+    Ok(crypto.with_publisher_sequence_store(detached_store))
+}
+
+fn text_delta_frames(
+    text: &str,
+    max_chunk_bytes: usize,
+    max_plaintext_frame_len: Option<u32>,
+) -> Result<Vec<(u8, Vec<u8>)>, QuicTextStreamError> {
+    if max_chunk_bytes == 0 {
+        return Err(QuicTextStreamError::EmptyChunkSize);
+    }
+    if max_chunk_bytes > AGENT_TEXT_STREAM_MAX_PLAINTEXT_FRAME_LEN as usize {
+        return Err(QuicTextStreamError::ChunkSizeTooLarge(max_chunk_bytes));
+    }
+    // Clamp the chunk size to the group policy cap when the caller supplied
+    // one. A plaintext within the cap always encrypts to a ciphertext within
+    // the record's `ciphertext<0..2^16-1>` field bound (cap + 16 <= 65535).
+    let max_chunk_bytes = max_chunk_bytes.min(effective_plaintext_cap(max_plaintext_frame_len));
+    Ok(split_text_deltas(text, max_chunk_bytes)
+        .into_iter()
+        .map(|chunk| {
+            (
+                cgka_traits::agent_text_stream::AGENT_TEXT_STREAM_RECORD_TEXT_DELTA,
+                chunk,
+            )
+        })
+        .collect())
 }
 
 pub fn random_stream_id() -> Vec<u8> {


### PR DESCRIPTION
## Split of #1594 (4/6)

App runtime consumes the account visibility journal, authorizes Left only from published Leave, restores epoch-backfill intents without persisting on uncertainty, and keeps exact-slot tombstones.

Targets `master` because fork stack branches cannot be used as bases on this repo. **Files changed vs `master` includes slices 1–3.** Review the latest commit, or the incremental compare:

https://github.com/marmot-protocol/mdk/compare/romainPellerin:split/1594-account-runtime...romainPellerin:split/1594-app

**Incremental diff vs slice 3:** 18 files, +18074 / −2360

Tests follow in slice 5.

**Stack on this repo (review latest commit / incremental compare, merge in this order):**
1. storage/journals — https://github.com/marmot-protocol/mdk/pull/1595
2. engine/transport exact-retry — https://github.com/marmot-protocol/mdk/pull/1596
3. account visibility + KeyPackage persist — https://github.com/marmot-protocol/mdk/pull/1597
4. app projection / Leave / tombstones / backfill — https://github.com/marmot-protocol/mdk/pull/1598
5. app tests — https://github.com/marmot-protocol/mdk/pull/1599
6. CLI / UniFFI / docs — https://github.com/marmot-protocol/mdk/pull/1600
