### PR TITLE
fix(engine,app): fork-aware deferral lineage and reorg-aware stall runs

### DIFF
--- a/crates/cgka-conformance-simulator/src/scenario_input_ledger.rs
+++ b/crates/cgka-conformance-simulator/src/scenario_input_ledger.rs
@@ -605,6 +605,7 @@ mod tests {
             &metadata,
             Ok(&IngestOutcome::TransportDeferred {
                 group_id: GroupId::new(vec![1]),
+                lineage: cgka_traits::ingest::DeferralLineage::Uncontested,
             }),
         );
 
@@ -624,6 +625,7 @@ mod tests {
             &metadata,
             Ok(&IngestOutcome::TransportDeferred {
                 group_id: cgka_traits::types::GroupId::new(vec![1]),
+                lineage: cgka_traits::ingest::DeferralLineage::Uncontested,
             }),
         );
 

--- a/crates/cgka-engine/src/audit_helpers.rs
+++ b/crates/cgka-engine/src/audit_helpers.rs
@@ -106,7 +106,7 @@ pub(crate) fn ingest_outcome_epoch(outcome: &IngestOutcome) -> Option<u64> {
 pub(crate) fn ingest_outcome_group_ref(outcome: &IngestOutcome) -> Option<String> {
     match outcome {
         IngestOutcome::Buffered { group_id, .. }
-        | IngestOutcome::TransportDeferred { group_id }
+        | IngestOutcome::TransportDeferred { group_id, .. }
         | IngestOutcome::ResourceRefused { group_id, .. } => Some(hex::encode(group_id.as_slice())),
         _ => None,
     }

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -611,7 +611,7 @@ impl<S: StorageProvider> Engine<S> {
                             crate::message_disposition::MessageDisposition::RetryPending.tag(),
                         ),
                     );
-                    let lineage = self.deferral_lineage(&group_id, !already_retained)?;
+                    let lineage = self.deferral_lineage(&group_id)?;
                     return Ok(IngestOutcome::TransportDeferred { group_id, lineage });
                 }
             }

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -611,7 +611,8 @@ impl<S: StorageProvider> Engine<S> {
                             crate::message_disposition::MessageDisposition::RetryPending.tag(),
                         ),
                     );
