### PR TITLE
Fix/refusal doc honesty and summary merge

### DIFF
--- a/crates/marmot-app/src/client/epoch_stall.rs
+++ b/crates/marmot-app/src/client/epoch_stall.rs
@@ -117,18 +117,36 @@ pub(crate) const EPOCH_STALL_BACKFILL_THRESHOLD: usize = 8;
 /// another stalled epoch, each of which needs a genuine commit plus a fresh
 /// stall run, so it delays the report by the same hours the field devices lost.
 ///
-/// Safety is structural on both sides: escalation only *reports*, it never
+/// Safety on the output side is structural: escalation only *reports*, it never
 /// changes recovery behavior — the stronger heal (key-package rotation plus full
-/// re-activation) stays an app decision — and an arm run cannot be inflated by
-/// minted traffic. Each additional arm needs either a real epoch advance, which
-/// only an authenticated commit produces, or a replay that came back having
-/// refused this group's own history, which is the engine reporting a local
-/// resource bound rather than anything a sender chose. The paced same-epoch
-/// re-arm a wedged group spends
-/// ([`EPOCH_STALL_WEDGE_REARM_INTERVAL_MS`]) is the one arm minted traffic can
-/// reach, and it deliberately does not count here, so the property survives it
-/// intact; what reports a wedged group instead is
-/// [`EPOCH_STALL_FRUITLESS_COMPLETION_THRESHOLD`].
+/// re-activation) stays an app decision.
+///
+/// Safety on the input side is weaker than it looks, and the weakness is
+/// recorded here rather than argued away. Each counted arm needs either a real
+/// epoch advance, which only an authenticated commit produces, or a replay that
+/// came back having refused this group's own history. Counting the refusal is
+/// right: it is genuine local evidence that the deferred-peel cap is full and
+/// that a replay could not retain what this group needs. But that cap is one
+/// minted traffic can saturate by itself (mdk#339 — a fresh wrap yields a fresh
+/// raw transport id, so a flood costs a sender nothing), and a saturated cap
+/// answers `ResourceRefused` to the account-wide replay's own fetch for the
+/// group too. That refusal lands in the drain's refused set, so
+/// [`EpochStallDetector::rearm_refused_groups`] clears the very latch the arm
+/// just set, and the next refusal takes the counted
+/// [`GroupStall::arm`] branch instead of the paced one. A flood therefore walks
+/// a group to this threshold in a run of retry backoffs rather than a run of
+/// real stalls. What it buys is a false report and nothing else — the arm run
+/// changes no recovery behavior — so the exposure is telemetry integrity, not
+/// amplification. It is bounded, known, and tracked with the cap itself
+/// (mdk#339); the loop is pinned by
+/// `a_saturated_cap_can_drive_counted_arms_through_the_refusal_loop`, and the
+/// remedy under discussion is a rate bound on refusal-driven re-arms, not
+/// dropping the count.
+///
+/// The paced same-epoch re-arm a wedged group spends
+/// ([`EPOCH_STALL_WEDGE_REARM_INTERVAL_MS`]) is a different path and does keep
+/// its property: it deliberately does not count here, and what reports a wedged
+/// group instead is [`EPOCH_STALL_FRUITLESS_COMPLETION_THRESHOLD`].
 pub(crate) const EPOCH_STALL_ESCALATION_ARM_THRESHOLD: u32 = 3;
 
 /// How long a group wedged at one stalled epoch must wait between paced
@@ -1789,6 +1807,57 @@ mod tests {
                 "hour {hour}: a paced re-arm is an arm of the replay, never of the run",
             );
         }