-                    return Ok(IngestOutcome::TransportDeferred { group_id });
+                    let lineage = self.deferral_lineage(&group_id, !already_retained)?;
+                    return Ok(IngestOutcome::TransportDeferred { group_id, lineage });
                 }
             }
             Err(PeelerError::StaleEpoch {

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -25,7 +25,7 @@ use cgka_traits::engine::{GroupEvent, GroupStateChange, SendIntent, SendResult};
 use cgka_traits::engine_state::EpochState;
 use cgka_traits::error::EngineError;
 use cgka_traits::ingest::{
-    InboundResourceLimit, IngestOutcome, InputRejectionCategory, LocalIngestState,
+    DeferralLineage, InboundResourceLimit, IngestOutcome, InputRejectionCategory, LocalIngestState,
 };
 use cgka_traits::message::{MessageRecord, MessageState, StoredMessagePayload};
 use cgka_traits::storage::{
@@ -174,6 +174,17 @@ pub(crate) struct DeferredPeelGroupState {
     /// logged, or copied into durable generation state, and process restart
     /// drops it naturally.
     candidate_cache: Option<DeferredPeelCandidateCacheEntry>,
+    /// Last replay-free verdict on whether this group's stored commit graph is
+    /// contested, as reported to a transport-deferred outcome's
+    /// [`cgka_traits::ingest::DeferralLineage`].
+    ///
+    /// Memoized for the same reason the candidate contexts beside it are: the
+    /// probe is a stored-message scan, and the input that asks for it is
+    /// attacker-mintable, so a redelivery storm must not turn one scan per
+    /// group into one scan per message. Dropped wherever the candidate cache
+    /// is, since every site that can change the stored commit graph already
+    /// invalidates that.
+    contested_graph: Option<bool>,
 }
 
 struct DeferredPeelCandidateCacheEntry {
@@ -1937,6 +1948,74 @@ impl<S: StorageProvider> Engine<S> {
         Ok(DeferredPeelWorkResult { status, progressed })
     }
 
+    /// What the engine can soundly claim about why a transport-deferred object
+    /// is unreadable.
+    ///
+    /// This is a claim about the GROUP, never about the message. At the
+    /// deferral point the object failed to decrypt under the live context,
+    /// every retained snapshot, and every candidate branch a sweep had
+    /// materialized, so nothing observable separates one unreadable object
+    /// from another — the per-message discriminator the success path derives
+    /// from `recovered_from_candidate_branch` simply does not exist here.
+    /// What remains sayable is the shape of the stored commit graph, and that
+    /// is the fact deciding which recovery can help: a fork whose rival commit
+    /// is already retained cannot be fixed by fetching more relay history,
+    /// while a gap whose commit never arrived can — and the second case is
+    /// indistinguishable from no fork at all, which is precisely why the
+    /// uncontested answer is the one that admits a backfill.
+    ///
+    /// Uses the sweep's own replay-free contested predicate over the same
+    /// retained-anchor window branch enumeration uses, so this label and the
+    /// branch work it describes cannot disagree.
+    ///
+    /// `reprobe_stored_graph` is false only for redelivery of a row this group
+    /// already retains. Every distinct undecryptable object still probes —
+    /// distinctness is what the consumer counts — while a repeat of one already
+    /// retained reuses the last verdict rather than paying a second
+    /// stored-message scan for input whose identity is attacker-mintable.
+    pub(crate) fn deferral_lineage(
+        &mut self,
+        group_id: &GroupId,
+        reprobe_stored_graph: bool,
+    ) -> Result<DeferralLineage, EngineError> {
+        let memo = self
+            .deferred_peel
+            .get(group_id)
+            .and_then(|state| state.contested_graph);
+        let contested = match memo {
+            Some(contested) if !reprobe_stored_graph => contested,
+            _ => {
+                let group = self.storage.get_group(group_id)?;
+                let policy = self
+                    .convergence_policy_for_group_ungated(group_id)
+                    .map_err(|error| {
+                        EngineError::Backend(format!("load convergence policy: {error}"))
+                    })?;
+                let contested = crate::openmls_projection::stored_graph_is_contested(
+                    &self.storage,
+                    group_id,
+                    group
+                        .epoch
+                        .0
+                        .saturating_sub(policy.convergence.max_rewind_commits),
+                )
+                .map_err(|error| {
+                    EngineError::Backend(format!("stored graph contested probe: {error}"))
+                })?;
+                self.deferred_peel
+                    .entry(group_id.clone())
+                    .or_default()
+                    .contested_graph = Some(contested);
+                contested
+            }
+        };
+        Ok(if contested {
+            DeferralLineage::ContestedFork
+        } else {
+            DeferralLineage::Uncontested
+        })
+    }
+
     /// Classify this group's convergence graph as contested or not, and
     /// materialize the candidate branches it offers.
     fn candidate_branch_peel(
@@ -2229,10 +2308,14 @@ impl<S: StorageProvider> Engine<S> {
     /// group, fingerprint, generation, and branch identities never leave
     /// engine memory.
     pub(crate) fn invalidate_deferred_peel_candidate_cache(&mut self, group_id: &GroupId) {
-        let invalidated = self
-            .deferred_peel
-            .get_mut(group_id)
-            .is_some_and(|state| state.candidate_cache.take().is_some());
+        let invalidated = self.deferred_peel.get_mut(group_id).is_some_and(|state| {
+            // The contested verdict is derived from the same stored commit
+            // graph these contexts are, so it goes stale on exactly the same
+            // events. Dropping it here rather than at its own set of sites is
+            // what keeps the two from drifting apart.
+            state.contested_graph = None;
+            state.candidate_cache.take().is_some()
+        });
         if invalidated {
             self.engine_metrics
                 .note_deferred_peel_candidate_cache_invalidation();

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -174,17 +174,6 @@ pub(crate) struct DeferredPeelGroupState {
     /// logged, or copied into durable generation state, and process restart
     /// drops it naturally.
     candidate_cache: Option<DeferredPeelCandidateCacheEntry>,
-    /// Last replay-free verdict on whether this group's stored commit graph is
-    /// contested, as reported to a transport-deferred outcome's
-    /// [`cgka_traits::ingest::DeferralLineage`].
-    ///
-    /// Memoized for the same reason the candidate contexts beside it are: the
-    /// probe is a stored-message scan, and the input that asks for it is
-    /// attacker-mintable, so a redelivery storm must not turn one scan per
-    /// group into one scan per message. Dropped wherever the candidate cache
-    /// is, since every site that can change the stored commit graph already
-    /// invalidates that.
-    contested_graph: Option<bool>,
 }
 
 struct DeferredPeelCandidateCacheEntry {
@@ -1968,47 +1957,39 @@ impl<S: StorageProvider> Engine<S> {
     /// retained-anchor window branch enumeration uses, so this label and the
     /// branch work it describes cannot disagree.
     ///
-    /// `reprobe_stored_graph` is false only for redelivery of a row this group
-    /// already retains. Every distinct undecryptable object still probes —
-    /// distinctness is what the consumer counts — while a repeat of one already
-    /// retained reuses the last verdict rather than paying a second
-    /// stored-message scan for input whose identity is attacker-mintable.
+    /// Deliberately unmemoized. A cached verdict would have to be validated
+    /// against `deferred_peel_context_fingerprint` to be trustworthy — the
+    /// candidate cache beside it is safe precisely because it is self-validating
+    /// that way — and that fingerprint folds `stored_convergence_commit_digests`,
+    /// which is the same full stored-message scan this probe is. So a correct
+    /// cache costs what it saves, while an uncorroborated one buys speed with
+    /// exactly the wrong error: a stale verdict here reads `Uncontested` on a
+    /// group that has since forked, which is the inversion this whole
+    /// discriminator exists to prevent.
+    ///
+    /// The scan is therefore paid per deferral, and bounded by where it sits.
+    /// It runs only after the per-group retained-row cap has admitted the row
+    /// (`has_peel_deferred_capacity`), so a flood of attacker-minted
+    /// undecryptable input is answered `ResourceRefused` without ever reaching
+    /// here; and it runs on the seam that already pays a durable message write
+    /// plus a forensic audit write for the same object.
     pub(crate) fn deferral_lineage(
         &mut self,
         group_id: &GroupId,
-        reprobe_stored_graph: bool,
     ) -> Result<DeferralLineage, EngineError> {
-        let memo = self
-            .deferred_peel
-            .get(group_id)
-            .and_then(|state| state.contested_graph);
-        let contested = match memo {
-            Some(contested) if !reprobe_stored_graph => contested,
-            _ => {
-                let group = self.storage.get_group(group_id)?;
-                let policy = self
-                    .convergence_policy_for_group_ungated(group_id)
-                    .map_err(|error| {
-                        EngineError::Backend(format!("load convergence policy: {error}"))
-                    })?;
-                let contested = crate::openmls_projection::stored_graph_is_contested(
-                    &self.storage,
-                    group_id,
-                    group
-                        .epoch
-                        .0
-                        .saturating_sub(policy.convergence.max_rewind_commits),
-                )
-                .map_err(|error| {
-                    EngineError::Backend(format!("stored graph contested probe: {error}"))
-                })?;
-                self.deferred_peel
-                    .entry(group_id.clone())
-                    .or_default()
-                    .contested_graph = Some(contested);
-                contested
-            }
-        };
+        let group = self.storage.get_group(group_id)?;
+        let policy = self
+            .convergence_policy_for_group_ungated(group_id)
+            .map_err(|error| EngineError::Backend(format!("load convergence policy: {error}")))?;
+        let contested = crate::openmls_projection::stored_graph_is_contested(
+            &self.storage,
+            group_id,
+            group
+                .epoch
+                .0
+                .saturating_sub(policy.convergence.max_rewind_commits),
+        )
+        .map_err(|error| EngineError::Backend(format!("stored graph contested probe: {error}")))?;
         Ok(if contested {
             DeferralLineage::ContestedFork
         } else {
@@ -2308,14 +2289,10 @@ impl<S: StorageProvider> Engine<S> {
     /// group, fingerprint, generation, and branch identities never leave
     /// engine memory.
     pub(crate) fn invalidate_deferred_peel_candidate_cache(&mut self, group_id: &GroupId) {
-        let invalidated = self.deferred_peel.get_mut(group_id).is_some_and(|state| {
-            // The contested verdict is derived from the same stored commit
-            // graph these contexts are, so it goes stale on exactly the same
-            // events. Dropping it here rather than at its own set of sites is
-            // what keeps the two from drifting apart.
-            state.contested_graph = None;
-            state.candidate_cache.take().is_some()
-        });
+        let invalidated = self
+            .deferred_peel
+            .get_mut(group_id)
+            .is_some_and(|state| state.candidate_cache.take().is_some());
         if invalidated {
             self.engine_metrics
                 .note_deferred_peel_candidate_cache_invalidation();

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -1762,6 +1762,23 @@ pub(crate) fn candidate_branch_peel<S: StorageProvider>(
     contexts.map(CandidateBranchPeel::contested_over)
 }
 
+/// Whether this group's stored commit graph is contested: two retained commits
+/// at or above the retained anchor fork from the same source epoch.
+///
+/// The replay-free half of [`candidate_branch_peel`], and deliberately the
+/// same predicate over the same seeded inputs — a second, privately restated
+/// notion of "forked" would drift from the one branch enumeration acts on
+/// without any test noticing. Costs the seeding scan and nothing more: no
+/// snapshot, no rewind, no OpenMLS replay.
+pub(crate) fn stored_graph_is_contested<S: StorageProvider>(
+    storage: &S,
+    group_id: &GroupId,
+    retained_anchor_epoch: u64,
+) -> Result<bool, OpenMlsProjectionError> {
+    let inputs = seed_stored_openmls_graph_inputs(storage, group_id, retained_anchor_epoch, None)?;
+    Ok(commits_share_a_source_epoch(&inputs.commit_messages))
+}
+
 /// Whether two distinct stored commits fork from the same source epoch — the
 /// structural precondition for more than one candidate branch.
 fn commits_share_a_source_epoch(commits: &[StoredCommitMessage]) -> bool {

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -20,7 +20,7 @@ use cgka_traits::engine::{
 };
 use cgka_traits::error::PeelerError;
 use cgka_traits::group_context::GroupContextSnapshot;
-use cgka_traits::ingest::{IngestOutcome, PeeledContent, PeeledMessage};
+use cgka_traits::ingest::{DeferralLineage, IngestOutcome, PeeledContent, PeeledMessage};
 use cgka_traits::message::{MessageRecord, MessageState, StoredMessagePayload};
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
@@ -9683,5 +9683,140 @@ async fn ingest_does_not_log_decrypted_message_content() {
             .unwrap()
             .contains("secret hello"),
         "audit output must never contain decrypted application content"
+    );
+}
+
+/// Build a group where Alice and Bob fork epoch 1 with competing invite
+/// commits, then hand back Carol (an epoch-gated observer still at epoch 1),
+/// both rival commits, and an epoch-2 application message Carol's peeler
+/// cannot read. The caller decides how much of the fork Carol gets to store,
+/// which is exactly what the deferral's lineage claim is derived from.
+async fn forked_epoch_with_an_unreadable_witness(
+    tag: &str,
+) -> (
+    Engine<SqliteAccountStorage>,
+    GroupId,
+    [TransportMessage; 2],
+    TransportMessage,
+) {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut bob, _bob_storage) = build_client(b"bob");
+    let (mut carol, _carol_storage) = build_epoch_gate_client(b"carol");
+    let (mut david, _david_storage) = build_client(b"david");
+    let (mut eve, _eve_storage) = build_client(b"eve");
+
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: tag.into(),
+            description: "".into(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![bob.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcome_for(&welcomes, b"bob"))
+        .await
+        .unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+    carol.drain_events();
+
+    let david_kp = david.fresh_key_package().await.unwrap();
+    let eve_kp = eve.fresh_key_package().await.unwrap();
+    let alice_invite = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david_kp],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let bob_invite = bob
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![eve_kp],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (alice_commit, alice_pending) = evolution(alice_invite);
+    let (bob_commit, _bob_pending) = evolution(bob_invite);
+    let commits = [route(alice_commit, &group_id), route(bob_commit, &group_id)];
+
+    // Alice adopts her own branch and speaks on it. The result is sealed under
+    // an epoch Carol has not reached, so Carol's peeler defers it.
+    alice.confirm_published(alice_pending).await.unwrap();
+    let witness = send_app(&mut alice, &group_id, b"unreadable on carol".to_vec()).await;
+    assert_eq!(
+        project_mls_message(&witness.payload)
+            .expect("witness projects")
+            .source_epoch,
+        Some(2)
+    );
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(1));
+
+    (carol, group_id, commits, witness)
+}
+
+/// A transport-deferred object on a group whose stored commit graph is
+/// contested must say so. The message itself proves nothing — decryption
+/// failed under every context this device holds — but two retained commits
+/// forking from one source epoch prove that part of this group's traffic is
+/// sealed under a branch this device has not adopted, and that is the fact
+/// deciding whether fetching more relay history can help at all.
+#[tokio::test]
+async fn a_deferral_on_a_contested_stored_graph_reports_contested_fork_lineage() {
+    let (mut carol, group_id, commits, witness) =
+        forked_epoch_with_an_unreadable_witness("deferral-lineage-contested").await;
+
+    for commit in &commits {
+        carol
+            .buffer_openmls_convergence_message_at(&group_id, commit.clone(), 1_000)
+            .expect("rival commit buffered");
+    }
+
+    let outcome = carol.ingest(witness).await.unwrap();
+    assert_eq!(
+        outcome,
+        IngestOutcome::TransportDeferred {
+            group_id: group_id.clone(),
+            lineage: DeferralLineage::ContestedFork,
+        },
+        "both sides of the fork are retained, so the deferral is fork-side: no relay backfill can supply the adoption it is missing"
+    );
+}
+
+/// The same message, the same unreadable peel, one branch retained instead of
+/// two: nothing here evidences a fork, so the deferral keeps the claim that
+/// admits a relay backfill. This is the pair that makes the discriminator
+/// mean something — without it the lineage could be a constant.
+#[tokio::test]
+async fn a_deferral_with_only_one_retained_branch_reports_uncontested_lineage() {
+    let (mut carol, group_id, commits, witness) =
+        forked_epoch_with_an_unreadable_witness("deferral-lineage-uncontested").await;
+
+    carol
+        .buffer_openmls_convergence_message_at(&group_id, commits[0].clone(), 1_000)
+        .expect("single commit buffered");
+
+    let outcome = carol.ingest(witness).await.unwrap();
+    assert_eq!(
+        outcome,
+        IngestOutcome::TransportDeferred {
+            group_id: group_id.clone(),
+            lineage: DeferralLineage::Uncontested,
+        },
+        "one retained commit cannot fork with itself; an absent rival looks exactly like missing history, which is what a backfill is for"
     );
 }

--- a/crates/marmot-app/src/client/epoch_stall.rs
+++ b/crates/marmot-app/src/client/epoch_stall.rs
@@ -474,41 +474,47 @@ impl GroupStall {
         self.last_arm_at_ms = None;
     }
 
-    /// End the run while leaving the arm clock standing.
+    /// End the arm run, leaving every epoch-scoped field standing.
     ///
-    /// The one caller is [`Self::observe_convergence_reorg`], and the exception
-    /// is what makes it safe. [`Self::end_run`] clears `last_arm_at_ms` because
-    /// its other callers immediately re-note an arm ([`Self::arm`],
-    /// [`Self::rearm_wedged`]) or clear `fired_at_epoch` in the same breath
-    /// ([`Self::observe_epoch`]), so the cleared mark is never read. A reorg
-    /// does neither: the epoch does not move, so `fired_at_epoch` still names
-    /// it, and the only route back to a replay from there is the paced re-arm
-    /// in [`Self::may_rearm_wedged`] — which reads exactly this mark. Clearing
-    /// it would wedge that gate shut for good on a group whose epoch never
-    /// moves again, which is the failure the paced re-arm exists to prevent.
+    /// The one caller is [`Self::observe_convergence_reorg`], and the narrow
+    /// blast radius is what makes it safe. [`Self::end_run`] is the *run and
+    /// epoch* reset: it also drops the frozen-epoch evidence and the arm clock,
+    /// which is right for its callers because each either re-notes an arm in
+    /// the same breath ([`Self::arm`], [`Self::rearm_wedged`]) or is itself an
+    /// epoch change ([`Self::observe_epoch`]). A same-epoch reorg is neither.
+    /// It does not move the epoch, so nothing keyed on the epoch has expired:
+    /// `fruitless_completions` and `fruitless_reported` still describe the
+    /// relays' verdict about the epoch this device is still sitting on,
+    /// `last_arm_at_ms` still paces re-arms at it, and `fired_at_epoch` /
+    /// `armed_at_epoch` still debounce it.
     ///
-    /// Preserving it is also the half that denies the reorg any leverage. The
-    /// mark keeps pacing consecutive replays an interval apart, so a member who
-    /// forks the group repeatedly cannot convert reorgs into unpaced
-    /// account-wide replays; all a reorg buys is that the arms behind it stop
-    /// counting toward a report.
-    fn end_run_keeping_the_arm_clock(&mut self) {
-        let arm_clock = self.last_arm_at_ms;
-        self.end_run();
-        self.last_arm_at_ms = arm_clock;
+    /// Both omissions are load-bearing, in opposite directions. Dropping
+    /// `last_arm_at_ms` would leave `fired_at_epoch` naming an epoch with no
+    /// mark to pace against, wedging [`Self::may_rearm_wedged`] shut for good on
+    /// a group whose epoch never moves again — the exact failure the paced
+    /// re-arm exists to prevent. Dropping the frozen-epoch evidence would hand a
+    /// recurring reorg the power to silence the wedge report, and reorgs do
+    /// recur: a losing commit is parked rather than consumed, so stored
+    /// convergence re-derives and re-announces the same withdrawal on every pass
+    /// it runs, and one unresolved fork plus ordinary member traffic produces a
+    /// reorg per pass indefinitely.
+    fn end_arm_run_keeping_epoch_evidence(&mut self) {
+        self.arms = 0;
+        self.escalated = false;
     }
 
-    /// Convergence adjudicated a fork for this group: a commit this device had
-    /// applied lost a same-epoch branch selection and was rolled back.
+    /// Convergence adjudicated a fork for this group: a commit on the branch
+    /// this device was following lost a same-epoch branch selection and its
+    /// state notifications were withdrawn.
     ///
-    /// Ends the unrecovered run, for the same reason a passage spanning two or
-    /// more epochs does. It is not proof the device reached the tip — nothing
-    /// at this layer ever is — but it is proof that authenticated commits are
-    /// arriving, being applied, and being adjudicated against each other, which
-    /// is the signature of a group that is alive rather than one this device
-    /// has fallen out of. And a device that is still behind stalls again at its
-    /// unchanged epoch, re-arms, and escalates off the fresh run: being wrong
-    /// here delays the report, it does not lose it.
+    /// Ends the unrecovered *arm run*, for the same reason a passage spanning
+    /// two or more epochs does. It is not proof the device reached the tip —
+    /// nothing at this layer ever is — but it is proof that authenticated
+    /// commits are arriving and being adjudicated against each other, which is
+    /// the signature of a group that is alive rather than one this device has
+    /// fallen out of. Escalating such a device recommends the wrong recovery:
+    /// an account-wide relay replay cannot supply the branch adoption that
+    /// fork-side traffic is waiting on.
     ///
     /// It has to be its own signal because nothing else carries it. A
     /// same-epoch reorg leaves `previous_tip == selected_tip`, so the engine
@@ -516,21 +522,39 @@ impl GroupStall {
     /// reports is unchanged — [`Self::observe_epoch`] returns early and decides
     /// nothing.
     ///
-    /// Deliberately does not touch `epoch`, `undecryptable`, `fired_at_epoch`,
-    /// or `armed_at_epoch`. Those four are keyed on the stalled epoch, and a
-    /// same-epoch reorg is exactly the movement that does not change it: the
-    /// device is still wherever it was, still unable to read whatever it could
-    /// not read, and still debounced against re-arming at this epoch.
+    /// ### What this hands an adversary, and what bounds it
     ///
-    /// Not mintable in the sense the undecryptable set is. A fresh envelope is
-    /// a fresh undecryptable id, but this event is emitted only where stored
-    /// convergence supersedes an authenticated commit this device already
-    /// applied — so producing one costs a real commit from a real member. Such
-    /// a member can already end runs at will by simply committing, since that
-    /// moves the epoch; a fork buys no capability an ordinary commit does not
-    /// already grant.
+    /// State it plainly: this is a new capability, and unlike an ordinary
+    /// commit it really can suppress the arm-run rule. An ordinary commit does
+    /// not — [`Self::observe_epoch`] continues a run across an epoch the device
+    /// *armed* at, which is the core rule of the escalation design — so a
+    /// member who can fork the group gains something here that a member who
+    /// merely commits does not have.
+    ///
+    /// Two things bound it. First, authentication holds: the withdrawal is
+    /// raised only by stored convergence adjudicating commits that already
+    /// passed authenticated admission, so a forgery is rejected against the
+    /// candidate state long before it can supersede anything, and a non-member
+    /// cannot provoke one at all. The capability is member-only, and a member
+    /// already outranks the threat model the arm-run threshold was written
+    /// against — that threshold exists to keep *minted undecryptable traffic*,
+    /// which anyone can publish, from inflating a run.
+    ///
+    /// Second, and this is the half that has to hold by construction rather
+    /// than by argument: the report a wedged group actually depends on is the
+    /// frozen-epoch one, escalated from the relays' own end-of-stored-events
+    /// verdict ([`Self::observe_fruitless_completion`]), and this method does
+    /// not touch its evidence. So no reorg cadence, however dense, can silence
+    /// a wedge report — it can only stop the arm *count* from being the thing
+    /// that raises it.
+    ///
+    /// Deliberately does not touch `epoch`, `undecryptable`, `fired_at_epoch`,
+    /// or `armed_at_epoch` either. Those are keyed on the stalled epoch, and a
+    /// same-epoch reorg is exactly the movement that does not change it: the
+    /// device is still where it was, still unable to read what it could not
+    /// read, and still debounced against re-arming here.
     fn observe_convergence_reorg(&mut self) {
-        self.end_run_keeping_the_arm_clock();
+        self.end_arm_run_keeping_epoch_evidence();
     }
 
     /// Record an arm at the current epoch and decide whether this run has now
@@ -871,9 +895,11 @@ impl EpochStallDetector {
     /// ends and what it deliberately leaves alone.
     ///
     /// The caller passes the group off the engine's own
-    /// [`GroupEvent::GroupStateInvalidated`] withdrawal, and passes it once per
-    /// rolled-back commit; ending an already-ended run is a no-op, so a pass
-    /// that rolls back several commits decides as one that rolled back one.
+    /// [`GroupEvent::GroupStateInvalidated`] withdrawal, once per superseded
+    /// commit. Ending an already-ended arm run is a no-op, so a pass that
+    /// withdraws several commits decides as one that withdrew one — and so does
+    /// the *next* pass re-announcing the same withdrawal, which is the ordinary
+    /// case for a fork that has not resolved.
     ///
     /// `get_mut` like [`Self::observe_epoch_passage`]: a reorg is evidence
     /// about a stall run, never the start of one, so a group with no stall
@@ -1707,12 +1733,12 @@ mod tests {
 
     /// A reorg ends the run without opening a window on the replay.
     ///
-    /// This is the exception `end_run_keeping_the_arm_clock` exists for, from
-    /// both sides. Clear the mark and the paced re-arm gate reads `None` and
-    /// stays shut forever on a wedged group — the very group the pacing was
-    /// added for. Clear `fired_at_epoch` instead and every reorg buys an
-    /// immediate unpaced account-wide replay, which is leverage a member who
-    /// forks the group at will would happily pay for.
+    /// This is one of the omissions `end_arm_run_keeping_epoch_evidence`
+    /// exists for, from both sides. Clear the mark and the paced re-arm gate
+    /// reads `None` and stays shut forever on a wedged group — the very group
+    /// the pacing was added for. Clear `fired_at_epoch` instead and every reorg
+    /// buys an immediate unpaced account-wide replay, which is leverage a
+    /// member who forks the group at will would happily pay for.
     #[test]
     fn a_reorg_ends_the_run_without_unlocking_an_unpaced_rearm() {
         let mut detector = EpochStallDetector::new(1, 3).with_wedge_rearm_interval_ms(HOUR_MS);
@@ -1734,6 +1760,84 @@ mod tests {
             BackfillDecision::Arm,
             "and the wedged group still earns its paced re-arm once the interval elapses",
         );
+    }
+
+    /// The shape that decides the whole rescope: a group whose fork never
+    /// resolves still escalates, off the relays' own verdict.
+    ///
+    /// Reorgs are not rare punctuation on a forked group — they recur. A losing
+    /// commit is parked rather than consumed, so every convergence pass
+    /// re-derives and re-announces the same withdrawal, and ordinary member
+    /// traffic is enough to run a pass per round indefinitely. If a reorg reset
+    /// the frozen-epoch evidence along with the arm run, the count below would
+    /// return to zero every round and this group — wedged at one epoch, relays
+    /// confirming round after round that they hold nothing that moves it —
+    /// could never report at all. Keeping the epoch-scoped evidence out of the
+    /// reset makes the report survive by construction rather than by cadence.
+    #[test]
+    fn a_chronically_forked_group_still_escalates_off_relay_confirmed_evidence() {
+        let mut detector = EpochStallDetector::new(1, 3)
+            .with_wedge_rearm_interval_ms(HOUR_MS)
+            .with_fruitless_completion_threshold(3);
+        let g = group(0x01);
+
+        let mut reports = Vec::new();
+        for round in 0..12u64 {
+            // Fresh undecryptable traffic arrives and the paced replay runs.
+            assert_eq!(
+                detector.observe_undecryptable(
+                    g.clone(),
+                    format!("fork-side-{round}"),
+                    EpochId(10),
+                    T0 + round * HOUR_MS,
+                ),
+                BackfillDecision::Arm,
+                "round {round}: a wedged group's paced re-arm is its only replay",
+            );
+            // The relays serve the account's stored history in full and it
+            // recovers nothing.
+            reports.extend(detector.observe_fruitless_completion([&g]));
+            // And the unresolved fork is re-adjudicated, announcing the same
+            // withdrawal again.
+            detector.observe_convergence_reorg(&g);
+        }
+
+        assert_eq!(
+            reports.len(),
+            1,
+            "exactly one report: earned on the third relay-confirmed completion, then latched for this epoch",
+        );
+        assert_eq!(reports[0].completions, 3);
+        assert_eq!(reports[0].stalled_epoch, 10);
+    }
+
+    /// Re-announcement is the ordinary case, not an edge one, so it must cost
+    /// the evidence nothing. The engine has no idempotence guard on the
+    /// withdrawal it derives from a parked losing commit; every pass emits the
+    /// same pair again.
+    #[test]
+    fn re_announcing_the_same_withdrawal_does_not_reset_the_frozen_epoch_evidence() {
+        let mut detector = EpochStallDetector::new(1, 3).with_fruitless_completion_threshold(3);
+        let g = group(0x01);
+
+        assert_eq!(
+            detector.observe_undecryptable(g.clone(), "m1".into(), EpochId(10), T0),
+            BackfillDecision::Arm
+        );
+        assert!(detector.observe_fruitless_completion([&g]).is_empty());
+        assert!(detector.observe_fruitless_completion([&g]).is_empty());
+
+        for _ in 0..10 {
+            detector.observe_convergence_reorg(&g);
+        }
+
+        let reports = detector.observe_fruitless_completion([&g]);
+        assert_eq!(
+            reports.len(),
+            1,
+            "ten re-announcements of one withdrawal must not spend the two completions already banked",
+        );
+        assert_eq!(reports[0].completions, 3);
     }
 
     /// A reorg is evidence about a run, never the start of one.
@@ -1787,7 +1891,7 @@ mod tests {
         );
     }
 
-    /// The blind spot this pacing exists for: a group whose epoch never moves    /// The blind spot this pacing exists for: a group whose epoch never moves
+    /// The blind spot this pacing exists for: a group whose epoch never moves
     /// arms once and nothing else can ever re-arm it, because `fired_at_epoch`
     /// is cleared only by an epoch change and the epoch cannot change without
     /// the very commit the replay could not find.

--- a/crates/marmot-app/src/client/epoch_stall.rs
+++ b/crates/marmot-app/src/client/epoch_stall.rs
@@ -82,8 +82,9 @@
 
 use std::collections::{HashMap, HashSet};
 
+use cgka_traits::ingest::{DeferralLineage, IngestOutcome};
 use cgka_traits::{EpochId, GroupId};
-use marmot_forensics::EpochBackfillDeferredReason;
+use marmot_forensics::{EpochBackfillDeferredReason, EpochStallBackfillTrigger};
 use rand::RngCore;
 
 /// Distinct undecryptable messages a group may accumulate at one stalled epoch
@@ -276,6 +277,43 @@ impl BackfillDecision {
     }
 }
 
+/// Which trigger a stall-arming ingest outcome records on its durable armed row.
+///
+/// **The chosen semantics for a fork-side deferral: it counts, it arms, and it
+/// says so.** A deferral whose group's stored commit graph is contested is
+/// evidence of being stuck exactly as any other undecryptable is, and it is fed
+/// to the detector unchanged — suppressing it would cost more than the wasted
+/// replay it saves. The detector's frozen-device escalation is gated on having
+/// armed at the epoch the evidence was gathered at
+/// ([`GroupStall::observe_fruitless_completion`]), so a group whose deferrals
+/// did not arm can never report at all — and a forked group that never resolves
+/// is precisely the wedge that most needs reporting. What changes is the label,
+/// not the decision: the armed row names the fork, so an incident that keeps
+/// arming under [`EpochStallBackfillTrigger::ContestedForkDeferral`] reads as a
+/// fork to adjudicate rather than a device to re-sync. That costs the
+/// escalation none of its #1590 properties — the evidence behind a report is
+/// still the relays' own end-of-stored-events verdict, and the label is derived
+/// from retained authenticated commits, so it cannot be minted by publishing
+/// undecryptable envelopes.
+///
+/// Routing the group to convergence, which is what actually recovers it, needs
+/// nothing here: the engine schedules a group for convergence on the same seam
+/// that defers the object, and the app absorbs that through
+/// `effects.pending_convergence` on the very same delivery.
+pub(crate) fn backfill_trigger_for(outcome: &IngestOutcome) -> EpochStallBackfillTrigger {
+    match outcome {
+        IngestOutcome::TransportDeferred {
+            lineage: DeferralLineage::ContestedFork,
+            ..
+        } => EpochStallBackfillTrigger::ContestedForkDeferral,
+        IngestOutcome::ResourceRefused { .. } => EpochStallBackfillTrigger::ResourceRefusal,
+        // Every other outcome reaching an arm decision is threshold evidence,
+        // including a deferral with no fork evidence behind it — which is the
+        // case a full-history replay is the right answer for.
+        _ => EpochStallBackfillTrigger::UndecryptableThreshold,
+    }
+}
+
 /// Per-group stall accounting.
 struct GroupStall {
     /// The epoch the undecryptable messages accumulated at; a new epoch resets
@@ -434,6 +472,65 @@ impl GroupStall {
         self.fruitless_reported = false;
         self.fruitless_completions = 0;
         self.last_arm_at_ms = None;
+    }
+
+    /// End the run while leaving the arm clock standing.
+    ///
+    /// The one caller is [`Self::observe_convergence_reorg`], and the exception
+    /// is what makes it safe. [`Self::end_run`] clears `last_arm_at_ms` because
+    /// its other callers immediately re-note an arm ([`Self::arm`],
+    /// [`Self::rearm_wedged`]) or clear `fired_at_epoch` in the same breath
+    /// ([`Self::observe_epoch`]), so the cleared mark is never read. A reorg
+    /// does neither: the epoch does not move, so `fired_at_epoch` still names
+    /// it, and the only route back to a replay from there is the paced re-arm
+    /// in [`Self::may_rearm_wedged`] — which reads exactly this mark. Clearing
+    /// it would wedge that gate shut for good on a group whose epoch never
+    /// moves again, which is the failure the paced re-arm exists to prevent.
+    ///
+    /// Preserving it is also the half that denies the reorg any leverage. The
+    /// mark keeps pacing consecutive replays an interval apart, so a member who
+    /// forks the group repeatedly cannot convert reorgs into unpaced
+    /// account-wide replays; all a reorg buys is that the arms behind it stop
+    /// counting toward a report.
+    fn end_run_keeping_the_arm_clock(&mut self) {
+        let arm_clock = self.last_arm_at_ms;
+        self.end_run();
+        self.last_arm_at_ms = arm_clock;
+    }
+
+    /// Convergence adjudicated a fork for this group: a commit this device had
+    /// applied lost a same-epoch branch selection and was rolled back.
+    ///
+    /// Ends the unrecovered run, for the same reason a passage spanning two or
+    /// more epochs does. It is not proof the device reached the tip — nothing
+    /// at this layer ever is — but it is proof that authenticated commits are
+    /// arriving, being applied, and being adjudicated against each other, which
+    /// is the signature of a group that is alive rather than one this device
+    /// has fallen out of. And a device that is still behind stalls again at its
+    /// unchanged epoch, re-arms, and escalates off the fresh run: being wrong
+    /// here delays the report, it does not lose it.
+    ///
+    /// It has to be its own signal because nothing else carries it. A
+    /// same-epoch reorg leaves `previous_tip == selected_tip`, so the engine
+    /// emits no `EpochChanged`, and the epoch every other `observe_*` call
+    /// reports is unchanged — [`Self::observe_epoch`] returns early and decides
+    /// nothing.
+    ///
+    /// Deliberately does not touch `epoch`, `undecryptable`, `fired_at_epoch`,
+    /// or `armed_at_epoch`. Those four are keyed on the stalled epoch, and a
+    /// same-epoch reorg is exactly the movement that does not change it: the
+    /// device is still wherever it was, still unable to read whatever it could
+    /// not read, and still debounced against re-arming at this epoch.
+    ///
+    /// Not mintable in the sense the undecryptable set is. A fresh envelope is
+    /// a fresh undecryptable id, but this event is emitted only where stored
+    /// convergence supersedes an authenticated commit this device already
+    /// applied — so producing one costs a real commit from a real member. Such
+    /// a member can already end runs at will by simply committing, since that
+    /// moves the epoch; a fork buys no capability an ordinary commit does not
+    /// already grant.
+    fn observe_convergence_reorg(&mut self) {
+        self.end_run_keeping_the_arm_clock();
     }
 
     /// Record an arm at the current epoch and decide whether this run has now
@@ -767,6 +864,26 @@ impl EpochStallDetector {
             stall.observe_epoch(from.next());
         }
         stall.observe_epoch(to);
+    }
+
+    /// Note that stored convergence adjudicated a fork for an already-tracked
+    /// `group`: see [`GroupStall::observe_convergence_reorg`] for what that
+    /// ends and what it deliberately leaves alone.
+    ///
+    /// The caller passes the group off the engine's own
+    /// [`GroupEvent::GroupStateInvalidated`] withdrawal, and passes it once per
+    /// rolled-back commit; ending an already-ended run is a no-op, so a pass
+    /// that rolls back several commits decides as one that rolled back one.
+    ///
+    /// `get_mut` like [`Self::observe_epoch_passage`]: a reorg is evidence
+    /// about a stall run, never the start of one, so a group with no stall
+    /// history stays untracked.
+    ///
+    /// [`GroupEvent::GroupStateInvalidated`]: cgka_traits::engine::GroupEvent::GroupStateInvalidated
+    pub(crate) fn observe_convergence_reorg(&mut self, group: &GroupId) {
+        if let Some(stall) = self.groups.get_mut(group) {
+            stall.observe_convergence_reorg();
+        }
     }
 
     /// Record one undecryptable message for `group` observed while the group is
@@ -1588,7 +1705,89 @@ mod tests {
         );
     }
 
-    /// The blind spot this pacing exists for: a group whose epoch never moves
+    /// A reorg ends the run without opening a window on the replay.
+    ///
+    /// This is the exception `end_run_keeping_the_arm_clock` exists for, from
+    /// both sides. Clear the mark and the paced re-arm gate reads `None` and
+    /// stays shut forever on a wedged group — the very group the pacing was
+    /// added for. Clear `fired_at_epoch` instead and every reorg buys an
+    /// immediate unpaced account-wide replay, which is leverage a member who
+    /// forks the group at will would happily pay for.
+    #[test]
+    fn a_reorg_ends_the_run_without_unlocking_an_unpaced_rearm() {
+        let mut detector = EpochStallDetector::new(1, 3).with_wedge_rearm_interval_ms(HOUR_MS);
+        let g = group(0x01);
+
+        assert_eq!(
+            detector.observe_undecryptable(g.clone(), "m1".into(), EpochId(10), T0),
+            BackfillDecision::Arm
+        );
+        detector.observe_convergence_reorg(&g);
+
+        assert_eq!(
+            detector.observe_undecryptable(g.clone(), "m2".into(), EpochId(10), T0 + HOUR_MS - 1),
+            BackfillDecision::Skip,
+            "the reorg left the arm clock standing, so pacing still gates the replay",
+        );
+        assert_eq!(
+            detector.observe_undecryptable(g.clone(), "m3".into(), EpochId(10), T0 + HOUR_MS),
+            BackfillDecision::Arm,
+            "and the wedged group still earns its paced re-arm once the interval elapses",
+        );
+    }
+
+    /// A reorg is evidence about a run, never the start of one.
+    #[test]
+    fn a_reorg_for_a_group_with_no_stall_history_leaves_it_untracked() {
+        let mut detector = stall_detector(1);
+        let g = group(0x01);
+
+        detector.observe_convergence_reorg(&g);
+
+        assert_eq!(
+            detector.observe_undecryptable(g, "m1".into(), EpochId(10), T0),
+            BackfillDecision::Arm,
+            "the first arm of a fresh run, not a second one off invented history",
+        );
+    }
+
+    /// Fork-side traffic still arms, and the row it arms says which kind of
+    /// recovery it is: the deferral counts as stall evidence exactly as any
+    /// other undecryptable does, because a fork that never resolves is a wedge
+    /// and the wedge report is gated on having armed.
+    #[test]
+    fn a_contested_fork_deferral_arms_under_its_own_trigger() {
+        let deferred = |lineage| IngestOutcome::TransportDeferred {
+            group_id: group(0x01),
+            lineage,
+        };
+
+        assert_eq!(
+            backfill_trigger_for(&deferred(DeferralLineage::ContestedFork)),
+            EpochStallBackfillTrigger::ContestedForkDeferral,
+        );
+        assert_eq!(
+            backfill_trigger_for(&deferred(DeferralLineage::Uncontested)),
+            EpochStallBackfillTrigger::UndecryptableThreshold,
+        );
+        assert_eq!(
+            backfill_trigger_for(&IngestOutcome::ResourceRefused {
+                group_id: group(0x01),
+                resource: cgka_traits::ingest::InboundResourceLimit::TransportDeferredCapacity,
+            }),
+            EpochStallBackfillTrigger::ResourceRefusal,
+        );
+
+        // And the label changes nothing about the decision: a fork-side
+        // deferral crosses the same threshold and arms the same replay.
+        let mut detector = stall_detector(1);
+        assert_eq!(
+            detector.observe_undecryptable(group(0x01), "fork-side".into(), EpochId(10), T0),
+            BackfillDecision::Arm,
+        );
+    }
+
+    /// The blind spot this pacing exists for: a group whose epoch never moves    /// The blind spot this pacing exists for: a group whose epoch never moves
     /// arms once and nothing else can ever re-arm it, because `fired_at_epoch`
     /// is cleared only by an epoch change and the epoch cannot change without
     /// the very commit the replay could not find.

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -453,8 +453,8 @@ impl AppClient {
     }
 
     /// Feed one effects batch's epoch-gap recovery evidence to the stall
-    /// detector: a resource refusal arms a replay, and an epoch passage reports
-    /// the movement that can end an unrecovered run.
+    /// detector: a resource refusal arms a replay, and an epoch passage or a
+    /// convergence reorg reports the activity that can end an unrecovered run.
     ///
     /// Both directions matter, and only this seam carries the second one. A
     /// delivery reports the epoch it was *read* at, which is where the device
@@ -510,6 +510,34 @@ impl AppClient {
                         decision,
                         EpochStallBackfillTrigger::ResourceRefusal,
                     );
+                }
+                // A convergence reorg is the third kind of recovery evidence,
+                // and the only one that never moves an epoch. Branch selection
+                // superseded an authenticated commit this device had applied;
+                // when the two branches carry the same epoch number the engine
+                // emits no `EpochChanged` for it at all, so without this arm a
+                // device that just crossed a fork resolution is indistinguishable
+                // from one that saw nothing.
+                //
+                // Matching the withdrawal rather than its `CommitRolledBack`
+                // twin is not a choice about which is better evidence: the
+                // engine pushes the pair back to back, once per rolled-back
+                // commit, with nothing fallible between them, so the two arms
+                // would decide identically and the second would only re-decide
+                // what the first already did.
+                cgka_traits::engine::GroupEvent::GroupStateInvalidated {
+                    group_id,
+                    reason:
+                        cgka_traits::engine::GroupStateInvalidationReason::SupersededByBranchSelection,
+                    ..
+                } => {
+                    // Deliberately not fed the carried `epoch`: that is the
+                    // source epoch of the fork the superseded commit lost, which
+                    // sits *behind* where this device is now. The detector's
+                    // observed epoch only ever moves forward, and handing it a
+                    // backward position would walk the per-epoch suppression
+                    // back with it.
+                    self.epoch_stall.observe_convergence_reorg(group_id);
                 }
                 _ => {}
             }
@@ -2216,7 +2244,11 @@ impl AppClient {
     /// Feed an unavailable group delivery to the epoch-stall detector.
     /// Transport-deferred input arms a backfill after the stalled-epoch
     /// threshold; resource refusal arms it immediately because it directly
-    /// proves the fetched history was not fully retained. Repeated arming that
+    /// proves the fetched history was not fully retained. A deferral whose
+    /// engine-reported lineage is fork-side arms on the same threshold and
+    /// carries its own trigger — see
+    /// [`backfill_trigger_for`](super::epoch_stall::backfill_trigger_for) for
+    /// why the label moves and the decision does not. Repeated arming that
     /// never recovers the group escalates onto the next successful sync summary,
     /// the seam every worker surface already publishes. Only observed under
     /// `CursorPersistence::Advance`: a `Frozen` wake-collection pass must not
@@ -2271,13 +2303,7 @@ impl AppClient {
             &group_id,
             record.epoch.0,
             decision,
-            match outcome {
-                IngestOutcome::TransportDeferred { .. } => {
-                    EpochStallBackfillTrigger::UndecryptableThreshold
-                }
-                IngestOutcome::ResourceRefused { .. } => EpochStallBackfillTrigger::ResourceRefusal,
-                _ => EpochStallBackfillTrigger::UndecryptableThreshold,
-            },
+            crate::client::epoch_stall::backfill_trigger_for(outcome),
         );
     }
 

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -13496,6 +13496,97 @@ fn an_epoch_passage(
     effects
 }
 
+/// One convergence pass that adjudicated a fork: the losing commit is rolled
+/// back and every state notification it produced is withdrawn.
+///
+/// The epoch on the withdrawal is the fork's SOURCE epoch — the epoch the
+/// superseded commit branched from — which is deliberately behind where the
+/// device sits. A same-epoch reorg emits no `EpochChanged` at all, so this pair
+/// is the only announcement the app ever gets that convergence moved the
+/// canonical branch under it.
+fn a_convergence_reorg(
+    group_id: &cgka_traits::GroupId,
+    fork_source_epoch: u64,
+) -> marmot_account::AccountDeviceEffects {
+    let invalidated_commit_id = cgka_traits::MessageId::new(vec![7u8; 32]);
+    let mut effects = marmot_account::AccountDeviceEffects::default();
+    effects
+        .events
+        .push(cgka_traits::engine::GroupEvent::CommitRolledBack {
+            group_id: group_id.clone(),
+            invalidated_commit_id: invalidated_commit_id.clone(),
+        });
+    effects
+        .events
+        .push(cgka_traits::engine::GroupEvent::GroupStateInvalidated {
+            group_id: group_id.clone(),
+            epoch: cgka_traits::EpochId(fork_source_epoch),
+            invalidated_commit_id,
+            reason: cgka_traits::engine::GroupStateInvalidationReason::SupersededByBranchSelection,
+        });
+    effects
+}
+
+/// A convergence reorg is liveness evidence and must end the unrecovered arm
+/// run, exactly as a spanning epoch passage does.
+///
+/// Nothing else can carry it. A same-epoch reorg leaves `previous_tip ==
+/// selected_tip`, so no `EpochChanged` is emitted, and the device's own epoch
+/// does not move — every other signal this detector reads is identical to a
+/// device that saw nothing at all. Without this the arms that accumulated
+/// while convergence was busy adjudicating a fork read as one unrecovered run
+/// and escalate a device onto the wrong recovery: relay backfill cannot supply
+/// the branch adoption that fork-side traffic is waiting for.
+#[tokio::test]
+async fn a_convergence_reorg_ends_the_unrecovered_arm_run() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://convergence-reorg.example")
+        .with_test_relay_client(relay.clone());
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client.create_group("convergence reorg", &[]).await.unwrap();
+
+    // Two arms of one run, at two epochs the device armed at.
+    assert_eq!(
+        client.epoch_stall.observe_resource_refusal(
+            group_id.clone(),
+            cgka_traits::EpochId(10),
+            epoch_stall_test_now_ms()
+        ),
+        crate::client::epoch_stall::BackfillDecision::Arm
+    );
+    assert_eq!(
+        client.epoch_stall.observe_resource_refusal(
+            group_id.clone(),
+            cgka_traits::EpochId(11),
+            epoch_stall_test_now_ms()
+        ),
+        crate::client::epoch_stall::BackfillDecision::Arm
+    );
+
+    // Convergence then resolves a fork this device was on the wrong side of.
+    client
+        .observe_recovery_evidence_then_fail_if_publish_failed(&a_convergence_reorg(&group_id, 9))
+        .expect("a batch carrying only a convergence reorg passes the publish gate");
+
+    // Without the reorg this third arm is the run's escalating one
+    // (`escalates_when_arms_repeat_without_passing_cleanly_through_an_epoch`
+    // pins that shape). With it, the arms before the reorg are not one
+    // unrecovered run.
+    assert_eq!(
+        client.epoch_stall.observe_resource_refusal(
+            group_id,
+            cgka_traits::EpochId(12),
+            epoch_stall_test_now_ms()
+        ),
+        crate::client::epoch_stall::BackfillDecision::Arm,
+        "a group whose fork convergence just adjudicated is alive; the arms it took to get there are not evidence that a replay is failing to recover it"
+    );
+}
+
 /// A maintenance tick's own epoch advance must reach the stall detector.
 ///
 /// A tick drains a recovered staged evolution and confirms it, which emits

--- a/crates/marmot-forensics/schema/audit-log-event.v3.schema.json
+++ b/crates/marmot-forensics/schema/audit-log-event.v3.schema.json
@@ -521,7 +521,7 @@
       ]
     },
     "epochStallBackfillTrigger": {
-      "enum": ["undecryptable_threshold", "resource_refusal"]
+      "enum": ["undecryptable_threshold", "contested_fork_deferral", "resource_refusal"]
     },
     "epochBackfillExecutionSeam": {
       "enum": ["startup", "receive", "explicit_catch_up", "maintenance"]

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -167,6 +167,15 @@ pub enum ConvergencePhase {
 #[serde(rename_all = "snake_case")]
 pub enum EpochStallBackfillTrigger {
     UndecryptableThreshold,
+    /// The undecryptable threshold was crossed on a group whose stored commit
+    /// graph is contested, so the traffic driving the arm is sealed under a
+    /// branch this device has not adopted. Recorded apart from
+    /// [`Self::UndecryptableThreshold`] because it changes what the replay can
+    /// possibly achieve, not whether it ran: the objects are already retained
+    /// locally, so no amount of relay history supplies the adoption they need —
+    /// convergence adjudication does. An incident that keeps arming under this
+    /// trigger is a fork to resolve, not a device to re-sync.
+    ContestedForkDeferral,
     ResourceRefusal,
 }
 

--- a/crates/marmot-forensics/src/audit/tests.rs
+++ b/crates/marmot-forensics/src/audit/tests.rs
@@ -963,6 +963,56 @@ fn audit_log_event_schema_tracks_kind_catalog() {
     assert_eq!(schema_tags, code_tags);
 }
 
+/// The trigger enum is a schema-visible catalog, so the two halves must move
+/// together. Without this the v3 `$defs` can be reverted to a narrower set — or
+/// left behind when a variant is added — and every other test still passes,
+/// because nothing else compares the two.
+#[test]
+fn v3_schema_tracks_the_epoch_stall_backfill_trigger_catalog() {
+    let triggers = [
+        EpochStallBackfillTrigger::UndecryptableThreshold,
+        EpochStallBackfillTrigger::ContestedForkDeferral,
+        EpochStallBackfillTrigger::ResourceRefusal,
+    ];
+    // Exhaustiveness guard: a new variant fails to compile here rather than
+    // silently shrinking the set this test compares.
+    for trigger in triggers {
+        match trigger {
+            EpochStallBackfillTrigger::UndecryptableThreshold
+            | EpochStallBackfillTrigger::ContestedForkDeferral
+            | EpochStallBackfillTrigger::ResourceRefusal => {}
+        }
+    }
+
+    let emitted = triggers
+        .iter()
+        .map(|trigger| {
+            serde_json::to_value(trigger)
+                .expect("trigger serializes")
+                .as_str()
+                .expect("trigger serializes to a string")
+                .to_string()
+        })
+        .collect::<std::collections::BTreeSet<_>>();
+
+    let schema: serde_json::Value =
+        serde_json::from_str(include_str!("../../schema/audit-log-event.v3.schema.json")).unwrap();
+    let defined = schema
+        .pointer("/$defs/epochStallBackfillTrigger/enum")
+        .and_then(serde_json::Value::as_array)
+        .expect("epochStallBackfillTrigger enum")
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .expect("trigger enum entry is a string")
+                .to_string()
+        })
+        .collect::<std::collections::BTreeSet<_>>();
+
+    assert_eq!(emitted, defined);
+}
+
 #[test]
 fn v3_schema_cannot_express_former_sensitive_audit_fields() {
     let schema = include_str!("../../schema/audit-log-event.v3.schema.json");

--- a/crates/traits/src/ingest.rs
+++ b/crates/traits/src/ingest.rs
@@ -35,7 +35,14 @@ pub enum IngestOutcome {
     /// currently available transport context, but a later canonical epoch,
     /// retained candidate, staged state, or repair may make it recoverable.
     /// The object remains outside convergence until peeling succeeds.
-    TransportDeferred { group_id: GroupId },
+    ///
+    /// `lineage` says which recovery can possibly help. See
+    /// [`DeferralLineage`] for what that claim is and — importantly — what it
+    /// is not.
+    TransportDeferred {
+        group_id: GroupId,
+        lineage: DeferralLineage,
+    },
     /// A local resource bound prevented the engine from retaining or
     /// processing an otherwise unclassified transport object. This is not a
     /// protocol rejection and must not make same-id redelivery a duplicate.
@@ -49,6 +56,42 @@ pub enum IngestOutcome {
     /// A standalone or commit-carried MLS proposal failed Marmot semantic
     /// admission before it could enter pending state or affect group state.
     Rejected { category: ProposalRejectionCategory },
+}
+
+/// Which recovery can make a [`IngestOutcome::TransportDeferred`] object
+/// readable.
+///
+/// **This is a claim about the group, not about the message.** At the deferral
+/// point decryption failed under the live context, every retained snapshot, and
+/// every candidate branch the engine had materialized, so nothing observable
+/// separates one unreadable object from another. What the engine can still
+/// state soundly is the shape of the group's stored commit graph, and that is
+/// what decides whether fetching more history from relays is even the right
+/// kind of answer.
+///
+/// The discriminator is deliberately one-way, in the same sense as the
+/// candidate-branch context set it is derived from: [`Self::ContestedFork`] is
+/// positive evidence, while [`Self::Uncontested`] is the absence of evidence
+/// rather than proof of its opposite.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DeferralLineage {
+    /// No two retained commits fork from the same source epoch, so this device
+    /// holds no evidence that any of this group's traffic is sealed under a
+    /// branch it has not adopted.
+    ///
+    /// Not a positive claim that the object is merely ahead of this device. A
+    /// fork whose rival commit never reached this device looks exactly like no
+    /// fork at all — and that case is precisely the one a relay backfill is the
+    /// right answer for, because the commit it needs really is missing history.
+    #[default]
+    Uncontested,
+    /// Two retained commits fork from the same source epoch: part of this
+    /// group's traffic is sealed under a branch this device has not adopted.
+    ///
+    /// A relay backfill cannot help such an object. The bytes already arrived;
+    /// what is missing is not history but adoption, and only convergence
+    /// adjudication over the commits already stored can supply it.
+    ContestedFork,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/traits/src/ingest.rs
+++ b/crates/traits/src/ingest.rs
@@ -73,7 +73,7 @@ pub enum IngestOutcome {
 /// candidate-branch context set it is derived from: [`Self::ContestedFork`] is
 /// positive evidence, while [`Self::Uncontested`] is the absence of evidence
 /// rather than proof of its opposite.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DeferralLineage {
     /// No two retained commits fork from the same source epoch, so this device
     /// holds no evidence that any of this group's traffic is sealed under a
@@ -83,7 +83,6 @@ pub enum DeferralLineage {
     /// fork whose rival commit never reached this device looks exactly like no
     /// fork at all — and that case is precisely the one a relay backfill is the
     /// right answer for, because the commit it needs really is missing history.
-    #[default]
     Uncontested,
     /// Two retained commits fork from the same source epoch: part of this
     /// group's traffic is sealed under a branch this device has not adopted.

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -20,7 +20,7 @@ use cgka_traits::engine::{
 use cgka_traits::engine_state::PendingStateRef;
 use cgka_traits::group::{Group, Member, ProtocolProfile};
 use cgka_traits::ingest::{
-    InboundResourceLimit, IngestOutcome, PeeledContent, PeeledMessage, StaleReason,
+    DeferralLineage, InboundResourceLimit, IngestOutcome, PeeledContent, PeeledMessage, StaleReason,
 };
 use cgka_traits::message::StoredMessagePayload;
 use cgka_traits::transport::{
@@ -458,7 +458,10 @@ fn snapshot_ingest_outcomes() {
     );
     insta::assert_json_snapshot!(
         "transport_deferred",
-        IngestOutcome::TransportDeferred { group_id: gid() }
+        IngestOutcome::TransportDeferred {
+            group_id: gid(),
+            lineage: DeferralLineage::Uncontested
+        }
     );
     insta::assert_json_snapshot!(
         "resource_refused_deferred_capacity",

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -464,6 +464,13 @@ fn snapshot_ingest_outcomes() {
         }
     );
     insta::assert_json_snapshot!(
+        "transport_deferred_contested_fork",
+        IngestOutcome::TransportDeferred {
+            group_id: gid(),
+            lineage: DeferralLineage::ContestedFork
+        }
+    );
+    insta::assert_json_snapshot!(
         "resource_refused_deferred_capacity",
         IngestOutcome::ResourceRefused {
             group_id: gid(),

--- a/crates/traits/tests/snapshots/snapshots__transport_deferred.snap
+++ b/crates/traits/tests/snapshots/snapshots__transport_deferred.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/traits/tests/snapshots.rs
-expression: "IngestOutcome::TransportDeferred { group_id: gid() }"
+expression: "IngestOutcome::TransportDeferred { group_id: gid(), lineage: DeferralLineage::Uncontested }"
 ---
 {
   "TransportDeferred": {
@@ -9,6 +9,7 @@ expression: "IngestOutcome::TransportDeferred { group_id: gid() }"
       170,
       170,
       170
-    ]
+    ],
+    "lineage": "Uncontested"
   }
 }

--- a/crates/traits/tests/snapshots/snapshots__transport_deferred_contested_fork.snap
+++ b/crates/traits/tests/snapshots/snapshots__transport_deferred_contested_fork.snap
@@ -1,0 +1,15 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: "IngestOutcome::TransportDeferred\n{ group_id: gid(), lineage: DeferralLineage::ContestedFork }"
+---
+{
+  "TransportDeferred": {
+    "group_id": [
+      170,
+      170,
+      170,
+      170
+    ],
+    "lineage": "ContestedFork"
+  }
+}

--- a/docs/marmot-architecture/audit-logging.md
+++ b/docs/marmot-architecture/audit-logging.md
@@ -1,7 +1,7 @@
 ---
 title: "Forensic Audit Logging Inventory"
 created: 2026-06-10
-updated: 2026-08-27
+updated: 2026-08-29
 tags: [marmot, architecture, audit, forensics, jsonl, privacy]
 status: current
 ---

--- a/docs/marmot-architecture/audit-logging.md
+++ b/docs/marmot-architecture/audit-logging.md
@@ -835,15 +835,16 @@ Metadata notes:
 
 Emitted when the app runtime's epoch-stall detector reads a group as stuck — traffic it cannot decrypt keeps arriving
 while the device's own epoch does not move — and arms one account-wide full-history transport replay to recover the
-commit it missed. Two triggers reach it: the group accumulated
-`threshold` distinct undecryptable messages while its own epoch did not move, or an inbound object was refused outright
+commit it missed. Three triggers reach it: the group accumulated
+`threshold` distinct undecryptable messages while its own epoch did not move, the same threshold was crossed on a group
+whose stored commit graph is contested, or an inbound object was refused outright
 (direct proof that the fetched history was not fully retained).
 
 | Field | Meaning |
 | --- | --- |
 | `stalled_epoch` | The device's own group epoch when the replay was armed. |
 | `threshold` | Distinct-undecryptable count in force in this build, so the row is self-describing when the constant is retuned. |
-| `trigger` | Which of the two triggers armed this replay: `undecryptable_threshold` or `resource_refusal`. Absent on rows written before the field existed. |
+| `trigger` | Which trigger armed this replay: `undecryptable_threshold`, `contested_fork_deferral`, or `resource_refusal`. Absent on rows written before the field existed. |
 
 Metadata notes:
 


### PR DESCRIPTION
Fork-aware deferral lineage and reorg-aware stall runs

One defect, two visible halves, both verified against the fleet's real fork incidents (distinct origin commits at epochs 15 and 17).

Half one: every undecryptable used to land as an undifferentiated TransportDeferred, so a device on the wrong side of a fork was treated like a device behind the tip and armed account-wide relay backfills that cannot help — the commit it is missing is on no relay; convergence has to resolve it. The engine now reports lineage on the deferral. The discriminator is deliberately group-level and one-way: DeferralLineage::ContestedFork means the stored commit graph provably holds two commits forking from one source epoch (the same replay-free predicate candidate_branch_peel gates on), while Uncontested means no such evidence — never "behind tip", which the engine cannot check. Fork-side deferrals still count toward the stall threshold and still arm (suppressing them would blind the wedge detector), but the armed audit row now carries a contested_fork_deferral trigger, so a group that keeps arming under it reads as a fork to adjudicate rather than a device to re-sync. The label derives from authenticated retained commits and cannot be minted by publishing garbage. The probe runs only after the deferred-peel cap has admitted the row, so a minted flood is refused before it can buy the scan. An earlier memoized version was dropped during review: its validity check would have cost the same full-group scan it was saving, and a stale entry reads Uncontested — exactly the inversion this change exists to prevent.

Half two: a same-epoch reorg emits no EpochChanged (the guard requires the tip to move), and the events that do announce it died in a catch-all, so the stall detector was blind to fork resolutions. GroupStateInvalidated now ends the unrecovered arm run — narrowly. The reset clears exactly the two run-scoped counters (arms, escalated) and touches nothing epoch-scoped: fruitless completions, the report latch, the pacing clock, and both arm latches all survive. That split is load-bearing and adversarially tested: reorgs recur on chronically forked groups from ordinary traffic (the engine re-announces the same withdrawals every convergence pass), and a wider reset provably let that cadence suppress escalation forever — the regression test drives twelve rounds of reorg-per-fruitless-replay and asserts exactly one report. The doc states the residual honestly: the reset is a new, member-only capability against the arm-run rule specifically; the relay-confirmed evidence path is untouched by construction, so no reorg cadence can silence a wedge report.

Wire change: IngestOutcome::TransportDeferred gains the lineage field (traits crate; ~30 match sites audited, one production construction site). Forensics: additive contested_fork_deferral enum value in the v3 schema, now pinned to the Rust catalog by a test with a compile-time exhaustiveness match. No conformance vector or FFI surface touches the outcome; canonical_scenarios unchanged (53/53).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Transport-deferred messages now indicate whether they involve an uncontested state or a contested fork.
- Epoch-stall recovery recognizes contested-fork deferrals and convergence reorganizations as recovery signals.
- Recovery tracking resets appropriately after branch reorganizations while preserving relevant evidence.

## Audit & Reporting

- Audit logs now record contested-fork deferrals as a distinct backfill trigger.

## Documentation

- Updated audit logging documentation to describe the additional trigger type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->