+    }
+
+    /// The exposure the test above does *not* cover, pinned as documentation.
+    ///
+    /// Deliberately green: this records today's behavior while the design
+    /// question is open, and is not a missed red. The fix, if there is one, is a
+    /// rate bound decided against the frozen-device escalation's liveness — not
+    /// something to land beside the pin.
+    ///
+    /// `paced_refused_rearms_never_escalate_by_themselves` holds only while a
+    /// group's latch stays set, which is the case when the account-wide replay
+    /// never runs or never refuses anything for this group. A saturated
+    /// deferred-peel cap breaks exactly that: the cap is one minted traffic can
+    /// fill by itself (mdk#339), it answers `ResourceRefused` to the replay's
+    /// own fetch for the group as well as to live traffic, and
+    /// [`EpochStallDetector::rearm_refused_groups`] then clears the latch the
+    /// arm just set. The next refusal takes the counted branch rather than the
+    /// paced one, so the loop refusal -> arm -> fruitless replay -> unlatch
+    /// walks straight to [`EPOCH_STALL_ESCALATION_ARM_THRESHOLD`] with no epoch
+    /// advance and no hour elapsed. Bounded by what escalation does: it reports.
+    #[test]
+    fn a_saturated_cap_can_drive_counted_arms_through_the_refusal_loop() {
+        let mut detector = EpochStallDetector::new(1, 3).with_wedge_rearm_interval_ms(HOUR_MS);
+        let g = group(0x01);
+        let refused: HashSet<GroupId> = std::iter::once(g.clone()).collect();
+
+        // One turn per whole-account replay: a flood-driven refusal, then the
+        // fruitless drain re-arming the group whose history it could not
+        // retain. Turns sit one retry backoff apart, far inside both the pacing
+        // interval and the run-continuation window.
+        let mut decisions = Vec::new();
+        for turn in 0..3u64 {
+            decisions.push(detector.observe_resource_refusal(
+                g.clone(),
+                EpochId(10),
+                T0 + turn * 15_000,
+            ));
+            detector.rearm_refused_groups(&refused);
+        }
+
+        assert_eq!(
+            decisions,
+            vec![
+                BackfillDecision::Arm,
+                BackfillDecision::Arm,
+                BackfillDecision::ArmAndEscalate { arms: 3 },
+            ],
+            "every refusal behind a fruitless replay takes the counted arm branch, so a \
+             saturated cap reaches the escalation threshold without an authenticated commit \
+             and without waiting out a single pacing interval",
+        );
     }
 
     /// A run is unbounded in wall-clock without this: an unrelated stall weeks

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -3004,6 +3004,7 @@ impl AppClient {
                             counts,
                             false,
                         );
+                        self.pending_failed_sync_summary.merge(summary);
                         return Err(err);
                     }
                 };

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -977,6 +977,13 @@ impl AppClient {
     /// reference a not-yet-live (quarantined) group must not abort the drain —
     /// projection lookups are best-effort.
     pub(crate) async fn drain_pending_session_events(&mut self) -> Result<SyncSummary, AppError> {
+        if cfg!(feature = "test-policy-overrides")
+            && self.app.config.dev_fail_pending_session_event_drain
+        {
+            return Err(AppError::BlockingTask(
+                "injected pending session event drain failure".to_owned(),
+            ));
+        }
         let effects = self.runtime.drain().await?;
         self.observe_drained_session_events(&effects).await
     }

--- a/crates/marmot-app/src/config.rs
+++ b/crates/marmot-app/src/config.rs
@@ -160,6 +160,14 @@ pub struct MarmotAppConfig {
     /// `test-policy-overrides`; this exercises retention of the already-applied
     /// event summary when a later step in the same delivery fails.
     pub dev_fail_ingest_after_application_event_ack: bool,
+    /// Dev/test-only fault injected at the no-inbound engine-event drain
+    /// (`drain_pending_session_events`). Honored only with
+    /// `test-policy-overrides`. The production failures of that step —
+    /// a resumed outbound fanout whose publish never lands, a storage read
+    /// behind its projection loop — all originate below the app boundary and
+    /// have no external driver, so this stands in for them when a caller's
+    /// handling of that error is what is under test.
+    pub dev_fail_pending_session_event_drain: bool,
     /// Accounts to search outward from when the searcher's own web of trust is
     /// empty, as pubkey hex.
     ///
@@ -224,6 +232,7 @@ impl Default for MarmotAppConfig {
             dev_fail_sync_before_delivery: None,
             dev_fail_sync_before_boundary_save: None,
             dev_fail_ingest_after_application_event_ack: false,
+            dev_fail_pending_session_event_drain: false,
             directory_search_fallback_seeds: Vec::new(),
         }
     }
@@ -391,6 +400,13 @@ impl MarmotAppConfig {
     /// test-policy builds. Normal builds ignore this field.
     pub fn with_dev_fail_ingest_after_application_event_ack(mut self) -> Self {
         self.dev_fail_ingest_after_application_event_ack = true;
+        self
+    }
+
+    /// Fail the no-inbound engine-event drain in test-policy builds. Normal
+    /// builds ignore this field.
+    pub fn with_dev_fail_pending_session_event_drain(mut self) -> Self {
+        self.dev_fail_pending_session_event_drain = true;
         self
     }
 }

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -2699,6 +2699,52 @@ fn a_failed_epoch_backfill_execution_paces_the_next_automatic_seam() {
     });
 }
 
+/// The drain step's `Err` arm owes the same summary hand-off both its siblings
+/// make.
+///
+/// `run_pending_epoch_backfill` accumulates the relay drain's summary — which
+/// includes anything a previous failed pass deferred, folded in by
+/// `checkpoint_sync_prefix` — and then drains the engine's no-inbound events.
+/// The relay-drain arm above it merges `err.partial_summary` on failure and the
+/// clear-intent arm below it merges `summary`; this one returned `Err` and
+/// dropped it. The rows are durable either way, but `account_worker` publishes a
+/// summary only on `Ok`, so what the drop costs is the runtime event stream:
+/// projected state that persists in storage and never surfaces to a subscriber.
+#[test]
+#[cfg(feature = "test-policy-overrides")]
+fn a_failed_event_drain_retains_the_backfill_prefix_for_the_next_seam() {
+    run_composed_app_runtime_test("backfill-drain-error-summary", || async {
+        let dir = tempfile::tempdir().unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let (_app, mut client, _group_id) = armed_epoch_backfill(
+            &dir,
+            &relay,
+            backfill_drain_test_config().with_dev_fail_pending_session_event_drain(),
+        )
+        .await;
+
+        // Progress this execution inherits: a prefix an earlier failed pass
+        // deferred, which the drain's own checkpoint folds into the summary the
+        // failing step below is holding.
+        let deferred = crate::SyncSummary {
+            joined_groups: vec![cgka_traits::GroupId::new(vec![0x42])],
+            ..Default::default()
+        };
+        client.pending_failed_sync_summary.merge(deferred.clone());
+
+        client
+            .run_pending_epoch_backfill(marmot_forensics::EpochBackfillExecutionSeam::Maintenance)
+            .await
+            .expect_err("the injected event-drain failure must surface");
+
+        assert_eq!(
+            client.pending_failed_sync_summary, deferred,
+            "a drain-step failure must hand its accumulated prefix back for the next \
+             successful seam instead of dropping it off the runtime event stream",
+        );
+    });
+}
+
 /// A fruitless replay re-arms only the groups whose refusals it counted.
 ///
 /// The clear is scoped to this drain's attribution rather than swept


### PR DESCRIPTION
Retain the failed drain's backfill prefix; correct the minted-traffic claim

Two independent items, both surfaced by this week's deep verification pass.

First, a real fix: the error arm of the epoch backfill's session-event drain step returned without merging its accumulated summary into pending_failed_sync_summary, while both sibling exits do. This was the one spot #1566 missed. The dropped content is the prior relay-drain prefix — audit rows were unaffected — so projected rows persisted in storage but never surfaced on the runtime event stream, because the worker publishes a summary only on Ok. One-line fix, pinned red-first: a drain-step failure now hands its prefix back for the next successful seam. The test drives the failure through a new dev_fail_pending_session_event_drain test-fault switch, following the existing dev-fault family (no production driver reaches that step from the app boundary).

Second, doc honesty with a pinned exposure, no behavior change: the escalation arm-threshold doc claimed an arm run "cannot be inflated by minted traffic" while the same file documents that the mdk#339 peel-deferred cap is attacker-saturable, and a saturated cap drives counted arms through the refusal re-arm loop (refusal arms, fruitless replay's rearm_refused_groups clears the latch, next refusal takes the counted branch — roughly 45 seconds to a false report at the 15s retry base). The doc now states the loop, why counting refusals is still right per-refusal, and why the exposure is bounded (escalation only reports — telemetry integrity, not amplification). The loop is pinned by a deliberately-green test beside the one that deliberately does not cover it; the remedy (a rate bound on refusal-driven re-arms) is a design question tracked separately rather than smuggled into this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization recovery when pending session events cannot be processed, preserving accumulated updates for a later retry.
  * Strengthened escalation handling under repeated resource refusals, including cases where activity occurs without an epoch change or pacing delay.

* **Tests**
  * Added regression coverage for synchronization recovery and refusal-driven escalation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->