### PR TITLE
fix: recover durable outbound sends after connectivity returns

### DIFF
--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -773,9 +773,7 @@ impl<S: StorageProvider> Engine<S> {
         &self,
         group_id: &GroupId,
     ) -> Result<Vec<OutboundFanout>, EngineError> {
-        if self.quarantined_groups.contains_key(group_id)
-            || self.unhydrated_groups.contains(group_id)
-        {
+        if self.ensure_group_live(group_id).is_err() {
             return Ok(Vec::new());
         }
         Ok(self.storage.list_outbound_fanouts_for_group(group_id)?)

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -767,6 +767,20 @@ impl<S: StorageProvider> Engine<S> {
             .collect())
     }
 
+    /// Read one live group's frozen fanouts in original staging order without
+    /// scanning every other group's durable outbox.
+    pub fn outbound_fanouts_for_group(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<Vec<OutboundFanout>, EngineError> {
+        if self.quarantined_groups.contains_key(group_id)
+            || self.unhydrated_groups.contains(group_id)
+        {
+            return Ok(Vec::new());
+        }
+        Ok(self.storage.list_outbound_fanouts_for_group(group_id)?)
+    }
+
     /// Delete a terminal fanout after its outcome has been returned.
     pub fn delete_outbound_fanout(&self, message_id: &MessageId) -> Result<(), EngineError> {
         if let Some(group_id) = self

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -663,32 +663,7 @@ impl<S: StorageProvider> Engine<S> {
         group_id: &GroupId,
         now_ms: u64,
     ) -> Result<Vec<SendResult>, EngineError> {
-        // Draining a seeded-but-unhydrated group promotes it first
-        // (mdk#1161); a hydration failure quarantines it and the gate below
-        // reports UnknownGroup.
-        let _ = self.ensure_hydrated(group_id);
-        // Quarantined groups vanish from every live surface; convergence and
-        // queued-intent drains must not touch their state (mdk#364).
-        self.ensure_group_live(group_id)?;
-        // A drain can be invoked directly without session-open hydration.
-        // Synchronize the durable halt before convergence or queued work can
-        // run so restart never bypasses `Unrecoverable`.
-        if self.sync_unrecoverable_halt_from_storage(group_id)? {
-            return Ok(Vec::new());
-        }
-        // Terminal: a removed copy must never publish, and the removed-copy
-        // gate in `do_send_ready` would turn every queued record into a
-        // permanent drain error that the app retries forever. Discard the
-        // queue and report nothing to drain. This is the defense-in-depth
-        // side; the marker sites (realization, commit-apply seam, convergence
-        // reorg) also purge at the moment the copy becomes removed.
-        if self.group_record_is_removed(group_id)? {
-            self.discard_queued_outbound_intents_for_removed_group(group_id)?;
-            return Ok(Vec::new());
-        }
-        if let Some(state) = self.epoch_manager.state(group_id)
-            && !matches!(state, EpochState::Stable { .. })
-        {
+        if !self.prepare_convergence_input_advance(group_id)? {
             return Ok(Vec::new());
         }
 
@@ -809,6 +784,41 @@ impl<S: StorageProvider> Engine<S> {
             }
         }
         Ok(drained)
+    }
+
+    fn prepare_convergence_input_advance(
+        &mut self,
+        group_id: &GroupId,
+    ) -> Result<bool, EngineError> {
+        // Advancing a seeded-but-unhydrated group promotes it first
+        // (mdk#1161); a hydration failure quarantines it and the gate below
+        // reports UnknownGroup.
+        let _ = self.ensure_hydrated(group_id);
+        // Quarantined groups vanish from every live surface; convergence and
+        // queued-intent drains must not touch their state (mdk#364).
+        self.ensure_group_live(group_id)?;
+        // An advance can be invoked directly without session-open hydration.
+        // Synchronize the durable halt before convergence or queued work can
+        // run so restart never bypasses `Unrecoverable`.
+        if self.sync_unrecoverable_halt_from_storage(group_id)? {
+            return Ok(false);
+        }
+        // Terminal: a removed copy must never publish, and the removed-copy
+        // gate in `do_send_ready` would turn every queued record into a
+        // permanent drain error that the app retries forever. Discard the
+        // queue and report nothing to drain. This is the defense-in-depth
+        // side; the marker sites (realization, commit-apply seam, convergence
+        // reorg) also purge at the moment the copy becomes removed.
+        if self.group_record_is_removed(group_id)? {
+            self.discard_queued_outbound_intents_for_removed_group(group_id)?;
+            return Ok(false);
+        }
+        if let Some(state) = self.epoch_manager.state(group_id)
+            && !matches!(state, EpochState::Stable { .. })
+        {
+            return Ok(false);
+        }
+        Ok(true)
     }
 
     async fn run_drain_maintenance(
@@ -1091,6 +1101,23 @@ impl<S: StorageProvider> Engine<S> {
     /// opaque transport bytes do not participate in canonicalization until a
     /// selected branch gives the peeler the epoch context needed to unwrap
     /// them.
+    pub async fn advance_convergence_inputs(
+        &mut self,
+        group_id: &GroupId,
+    ) -> Result<bool, EngineError> {
+        if !self.prepare_convergence_input_advance(group_id)? {
+            return Ok(false);
+        }
+        let now_ms = self.convergence_now_ms();
+        self.advance_convergence_inputs_until_settled(group_id, now_ms)
+            .await
+    }
+
+    /// Drive stored OpenMLS inputs to stability at an explicit monotonic time.
+    ///
+    /// This lower-level form is used by deterministic harnesses. Hosts should
+    /// normally call [`Self::advance_convergence_inputs`] so the engine owns
+    /// the convergence clock.
     pub async fn advance_convergence_inputs_until_settled(
         &mut self,
         group_id: &GroupId,

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -4427,6 +4427,13 @@ async fn durable_unrecoverable_halt_blocks_queued_drain_without_rehydration() {
         .await
         .expect("durable halt pauses queued drain");
     assert!(drained.is_empty());
+    assert!(
+        !alice
+            .advance_convergence_inputs(&group_id)
+            .await
+            .expect("durable halt also pauses convergence-only advance"),
+        "a durable unrecoverable halt must gate the narrower convergence path"
+    );
     assert_eq!(
         storage
             .list_queued_outbound_intents(&group_id)

--- a/crates/cgka-engine/tests/hydration_quarantine.rs
+++ b/crates/cgka-engine/tests/hydration_quarantine.rs
@@ -1310,6 +1310,10 @@ async fn quarantined_group_blocks_convergence_and_send() {
             .await,
         Err(EngineError::UnknownGroup(id)) if id == group_id
     ));
+    assert!(matches!(
+        alice.advance_convergence_inputs(&group_id).await,
+        Err(EngineError::UnknownGroup(id)) if id == group_id
+    ));
 
     let result = alice
         .converge_stored_openmls_messages_at(&group_id, 1_000_000)

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -1522,10 +1522,25 @@ async fn drain_on_removed_copy_discards_queued_intents_without_error() {
         "realization must discard queued outbound intents"
     );
 
-    // Drain-side defense in depth: an intent queued after the copy is already
-    // marked removed (any ordering the marker-site purges missed) is
-    // discarded by the drain itself — no error, nothing drained, queue empty.
+    // Convergence-only defense in depth: an intent queued after the copy is
+    // already marked removed (any ordering the marker-site purges missed) is
+    // discarded before protocol settlement can touch the removed copy.
     queue_app_message_intent(&bob_storage, &bob, &group_id, 0x53);
+    assert!(
+        !bob.advance_convergence_inputs(&group_id)
+            .await
+            .expect("convergence-only advance on a removed copy must not error")
+    );
+    assert!(
+        bob_storage
+            .list_queued_outbound_intents(&group_id)
+            .unwrap()
+            .is_empty(),
+        "convergence-only advance must discard queued intents for a removed copy"
+    );
+
+    // The ordinary drain retains the same defense.
+    queue_app_message_intent(&bob_storage, &bob, &group_id, 0x54);
     let drained = bob
         .converge_and_drain_queued_outbound_intents(&group_id, 1_000_000)
         .await

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -997,6 +997,32 @@ impl AccountDeviceSession {
         Ok(self.collect_effects(results))
     }
 
+    /// Settle retained convergence inputs without draining queued outbound
+    /// intents.
+    ///
+    /// A host uses this narrower operation when an older durable transport
+    /// fanout still blocks newer user-authored sends. Protocol settlement,
+    /// epoch progression, and fork healing remain live while queued work stays
+    /// behind the fanout ordering barrier.
+    pub async fn advance_convergence_inputs(
+        &mut self,
+        group_id: &GroupId,
+    ) -> SessionResult<SessionEffects> {
+        tracing::debug!(
+            target: TRACE_TARGET,
+            method = "advance_convergence_inputs",
+            "advancing convergence inputs without draining queued outbound intents"
+        );
+        let settled = self.engine.advance_convergence_inputs(group_id).await?;
+        tracing::debug!(
+            target: TRACE_TARGET,
+            method = "advance_convergence_inputs",
+            settled,
+            "convergence inputs advanced"
+        );
+        Ok(self.collect_effects(Vec::new()))
+    }
+
     pub fn has_pending_convergence_inputs(&self, group_id: &GroupId) -> SessionResult<bool> {
         Ok(self.engine.has_pending_convergence_inputs(group_id)?)
     }

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -1160,6 +1160,13 @@ impl AccountDeviceSession {
         Ok(self.engine.outbound_fanouts()?)
     }
 
+    pub fn outbound_fanouts_for_group(
+        &self,
+        group_id: &GroupId,
+    ) -> SessionResult<Vec<OutboundFanout>> {
+        Ok(self.engine.outbound_fanouts_for_group(group_id)?)
+    }
+
     pub fn delete_outbound_fanout(&self, message_id: &MessageId) -> SessionResult<()> {
         self.engine.delete_outbound_fanout(message_id)?;
         Ok(())

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -1002,8 +1002,11 @@ impl AccountDeviceSession {
     ///
     /// A host uses this narrower operation when an older durable transport
     /// fanout still blocks newer user-authored sends. Protocol settlement,
-    /// epoch progression, and fork healing remain live while queued work stays
-    /// behind the fanout ordering barrier.
+    /// epoch progression, and fork healing remain live while queued outbound
+    /// intents, pending disband work, and drain maintenance (including a due
+    /// self-remove auto-commit) stay behind the fanout ordering barrier. That
+    /// deferral can remain unbounded while the oldest fanout has an outstanding
+    /// target.
     pub async fn advance_convergence_inputs(
         &mut self,
         group_id: &GroupId,

--- a/crates/marmot-account/src/lib.rs
+++ b/crates/marmot-account/src/lib.rs
@@ -27,9 +27,10 @@ pub use key_package::{
 pub use routing::{StaticTransportRouting, TransportRoutingError, TransportRoutingPolicy};
 pub use runtime::{
     AccountDeviceEffects, AccountDeviceRuntime, AccountIngestEffects, CompletedWelcomePublishTask,
-    PendingResolution, PreparedSessionCommit, PreparedSessionSend, PreparedWelcomePublishTask,
-    PublishFailure, PublishedApplicationMessage, UnresolvedApplicationMessage, UnresolvedPublish,
-    UnresolvedPublishReason, WelcomeDeliveryFailure,
+    FailedApplicationMessage, PendingResolution, PreparedSessionCommit, PreparedSessionSend,
+    PreparedWelcomePublishTask, PublishFailure, PublishedApplicationMessage,
+    UnresolvedApplicationMessage, UnresolvedPublish, UnresolvedPublishReason,
+    WelcomeDeliveryFailure,
 };
 pub use secret_store::{AccountSecretStore, KeychainSecretStore, LocalFileSecretStore};
 pub use time::{

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -96,6 +96,7 @@ struct PublishStatus {
     accepted_by_any_endpoint: bool,
     possible_ambiguous_exposure: bool,
     retry_deferred: bool,
+    terminal_failure: bool,
 }
 
 struct PendingFanoutContinuation {
@@ -2018,9 +2019,12 @@ where
         // Retry the group's already-frozen transport events before producing
         // any newer convergence work. This preserves send order and ensures a
         // scheduled outbound wake actually drives the exact retained bytes.
-        let mut output = self
+        let (mut output, blocked_groups) = self
             .resume_outbound_fanouts_for_group(Some(group_id))
             .await?;
+        if blocked_groups.contains(group_id) {
+            return Ok(output);
+        }
         let effects = self.session.advance_convergence(group_id).await?;
         output.extend(self.publish_session_effects(effects).await?);
         Ok(output)
@@ -2262,7 +2266,9 @@ where
 
     /// Resume every incomplete frozen fanout in original staging order.
     pub async fn resume_outbound_fanouts(&mut self) -> AccountResult<AccountDeviceEffects> {
-        self.resume_outbound_fanouts_for_group(None).await
+        self.resume_outbound_fanouts_for_group(None)
+            .await
+            .map(|(effects, _blocked_groups)| effects)
     }
 
     /// Retire terminal accepted application fanouts only after the app has
@@ -2301,7 +2307,7 @@ where
     async fn resume_outbound_fanouts_for_group(
         &mut self,
         group_id: Option<&GroupId>,
-    ) -> AccountResult<AccountDeviceEffects> {
+    ) -> AccountResult<(AccountDeviceEffects, HashSet<GroupId>)> {
         let fanouts = match group_id {
             Some(group_id) => self.session.outbound_fanouts_for_group(group_id)?,
             None => self.session.outbound_fanouts()?,
@@ -2337,13 +2343,23 @@ where
                 record_published_application_fanout(&fanout, &mut output);
                 output.fanout.push(outcome);
             } else {
+                let reason = "insufficient publish acknowledgements".to_owned();
+                output.failures.push(PublishFailure {
+                    message_id: fanout
+                        .published_message_id()
+                        .unwrap_or_else(|| fanout.message_id())
+                        .clone(),
+                    reason: reason.clone(),
+                });
+                record_failed_application_fanout(&fanout, reason, &mut output);
+                output.fanout.push(outcome);
                 self.session.delete_outbound_fanout(fanout.message_id())?;
             }
         }
         self.publish_queue(&mut output, &mut queue, None).await?;
         self.reconcile_confirmed_own_leaf_rotations(&output.events)?;
         self.reconcile_superseded_maintenance(&output.events)?;
-        Ok(output)
+        Ok((output, blocked_groups))
     }
 
     fn reconcile_confirmed_own_leaf_rotations(
@@ -2498,9 +2514,28 @@ where
                     "published queued message but could not clear its durable intent"
                 );
             }
+        } else if status.terminal_failure {
+            if self
+                .session
+                .confirm_regenerated_queued_intent(&intent)
+                .is_err()
+            {
+                // Every target failed terminally, so the logical queued intent
+                // is complete even though it was not delivered. If durable
+                // cleanup fails, retain and re-arm it rather than losing the
+                // obligation.
+                self.session.retry_regenerated_queued_intent(&intent);
+                tracing::warn!(
+                    target: TRACE_TARGET,
+                    method = "resolve_regenerated_queued_intent",
+                    error_kind = "terminal_queued_intent_cleanup",
+                    "terminal queued message failed but its durable intent could not be cleared"
+                );
+            }
         } else {
-            // Nothing accepted the publish. The durable intent was never
-            // deleted; re-arm its group for the normal convergence retry.
+            // Nothing accepted, but routing/setup failure or at least one
+            // retryable or ambiguously exposed target means terminal failure
+            // has not been proved. Preserve and re-arm the durable intent.
             self.session.retry_regenerated_queued_intent(&intent);
         }
     }
@@ -3359,6 +3394,8 @@ where
             accepted_by_any_endpoint: report.accepted_count() > 0,
             possible_ambiguous_exposure,
             retry_deferred: fanout_outcome.outstanding_targets > 0,
+            terminal_failure: report.accepted_count() == 0
+                && fanout_outcome.outstanding_targets == 0,
         };
         let publish_failure_reason =
             if fanout_outcome.outstanding_targets > 0 && !status.met_required_acks {
@@ -3403,6 +3440,8 @@ where
         }
         if status.accepted_by_any_endpoint {
             record_published_application_fanout(&fanout, output);
+        } else if let Some(reason) = publish_failure_reason {
+            record_failed_application_fanout(&fanout, reason, output);
         } else if let Some(application) = fanout.application_message()
             && status.retry_deferred
         {
@@ -3680,6 +3719,7 @@ where
                 accepted_by_any_endpoint: accepted_before > 0,
                 possible_ambiguous_exposure: fanout.possible_exposure,
                 retry_deferred,
+                terminal_failure: false,
             }));
         }
         let attempt_target = publish_target_with_endpoints(&target, retry_endpoints.clone());
@@ -3783,6 +3823,7 @@ where
                     accepted_by_any_endpoint: accepted_before > 0,
                     possible_ambiguous_exposure: true,
                     retry_deferred: false,
+                    terminal_failure: false,
                 });
             }
         };
@@ -3857,6 +3898,7 @@ where
             accepted_by_any_endpoint,
             possible_ambiguous_exposure: fanout.possible_exposure,
             retry_deferred: false,
+            terminal_failure: !published && !accepted_by_any_endpoint && !fanout.possible_exposure,
         })
     }
 }
@@ -3994,6 +4036,29 @@ fn record_published_application_fanout(fanout: &OutboundFanout, output: &mut Acc
             source_epoch: application.source_epoch,
             retention: application.retention,
         });
+}
+
+/// Report a terminal application publish with the app-event identity retained
+/// on its durable fanout. This remains replayable across the crash window
+/// between persisting the terminal target states and deleting the fanout.
+fn record_failed_application_fanout(
+    fanout: &OutboundFanout,
+    reason: String,
+    output: &mut AccountDeviceEffects,
+) {
+    let Some(application) = fanout.application_message() else {
+        return;
+    };
+    let message_id = fanout
+        .published_message_id()
+        .unwrap_or_else(|| fanout.message_id())
+        .clone();
+    output.failed_app_messages.push(FailedApplicationMessage {
+        group_id: application.group_id.clone(),
+        app_event_id: application.app_event_id.clone(),
+        message_id,
+        reason,
+    });
 }
 
 fn apply_report_to_fanout(
@@ -4261,6 +4326,10 @@ pub struct AccountDeviceEffects {
     /// Application-message identity attached to unresolved publication so app
     /// consumers can keep exactly the affected local row in a sending state.
     pub unresolved_app_messages: Vec<UnresolvedApplicationMessage>,
+    /// Application messages whose publication reached a definitive terminal
+    /// failure, carrying the local app-event identity needed to invalidate only
+    /// the affected optimistic projection.
+    pub failed_app_messages: Vec<FailedApplicationMessage>,
     /// Application messages accepted by at least one transport endpoint,
     /// carrying source-state metadata captured by the exact MLS encryption
     /// operation and the adapter-visible transport id.
@@ -4281,6 +4350,14 @@ pub struct PublishedApplicationMessage {
     pub message_id: cgka_traits::MessageId,
     pub source_epoch: EpochId,
     pub retention: cgka_traits::app_event::AppMessageRetentionDecision,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FailedApplicationMessage {
+    pub group_id: GroupId,
+    pub app_event_id: String,
+    pub message_id: cgka_traits::MessageId,
+    pub reason: String,
 }
 
 impl AccountDeviceEffects {
@@ -4311,6 +4388,8 @@ impl AccountDeviceEffects {
             .append(&mut other.unresolved_publishes);
         self.unresolved_app_messages
             .append(&mut other.unresolved_app_messages);
+        self.failed_app_messages
+            .append(&mut other.failed_app_messages);
         self.published_app_messages
             .append(&mut other.published_app_messages);
         self.welcome_failures.append(&mut other.welcome_failures);

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -2222,6 +2222,39 @@ where
         self.resume_outbound_fanouts_for_group(None).await
     }
 
+    /// Retire terminal accepted application fanouts only after the app has
+    /// durably finalized their optimistic projections.
+    ///
+    /// Until this acknowledgement arrives, restart drains replay the same
+    /// publication metadata. App projection is idempotent, so a crash between
+    /// its database commit and this call leaves a harmless replay instead of a
+    /// permanently pending message.
+    pub fn acknowledge_published_app_messages(
+        &self,
+        published_messages: &[PublishedApplicationMessage],
+    ) -> AccountResult<()> {
+        for published in published_messages {
+            let fanouts = self
+                .session
+                .outbound_fanouts_for_group(&published.group_id)?;
+            for fanout in fanouts {
+                let outcome = fanout.outcome();
+                let matches_publication = fanout.application_message().is_some_and(|application| {
+                    application.app_event_id == published.app_event_id
+                        && outcome.message_id == published.message_id
+                });
+                if matches_publication
+                    && outcome.accepted_targets > 0
+                    && outcome.fanout_complete
+                    && !matches!(fanout.mls_state(), FanoutMlsState::Pending(_))
+                {
+                    self.session.delete_outbound_fanout(fanout.message_id())?;
+                }
+            }
+        }
+        Ok(())
+    }
+
     async fn resume_outbound_fanouts_for_group(
         &mut self,
         group_id: Option<&GroupId>,
@@ -2238,6 +2271,9 @@ where
                 || matches!(fanout.mls_state(), FanoutMlsState::Pending(_))
             {
                 Box::pin(self.drive_outbound_fanout(fanout, &mut output, &mut queue, None)).await?;
+            } else if outcome.accepted_targets > 0 && fanout.application_message().is_some() {
+                record_published_application_fanout(&fanout, &mut output);
+                output.fanout.push(outcome);
             } else {
                 self.session.delete_outbound_fanout(fanout.message_id())?;
             }
@@ -3149,7 +3185,6 @@ where
     ) -> AccountResult<PublishStatus> {
         self.resolve_outbound_fanout_mls(&mut fanout, output, queue, context.clone())
             .await?;
-        let application_was_accepted = fanout.outcome().accepted_targets > 0;
         let endpoints = fanout.request().target.endpoints().to_vec();
         let now_ms = self.wall_clock.now().0.saturating_mul(1_000);
         let due = fanout
@@ -3304,31 +3339,23 @@ where
                 });
             }
         }
-        if let Some(application) = fanout.application_message() {
-            if status.accepted_by_any_endpoint && !application_was_accepted {
-                output
-                    .published_app_messages
-                    .push(PublishedApplicationMessage {
-                        group_id: application.group_id.clone(),
-                        app_event_id: application.app_event_id.clone(),
-                        message_id: report.message_id.clone(),
-                        source_epoch: application.source_epoch,
-                        retention: application.retention,
-                    });
-            } else if status.retry_deferred && !status.accepted_by_any_endpoint {
-                output
-                    .unresolved_app_messages
-                    .push(UnresolvedApplicationMessage {
-                        group_id: application.group_id.clone(),
-                        app_event_id: application.app_event_id.clone(),
-                        message_id: report.message_id.clone(),
-                        reason: if possible_ambiguous_exposure {
-                            UnresolvedPublishReason::AcknowledgementUnknown
-                        } else {
-                            UnresolvedPublishReason::RetryableUnavailable
-                        },
-                    });
-            }
+        if status.accepted_by_any_endpoint {
+            record_published_application_fanout(&fanout, output);
+        } else if let Some(application) = fanout.application_message()
+            && status.retry_deferred
+        {
+            output
+                .unresolved_app_messages
+                .push(UnresolvedApplicationMessage {
+                    group_id: application.group_id.clone(),
+                    app_event_id: application.app_event_id.clone(),
+                    message_id: report.message_id.clone(),
+                    reason: if possible_ambiguous_exposure {
+                        UnresolvedPublishReason::AcknowledgementUnknown
+                    } else {
+                        UnresolvedPublishReason::RetryableUnavailable
+                    },
+                });
         }
         if fanout_outcome.outstanding_targets > 0
             && let Some(group_id) = fanout.group_id()
@@ -3343,6 +3370,7 @@ where
         output.fanout.push(fanout_outcome.clone());
         if fanout_outcome.fanout_complete
             && !matches!(fanout.mls_state(), FanoutMlsState::Pending(_))
+            && !(fanout_outcome.accepted_targets > 0 && fanout.application_message().is_some())
         {
             self.session.delete_outbound_fanout(fanout.message_id())?;
         }
@@ -3866,6 +3894,31 @@ fn frozen_fanout_report(fanout: &OutboundFanout) -> TransportPublishReport {
         failed,
         required_acks: fanout.request().required_acks,
     }
+}
+
+/// Replay the app-visible acknowledgement derived from a durable accepted
+/// fanout. The projection is an idempotent upsert, so emitting this on every
+/// recovery pass is safe until the app explicitly acknowledges persistence.
+fn record_published_application_fanout(fanout: &OutboundFanout, output: &mut AccountDeviceEffects) {
+    if fanout.outcome().accepted_targets == 0 {
+        return;
+    }
+    let Some(application) = fanout.application_message() else {
+        return;
+    };
+    let message_id = fanout
+        .published_message_id()
+        .unwrap_or_else(|| fanout.message_id())
+        .clone();
+    output
+        .published_app_messages
+        .push(PublishedApplicationMessage {
+            group_id: application.group_id.clone(),
+            app_event_id: application.app_event_id.clone(),
+            message_id,
+            source_epoch: application.source_epoch,
+            retention: application.retention,
+        });
 }
 
 fn apply_report_to_fanout(

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -2022,10 +2022,17 @@ where
         let (mut output, blocked_groups) = self
             .resume_outbound_fanouts_for_group(Some(group_id))
             .await?;
-        if blocked_groups.contains(group_id) {
-            return Ok(output);
-        }
-        let effects = self.session.advance_convergence(group_id).await?;
+        // An older deferred transport fanout blocks only newly queued
+        // outbound intents. Convergence inputs must still settle: otherwise a
+        // permanently unavailable relay can wedge epoch progression and fork
+        // healing forever. Any protocol effects produced by settlement remain
+        // observable while the queued-intent drain stays ordered behind the
+        // frozen fanout.
+        let effects = if blocked_groups.contains(group_id) {
+            self.session.advance_convergence_inputs(group_id).await?
+        } else {
+            self.session.advance_convergence(group_id).await?
+        };
         output.extend(self.publish_session_effects(effects).await?);
         Ok(output)
     }

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -24,11 +24,11 @@ use cgka_traits::maintenance::{
 };
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::{
-    EpochId, FanoutMlsState, FanoutPendingKind, GroupId, MemberId, OutboundFanout,
-    OutboundFanoutOutcome, StorageError, Timestamp, TransportAccountActivation, TransportAdapter,
-    TransportAdapterError, TransportDelivery, TransportEndpoint, TransportEndpointFailure,
-    TransportEndpointFailureKind, TransportEndpointReceipt, TransportGroupSync,
-    TransportPublishReport, TransportPublishRequest, TransportPublishTarget,
+    EpochId, FanoutMlsState, FanoutPendingKind, GroupId, MemberId, OutboundApplicationMessage,
+    OutboundFanout, OutboundFanoutOutcome, StorageError, Timestamp, TransportAccountActivation,
+    TransportAdapter, TransportAdapterError, TransportDelivery, TransportEndpoint,
+    TransportEndpointFailure, TransportEndpointFailureKind, TransportEndpointReceipt,
+    TransportGroupSync, TransportPublishReport, TransportPublishRequest, TransportPublishTarget,
 };
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
@@ -58,8 +58,12 @@ const MAINTENANCE_QUIET_SECS: u64 = 60;
 const PERIODIC_MIN_SECS: u64 = 24 * 24 * 60 * 60;
 const PERIODIC_MAX_SECS: u64 = 36 * 24 * 60 * 60;
 const TRANSPORT_FANOUT_RETENTION_SECS: u64 = 24 * 60 * 60;
-const FROZEN_FANOUT_RETRY_BASE_MS: u64 = 30 * 1_000;
-const FROZEN_FANOUT_RETRY_MAX_MS: u64 = 60 * 60 * 1_000;
+const FROZEN_FANOUT_AMBIGUOUS_RETRY_BASE_MS: u64 = 30 * 1_000;
+const FROZEN_FANOUT_AMBIGUOUS_RETRY_MAX_MS: u64 = 60 * 60 * 1_000;
+/// A relay that proved it never accepted the event can be retried promptly.
+/// Keep this aligned with the adapter's fixed reconnect interval so restoring
+/// connectivity does not leave a user send behind the ambiguity backoff.
+const FROZEN_FANOUT_UNAVAILABLE_RETRY_DELAY_MS: u64 = 5 * 1_000;
 
 /// Run independent async work with fixed fan-out while returning results in
 /// input order. Completion order therefore cannot reorder reports or select a
@@ -2006,8 +2010,15 @@ where
         &mut self,
         group_id: &GroupId,
     ) -> AccountResult<AccountDeviceEffects> {
+        // Retry the group's already-frozen transport events before producing
+        // any newer convergence work. This preserves send order and ensures a
+        // scheduled outbound wake actually drives the exact retained bytes.
+        let mut output = self
+            .resume_outbound_fanouts_for_group(Some(group_id))
+            .await?;
         let effects = self.session.advance_convergence(group_id).await?;
-        self.publish_session_effects(effects).await
+        output.extend(self.publish_session_effects(effects).await?);
+        Ok(output)
     }
 
     pub fn has_pending_convergence_inputs(&self, group_id: &GroupId) -> AccountResult<bool> {
@@ -2016,6 +2027,17 @@ where
 
     pub fn has_queued_outbound_intents(&self, group_id: &GroupId) -> AccountResult<bool> {
         Ok(self.session.has_queued_outbound_intents(group_id)?)
+    }
+
+    pub fn has_pending_outbound_fanouts(&self, group_id: &GroupId) -> AccountResult<bool> {
+        Ok(self
+            .session
+            .outbound_fanouts_for_group(group_id)?
+            .iter()
+            .any(|fanout| {
+                fanout.outcome().outstanding_targets > 0
+                    || matches!(fanout.mls_state(), FanoutMlsState::Pending(_))
+            }))
     }
 
     pub fn prepare_convergence_cutoff_delay_ms(
@@ -2130,51 +2152,25 @@ where
                     source_epoch,
                     retention,
                 } => {
-                    let reports_before = output.reports.len();
-                    let unresolved_before = output.unresolved_publishes.len();
-                    let status =
-                        Box::pin(self.publish_one(msg, None, output, queue, context.clone()))
-                            .await?;
-                    if status.accepted_by_any_endpoint {
-                        if let Some(message_id) = output
-                            .reports
-                            .get(reports_before)
-                            .map(|report| report.message_id.clone())
-                        {
-                            output
-                                .published_app_messages
-                                .push(PublishedApplicationMessage {
-                                    group_id,
-                                    app_event_id,
-                                    message_id,
-                                    source_epoch,
-                                    retention,
-                                });
-                        } else {
-                            tracing::warn!(
-                                target: TRACE_TARGET,
-                                method = "publish_session_effects_with_audit_context",
-                                error_kind = "accepted_app_publish_report_missing",
-                                "accepted application publish had no transport report"
-                            );
-                        }
-                    } else if status.retry_deferred
-                        && let Some(unresolved) = output.unresolved_publishes.get(unresolved_before)
-                    {
-                        output
-                            .unresolved_app_messages
-                            .push(UnresolvedApplicationMessage {
-                                group_id,
-                                app_event_id,
-                                message_id: unresolved.message_id.clone(),
-                                reason: unresolved.reason,
-                            });
-                    }
+                    let status = Box::pin(self.publish_one(
+                        msg,
+                        None,
+                        Some(OutboundApplicationMessage {
+                            group_id,
+                            app_event_id,
+                            source_epoch,
+                            retention,
+                        }),
+                        output,
+                        queue,
+                        context.clone(),
+                    ))
+                    .await?;
                     self.resolve_regenerated_queued_intent(queued_intent, status);
                 }
                 PublishWork::Proposal { msg, queued_intent } => {
                     let status =
-                        Box::pin(self.publish_one(msg, None, output, queue, context.clone()))
+                        Box::pin(self.publish_one(msg, None, None, output, queue, context.clone()))
                             .await?;
                     self.resolve_regenerated_queued_intent(queued_intent, status);
                 }
@@ -2218,7 +2214,17 @@ where
 
     /// Resume every incomplete frozen fanout in original staging order.
     pub async fn resume_outbound_fanouts(&mut self) -> AccountResult<AccountDeviceEffects> {
-        let fanouts = self.session.outbound_fanouts()?;
+        self.resume_outbound_fanouts_for_group(None).await
+    }
+
+    async fn resume_outbound_fanouts_for_group(
+        &mut self,
+        group_id: Option<&GroupId>,
+    ) -> AccountResult<AccountDeviceEffects> {
+        let fanouts = match group_id {
+            Some(group_id) => self.session.outbound_fanouts_for_group(group_id)?,
+            None => self.session.outbound_fanouts()?,
+        };
         let mut output = AccountDeviceEffects::default();
         let mut queue = VecDeque::new();
         for fanout in fanouts {
@@ -2543,7 +2549,7 @@ where
             return Ok(());
         };
         debug_assert!(messages.next().is_none());
-        Box::pin(self.publish_one(message, Some(pending), output, queue, context)).await?;
+        Box::pin(self.publish_one(message, Some(pending), None, output, queue, context)).await?;
         Ok(())
     }
 
@@ -2571,6 +2577,7 @@ where
                 kind: FanoutPendingKind::CreateGroup,
                 post_confirmation_welcomes: welcomes.collect(),
             }),
+            None,
             output,
             queue,
             context,
@@ -2764,6 +2771,7 @@ where
                 kind: self.session.pending_fanout_kind(pending)?,
                 post_confirmation_welcomes: welcomes,
             }),
+            None,
             output,
             queue,
             context,
@@ -2990,6 +2998,7 @@ where
         &mut self,
         message: TransportMessage,
         pending: Option<PendingStateRef>,
+        application_message: Option<OutboundApplicationMessage>,
         output: &mut AccountDeviceEffects,
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
@@ -3005,6 +3014,7 @@ where
         self.publish_one_with_post_confirmation_welcomes(
             message,
             continuation,
+            application_message,
             output,
             queue,
             context,
@@ -3016,6 +3026,7 @@ where
         &mut self,
         message: TransportMessage,
         continuation: Option<PendingFanoutContinuation>,
+        application_message: Option<OutboundApplicationMessage>,
         output: &mut AccountDeviceEffects,
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
@@ -3069,7 +3080,7 @@ where
                     }
                 }
             };
-            let fanout = match OutboundFanout::stage_with_post_confirmation_welcomes(
+            let mut fanout = match OutboundFanout::stage_with_post_confirmation_welcomes(
                 TransportPublishRequest {
                     account_id: self.session.self_id(),
                     message,
@@ -3090,6 +3101,13 @@ where
                     return Err(error.into());
                 }
             };
+            if let Some(application_message) = application_message
+                && let Err(error) = fanout.set_application_message(application_message)
+            {
+                self.rollback_unstaged_pending(pending, output, queue)
+                    .await?;
+                return Err(error.into());
+            }
             if let Err(error) = self.session.put_outbound_fanout(&fanout) {
                 self.rollback_unstaged_pending(pending, output, queue)
                     .await?;
@@ -3126,6 +3144,7 @@ where
     ) -> AccountResult<PublishStatus> {
         self.resolve_outbound_fanout_mls(&mut fanout, output, queue, context.clone())
             .await?;
+        let application_was_accepted = fanout.outcome().accepted_targets > 0;
         let endpoints = fanout.request().target.endpoints().to_vec();
         let now_ms = self.wall_clock.now().0.saturating_mul(1_000);
         let due = fanout
@@ -3279,6 +3298,42 @@ where
                         .unwrap_or_else(|| "welcome publish failed".into()),
                 });
             }
+        }
+        if let Some(application) = fanout.application_message() {
+            if status.accepted_by_any_endpoint && !application_was_accepted {
+                output
+                    .published_app_messages
+                    .push(PublishedApplicationMessage {
+                        group_id: application.group_id.clone(),
+                        app_event_id: application.app_event_id.clone(),
+                        message_id: report.message_id.clone(),
+                        source_epoch: application.source_epoch,
+                        retention: application.retention,
+                    });
+            } else if status.retry_deferred && !status.accepted_by_any_endpoint {
+                output
+                    .unresolved_app_messages
+                    .push(UnresolvedApplicationMessage {
+                        group_id: application.group_id.clone(),
+                        app_event_id: application.app_event_id.clone(),
+                        message_id: report.message_id.clone(),
+                        reason: if possible_ambiguous_exposure {
+                            UnresolvedPublishReason::AcknowledgementUnknown
+                        } else {
+                            UnresolvedPublishReason::RetryableUnavailable
+                        },
+                    });
+            }
+        }
+        if fanout_outcome.outstanding_targets > 0
+            && let Some(group_id) = fanout.group_id()
+            && !output.pending_convergence.contains(group_id)
+        {
+            // The exact event is already durable, but the app worker still
+            // needs a scheduling edge that survives the current command. It
+            // will query the stored fanout before arming and retry these same
+            // bytes when the per-target delay expires.
+            output.pending_convergence.push(group_id.clone());
         }
         output.fanout.push(fanout_outcome.clone());
         if fanout_outcome.fanout_complete
@@ -3746,15 +3801,20 @@ fn frozen_fanout_target_retry_due(fanout: &OutboundFanout, index: usize, now_ms:
 
     match fanout.target_status(index) {
         Some(FanoutTargetStatus::NotAttempted | FanoutTargetStatus::Attempting) => true,
-        Some(FanoutTargetStatus::PossiblyExposed | FanoutTargetStatus::RetryableUnavailable) => {
+        Some(FanoutTargetStatus::PossiblyExposed) => {
             let attempt_count = fanout.target_attempt_count(index);
             let shift = attempt_count.saturating_sub(1).min(7);
-            let backoff_ms = FROZEN_FANOUT_RETRY_BASE_MS
+            let backoff_ms = FROZEN_FANOUT_AMBIGUOUS_RETRY_BASE_MS
                 .saturating_mul(1_u64 << shift)
-                .min(FROZEN_FANOUT_RETRY_MAX_MS);
+                .min(FROZEN_FANOUT_AMBIGUOUS_RETRY_MAX_MS);
             fanout
                 .target_last_attempt_at_ms(index)
                 .is_none_or(|last| now_ms >= last.saturating_add(backoff_ms))
+        }
+        Some(FanoutTargetStatus::RetryableUnavailable) => {
+            fanout.target_last_attempt_at_ms(index).is_none_or(|last| {
+                now_ms >= last.saturating_add(FROZEN_FANOUT_UNAVAILABLE_RETRY_DELAY_MS)
+            })
         }
         Some(FanoutTargetStatus::Accepted | FanoutTargetStatus::Failed) | None => false,
     }
@@ -4190,6 +4250,56 @@ pub enum PendingResolution {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn failed_frozen_fanout(kind: TransportEndpointFailureKind) -> OutboundFanout {
+        let group_id = GroupId::new(vec![0x11; 16]);
+        let transport_group_id = vec![0x22; 32];
+        let endpoint = TransportEndpoint("wss://relay.example".into());
+        let request = TransportPublishRequest {
+            account_id: MemberId::new(vec![0x33; 32]),
+            message: TransportMessage {
+                id: cgka_traits::MessageId::new(vec![0x44; 32]),
+                payload: vec![0x55],
+                timestamp: Timestamp(1),
+                causal_deps: Vec::new(),
+                source: cgka_traits::transport::TransportSource("nostr".into()),
+                envelope: TransportEnvelope::GroupMessage {
+                    transport_group_id: transport_group_id.clone(),
+                },
+            },
+            target: TransportPublishTarget::Group {
+                group_id,
+                transport_group_id,
+                endpoints: vec![endpoint.clone()],
+            },
+            required_acks: 1,
+        };
+        let mut fanout = OutboundFanout::stage(request, None, None, 1_000).unwrap();
+        fanout.mark_attempt_started_at(0, 1_000).unwrap();
+        fanout
+            .record_target_failure(
+                0,
+                TransportEndpointFailure {
+                    endpoint,
+                    reason: "test failure".into(),
+                    kind,
+                    rejection_category: None,
+                },
+            )
+            .unwrap();
+        fanout
+    }
+
+    #[test]
+    fn unavailable_fanout_retries_promptly_without_shortening_ambiguous_backoff() {
+        let unavailable = failed_frozen_fanout(TransportEndpointFailureKind::RetryableUnavailable);
+        assert!(!frozen_fanout_target_retry_due(&unavailable, 0, 5_999));
+        assert!(frozen_fanout_target_retry_due(&unavailable, 0, 6_000));
+
+        let ambiguous = failed_frozen_fanout(TransportEndpointFailureKind::PossiblyExposed);
+        assert!(!frozen_fanout_target_retry_due(&ambiguous, 0, 30_999));
+        assert!(frozen_fanout_target_retry_due(&ambiguous, 0, 31_000));
+    }
 
     fn published_message(id: u8) -> PublishedApplicationMessage {
         PublishedApplicationMessage {

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -2010,6 +2010,11 @@ where
         &mut self,
         group_id: &GroupId,
     ) -> AccountResult<AccountDeviceEffects> {
+        // A deferred-open session intentionally hides this group's durable
+        // fanouts until full hydration restores its pending lifecycle. Hydrate
+        // before the targeted lookup so this same scheduled pass can resume
+        // those exact frozen bytes instead of waiting for another wake.
+        let _ = self.session.ensure_group_hydrated(group_id)?;
         // Retry the group's already-frozen transport events before producing
         // any newer convergence work. This preserves send order and ensures a
         // scheduled outbound wake actually drives the exact retained bytes.

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -2040,9 +2040,52 @@ where
             .outbound_fanouts_for_group(group_id)?
             .iter()
             .any(|fanout| {
-                fanout.outcome().outstanding_targets > 0
+                let outcome = fanout.outcome();
+                outcome.outstanding_targets > 0
                     || matches!(fanout.mls_state(), FanoutMlsState::Pending(_))
+                    || (outcome.accepted_targets > 0 && fanout.application_message().is_some())
             }))
+    }
+
+    /// Return the earliest durable retry cutoff for an incomplete frozen
+    /// fanout in `group_id`.
+    ///
+    /// `None` means the group has no network retry cutoff to honor. It may
+    /// still have local-only work, such as acknowledgement cleanup for an
+    /// accepted application-message fanout; callers should schedule that on
+    /// their ordinary retry delay. A zero delay means at least one exact event
+    /// is eligible now (including after a connectivity-restored wake).
+    pub fn outbound_fanout_retry_delay_ms(&self, group_id: &GroupId) -> AccountResult<Option<u64>> {
+        let now_ms = self.wall_clock.now_ms();
+        for fanout in self.session.outbound_fanouts_for_group(group_id)? {
+            let outcome = fanout.outcome();
+            if outcome.accepted_targets > 0
+                && outcome.fanout_complete
+                && fanout.application_message().is_some()
+            {
+                // Local projection acknowledgement cleanup should not wait
+                // behind an unrelated transport backoff in the same group.
+                return Ok(None);
+            }
+            if outcome.outstanding_targets == 0 {
+                if matches!(fanout.mls_state(), FanoutMlsState::Pending(_)) {
+                    return Ok(None);
+                }
+                continue;
+            }
+            let mut earliest = None;
+            for index in fanout.outstanding_target_indexes() {
+                if let Some(delay_ms) = frozen_fanout_target_retry_delay_ms(&fanout, index, now_ms)
+                {
+                    earliest = Some(earliest.map_or(delay_ms, |prior: u64| prior.min(delay_ms)));
+                }
+            }
+            // The first incomplete fanout is the group-scoped ordering
+            // barrier, so later NotAttempted records cannot pull this cutoff
+            // forward and cause a scheduler polling loop.
+            return Ok(earliest);
+        }
+        Ok(None)
     }
 
     pub fn prepare_convergence_cutoff_delay_ms(
@@ -2265,12 +2308,31 @@ where
         };
         let mut output = AccountDeviceEffects::default();
         let mut queue = VecDeque::new();
+        let mut blocked_groups = HashSet::new();
         for fanout in fanouts {
+            if fanout
+                .group_id()
+                .is_some_and(|fanout_group| blocked_groups.contains(fanout_group))
+            {
+                continue;
+            }
             let outcome = fanout.outcome();
             if outcome.outstanding_targets > 0
                 || matches!(fanout.mls_state(), FanoutMlsState::Pending(_))
             {
-                Box::pin(self.drive_outbound_fanout(fanout, &mut output, &mut queue, None)).await?;
+                let fanout_group = fanout.group_id().cloned();
+                let status =
+                    Box::pin(self.drive_outbound_fanout(fanout, &mut output, &mut queue, None))
+                        .await?;
+                if status.retry_deferred
+                    && let Some(fanout_group) = fanout_group
+                {
+                    // Preserve per-group staging order. An older exact event
+                    // that is still in durable backoff is a barrier for newer
+                    // fanouts in this group, but must not block unrelated
+                    // groups during an account-wide drain.
+                    blocked_groups.insert(fanout_group);
+                }
             } else if outcome.accepted_targets > 0 && fanout.application_message().is_some() {
                 record_published_application_fanout(&fanout, &mut output);
                 output.fanout.push(outcome);
@@ -3830,10 +3892,18 @@ fn ambiguous_endpoint_failure(endpoint: TransportEndpoint) -> TransportEndpointF
 }
 
 fn frozen_fanout_target_retry_due(fanout: &OutboundFanout, index: usize, now_ms: u64) -> bool {
+    frozen_fanout_target_retry_delay_ms(fanout, index, now_ms) == Some(0)
+}
+
+fn frozen_fanout_target_retry_delay_ms(
+    fanout: &OutboundFanout,
+    index: usize,
+    now_ms: u64,
+) -> Option<u64> {
     use cgka_traits::FanoutTargetStatus;
 
     match fanout.target_status(index) {
-        Some(FanoutTargetStatus::NotAttempted | FanoutTargetStatus::Attempting) => true,
+        Some(FanoutTargetStatus::NotAttempted | FanoutTargetStatus::Attempting) => Some(0),
         Some(FanoutTargetStatus::PossiblyExposed) => {
             let attempt_count = fanout.target_attempt_count(index);
             let shift = attempt_count.saturating_sub(1).min(7);
@@ -3842,14 +3912,19 @@ fn frozen_fanout_target_retry_due(fanout: &OutboundFanout, index: usize, now_ms:
                 .min(FROZEN_FANOUT_AMBIGUOUS_RETRY_MAX_MS);
             fanout
                 .target_last_attempt_at_ms(index)
-                .is_none_or(|last| now_ms >= last.saturating_add(backoff_ms))
+                .map_or(Some(0), |last| {
+                    Some(last.saturating_add(backoff_ms).saturating_sub(now_ms))
+                })
         }
-        Some(FanoutTargetStatus::RetryableUnavailable) => {
-            fanout.target_last_attempt_at_ms(index).is_none_or(|last| {
-                now_ms >= last.saturating_add(FROZEN_FANOUT_UNAVAILABLE_RETRY_DELAY_MS)
-            })
-        }
-        Some(FanoutTargetStatus::Accepted | FanoutTargetStatus::Failed) | None => false,
+        Some(FanoutTargetStatus::RetryableUnavailable) => fanout
+            .target_last_attempt_at_ms(index)
+            .map_or(Some(0), |last| {
+                Some(
+                    last.saturating_add(FROZEN_FANOUT_UNAVAILABLE_RETRY_DELAY_MS)
+                        .saturating_sub(now_ms),
+                )
+            }),
+        Some(FanoutTargetStatus::Accepted | FanoutTargetStatus::Failed) | None => None,
     }
 }
 

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -12,7 +12,9 @@ use cgka_session::{AccountDeviceSession, PublishWork, SessionConfig};
 use cgka_traits::app_components::{
     AppComponentData, GROUP_MESSAGE_RETENTION_COMPONENT_ID, default_group_components,
 };
-use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MarmotAppEvent};
+use cgka_traits::app_event::{
+    AppMessageRetentionDecision, MARMOT_APP_EVENT_KIND_CHAT, MarmotAppEvent,
+};
 use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
 use cgka_traits::engine::{CreateGroupRequest, GroupEvent, SendIntent};
 use cgka_traits::error::PeelerError;
@@ -25,11 +27,12 @@ use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
 };
 use cgka_traits::{
-    EpochId, FanoutMlsState, FanoutTargetStatus, GroupId, MemberId, MessageId, OutboundFanout,
-    TransportAccountActivation, TransportAdapter, TransportAdapterError, TransportDelivery,
-    TransportDeliveryPlane, TransportDeliverySource, TransportEndpoint, TransportEndpointFailure,
-    TransportEndpointFailureKind, TransportEndpointReceipt, TransportEndpointRejectionCategory,
-    TransportGroupSync, TransportPublishFailure, TransportPublishReport, TransportPublishRequest,
+    EpochId, FanoutMlsState, FanoutTargetStatus, GroupId, MemberId, MessageId,
+    OutboundApplicationMessage, OutboundFanout, TransportAccountActivation, TransportAdapter,
+    TransportAdapterError, TransportDelivery, TransportDeliveryPlane, TransportDeliverySource,
+    TransportEndpoint, TransportEndpointFailure, TransportEndpointFailureKind,
+    TransportEndpointReceipt, TransportEndpointRejectionCategory, TransportGroupSync,
+    TransportPublishFailure, TransportPublishReport, TransportPublishRequest,
     TransportPublishTarget,
 };
 use marmot_account::{

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -224,6 +224,26 @@ fn session(
     session_with_registry(path, key, identity, FeatureRegistry::new())
 }
 
+fn deferred_session(
+    path: impl Into<std::path::PathBuf>,
+    key: &SqlCipherKey,
+    identity: &[u8],
+) -> AccountDeviceSession {
+    let keys = deterministic_nostr_keys(identity);
+    AccountDeviceSession::open(
+        SessionConfig::new(
+            path,
+            SqlCipherKey::new(key.as_secret_str()).unwrap(),
+            pad32(identity),
+            Box::new(MockPeeler),
+        )
+        .legacy_compatibility_profile()
+        .account_identity_proof_signer(Arc::new(NostrAccountIdentityProofSigner { keys }))
+        .defer_group_hydration(),
+    )
+    .unwrap()
+}
+
 fn current_session(
     path: impl Into<std::path::PathBuf>,
     key: &SqlCipherKey,

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -3832,6 +3832,15 @@ async fn published_app_messages_carry_exact_source_state_and_adapter_identity() 
         1,
         "an accepted app fanout must remain durable until app projection acknowledges it"
     );
+    assert!(
+        runtime.has_pending_outbound_fanouts(&group_id).unwrap(),
+        "terminal accepted app fanout must remain scheduler-visible until cleanup acknowledgement"
+    );
+    assert_eq!(
+        runtime.outbound_fanout_retry_delay_ms(&group_id).unwrap(),
+        None,
+        "local-only acknowledgement cleanup uses the scheduler's ordinary delay"
+    );
 
     // Simulate termination after relay acceptance was persisted but before the
     // app finalized its optimistic timeline row. Reopening must replay the

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -3742,8 +3742,9 @@ async fn published_app_messages_carry_exact_source_state_and_adapter_identity() 
     let key = SqlCipherKey::new("marmot published app metadata key").unwrap();
     let mut supported = default_group_components();
     supported.insert(GROUP_MESSAGE_RETENTION_COMPONENT_ID);
+    let alice_path = dir.path().join("alice-published-app.sqlite");
     let mut alice = session_with_registry_and_components(
-        dir.path().join("alice-published-app.sqlite"),
+        &alice_path,
         &key,
         b"alice-published-app",
         selfremove_registry(),
@@ -3754,7 +3755,7 @@ async fn published_app_messages_carry_exact_source_state_and_adapter_identity() 
         &key,
         b"bob-published-app",
         selfremove_registry(),
-        supported,
+        supported.clone(),
     );
     let bob_kp = bob.fresh_key_package().await.unwrap();
     let alice_hex = hex::encode(alice.self_id().as_slice());
@@ -3794,8 +3795,12 @@ async fn published_app_messages_carry_exact_source_state_and_adapter_identity() 
             "wss://published-app-group.example".into(),
         )],
     );
-    let mut runtime =
-        AccountDeviceRuntime::new(alice, adapter, policy, RecordingKeyPackages::default());
+    let mut runtime = AccountDeviceRuntime::new(
+        alice,
+        adapter.clone(),
+        policy.clone(),
+        RecordingKeyPackages::default(),
+    );
 
     let payload = app_payload_for(&alice_hex, b"typed metadata");
     let app_event_id = MarmotAppEvent::decode(&payload).unwrap().id;
@@ -3811,15 +3816,57 @@ async fn published_app_messages_carry_exact_source_state_and_adapter_identity() 
         adapter_handle.publishes()[0].message.id,
         "test adapter must exercise transport id replacement"
     );
+    let expected_publication = PublishedApplicationMessage {
+        group_id: group_id.clone(),
+        app_event_id: app_event_id.clone(),
+        message_id: reported_message_id,
+        source_epoch: EpochId(1),
+        retention: cgka_traits::AppMessageRetentionDecision::new(1_700_000_000, 90),
+    };
     assert_eq!(
         effects.published_app_messages,
-        vec![PublishedApplicationMessage {
-            group_id: group_id.clone(),
-            app_event_id,
-            message_id: reported_message_id,
-            source_epoch: EpochId(1),
-            retention: cgka_traits::AppMessageRetentionDecision::new(1_700_000_000, 90),
-        }]
+        vec![expected_publication.clone()]
+    );
+    assert_eq!(
+        runtime.session().outbound_fanouts().unwrap().len(),
+        1,
+        "an accepted app fanout must remain durable until app projection acknowledges it"
+    );
+
+    // Simulate termination after relay acceptance was persisted but before the
+    // app finalized its optimistic timeline row. Reopening must replay the
+    // exact publication metadata instead of deleting the only recovery record.
+    drop(runtime);
+    let reopened = session_with_registry_and_components(
+        &alice_path,
+        &key,
+        b"alice-published-app",
+        selfremove_registry(),
+        supported.clone(),
+    );
+    let mut runtime =
+        AccountDeviceRuntime::new(reopened, adapter, policy, RecordingKeyPackages::default());
+    let recovered = runtime.resume_outbound_fanouts().await.unwrap();
+    assert_eq!(
+        recovered.published_app_messages,
+        vec![expected_publication],
+        "restart recovery must replay an accepted app publication for idempotent projection"
+    );
+    runtime
+        .acknowledge_published_app_messages(&recovered.published_app_messages)
+        .unwrap();
+    assert!(
+        runtime.session().outbound_fanouts().unwrap().is_empty(),
+        "app projection acknowledgement must retire the terminal recovery record"
+    );
+    assert!(
+        runtime
+            .resume_outbound_fanouts()
+            .await
+            .unwrap()
+            .published_app_messages
+            .is_empty(),
+        "an acknowledged app publication must not replay again"
     );
 
     let leave = bob

--- a/crates/marmot-account/tests/runtime/frozen_fanout.rs
+++ b/crates/marmot-account/tests/runtime/frozen_fanout.rs
@@ -218,7 +218,244 @@ async fn frozen_fanout_ambiguous_adapter_errors_remain_unresolved() {
 }
 
 #[tokio::test]
-async fn deferred_fanout_blocks_newer_same_group_fanouts_and_sets_the_retry_cutoff() {
+async fn terminal_application_fanout_replays_failure_after_restart_before_delete() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot terminal app fanout key").unwrap();
+    let mut alice = session(
+        dir.path().join("alice.sqlite"),
+        &key,
+        b"alice-terminal-app-fanout",
+    );
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "terminal app fanout".into(),
+            description: String::new(),
+            members: Vec::new(),
+            required_features: Vec::new(),
+            app_components: Vec::new(),
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id;
+    let pending = match &created.effects.publish[0] {
+        PublishWork::GroupCreated { pending, .. } => *pending,
+        other => panic!("expected GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+
+    let endpoint = TransportEndpoint("wss://terminal-app-fanout.example".into());
+    let message_id = MessageId::new(vec![0xA1; 32]);
+    let mut fanout = OutboundFanout::stage(
+        TransportPublishRequest {
+            account_id: alice.self_id(),
+            message: TransportMessage {
+                id: message_id.clone(),
+                payload: vec![0xA1],
+                timestamp: Timestamp(100),
+                causal_deps: Vec::new(),
+                source: TransportSource("terminal-app-fanout-test".into()),
+                envelope: TransportEnvelope::GroupMessage {
+                    transport_group_id: group_id.as_slice().to_vec(),
+                },
+            },
+            target: TransportPublishTarget::Group {
+                group_id: group_id.clone(),
+                transport_group_id: group_id.as_slice().to_vec(),
+                endpoints: vec![endpoint.clone()],
+            },
+            required_acks: 1,
+        },
+        None,
+        None,
+        100_000,
+    )
+    .unwrap();
+    fanout
+        .set_application_message(OutboundApplicationMessage {
+            group_id: group_id.clone(),
+            app_event_id: "terminal-app-event".into(),
+            source_epoch: EpochId(1),
+            retention: AppMessageRetentionDecision::new(100, 0),
+        })
+        .unwrap();
+    fanout.mark_attempt_started_at(0, 100_000).unwrap();
+    fanout
+        .record_target_failure(
+            0,
+            TransportEndpointFailure {
+                endpoint: endpoint.clone(),
+                reason: "relay rejected the event".into(),
+                kind: TransportEndpointFailureKind::TerminalRejected,
+                rejection_category: Some(TransportEndpointRejectionCategory::Blocked),
+            },
+        )
+        .unwrap();
+    assert!(fanout.outcome().fanout_complete);
+    alice.put_outbound_fanout(&fanout).unwrap();
+
+    let policy = StaticTransportRouting::new(Vec::new()).with_group_route(
+        group_id.clone(),
+        group_id.as_slice().to_vec(),
+        vec![endpoint],
+    );
+    let mut runtime = AccountDeviceRuntime::new(
+        alice,
+        RecordingAdapter::default(),
+        policy,
+        RecordingKeyPackages::default(),
+    );
+
+    let effects = runtime.resume_outbound_fanouts().await.unwrap();
+
+    assert!(matches!(
+        effects.failures.as_slice(),
+        [marmot_account::PublishFailure {
+            message_id: failed_message_id,
+            reason,
+        }] if failed_message_id == &message_id
+            && reason == "insufficient publish acknowledgements"
+    ));
+    assert!(matches!(
+        effects.failed_app_messages.as_slice(),
+        [marmot_account::FailedApplicationMessage {
+            group_id: failed_group_id,
+            app_event_id,
+            message_id: failed_message_id,
+            reason,
+        }] if failed_group_id == &group_id
+            && app_event_id == "terminal-app-event"
+            && failed_message_id == &message_id
+            && reason == "insufficient publish acknowledgements"
+    ));
+    assert!(runtime.session().outbound_fanouts().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn terminally_failed_queued_app_message_is_retired_instead_of_rearmed() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot terminal queued app key").unwrap();
+    let mut alice = session(
+        dir.path().join("alice.sqlite"),
+        &key,
+        b"alice-terminal-queued-app",
+    );
+    let sender_hex = hex::encode(alice.self_id().as_slice());
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "terminal queued app".into(),
+            description: String::new(),
+            members: Vec::new(),
+            required_features: Vec::new(),
+            app_components: Vec::new(),
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id;
+    let pending = match &created.effects.publish[0] {
+        PublishWork::GroupCreated { pending, .. } => *pending,
+        other => panic!("expected GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+
+    let endpoint = TransportEndpoint("wss://terminal-queued-app.example".into());
+    let adapter = RecordingAdapter::default();
+    adapter.fail_endpoints_as(
+        vec![endpoint.clone()],
+        TransportEndpointFailureKind::TerminalRejected,
+    );
+    let policy = StaticTransportRouting::new(Vec::new()).with_group_route(
+        group_id.clone(),
+        group_id.as_slice().to_vec(),
+        vec![endpoint],
+    );
+    let mut runtime = AccountDeviceRuntime::new(
+        alice,
+        adapter.clone(),
+        policy,
+        RecordingKeyPackages::default(),
+    );
+
+    let queued = runtime
+        .queue_app_message_with_audit_context(
+            group_id.clone(),
+            app_payload_for(&sender_hex, b"terminal queued message"),
+            Default::default(),
+        )
+        .await
+        .unwrap();
+    assert!(queued.failures.is_empty());
+    assert!(adapter.publishes().is_empty());
+
+    let failed = runtime.advance_convergence(&group_id).await.unwrap();
+    assert_eq!(failed.failed_app_messages.len(), 1);
+    let publish_count = adapter.publishes().len();
+    assert_eq!(publish_count, 1);
+
+    let repeated = runtime.advance_convergence(&group_id).await.unwrap();
+    assert!(repeated.failed_app_messages.is_empty());
+    assert_eq!(
+        adapter.publishes().len(),
+        publish_count,
+        "a terminally failed queued intent must not regenerate on the next convergence pass"
+    );
+}
+
+#[tokio::test]
+async fn queued_app_message_with_missing_route_remains_retryable() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot queued app missing route key").unwrap();
+    let mut alice = session(
+        dir.path().join("alice.sqlite"),
+        &key,
+        b"alice-queued-app-missing-route",
+    );
+    let sender_hex = hex::encode(alice.self_id().as_slice());
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "queued app missing route".into(),
+            description: String::new(),
+            members: Vec::new(),
+            required_features: Vec::new(),
+            app_components: Vec::new(),
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id;
+    let pending = match &created.effects.publish[0] {
+        PublishWork::GroupCreated { pending, .. } => *pending,
+        other => panic!("expected GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+
+    let mut runtime = AccountDeviceRuntime::new(
+        alice,
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(Vec::new()),
+        RecordingKeyPackages::default(),
+    );
+    runtime
+        .queue_app_message_with_audit_context(
+            group_id.clone(),
+            app_payload_for(&sender_hex, b"wait for a route"),
+            Default::default(),
+        )
+        .await
+        .unwrap();
+
+    let failed = runtime.advance_convergence(&group_id).await.unwrap();
+    assert_eq!(failed.failures.len(), 1);
+    assert!(failed.failed_app_messages.is_empty());
+    assert!(
+        runtime.has_queued_outbound_intents(&group_id).unwrap(),
+        "a routing failure has not proved terminal delivery failure"
+    );
+}
+
+#[tokio::test]
+async fn deferred_fanout_blocks_newer_same_group_fanouts_and_convergence_work() {
     let dir = tempfile::tempdir().unwrap();
     let key = SqlCipherKey::new("marmot ordered fanout key").unwrap();
     let mut alice = session(dir.path().join("alice.sqlite"), &key, b"alice-ordered-fanout");
@@ -239,6 +476,15 @@ async fn deferred_fanout_blocks_newer_same_group_fanouts_and_sets_the_retry_cuto
         other => panic!("expected GroupCreated publish work, got {other:?}"),
     };
     alice.confirm_published(pending).await.unwrap();
+    let sender_hex = hex::encode(alice.self_id().as_slice());
+    alice
+        .queue_app_message_with_audit_context(
+            group_id.clone(),
+            app_payload_for(&sender_hex, b"newer queued message"),
+            Default::default(),
+        )
+        .await
+        .unwrap();
 
     let endpoint = TransportEndpoint("wss://ordered-fanout.example".into());
     let make_request = |id: u8| TransportPublishRequest {
@@ -296,7 +542,7 @@ async fn deferred_fanout_blocks_newer_same_group_fanouts_and_sets_the_retry_cuto
         Arc::new(TestRandom::new(0)),
     );
 
-    let effects = runtime.resume_outbound_fanouts().await.unwrap();
+    let effects = runtime.advance_convergence(&group_id).await.unwrap();
 
     assert!(effects.reports.is_empty());
     assert!(adapter.publishes().is_empty());
@@ -314,6 +560,10 @@ async fn deferred_fanout_blocks_newer_same_group_fanouts_and_sets_the_retry_cuto
         stored[1].target_status(0),
         Some(FanoutTargetStatus::NotAttempted),
         "the newer event must remain untouched until the older obligation is retryable"
+    );
+    assert!(
+        runtime.has_queued_outbound_intents(&group_id).unwrap(),
+        "newer queued convergence work must remain behind the older durable fanout"
     );
 }
 

--- a/crates/marmot-account/tests/runtime/frozen_fanout.rs
+++ b/crates/marmot-account/tests/runtime/frozen_fanout.rs
@@ -753,7 +753,10 @@ async fn frozen_fanout_typed_unavailable_is_retryable_but_rejection_is_terminal(
     .await;
 }
 
-async fn assert_frozen_fanout_restart_edge(send_before_ack_persist: bool) {
+async fn assert_frozen_fanout_restart_edge(
+    send_before_ack_persist: bool,
+    resume_via_deferred_advance: bool,
+) {
     let dir = tempfile::tempdir().unwrap();
     let alice_path = dir.path().join("alice-restart-edge.sqlite");
     let key_text = "marmot fanout restart edge key";
@@ -839,11 +842,22 @@ async fn assert_frozen_fanout_restart_edge(send_before_ack_persist: bool) {
     let pre_restart_publish_count = adapter.publishes().len();
     drop(alice);
 
-    let reopened = session(
-        &alice_path,
-        &SqlCipherKey::new(key_text).unwrap(),
-        b"alice-fanout-restart-edge",
-    );
+    let reopened = if resume_via_deferred_advance {
+        deferred_session(
+            &alice_path,
+            &SqlCipherKey::new(key_text).unwrap(),
+            b"alice-fanout-restart-edge",
+        )
+    } else {
+        session(
+            &alice_path,
+            &SqlCipherKey::new(key_text).unwrap(),
+            b"alice-fanout-restart-edge",
+        )
+    };
+    if resume_via_deferred_advance {
+        assert_eq!(reopened.unhydrated_group_ids(), vec![group_id.clone()]);
+    }
     let replacement_policy = StaticTransportRouting::new(vec![TransportEndpoint(
         "wss://replacement-inbox.example".into(),
     )])
@@ -858,10 +872,15 @@ async fn assert_frozen_fanout_restart_edge(send_before_ack_persist: bool) {
         replacement_policy,
         RecordingKeyPackages::default(),
     );
-    let effects = resumed.drain().await.unwrap();
+    let effects = if resume_via_deferred_advance {
+        resumed.advance_convergence(&group_id).await.unwrap()
+    } else {
+        resumed.drain().await.unwrap()
+    };
 
     assert!(effects.fanout[0].mls_confirmed);
     assert!(effects.fanout[0].fanout_complete);
+    assert!(resumed.session().unhydrated_group_ids().is_empty());
     assert_eq!(resumed.session().epoch(&group_id).unwrap().0, 2);
     let attempts = adapter.publishes();
     let resumed_attempts = &attempts[pre_restart_publish_count..];
@@ -883,8 +902,13 @@ async fn assert_frozen_fanout_restart_edge(send_before_ack_persist: bool) {
 
 #[tokio::test]
 async fn frozen_fanout_resumes_after_intent_and_after_send_before_ack_persistence() {
-    assert_frozen_fanout_restart_edge(false).await;
-    assert_frozen_fanout_restart_edge(true).await;
+    assert_frozen_fanout_restart_edge(false, false).await;
+    assert_frozen_fanout_restart_edge(true, false).await;
+}
+
+#[tokio::test]
+async fn scheduled_advance_hydrates_before_resuming_frozen_fanout() {
+    assert_frozen_fanout_restart_edge(false, true).await;
 }
 
 #[tokio::test]

--- a/crates/marmot-account/tests/runtime/frozen_fanout.rs
+++ b/crates/marmot-account/tests/runtime/frozen_fanout.rs
@@ -544,6 +544,10 @@ async fn deferred_fanout_blocks_newer_sends_but_not_convergence_settlement() {
     let newer = OutboundFanout::stage(make_request(2), None, None, 100_001).unwrap();
     alice.put_outbound_fanout(&older).unwrap();
     alice.put_outbound_fanout(&newer).unwrap();
+    let convergence_delay = alice
+        .prepare_convergence_cutoff_delay_ms(&group_id)
+        .unwrap()
+        .expect("buffered commit must open a convergence pass");
 
     let adapter = RecordingAdapter::default();
     let wall = Arc::new(TestWallClock::new(100));
@@ -564,7 +568,7 @@ async fn deferred_fanout_blocks_newer_sends_but_not_convergence_settlement() {
         Arc::new(TestRandom::new(0)),
     );
 
-    tokio::time::sleep(Duration::from_millis(1_100)).await;
+    tokio::time::sleep(Duration::from_millis(convergence_delay.saturating_add(1))).await;
 
     let effects = runtime.advance_convergence(&group_id).await.unwrap();
 

--- a/crates/marmot-account/tests/runtime/frozen_fanout.rs
+++ b/crates/marmot-account/tests/runtime/frozen_fanout.rs
@@ -455,15 +455,17 @@ async fn queued_app_message_with_missing_route_remains_retryable() {
 }
 
 #[tokio::test]
-async fn deferred_fanout_blocks_newer_same_group_fanouts_and_convergence_work() {
+async fn deferred_fanout_blocks_newer_sends_but_not_convergence_settlement() {
     let dir = tempfile::tempdir().unwrap();
     let key = SqlCipherKey::new("marmot ordered fanout key").unwrap();
     let mut alice = session(dir.path().join("alice.sqlite"), &key, b"alice-ordered-fanout");
+    let mut bob = session(dir.path().join("bob.sqlite"), &key, b"bob-ordered-fanout");
+    let bob_key_package = bob.fresh_key_package().await.unwrap();
     let created = alice
         .create_group(CreateGroupRequest {
             name: "ordered fanout".into(),
             description: String::new(),
-            members: Vec::new(),
+            members: vec![bob_key_package],
             required_features: Vec::new(),
             app_components: Vec::new(),
             initial_admins: Vec::new(),
@@ -471,11 +473,31 @@ async fn deferred_fanout_blocks_newer_same_group_fanouts_and_convergence_work() 
         .await
         .unwrap();
     let group_id = created.group_id;
-    let pending = match &created.effects.publish[0] {
-        PublishWork::GroupCreated { pending, .. } => *pending,
+    let (pending, welcome) = match &created.effects.publish[0] {
+        PublishWork::GroupCreated { pending, welcomes } => (*pending, welcomes[0].clone()),
         other => panic!("expected GroupCreated publish work, got {other:?}"),
     };
     alice.confirm_published(pending).await.unwrap();
+    bob.ingest(welcome).await.unwrap();
+
+    let bob_update = bob
+        .send(SendIntent::SelfUpdate {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    let (commit, update_pending) = match &bob_update.publish[0] {
+        PublishWork::GroupEvolution { msg, pending, .. } => (msg.clone(), *pending),
+        other => panic!("expected GroupEvolution publish work, got {other:?}"),
+    };
+    bob.confirm_published(update_pending).await.unwrap();
+    let buffered = alice.ingest(commit).await.unwrap();
+    assert!(matches!(
+        buffered.outcome,
+        cgka_traits::ingest::IngestOutcome::Buffered { .. }
+    ));
+    assert!(alice.has_pending_convergence_inputs(&group_id).unwrap());
+
     let sender_hex = hex::encode(alice.self_id().as_slice());
     alice
         .queue_app_message_with_audit_context(
@@ -542,10 +564,16 @@ async fn deferred_fanout_blocks_newer_same_group_fanouts_and_convergence_work() 
         Arc::new(TestRandom::new(0)),
     );
 
+    tokio::time::sleep(Duration::from_millis(1_100)).await;
+
     let effects = runtime.advance_convergence(&group_id).await.unwrap();
 
     assert!(effects.reports.is_empty());
     assert!(adapter.publishes().is_empty());
+    assert!(
+        !runtime.has_pending_convergence_inputs(&group_id).unwrap(),
+        "the older transport fanout must not wedge convergence settlement"
+    );
     assert_eq!(
         runtime.outbound_fanout_retry_delay_ms(&group_id).unwrap(),
         Some(30_000),
@@ -563,7 +591,7 @@ async fn deferred_fanout_blocks_newer_same_group_fanouts_and_convergence_work() 
     );
     assert!(
         runtime.has_queued_outbound_intents(&group_id).unwrap(),
-        "newer queued convergence work must remain behind the older durable fanout"
+        "newer queued outbound work must remain behind the older durable fanout"
     );
 }
 

--- a/crates/marmot-account/tests/runtime/frozen_fanout.rs
+++ b/crates/marmot-account/tests/runtime/frozen_fanout.rs
@@ -218,6 +218,106 @@ async fn frozen_fanout_ambiguous_adapter_errors_remain_unresolved() {
 }
 
 #[tokio::test]
+async fn deferred_fanout_blocks_newer_same_group_fanouts_and_sets_the_retry_cutoff() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot ordered fanout key").unwrap();
+    let mut alice = session(dir.path().join("alice.sqlite"), &key, b"alice-ordered-fanout");
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "ordered fanout".into(),
+            description: String::new(),
+            members: Vec::new(),
+            required_features: Vec::new(),
+            app_components: Vec::new(),
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id;
+    let pending = match &created.effects.publish[0] {
+        PublishWork::GroupCreated { pending, .. } => *pending,
+        other => panic!("expected GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+
+    let endpoint = TransportEndpoint("wss://ordered-fanout.example".into());
+    let make_request = |id: u8| TransportPublishRequest {
+        account_id: alice.self_id(),
+        message: TransportMessage {
+            id: MessageId::new(vec![id; 32]),
+            payload: vec![id],
+            timestamp: Timestamp(100),
+            causal_deps: Vec::new(),
+            source: TransportSource("ordered-fanout-test".into()),
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: group_id.as_slice().to_vec(),
+            },
+        },
+        target: TransportPublishTarget::Group {
+            group_id: group_id.clone(),
+            transport_group_id: group_id.as_slice().to_vec(),
+            endpoints: vec![endpoint.clone()],
+        },
+        required_acks: 1,
+    };
+    let mut older = OutboundFanout::stage(make_request(1), None, None, 100_000).unwrap();
+    older.mark_attempt_started_at(0, 100_000).unwrap();
+    older
+        .record_target_failure(
+            0,
+            TransportEndpointFailure {
+                endpoint: endpoint.clone(),
+                reason: "acknowledgement unknown".into(),
+                kind: TransportEndpointFailureKind::PossiblyExposed,
+                rejection_category: None,
+            },
+        )
+        .unwrap();
+    let newer = OutboundFanout::stage(make_request(2), None, None, 100_001).unwrap();
+    alice.put_outbound_fanout(&older).unwrap();
+    alice.put_outbound_fanout(&newer).unwrap();
+
+    let adapter = RecordingAdapter::default();
+    let wall = Arc::new(TestWallClock::new(100));
+    let policy = StaticTransportRouting::new(Vec::new()).with_group_route(
+        group_id.clone(),
+        group_id.as_slice().to_vec(),
+        vec![endpoint],
+    );
+    let mut runtime = AccountDeviceRuntime::new(
+        alice,
+        adapter.clone(),
+        policy,
+        RecordingKeyPackages::default(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(0)),
+    );
+
+    let effects = runtime.resume_outbound_fanouts().await.unwrap();
+
+    assert!(effects.reports.is_empty());
+    assert!(adapter.publishes().is_empty());
+    assert_eq!(
+        runtime.outbound_fanout_retry_delay_ms(&group_id).unwrap(),
+        Some(30_000),
+        "the later NotAttempted fanout must not pull the older retry cutoff forward"
+    );
+    let stored = runtime
+        .session()
+        .outbound_fanouts_for_group(&group_id)
+        .unwrap();
+    assert_eq!(stored.len(), 2);
+    assert_eq!(
+        stored[1].target_status(0),
+        Some(FanoutTargetStatus::NotAttempted),
+        "the newer event must remain untouched until the older obligation is retryable"
+    );
+}
+
+#[tokio::test]
 async fn ambiguous_commit_retries_exact_event_after_restart_and_peer_can_advance() {
     let dir = tempfile::tempdir().unwrap();
     let alice_path = dir.path().join("alice-unknown-retry.sqlite");

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -3128,6 +3128,24 @@ impl AppClient {
             Ok(()) => return Ok(()),
             Err(publish_err) => publish_err,
         };
+        // This send failed, but the aggregate batch can still contain a
+        // successfully published sibling. Finalize and broadcast that sibling
+        // before returning the current send's error; otherwise its durable row
+        // remains visibly pending until an unrelated recovery pass. Keep this
+        // best-effort so projection trouble cannot mask the primary publish
+        // failure.
+        self.remember_published_reports(effects);
+        match self.finalize_published_app_message_source_retention(effects) {
+            Ok(updates) => self.pending_projection_updates.extend(updates),
+            Err(error) => {
+                tracing::warn!(
+                    target: "marmot_app::messages",
+                    method = "send_app_event_with_local_projection",
+                    error_kind = error.privacy_safe_kind(),
+                    "failed to finalize a successful sibling from a failed send batch"
+                );
+            }
+        }
         // The send itself failed to reach anyone, but any peer commits it
         // folded are durably applied — broadcast them before surfacing the
         // publish failure, best-effort so a projection error cannot mask

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -346,6 +346,10 @@ pub struct AppClient {
     /// acknowledged on the durable engine-to-app outbox. The acknowledgement is
     /// committed with the account projection and any frontier clear.
     pub(crate) pending_application_event_acks: HashSet<MessageId>,
+    /// One-shot test-policy fault at the projection/fanout cleanup boundary.
+    /// Kept on the client rather than re-reading config so the first failure
+    /// leaves the autonomous retry free to succeed.
+    pub(crate) fail_next_published_app_message_acknowledgement: bool,
     /// A live ingest changed the in-memory transport routing table after its
     /// durable projection was committed. The account worker publishes the
     /// resulting app summary before it asks the relay plane to rebuild its
@@ -3008,7 +3012,7 @@ impl AppClient {
             }
         };
         if let Err(publish_err) = self
-            .observe_recovery_evidence_then_gate_send_publish(&effects)
+            .observe_recovery_evidence_then_gate_send_publish(&effects, group_id, &app_event_id)
             .await
         {
             self.retract_failed_local_projection(
@@ -3092,20 +3096,35 @@ impl AppClient {
         ))
     }
 
-    /// Apply the publish gate to a completed send's effects — observing the same
-    /// batch's epoch-gap recovery evidence first — and, when the gate fails,
-    /// broadcast the peer commits the send folded before the caller surfaces the
-    /// error.
+    /// Apply the publish gate to one completed application send's effects —
+    /// observing the same batch's epoch-gap recovery evidence first — and,
+    /// when that send failed, broadcast peer commits the batch folded before
+    /// the caller surfaces the error.
     ///
     /// Split out of `send_app_event_with_local_projection` so the ordering is
-    /// exercisable against a given batch of effects. The caller keeps the
-    /// local-projection retraction, which needs that send's own locals.
+    /// exercisable against a given batch of effects. An aggregate effects batch
+    /// can contain an accepted or retained current send plus an unrelated
+    /// sibling failure; that sibling must not retract an already-delivered row.
+    /// The caller keeps the local-projection retraction, which needs the send's
+    /// own locals.
     pub(crate) async fn observe_recovery_evidence_then_gate_send_publish(
         &mut self,
         effects: &marmot_account::AccountDeviceEffects,
+        group_id: &GroupId,
+        app_event_id: &str,
     ) -> Result<(), AppError> {
-        let publish_err = match self.observe_recovery_evidence_then_fail_if_publish_failed(effects)
-        {
+        self.observe_recovery_evidence(effects);
+        self.remember_pending_convergence_groups(effects);
+        let current_send_is_retained =
+            effects.published_app_messages.iter().any(|published| {
+                published.group_id == *group_id && published.app_event_id == app_event_id
+            }) || effects.unresolved_app_messages.iter().any(|unresolved| {
+                unresolved.group_id == *group_id && unresolved.app_event_id == app_event_id
+            });
+        if current_send_is_retained {
+            return Ok(());
+        }
+        let publish_err = match fail_if_publish_failed(effects) {
             Ok(()) => return Ok(()),
             Err(publish_err) => publish_err,
         };

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -3115,6 +3115,21 @@ impl AppClient {
     ) -> Result<(), AppError> {
         self.observe_recovery_evidence(effects);
         self.remember_pending_convergence_groups(effects);
+        match self
+            .invalidate_failed_app_message_projections(effects, Some((group_id, app_event_id)))
+        {
+            Ok(failed_updates) => self.pending_projection_updates.extend(failed_updates),
+            Err(error) => {
+                // A sibling projection failure must not retract the current
+                // send when its own fanout was accepted or retained.
+                tracing::warn!(
+                    target: "marmot_app::messages",
+                    method = "send_app_event_with_local_projection",
+                    error_kind = error.privacy_safe_kind(),
+                    "failed to invalidate a terminally failed sibling from a send batch"
+                );
+            }
+        }
         let current_send_is_retained =
             effects.published_app_messages.iter().any(|published| {
                 published.group_id == *group_id && published.app_event_id == app_event_id
@@ -3877,6 +3892,8 @@ impl AppClient {
         // every timeline and chat-list subscriber still shows pending.
         let finalize_updates = self.finalize_published_app_message_source_retention(effects)?;
         self.pending_projection_updates.extend(finalize_updates);
+        let failed_updates = self.invalidate_failed_app_message_projections(effects, None)?;
+        self.pending_projection_updates.extend(failed_updates);
         // A manual retry can complete one frozen fanout while another publish
         // in the same convergence batch fails. Finalize that success before
         // surfacing the unrelated failure because its fanout is already gone.

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -3830,7 +3830,6 @@ impl AppClient {
         // Observe before the publish gate, for the reason spelled out in
         // `observe_drained_session_events`.
         self.observe_recovery_evidence(effects);
-        fail_if_publish_failed(effects)?;
         self.remember_published_reports(effects);
         // This is the path that releases sends the engine had retained, so its
         // finalize updates carry the pending -> delivered flip for each of them.
@@ -3841,6 +3840,10 @@ impl AppClient {
         // every timeline and chat-list subscriber still shows pending.
         let finalize_updates = self.finalize_published_app_message_source_retention(effects)?;
         self.pending_projection_updates.extend(finalize_updates);
+        // A manual retry can complete one frozen fanout while another publish
+        // in the same convergence batch fails. Finalize that success before
+        // surfacing the unrelated failure because its fanout is already gone.
+        fail_if_publish_failed(effects)?;
         self.refresh_group(group_id);
         self.prune_plaintext_retention_for_group(group_id)?;
         self.save_state_with_pending_local_group_deletion_frontier_clears()?;

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -590,6 +590,8 @@ impl AppClient {
                 updates.push(update);
             }
         }
+        self.runtime
+            .acknowledge_published_app_messages(&effects.published_app_messages)?;
         Ok(updates)
     }
 

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -621,6 +621,37 @@ impl AppClient {
         Ok(updates)
     }
 
+    /// Invalidates local projections for application messages whose durable
+    /// fanouts reached a terminal publish failure.
+    ///
+    /// A direct send excludes its own optimistic row because the caller owns
+    /// that row's callback-delivered retraction. Sibling failures and recovery
+    /// batches have no such caller, so their updates are returned for the
+    /// account worker to broadcast.
+    pub(crate) fn invalidate_failed_app_message_projections(
+        &self,
+        effects: &marmot_account::AccountDeviceEffects,
+        excluded: Option<(&GroupId, &str)>,
+    ) -> Result<Vec<crate::AppProjectionUpdate>, AppError> {
+        let mut updates = Vec::new();
+        for failed in &effects.failed_app_messages {
+            if excluded.is_some_and(|(group_id, app_event_id)| {
+                failed.group_id == *group_id && failed.app_event_id == app_event_id
+            }) {
+                continue;
+            }
+            if let Some(update) = self.app.invalidate_timeline_app_event(
+                &self.state.label,
+                &hex::encode(failed.group_id.as_slice()),
+                &failed.app_event_id,
+                crate::LOCAL_PUBLISH_FAILED_REASON,
+            )? {
+                updates.push(update);
+            }
+        }
+        Ok(updates)
+    }
+
     pub(crate) fn prune_plaintext_retention_for_group(
         &self,
         group_id: &GroupId,

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -590,12 +590,9 @@ impl AppClient {
                 updates.push(update);
             }
         }
-        let acknowledgement = if cfg!(feature = "test-policy-overrides")
-            && self
-                .app
-                .config
-                .dev_fail_published_app_message_acknowledgement
-        {
+        let fail_acknowledgement = cfg!(feature = "test-policy-overrides")
+            && std::mem::take(&mut self.fail_next_published_app_message_acknowledgement);
+        let acknowledgement = if fail_acknowledgement {
             Err(AppError::BlockingTask(
                 "injected published application-message acknowledgement failure".to_owned(),
             ))
@@ -606,9 +603,14 @@ impl AppClient {
         };
         if let Err(error) = acknowledgement {
             // Projection is already durable, and the accepted fanout remains
-            // durable when acknowledgement fails. Return the delivery update
-            // so subscribers leave Sending; the next recovery drain replays
-            // the publication metadata and retries this idempotent cleanup.
+            // durable when acknowledgement fails. Schedule its group so a
+            // cleanup-only replay runs without waiting for unrelated traffic;
+            // resume recognizes this terminal fanout and never republishes its
+            // network bytes.
+            for published in &effects.published_app_messages {
+                self.pending_convergence_groups
+                    .insert(published.group_id.clone());
+            }
             tracing::warn!(
                 target: "marmot_app::client::projection",
                 method = "finalize_published_app_message_source_retention",

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -590,8 +590,32 @@ impl AppClient {
                 updates.push(update);
             }
         }
-        self.runtime
-            .acknowledge_published_app_messages(&effects.published_app_messages)?;
+        let acknowledgement = if cfg!(feature = "test-policy-overrides")
+            && self
+                .app
+                .config
+                .dev_fail_published_app_message_acknowledgement
+        {
+            Err(AppError::BlockingTask(
+                "injected published application-message acknowledgement failure".to_owned(),
+            ))
+        } else {
+            self.runtime
+                .acknowledge_published_app_messages(&effects.published_app_messages)
+                .map_err(AppError::from)
+        };
+        if let Err(error) = acknowledgement {
+            // Projection is already durable, and the accepted fanout remains
+            // durable when acknowledgement fails. Return the delivery update
+            // so subscribers leave Sending; the next recovery drain replays
+            // the publication metadata and retries this idempotent cleanup.
+            tracing::warn!(
+                target: "marmot_app::client::projection",
+                method = "finalize_published_app_message_source_retention",
+                error_kind = error.privacy_safe_kind(),
+                "published application-message cleanup deferred",
+            );
+        }
         Ok(updates)
     }
 

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -366,12 +366,12 @@ pub(crate) enum ConvergenceScheduleState {
     /// trigger). Re-check on the fallback delay; only this state counts
     /// toward the unsettled re-arm cap.
     PendingUnopenable,
-    /// No convergence work, but durable queued outbound intents remain. The
-    /// scheduled drain regenerates and publishes them (and a failed sync on
-    /// that tick triggers transport reactivation), so the wakeup stays armed
-    /// on the fallback delay — but a healthy waiting queue is not unsettled
-    /// convergence and never counts toward the re-arm cap.
-    PendingOutbound,
+    /// No convergence work, but durable outbound work remains. A frozen
+    /// transport event carries its earliest retry cutoff; queued intents and
+    /// local-only acknowledgement cleanup use the scheduler's ordinary delay.
+    /// This state is not unsettled convergence and never counts toward the
+    /// re-arm cap.
+    PendingOutbound { retry_after_ms: Option<u64> },
 }
 
 enum SyncCheckpointError {
@@ -443,10 +443,14 @@ impl AppClient {
             None => {
                 if self.runtime.has_pending_convergence_inputs(group_id)? {
                     Ok(ConvergenceScheduleState::PendingUnopenable)
-                } else if self.runtime.has_queued_outbound_intents(group_id)?
-                    || self.runtime.has_pending_outbound_fanouts(group_id)?
-                {
-                    Ok(ConvergenceScheduleState::PendingOutbound)
+                } else if self.runtime.has_queued_outbound_intents(group_id)? {
+                    Ok(ConvergenceScheduleState::PendingOutbound {
+                        retry_after_ms: None,
+                    })
+                } else if self.runtime.has_pending_outbound_fanouts(group_id)? {
+                    Ok(ConvergenceScheduleState::PendingOutbound {
+                        retry_after_ms: self.runtime.outbound_fanout_retry_delay_ms(group_id)?,
+                    })
                 } else {
                     match self.runtime.deferred_peel_cutoff_delay_ms(group_id)? {
                         Some(0) => Ok(ConvergenceScheduleState::Ready),
@@ -466,7 +470,9 @@ impl AppClient {
         }
     }
 
-    fn remember_pending_convergence_groups(
+    /// Retain engine-provided scheduling edges from an effects batch until the
+    /// account worker can arm their group timers.
+    pub(crate) fn remember_pending_convergence_groups(
         &mut self,
         effects: &marmot_account::AccountDeviceEffects,
     ) {

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -1057,17 +1057,18 @@ impl AppClient {
         // state. The two conditions are correlated rather than independent: this
         // drain publishes, so the failure and the refusal ride the same effects.
         self.observe_recovery_evidence(effects);
-        fail_if_publish_failed(effects)?;
         let mut summary = SyncSummary::default();
         // `runtime.drain()` also resumes durable outbound fanouts. That work
         // can publish an accepted-pending application message without emitting
         // any engine event, so it must be projected before the eventless fast
-        // path below. Otherwise the exact event reaches the relay while the
-        // sender's durable timeline row remains stuck in `Sending` forever.
+        // path or publish-failure gate below. A batch can contain one fanout
+        // that succeeded alongside another publish that failed; the successful
+        // row must not remain stuck in `Sending` after its fanout is deleted.
         self.remember_published_reports(effects);
         summary
             .projection_updates
             .extend(self.finalize_published_app_message_source_retention(effects)?);
+        fail_if_publish_failed(effects)?;
         if effects.events.is_empty() {
             self.drain_epoch_stall_escalations(&mut summary);
             return Ok(summary);
@@ -3328,9 +3329,12 @@ impl AppClient {
         // Observe before the publish gate, for the reason spelled out in
         // `observe_drained_session_events`.
         self.observe_recovery_evidence(effects);
-        fail_if_publish_failed(effects)?;
         self.remember_published_reports(effects);
         let finalize_updates = self.finalize_published_app_message_source_retention(effects)?;
+        // Preserve successful publications in a mixed batch before surfacing
+        // an unrelated hard failure. Their durable fanouts are already gone,
+        // so a later pass cannot reconstruct this source metadata.
+        fail_if_publish_failed(effects)?;
         let publish_new_message_notification =
             effects.published_app_messages.iter().any(|published| {
                 let group_id_hex = hex::encode(published.group_id.as_slice());

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -423,7 +423,9 @@ impl AppClient {
             None => {
                 if self.runtime.has_pending_convergence_inputs(group_id)? {
                     Ok(ConvergenceScheduleState::PendingUnopenable)
-                } else if self.runtime.has_queued_outbound_intents(group_id)? {
+                } else if self.runtime.has_queued_outbound_intents(group_id)?
+                    || self.runtime.has_pending_outbound_fanouts(group_id)?
+                {
                     Ok(ConvergenceScheduleState::PendingOutbound)
                 } else {
                     match self.runtime.deferred_peel_cutoff_delay_ms(group_id)? {
@@ -561,16 +563,16 @@ impl AppClient {
     /// a device that recovered stays counted as stuck — so it is observed on the
     /// same side of the gate.
     ///
-    /// Recovery evidence only. `remember_pending_convergence_groups` is
-    /// deliberately not paired here the way it is at the convergence and inbound
-    /// seams: the callers of this gate do not remember pending convergence on
-    /// their success paths either, so recording it on the failure path alone
-    /// would invent a scheduling contract they do not otherwise hold.
+    /// Retained exact fanouts are non-failure effects, but they still require a
+    /// worker wake. Remember their engine-provided scheduling edge here so all
+    /// direct send operations (messages and group-state changes alike) retry
+    /// automatically after temporary transport loss.
     pub(crate) fn observe_recovery_evidence_then_fail_if_publish_failed(
         &mut self,
         effects: &marmot_account::AccountDeviceEffects,
     ) -> Result<(), AppError> {
         self.observe_recovery_evidence(effects);
+        self.remember_pending_convergence_groups(effects);
         fail_if_publish_failed(effects)
     }
 

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -1065,10 +1065,12 @@ impl AppClient {
         // that succeeded alongside another publish that failed; the successful
         // row must not remain stuck in `Sending` after its fanout is deleted.
         self.remember_published_reports(effects);
-        summary
-            .projection_updates
-            .extend(self.finalize_published_app_message_source_retention(effects)?);
-        fail_if_publish_failed(effects)?;
+        let finalize_updates = self.finalize_published_app_message_source_retention(effects)?;
+        if let Err(error) = fail_if_publish_failed(effects) {
+            self.pending_projection_updates.extend(finalize_updates);
+            return Err(error);
+        }
+        summary.projection_updates.extend(finalize_updates);
         if effects.events.is_empty() {
             self.drain_epoch_stall_escalations(&mut summary);
             return Ok(summary);
@@ -3334,7 +3336,10 @@ impl AppClient {
         // Preserve successful publications in a mixed batch before surfacing
         // an unrelated hard failure. Their durable fanouts are already gone,
         // so a later pass cannot reconstruct this source metadata.
-        fail_if_publish_failed(effects)?;
+        if let Err(error) = fail_if_publish_failed(effects) {
+            self.pending_projection_updates.extend(finalize_updates);
+            return Err(error);
+        }
         let publish_new_message_notification =
             effects.published_app_messages.iter().any(|published| {
                 let group_id_hex = hex::encode(published.group_id.as_slice());

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -391,6 +391,26 @@ impl StagedSyncError {
 }
 
 impl AppClient {
+    /// Persist a host connectivity-restored edge into every exact fanout whose
+    /// prior attempt was proven unavailable, then schedule its group for an
+    /// immediate worker pass. Ambiguous fanouts keep their original clocks.
+    pub(crate) fn note_connectivity_restored(&mut self) -> Result<usize, AppError> {
+        let mut woken_targets = 0;
+        for mut fanout in self.runtime.session().outbound_fanouts()? {
+            let woken = fanout.wake_retryable_unavailable_targets();
+            if woken == 0 {
+                continue;
+            }
+            let group_id = fanout.group_id().cloned();
+            self.runtime.session().put_outbound_fanout(&fanout)?;
+            if let Some(group_id) = group_id {
+                self.pending_convergence_groups.insert(group_id);
+            }
+            woken_targets += woken;
+        }
+        Ok(woken_targets)
+    }
+
     pub(crate) fn take_pending_convergence_groups(&mut self) -> Vec<cgka_traits::GroupId> {
         self.pending_convergence_groups.drain().collect()
     }
@@ -1039,6 +1059,15 @@ impl AppClient {
         self.observe_recovery_evidence(effects);
         fail_if_publish_failed(effects)?;
         let mut summary = SyncSummary::default();
+        // `runtime.drain()` also resumes durable outbound fanouts. That work
+        // can publish an accepted-pending application message without emitting
+        // any engine event, so it must be projected before the eventless fast
+        // path below. Otherwise the exact event reaches the relay while the
+        // sender's durable timeline row remains stuck in `Sending` forever.
+        self.remember_published_reports(effects);
+        summary
+            .projection_updates
+            .extend(self.finalize_published_app_message_source_retention(effects)?);
         if effects.events.is_empty() {
             self.drain_epoch_stall_escalations(&mut summary);
             return Ok(summary);

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -599,6 +599,8 @@ impl AppClient {
     ) -> Result<(), AppError> {
         self.observe_recovery_evidence(effects);
         self.remember_pending_convergence_groups(effects);
+        let failed_updates = self.invalidate_failed_app_message_projections(effects, None)?;
+        self.pending_projection_updates.extend(failed_updates);
         fail_if_publish_failed(effects)
     }
 
@@ -1072,11 +1074,14 @@ impl AppClient {
         // row must not remain stuck in `Sending` after its fanout is deleted.
         self.remember_published_reports(effects);
         let finalize_updates = self.finalize_published_app_message_source_retention(effects)?;
+        let failed_updates = self.invalidate_failed_app_message_projections(effects, None)?;
         if let Err(error) = fail_if_publish_failed(effects) {
             self.pending_projection_updates.extend(finalize_updates);
+            self.pending_projection_updates.extend(failed_updates);
             return Err(error);
         }
         summary.projection_updates.extend(finalize_updates);
+        summary.projection_updates.extend(failed_updates);
         if effects.events.is_empty() {
             self.drain_epoch_stall_escalations(&mut summary);
             return Ok(summary);
@@ -3339,11 +3344,13 @@ impl AppClient {
         self.observe_recovery_evidence(effects);
         self.remember_published_reports(effects);
         let finalize_updates = self.finalize_published_app_message_source_retention(effects)?;
+        let failed_updates = self.invalidate_failed_app_message_projections(effects, None)?;
         // Preserve successful publications in a mixed batch before surfacing
         // an unrelated hard failure. Their durable fanouts are already gone,
         // so a later pass cannot reconstruct this source metadata.
         if let Err(error) = fail_if_publish_failed(effects) {
             self.pending_projection_updates.extend(finalize_updates);
+            self.pending_projection_updates.extend(failed_updates);
             return Err(error);
         }
         let publish_new_message_notification =
@@ -3364,6 +3371,7 @@ impl AppClient {
         let display_names = self.app.display_names_by_id()?;
         let mut summary = SyncSummary::default();
         summary.projection_updates.extend(finalize_updates);
+        summary.projection_updates.extend(failed_updates);
         let source_message_id_hex = String::new();
         let source_received_at = unix_now_seconds();
         let routes_dirty = self

--- a/crates/marmot-app/src/config.rs
+++ b/crates/marmot-app/src/config.rs
@@ -168,6 +168,11 @@ pub struct MarmotAppConfig {
     /// have no external driver, so this stands in for them when a caller's
     /// handling of that error is what is under test.
     pub dev_fail_pending_session_event_drain: bool,
+    /// Dev/test-only fault injected after published application-message source
+    /// retention is finalized but before its durable fanout is acknowledged.
+    /// Honored only with `test-policy-overrides`; this exercises the recovery
+    /// boundary where projection is committed but fanout cleanup must retry.
+    pub dev_fail_published_app_message_acknowledgement: bool,
     /// Accounts to search outward from when the searcher's own web of trust is
     /// empty, as pubkey hex.
     ///
@@ -233,6 +238,7 @@ impl Default for MarmotAppConfig {
             dev_fail_sync_before_boundary_save: None,
             dev_fail_ingest_after_application_event_ack: false,
             dev_fail_pending_session_event_drain: false,
+            dev_fail_published_app_message_acknowledgement: false,
             directory_search_fallback_seeds: Vec::new(),
         }
     }
@@ -407,6 +413,13 @@ impl MarmotAppConfig {
     /// builds ignore this field.
     pub fn with_dev_fail_pending_session_event_drain(mut self) -> Self {
         self.dev_fail_pending_session_event_drain = true;
+        self
+    }
+
+    /// Fail published application-message acknowledgement in test-policy
+    /// builds. Normal builds ignore this field.
+    pub fn with_dev_fail_published_app_message_acknowledgement(mut self) -> Self {
+        self.dev_fail_published_app_message_acknowledgement = true;
         self
     }
 }

--- a/crates/marmot-app/src/config.rs
+++ b/crates/marmot-app/src/config.rs
@@ -168,8 +168,9 @@ pub struct MarmotAppConfig {
     /// have no external driver, so this stands in for them when a caller's
     /// handling of that error is what is under test.
     pub dev_fail_pending_session_event_drain: bool,
-    /// Dev/test-only fault injected after published application-message source
-    /// retention is finalized but before its durable fanout is acknowledged.
+    /// Dev/test-only one-shot fault injected after published
+    /// application-message source retention is finalized but before its
+    /// durable fanout is acknowledged.
     /// Honored only with `test-policy-overrides`; this exercises the recovery
     /// boundary where projection is committed but fanout cleanup must retry.
     pub dev_fail_published_app_message_acknowledgement: bool,
@@ -416,8 +417,8 @@ impl MarmotAppConfig {
         self
     }
 
-    /// Fail published application-message acknowledgement in test-policy
-    /// builds. Normal builds ignore this field.
+    /// Fail the next published application-message acknowledgement in
+    /// test-policy builds. Normal builds ignore this field.
     pub fn with_dev_fail_published_app_message_acknowledgement(mut self) -> Self {
         self.dev_fail_published_app_message_acknowledgement = true;
         self

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1700,6 +1700,11 @@ impl MarmotApp {
             pending_convergence_groups: std::collections::HashSet::new(),
             pending_local_group_deletion_frontier_clears: std::collections::HashMap::new(),
             pending_application_event_acks: std::collections::HashSet::new(),
+            fail_next_published_app_message_acknowledgement: cfg!(
+                feature = "test-policy-overrides"
+            ) && self
+                .config
+                .dev_fail_published_app_message_acknowledgement,
             pending_runtime_group_subscription_refresh: false,
             checkpointed_transport_timestamp,
             delivery_overflow_recovery_pending: open.delivery_overflow_recovery_pending,

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -102,6 +102,12 @@ pub(crate) enum AccountWorkerCommand {
     CatchUp {
         respond: oneshot::Sender<Result<(), AccountCatchUpFailure>>,
     },
+    /// The host observed usable connectivity after an outage. Interrupt
+    /// transport-failure backoff for already-durable convergence work; this
+    /// signal never creates or replays application work on its own.
+    ConnectivityRestored {
+        respond: oneshot::Sender<Result<(), AppError>>,
+    },
     /// Startup-coalesced catch-up response held in the same FIFO as deferred
     /// mutations so later live reads cannot bypass those mutations.
     StartupCatchUpResult {
@@ -947,6 +953,7 @@ async fn run_app_runtime_account_worker(
                         account_label: &account_label,
                         shared: &shared,
                         media_http: &media_http,
+                        scheduled_convergence: &mut scheduled_convergence,
                     },
                 )
                 .await;
@@ -1191,6 +1198,7 @@ async fn run_app_runtime_account_worker(
                                             account_label: &account_label,
                                             shared: &shared,
                                             media_http: &media_http,
+                                            scheduled_convergence: &mut scheduled_convergence,
                                         },
                                     )
                                     .await;
@@ -1337,19 +1345,22 @@ async fn run_app_runtime_account_worker(
                                     _ = &mut retry_delay => break,
                                     command = commands.recv() => {
                                         match command {
-                                            Some(command @ AccountWorkerCommand::CatchUp { .. }) => {
-                                                // A host connectivity-restored edge is the one
-                                                // command that is meaningful without an engine
-                                                // session: retain its response and use it to end
-                                                // only this stale sleep. Coalesce an already
-                                                // queued burst into the same reopen attempt; new
-                                                // signals can still interrupt later sleeps, so
-                                                // extra attempts remain bounded by host signal
-                                                // rate while the network stays unavailable.
+                                            Some(
+                                                command @ (AccountWorkerCommand::CatchUp { .. }
+                                                | AccountWorkerCommand::ConnectivityRestored { .. }),
+                                            ) => {
+                                                // Host recovery commands are meaningful without
+                                                // an engine session: retain their responses and use
+                                                // them to end only this stale sleep. Coalesce an
+                                                // already queued burst into the same reopen attempt;
+                                                // new signals can still interrupt later sleeps, so
+                                                // extra attempts remain bounded by host signal rate
+                                                // while the network stays unavailable.
                                                 pending.push_back(command);
                                                 while let Ok(command) = commands.try_recv() {
                                                     match command {
-                                                        command @ AccountWorkerCommand::CatchUp { .. } => {
+                                                        command @ (AccountWorkerCommand::CatchUp { .. }
+                                                        | AccountWorkerCommand::ConnectivityRestored { .. }) => {
                                                             pending.push_back(command);
                                                         }
                                                         command => drop(command),
@@ -2529,6 +2540,7 @@ struct AccountWorkerCommandContext<'a> {
     account_label: &'a str,
     shared: &'a RuntimeSharedServices,
     media_http: &'a MediaHttpContext,
+    scheduled_convergence: &'a mut ScheduledConvergence,
 }
 
 /// Commands that arrived while a previous handler held `&mut client` stay in
@@ -2550,8 +2562,14 @@ async fn handle_account_worker_command(
         account_label,
         shared,
         media_http,
+        scheduled_convergence,
     } = context;
     match command {
+        AccountWorkerCommand::ConnectivityRestored { respond } => {
+            let result = client.note_connectivity_restored().map(|_| ());
+            scheduled_convergence.wake_after_connectivity_restored();
+            let _ = respond.send(result);
+        }
         AccountWorkerCommand::NetworkStartupSettled { respond } => {
             let _ = respond.send(());
         }
@@ -4155,6 +4173,24 @@ impl ScheduledConvergence {
         self.reset_timer_to_earliest();
     }
 
+    /// A host-provided usable-connectivity edge invalidates transport-failure
+    /// backoff. Wake every already-scheduled group now; an in-window
+    /// convergence pass will simply re-arm its true cutoff, while pending
+    /// outbound work gets an immediate chance to drain. Reset only error
+    /// retries so a relay that is still reconnecting starts again from the
+    /// short backoff instead of returning directly to the 60-second cap.
+    fn wake_after_connectivity_restored(&mut self) {
+        if self.deadlines.is_empty() {
+            return;
+        }
+        let now = TokioInstant::now();
+        self.deadlines
+            .values_mut()
+            .for_each(|deadline| *deadline = now);
+        self.retry_attempts.clear();
+        self.reset_timer_to_earliest();
+    }
+
     /// Re-arm the timer for groups whose scheduled pass did not settle stored
     /// convergence inputs (for example, the tick fired inside the quiescence
     /// window). Unlike [`Self::schedule_retry_groups`], this is not an error
@@ -5378,6 +5414,7 @@ mod tests {
             worker_lifetime: media_http_worker_lifetime,
         };
         let (mut unused_commands, mut unused_pending) = unused_account_worker_command_io();
+        let mut scheduled_convergence = ScheduledConvergence::new(Duration::ZERO);
         handle_account_worker_command(
             &mut client,
             AccountWorkerCommand::RepairFullHistory { respond },
@@ -5390,6 +5427,7 @@ mod tests {
                 account_label: "alice",
                 shared: &shared,
                 media_http: &media_http,
+                scheduled_convergence: &mut scheduled_convergence,
             },
         )
         .await;

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -4126,17 +4126,24 @@ impl ScheduledConvergence {
             ConvergenceScheduleState::PendingUnopenable => {
                 self.schedule_unsettled_groups([group_id.clone()]);
             }
-            ConvergenceScheduleState::PendingOutbound => {
+            ConvergenceScheduleState::PendingOutbound { retry_after_ms } => {
                 // A waiting outbound queue keeps the wakeup armed on the
-                // normal delay but is not unsettled convergence: it never
-                // feeds the re-arm cap, so a healthy queue cannot be demoted
-                // to error backoff (transport failures reach backoff through
-                // the sync/drain error paths instead). It also clears the
-                // counter: this state means pending inputs are gone, so any
-                // prior unopenable streak genuinely ended.
+                // durable fanout's exact cutoff (or the normal delay for
+                // queued/local-only work) but is not unsettled convergence:
+                // it never feeds the re-arm cap. It also clears the counter:
+                // this state means pending inputs are gone, so any prior
+                // unopenable streak genuinely ended.
                 self.retry_attempts.remove(group_id);
                 self.unsettled_rearm_attempts.remove(group_id);
-                self.arm_no_later(group_id.clone(), TokioInstant::now() + self.normal_delay());
+                let delay = retry_after_ms.map_or_else(
+                    || self.normal_delay(),
+                    |remaining_ms| {
+                        Duration::from_millis(remaining_ms)
+                            .max(MIN_CONVERGENCE_SETTLEMENT_DELAY)
+                            .saturating_add(self.test_delay)
+                    },
+                );
+                self.arm_no_later(group_id.clone(), TokioInstant::now() + delay);
                 self.reset_timer_to_earliest();
             }
         }
@@ -5878,7 +5885,12 @@ mod tests {
         let mut scheduled = ScheduledConvergence::new(Duration::from_millis(1_100));
 
         for _ in 0..=CONVERGENCE_UNSETTLED_MAX_REARMS {
-            scheduled.schedule_after_pass(&group_id, ConvergenceScheduleState::PendingOutbound);
+            scheduled.schedule_after_pass(
+                &group_id,
+                ConvergenceScheduleState::PendingOutbound {
+                    retry_after_ms: None,
+                },
+            );
             scheduled.take_ready();
         }
 
@@ -5893,11 +5905,41 @@ mod tests {
         for _ in 0..=CONVERGENCE_UNSETTLED_MAX_REARMS {
             scheduled.schedule_after_pass(&group_id, ConvergenceScheduleState::PendingUnopenable);
             scheduled.take_ready();
-            scheduled.schedule_after_pass(&group_id, ConvergenceScheduleState::PendingOutbound);
+            scheduled.schedule_after_pass(
+                &group_id,
+                ConvergenceScheduleState::PendingOutbound {
+                    retry_after_ms: None,
+                },
+            );
             scheduled.take_ready();
         }
         assert!(!scheduled.unsettled_rearm_attempts.contains_key(&group_id));
         assert!(!scheduled.retry_attempts.contains_key(&group_id));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pending_outbound_arms_at_the_durable_retry_cutoff() {
+        let group_id = test_group_id(16);
+        let mut scheduled = ScheduledConvergence::new(Duration::from_millis(1_100));
+        let before = TokioInstant::now();
+
+        scheduled.schedule_after_pass(
+            &group_id,
+            ConvergenceScheduleState::PendingOutbound {
+                retry_after_ms: Some(30_000),
+            },
+        );
+
+        assert_eq!(
+            scheduled.deadlines[&group_id],
+            before + Duration::from_secs(30),
+            "a frozen fanout must sleep until its durable cutoff instead of polling every settlement interval"
+        );
+        tokio::time::advance(Duration::from_millis(1_100)).await;
+        assert!(
+            scheduled.deadlines[&group_id] > TokioInstant::now(),
+            "the ordinary convergence delay must not wake a backpressured fanout"
+        );
     }
 
     #[tokio::test]

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -5942,6 +5942,32 @@ mod tests {
         );
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn connectivity_restore_wakes_pending_outbound_before_durable_cutoff() {
+        let group_id = test_group_id(17);
+        let mut scheduled = ScheduledConvergence::new(Duration::from_millis(1_100));
+        let before = TokioInstant::now();
+
+        scheduled.schedule_after_pass(
+            &group_id,
+            ConvergenceScheduleState::PendingOutbound {
+                retry_after_ms: Some(5_000),
+            },
+        );
+        assert_eq!(
+            scheduled.deadlines[&group_id],
+            before + Duration::from_secs(5)
+        );
+
+        scheduled.wake_after_connectivity_restored();
+
+        assert_eq!(
+            scheduled.deadlines[&group_id],
+            TokioInstant::now(),
+            "connectivity recovery must make a backpressured fanout immediately eligible"
+        );
+    }
+
     #[tokio::test]
     async fn collecting_tick_does_not_increment_rearm_counter() {
         let group_id = test_group_id(13);

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Semaphore;
 use tokio::sync::{Mutex, Notify, broadcast, mpsc, oneshot, watch};
 use tokio::task::{JoinHandle, JoinSet};
-use tokio::time::timeout;
+use tokio::time::{sleep, timeout};
 
 use crate::agent_streams::AgentStreamWatchManager;
 use crate::app_telemetry::{
@@ -201,6 +201,11 @@ struct GeneratedSetupTasks {
 
 const GENERATED_SETUP_BACKGROUND_MAX_ATTEMPTS: usize = 3;
 const GENERATED_SETUP_BACKGROUND_RETRY_BASE_DELAY: Duration = Duration::from_millis(100);
+const ACCOUNT_CATCH_UP_TRANSIENT_RETRY_DELAYS: [Duration; 3] = [
+    Duration::from_millis(250),
+    Duration::from_secs(1),
+    Duration::from_secs(3),
+];
 
 #[derive(Clone)]
 pub struct RuntimeSharedServices {
@@ -1314,6 +1319,14 @@ impl MarmotAppRuntime {
 
     pub async fn catch_up_accounts(&self) -> Result<(), AppError> {
         self.accounts.catch_up_accounts().await.map(|_| ())
+    }
+
+    /// Notify every running account worker that the host has observed usable
+    /// connectivity after an outage. This interrupts transport retry backoff
+    /// for already-durable work; callers may separately request catch-up when
+    /// they also need inbound relay synchronization.
+    pub async fn notify_connectivity_restored(&self) -> Result<(), AppError> {
+        self.accounts.notify_connectivity_restored().await
     }
 
     /// Catch up every running account worker and report how many account
@@ -4560,6 +4573,110 @@ pub struct CatchUpAccountsSummary {
     pub accounts_considered: usize,
 }
 
+fn is_transient_account_catch_up_error(error: &AppError) -> bool {
+    match error {
+        AppError::AccountCatchUp(failure) => {
+            let classification = failure.classification();
+            matches!(
+                classification.failure_stage,
+                SyncFailureStage::TransportActivation
+                    | SyncFailureStage::GroupSubscriptionSync
+                    | SyncFailureStage::RelayReceive
+            ) && !matches!(
+                classification.error_class,
+                SyncErrorClass::Protocol
+                    | SyncErrorClass::Crypto
+                    | SyncErrorClass::Storage
+                    | SyncErrorClass::Cancelled
+            )
+        }
+        _ => false,
+    }
+}
+
+async fn run_account_catch_up_pass(
+    commands: Vec<mpsc::Sender<AccountWorkerCommand>>,
+    response_wait: Duration,
+) -> Vec<(mpsc::Sender<AccountWorkerCommand>, Result<(), AppError>)> {
+    let mut responses = Vec::with_capacity(commands.len());
+    let mut outcomes = Vec::with_capacity(commands.len());
+    for command in commands {
+        let (respond, response) = oneshot::channel();
+        if command
+            .send(AccountWorkerCommand::CatchUp { respond })
+            .await
+            .is_err()
+        {
+            outcomes.push((command, Err(AppError::TransportClosed)));
+        } else {
+            responses.push((command, response));
+        }
+    }
+    for (command, response) in responses {
+        let outcome = match timeout(response_wait, response).await {
+            Ok(Ok(Ok(()))) => Ok(()),
+            Ok(Ok(Err(failure))) => Err(AppError::AccountCatchUp(failure)),
+            Ok(Err(_)) => Err(AppError::TransportClosed),
+            Err(_) => Err(AppError::AccountCatchUp(AccountCatchUpFailure::new(
+                "account worker catch-up timed out".into(),
+                SyncFailureClassification::new(
+                    SyncFailureStage::AccountWorker,
+                    SyncErrorClass::Timeout,
+                ),
+            ))),
+        };
+        outcomes.push((command, outcome));
+    }
+    outcomes
+}
+
+async fn catch_up_account_commands_with_retry(
+    commands: Vec<mpsc::Sender<AccountWorkerCommand>>,
+    response_wait: Duration,
+    retry_delays: &[Duration],
+) -> Result<(), AppError> {
+    let mut pending_commands = commands;
+    let mut retry_delays = retry_delays.iter();
+    let mut first_terminal_error = None;
+
+    loop {
+        let outcomes = run_account_catch_up_pass(pending_commands, response_wait).await;
+        let mut retry_commands = Vec::new();
+        let mut first_retryable_error = None;
+        for (command, outcome) in outcomes {
+            let Err(error) = outcome else {
+                continue;
+            };
+            if is_transient_account_catch_up_error(&error) {
+                retry_commands.push(command);
+                if first_retryable_error.is_none() {
+                    first_retryable_error = Some(error);
+                }
+            } else if first_terminal_error.is_none() {
+                first_terminal_error = Some(error);
+            }
+        }
+
+        if retry_commands.is_empty() {
+            return first_terminal_error.map_or(Ok(()), Err);
+        }
+        let Some(retry_delay) = retry_delays.next() else {
+            return Err(first_terminal_error
+                .or(first_retryable_error)
+                .expect("retry commands always carry an error"));
+        };
+        tracing::debug!(
+            target: "marmot_app::runtime",
+            method = "catch_up_accounts",
+            retry_accounts = retry_commands.len(),
+            retry_delay_ms = retry_delay.as_millis() as u64,
+            "retrying transient account catch-up failures",
+        );
+        sleep(*retry_delay).await;
+        pending_commands = retry_commands;
+    }
+}
+
 impl AccountManager {
     fn new(
         app: MarmotApp,
@@ -5043,6 +5160,33 @@ impl AccountManager {
         result
     }
 
+    pub async fn notify_connectivity_restored(&self) -> Result<(), AppError> {
+        self.shared.lifecycle().ensure_running()?;
+        let commands = self.running_account_commands().await;
+        let mut responses = Vec::with_capacity(commands.len());
+        for command in commands {
+            let (respond, response) = oneshot::channel();
+            command
+                .send(AccountWorkerCommand::ConnectivityRestored { respond })
+                .await
+                .map_err(|_| AppError::TransportClosed)?;
+            responses.push(response);
+        }
+        for response in responses {
+            match timeout(APP_RUNTIME_ACCOUNT_READY_WAIT, response).await {
+                Ok(Ok(Ok(()))) => {}
+                Ok(Ok(Err(error))) => return Err(error),
+                Ok(Err(_)) => return Err(AppError::TransportClosed),
+                Err(_) => {
+                    return Err(AppError::BlockingTask(
+                        "account worker connectivity-restored wake timed out".into(),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
     async fn running_account_commands(&self) -> Vec<mpsc::Sender<AccountWorkerCommand>> {
         self.workers
             .lock()
@@ -5057,32 +5201,12 @@ impl AccountManager {
         commands: Vec<mpsc::Sender<AccountWorkerCommand>>,
     ) -> Result<(), AppError> {
         self.shared.lifecycle().ensure_running()?;
-        let mut responses = Vec::with_capacity(commands.len());
-        for command in commands {
-            let (respond, response) = oneshot::channel();
-            command
-                .send(AccountWorkerCommand::CatchUp { respond })
-                .await
-                .map_err(|_| AppError::TransportClosed)?;
-            responses.push(response);
-        }
-        for response in responses {
-            match timeout(APP_RUNTIME_ACCOUNT_READY_WAIT, response).await {
-                Ok(Ok(Ok(()))) => {}
-                Ok(Ok(Err(failure))) => return Err(AppError::AccountCatchUp(failure)),
-                Ok(Err(_)) => return Err(AppError::TransportClosed),
-                Err(_) => {
-                    return Err(AppError::AccountCatchUp(AccountCatchUpFailure::new(
-                        "account worker catch-up timed out".into(),
-                        SyncFailureClassification::new(
-                            SyncFailureStage::AccountWorker,
-                            SyncErrorClass::Timeout,
-                        ),
-                    )));
-                }
-            }
-        }
-        Ok(())
+        catch_up_account_commands_with_retry(
+            commands,
+            APP_RUNTIME_ACCOUNT_READY_WAIT,
+            &ACCOUNT_CATCH_UP_TRANSIENT_RETRY_DELAYS,
+        )
+        .await
     }
 
     /// Delete one local JSONL audit log file.

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -2415,6 +2415,115 @@ async fn account_worker_response_deadline_reports_unknown_completion() {
     assert!(matches!(error, AppError::AccountWorkerResponseTimedOut));
 }
 
+fn transient_transport_catch_up_failure() -> AccountCatchUpFailure {
+    AccountCatchUpFailure::new(
+        "runtime catch-up failed: account_transport".into(),
+        SyncFailureClassification::new(
+            SyncFailureStage::TransportActivation,
+            SyncErrorClass::Unknown,
+        ),
+    )
+}
+
+#[tokio::test]
+async fn catch_up_retries_only_the_worker_with_a_transient_transport_failure() {
+    let (flaky_tx, mut flaky_rx) = mpsc::channel(4);
+    let flaky = tokio::spawn(async move {
+        let mut attempts = 0;
+        while let Some(command) = flaky_rx.recv().await {
+            let AccountWorkerCommand::CatchUp { respond } = command else {
+                panic!("unexpected worker command");
+            };
+            attempts += 1;
+            let result = if attempts == 1 {
+                Err(transient_transport_catch_up_failure())
+            } else {
+                Ok(())
+            };
+            let _ = respond.send(result);
+            if attempts == 2 {
+                return attempts;
+            }
+        }
+        attempts
+    });
+    let (healthy_tx, mut healthy_rx) = mpsc::channel(4);
+    let healthy = tokio::spawn(async move {
+        let Some(AccountWorkerCommand::CatchUp { respond }) = healthy_rx.recv().await else {
+            panic!("expected catch-up command");
+        };
+        let _ = respond.send(Ok(()));
+        1
+    });
+
+    catch_up_account_commands_with_retry(
+        vec![flaky_tx, healthy_tx],
+        Duration::from_secs(1),
+        &[Duration::ZERO],
+    )
+    .await
+    .expect("the transient worker should recover");
+
+    assert_eq!(flaky.await.unwrap(), 2);
+    assert_eq!(healthy.await.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn catch_up_returns_after_transient_retry_budget_is_exhausted() {
+    let (worker_tx, mut worker_rx) = mpsc::channel(8);
+    let worker = tokio::spawn(async move {
+        let mut attempts = 0;
+        while let Some(command) = worker_rx.recv().await {
+            let AccountWorkerCommand::CatchUp { respond } = command else {
+                panic!("unexpected worker command");
+            };
+            attempts += 1;
+            let _ = respond.send(Err(transient_transport_catch_up_failure()));
+            if attempts == 3 {
+                return attempts;
+            }
+        }
+        attempts
+    });
+
+    let error = catch_up_account_commands_with_retry(
+        vec![worker_tx],
+        Duration::from_secs(1),
+        &[Duration::ZERO, Duration::ZERO],
+    )
+    .await
+    .expect_err("a permanently failing worker must still surface its error");
+
+    assert!(matches!(error, AppError::AccountCatchUp(_)));
+    assert_eq!(worker.await.unwrap(), 3);
+}
+
+#[tokio::test]
+async fn catch_up_does_not_retry_a_closed_worker_response() {
+    let (worker_tx, mut worker_rx) = mpsc::channel(2);
+    let worker = tokio::spawn(async move {
+        let Some(AccountWorkerCommand::CatchUp { respond }) = worker_rx.recv().await else {
+            panic!("expected catch-up command");
+        };
+        drop(respond);
+
+        if let Ok(Some(_)) = timeout(Duration::from_millis(50), worker_rx.recv()).await {
+            panic!("a closed worker response cannot recover on the same channel");
+        }
+    });
+
+    let error = catch_up_account_commands_with_retry(
+        vec![worker_tx],
+        Duration::from_secs(1),
+        &[Duration::ZERO],
+    )
+    .await
+    .expect_err("a closed worker response must remain terminal");
+
+    assert!(matches!(error, AppError::TransportClosed));
+    worker.await.unwrap();
+}
+
 #[test]
 fn key_package_deletion_relay_failures_dedupe_privacy_safe_publish_endpoint_categories() {
     use crate::KeyPackageDeletionResult;

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -11583,7 +11583,7 @@ fn group_state_invalidated_event_tombstones_origin_commit_system_rows() {
 /// The swept row's terminal outcome is asserted where it is stored, on the row
 /// itself. #1384 deliberately demotes a failed local send out of the chat
 /// preview ("keep failed local sends visible without letting them pin chat
-/// previews", `CHAT_LIST_PREVIEW_ORDER_DESC` in `storage-sqlite/src/chat_list.rs`),
+/// previews", `chat_list_preview_order_desc` in `storage-sqlite/src/chat_list.rs`),
 /// so once a send that did reach the relay exists the preview falls back to it
 /// rather than rendering the swept row's `Failed`. That fallback is asserted
 /// here too, because it is the same thing this test guards: after the sweep
@@ -15138,6 +15138,251 @@ async fn unavailable_send_retries_the_exact_event_after_transport_recovers() {
 }
 
 #[tokio::test]
+async fn connectivity_restored_wakes_a_retained_send_before_the_retry_timer() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("sender")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://send-recovery-wake.example")
+        .with_test_relay_client(relay.clone());
+    let mut setup_client = app.client("sender").await.unwrap();
+    let group_id = setup_client
+        .create_group("send recovery wake", &[])
+        .await
+        .unwrap();
+    drop(setup_client);
+
+    let runtime = MarmotAppRuntime::new(app.clone());
+    runtime.reconcile_accounts().await.unwrap();
+    let attempts_before = relay.attempted_event_ids().len();
+    relay.fail_publishes_as_unavailable();
+
+    for plaintext in ["first wake retained send", "second wake retained send"] {
+        let summary = runtime
+            .send_message("sender", &group_id, plaintext.as_bytes().to_vec())
+            .await
+            .expect("a temporary transport failure must retain the send");
+        assert_eq!(
+            summary.accept_disposition,
+            cgka_traits::SendAcceptDisposition::CompletionUnknown
+        );
+    }
+    let failed_ids = relay.attempted_event_ids()[attempts_before..].to_vec();
+    assert_eq!(failed_ids.len(), 2);
+
+    relay.allow_publishes();
+    runtime
+        .notify_connectivity_restored()
+        .await
+        .expect("the host connectivity signal must reach every account worker");
+
+    let group_id_hex = hex::encode(group_id.as_slice());
+    tokio::time::timeout(std::time::Duration::from_millis(750), async {
+        loop {
+            let timeline = app
+                .timeline_messages_with_query(
+                    "sender",
+                    TimelineMessageQuery {
+                        group_id_hex: Some(group_id_hex.clone()),
+                        ..TimelineMessageQuery::default()
+                    },
+                )
+                .unwrap();
+            if timeline.messages.len() == 2
+                && timeline
+                    .messages
+                    .iter()
+                    .all(|message| message.source_message_id_hex.is_some())
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("connectivity recovery must not wait for the normal 1.1 second convergence timer");
+
+    let published_in_order = relay
+        .published_event_ids()
+        .into_iter()
+        .filter(|event_id| failed_ids.contains(event_id))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        published_in_order, failed_ids,
+        "one recovery wake must finalize retained sends once and in order"
+    );
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn connectivity_restored_during_reconnect_wakes_the_retained_send() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("sender")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://reconnect-send-recovery.example")
+        .with_test_relay_client(relay.clone());
+    let mut setup_client = app.client("sender").await.unwrap();
+    let group_id = setup_client
+        .create_group("reconnect send recovery", &[])
+        .await
+        .unwrap();
+    drop(setup_client);
+
+    let runtime = MarmotAppRuntime::new(app.clone());
+    runtime.reconcile_accounts().await.unwrap();
+    let attempts_before = relay.attempted_event_ids().len();
+    relay.fail_publishes_as_unavailable();
+    let summary = runtime
+        .send_message("sender", &group_id, b"retained across reconnect".to_vec())
+        .await
+        .expect("a temporary transport failure must retain the send");
+    assert_eq!(
+        summary.accept_disposition,
+        cgka_traits::SendAcceptDisposition::CompletionUnknown
+    );
+    let failed_event_id = relay.attempted_event_ids()[attempts_before].clone();
+
+    relay.allow_publishes();
+    runtime
+        .shared_services()
+        .relay_plane()
+        .simulate_notification_recovery_for_test(1);
+    let backoff_deadline = std::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        match runtime.unhydrated_group_count_for_test("sender").await {
+            Err(AppError::TransportClosed) => break,
+            Ok(_) => tokio::task::yield_now().await,
+            Err(error) => panic!("unexpected reconnect probe error: {error:?}"),
+        }
+        assert!(
+            std::time::Instant::now() < backoff_deadline,
+            "account worker did not enter reconnect backoff"
+        );
+    }
+
+    runtime
+        .notify_connectivity_restored()
+        .await
+        .expect("the reconnecting worker must retain the connectivity wake");
+
+    let group_id_hex = hex::encode(group_id.as_slice());
+    tokio::time::timeout(Duration::from_millis(750), async {
+        loop {
+            let timeline = app
+                .timeline_messages_with_query(
+                    "sender",
+                    TimelineMessageQuery {
+                        group_id_hex: Some(group_id_hex.clone()),
+                        ..TimelineMessageQuery::default()
+                    },
+                )
+                .unwrap();
+            if timeline.messages.len() == 1 && timeline.messages[0].source_message_id_hex.is_some()
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("the retained connectivity wake must retry before the normal timer");
+
+    assert_eq!(
+        relay
+            .published_event_ids()
+            .iter()
+            .filter(|event_id| *event_id == &failed_event_id)
+            .count(),
+        1,
+        "reconnect recovery must accept the exact retained event once"
+    );
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn eventless_drain_projects_every_retained_send_it_publishes() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("sender")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://eventless-drain.example")
+        .with_test_relay_client(relay.clone());
+    let mut client = app.client("sender").await.unwrap();
+    let group_id = client.create_group("eventless drain", &[]).await.unwrap();
+    relay.fail_publishes_as_unavailable();
+
+    for plaintext in ["first eventless retained", "second eventless retained"] {
+        let summary = client
+            .send_with_local_projection(&group_id, plaintext.as_bytes(), |_| {})
+            .await
+            .expect("a temporary transport failure must retain the send");
+        assert_eq!(
+            summary.accept_disposition,
+            cgka_traits::SendAcceptDisposition::CompletionUnknown
+        );
+    }
+
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let pending = app
+        .timeline_messages_with_query(
+            "sender",
+            TimelineMessageQuery {
+                group_id_hex: Some(group_id_hex.clone()),
+                ..TimelineMessageQuery::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(pending.messages.len(), 2);
+    assert!(
+        pending
+            .messages
+            .iter()
+            .all(|message| message.source_message_id_hex.is_none())
+    );
+
+    relay.allow_publishes();
+    assert_eq!(
+        client
+            .note_connectivity_restored()
+            .expect("the connectivity edge must wake exact unavailable fanouts"),
+        2
+    );
+    let summary = client
+        .drain_pending_session_events()
+        .await
+        .expect("the eventless drain must resume the durable fanouts");
+    assert_eq!(
+        summary.projection_updates.len(),
+        2,
+        "both pending-to-sent transitions must reach runtime subscribers"
+    );
+
+    let recovered = app
+        .timeline_messages_with_query(
+            "sender",
+            TimelineMessageQuery {
+                group_id_hex: Some(group_id_hex),
+                ..TimelineMessageQuery::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(recovered.messages.len(), 2);
+    assert!(
+        recovered
+            .messages
+            .iter()
+            .all(|message| message.source_message_id_hex.is_some()),
+        "eventless drain publication must persist every pending-to-sent transition"
+    );
+}
+
+#[tokio::test]
 async fn two_unavailable_sends_retry_once_in_order_after_transport_recovers() {
     let dir = tempfile::tempdir().unwrap();
     AccountHome::open(dir.path())
@@ -15245,7 +15490,11 @@ async fn unavailable_group_invite_retries_the_exact_commit_after_transport_recov
         .expect("the invite commit must reach the transport boundary");
 
     relay.allow_publishes();
-    tokio::time::timeout(std::time::Duration::from_secs(12), async {
+    runtime
+        .notify_connectivity_restored()
+        .await
+        .expect("the host connectivity signal must wake the retained invite");
+    tokio::time::timeout(std::time::Duration::from_millis(750), async {
         loop {
             if relay
                 .published_event_ids()
@@ -15258,7 +15507,7 @@ async fn unavailable_group_invite_retries_the_exact_commit_after_transport_recov
         }
     })
     .await
-    .expect("the retained invite commit must finalize after connectivity returns");
+    .expect("the retained invite commit must finalize without waiting for its retry timer");
 
     assert_eq!(
         runtime

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -13324,6 +13324,7 @@ async fn a_publish_failure_after_scheduled_convergence_still_arms_recovery() {
 #[derive(Clone, Copy)]
 enum MixedPublishObservation {
     DirectSend,
+    DirectSendCurrentFailed,
     Drained,
     Scheduled,
     Retry,
@@ -13389,6 +13390,14 @@ async fn assert_mixed_publish_batch_finalizes_successful_message(
                 client.pending_projection_updates.extend(updates);
                 Ok(SyncSummary::default())
             }),
+        MixedPublishObservation::DirectSendCurrentFailed => client
+            .observe_recovery_evidence_then_gate_send_publish(
+                &effects,
+                &group_id,
+                "failed-current-message",
+            )
+            .await
+            .map(|()| SyncSummary::default()),
         MixedPublishObservation::Drained => client.observe_drained_session_events(&effects).await,
         MixedPublishObservation::Scheduled => {
             client
@@ -13442,6 +13451,14 @@ async fn assert_mixed_publish_batch_finalizes_successful_message(
 async fn direct_send_mixed_batch_preserves_the_current_delivered_message() {
     assert_mixed_publish_batch_finalizes_successful_message(MixedPublishObservation::DirectSend)
         .await;
+}
+
+#[tokio::test]
+async fn direct_send_mixed_batch_finalizes_successful_sibling_before_current_error() {
+    assert_mixed_publish_batch_finalizes_successful_message(
+        MixedPublishObservation::DirectSendCurrentFailed,
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -13438,6 +13438,85 @@ async fn retry_mixed_publish_batch_finalizes_success_before_failure() {
     assert_mixed_publish_batch_finalizes_successful_message(MixedPublishObservation::Retry).await;
 }
 
+#[tokio::test]
+#[cfg(feature = "test-policy-overrides")]
+async fn published_message_delivery_update_survives_acknowledgement_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let config = MarmotAppConfig::default().with_dev_fail_published_app_message_acknowledgement();
+    let app = MarmotApp::with_relay_and_config(
+        dir.path(),
+        "wss://ack-failure.example".to_owned(),
+        config,
+    )
+    .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client
+        .create_group("acknowledgement failure", &[])
+        .await
+        .unwrap();
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let app_event_id = "delivered-before-acknowledgement";
+
+    app.record_account_app_event(
+        "alice",
+        &AppMessageProjection {
+            message_id_hex: app_event_id.to_owned(),
+            source_message_id_hex: None,
+            direction: "sent".to_owned(),
+            group_id_hex: group_id_hex.clone(),
+            sender: account.account_id_hex,
+            plaintext: "delivery survives cleanup failure".to_owned(),
+            kind: MARMOT_APP_EVENT_KIND_CHAT,
+            tags: Vec::new(),
+            source_epoch: Some(1),
+            retention: None,
+            recorded_at: Some(10),
+            origin_commit_id: None,
+            moderation_grant: false,
+        },
+    )
+    .unwrap();
+
+    let published_message_id = cgka_traits::MessageId::new(vec![0xac; 32]);
+    let effects = marmot_account::AccountDeviceEffects {
+        published_app_messages: vec![marmot_account::PublishedApplicationMessage {
+            group_id,
+            app_event_id: app_event_id.to_owned(),
+            message_id: published_message_id.clone(),
+            source_epoch: cgka_traits::EpochId(1),
+            retention: AppMessageRetentionDecision::new(10, 0),
+        }],
+        ..Default::default()
+    };
+
+    let summary = client
+        .observe_drained_session_events(&effects)
+        .await
+        .expect("fanout cleanup failure must not hide a committed delivery update");
+    assert_eq!(summary.projection_updates.len(), 1);
+
+    let row = app
+        .timeline_messages_with_query(
+            "alice",
+            storage_sqlite::TimelineMessageQuery {
+                group_id_hex: Some(group_id_hex),
+                ..storage_sqlite::TimelineMessageQuery::default()
+            },
+        )
+        .unwrap()
+        .messages
+        .into_iter()
+        .find(|message| message.message_id_hex == app_event_id)
+        .expect("the finalized local message remains in the timeline");
+    assert_eq!(
+        row.source_message_id_hex,
+        Some(hex::encode(published_message_id.as_slice()))
+    );
+}
+
 /// A resource refusal carried by a host-requested convergence retry must arm
 /// epoch-gap recovery even when that same pass's publish check fails it.
 ///

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -13343,6 +13343,8 @@ async fn assert_mixed_publish_batch_finalizes_successful_message(
     let group_id = client.create_group("mixed publish", &[]).await.unwrap();
     let group_id_hex = hex::encode(group_id.as_slice());
     let app_event_id = "successful-app-message";
+    let failed_app_event_id = "failed-app-message";
+    let local_account_id_hex = account.account_id_hex;
 
     app.record_account_app_event(
         "alice",
@@ -13351,7 +13353,7 @@ async fn assert_mixed_publish_batch_finalizes_successful_message(
             source_message_id_hex: None,
             direction: "sent".to_owned(),
             group_id_hex: group_id_hex.clone(),
-            sender: account.account_id_hex,
+            sender: local_account_id_hex.clone(),
             plaintext: "successful sibling publish".to_owned(),
             kind: MARMOT_APP_EVENT_KIND_CHAT,
             tags: Vec::new(),
@@ -13363,8 +13365,28 @@ async fn assert_mixed_publish_batch_finalizes_successful_message(
         },
     )
     .unwrap();
+    app.record_account_app_event(
+        "alice",
+        &AppMessageProjection {
+            message_id_hex: failed_app_event_id.to_owned(),
+            source_message_id_hex: None,
+            direction: "sent".to_owned(),
+            group_id_hex: group_id_hex.clone(),
+            sender: local_account_id_hex,
+            plaintext: "failed sibling publish".to_owned(),
+            kind: MARMOT_APP_EVENT_KIND_CHAT,
+            tags: Vec::new(),
+            source_epoch: Some(1),
+            retention: None,
+            recorded_at: Some(11),
+            origin_commit_id: None,
+            moderation_grant: false,
+        },
+    )
+    .unwrap();
 
     let published_message_id = cgka_traits::MessageId::new(vec![0xcd; 32]);
+    let failed_message_id = cgka_traits::MessageId::new(vec![0xee; 32]);
     let retention = AppMessageRetentionDecision::new(10, 0);
     let effects = marmot_account::AccountDeviceEffects {
         published_app_messages: vec![marmot_account::PublishedApplicationMessage {
@@ -13375,7 +13397,13 @@ async fn assert_mixed_publish_batch_finalizes_successful_message(
             retention,
         }],
         failures: vec![marmot_account::PublishFailure {
-            message_id: cgka_traits::MessageId::new(vec![0xee; 32]),
+            message_id: failed_message_id.clone(),
+            reason: "unrelated sibling publish failed".to_owned(),
+        }],
+        failed_app_messages: vec![marmot_account::FailedApplicationMessage {
+            group_id: group_id.clone(),
+            app_event_id: failed_app_event_id.to_owned(),
+            message_id: failed_message_id,
             reason: "unrelated sibling publish failed".to_owned(),
         }],
         ..Default::default()
@@ -13421,15 +13449,15 @@ async fn assert_mixed_publish_batch_finalizes_successful_message(
     }
     assert_eq!(
         client.take_pending_projection_updates().len(),
-        1,
-        "a committed pending-to-sent flip must remain available for runtime broadcast after the batch errors"
+        2,
+        "the delivered and failed sibling updates must remain available for runtime broadcast"
     );
 
     let row = app
         .timeline_messages_with_query(
             "alice",
             storage_sqlite::TimelineMessageQuery {
-                group_id_hex: Some(group_id_hex),
+                group_id_hex: Some(group_id_hex.clone()),
                 ..storage_sqlite::TimelineMessageQuery::default()
             },
         )
@@ -13445,6 +13473,24 @@ async fn assert_mixed_publish_batch_finalizes_successful_message(
     );
     assert_eq!(row.source_epoch, Some(1));
     assert_eq!(row.retention_seconds, Some(retention.retention_seconds));
+    let failed_row = app
+        .timeline_messages_with_query(
+            "alice",
+            storage_sqlite::TimelineMessageQuery {
+                group_id_hex: Some(group_id_hex),
+                ..storage_sqlite::TimelineMessageQuery::default()
+            },
+        )
+        .unwrap()
+        .messages
+        .into_iter()
+        .find(|message| message.message_id_hex == failed_app_event_id)
+        .expect("failed sibling remains visible in the timeline");
+    assert_eq!(
+        failed_row.invalidation_status.as_deref(),
+        Some(crate::LOCAL_PUBLISH_FAILED_REASON),
+        "a terminally failed sibling must leave Sending without failing the delivered current send"
+    );
 }
 
 #[tokio::test]

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -268,6 +268,7 @@ fn legacy_inline_group_image_create_rejects_oversized_input_before_canonical_cre
 pub(crate) struct ScriptedPushRelayClient {
     publish_results: std::sync::Mutex<std::collections::VecDeque<bool>>,
     published_events: std::sync::Mutex<Vec<NostrTransportEvent>>,
+    attempted_events: std::sync::Mutex<Vec<NostrTransportEvent>>,
     subscriptions: std::sync::Mutex<Vec<NostrSubscription>>,
     subscription_attempts: std::sync::Mutex<Vec<NostrSubscription>>,
     block_next_subscribe: std::sync::atomic::AtomicBool,
@@ -284,6 +285,7 @@ pub(crate) struct ScriptedPushRelayClient {
     block_account_subscribe: std::sync::Mutex<Option<Vec<u8>>>,
     block_account_group_subscribe: std::sync::Mutex<Option<Vec<u8>>>,
     zero_ack_next_publish: std::sync::atomic::AtomicBool,
+    fail_publish_unavailable: std::sync::atomic::AtomicBool,
     fail_publish_kind: std::sync::Mutex<Option<u64>>,
     batch_calls: std::sync::atomic::AtomicUsize,
     publish_started: tokio::sync::Notify,
@@ -357,6 +359,15 @@ impl ScriptedPushRelayClient {
 
     fn published_event_ids(&self) -> Vec<String> {
         self.published_events
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|event| event.id.clone())
+            .collect()
+    }
+
+    fn attempted_event_ids(&self) -> Vec<String> {
+        self.attempted_events
             .lock()
             .unwrap()
             .iter()
@@ -467,6 +478,16 @@ impl ScriptedPushRelayClient {
     fn zero_ack_next_publish(&self) {
         self.zero_ack_next_publish
             .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    fn fail_publishes_as_unavailable(&self) {
+        self.fail_publish_unavailable
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    fn allow_publishes(&self) {
+        self.fail_publish_unavailable
+            .store(false, std::sync::atomic::Ordering::SeqCst);
     }
 
     fn fail_publishes_of_kind(&self, kind: u64) {
@@ -661,6 +682,27 @@ impl NostrRelayClient for ScriptedPushRelayClient {
         event: &NostrTransportEvent,
         _required_acks: usize,
     ) -> Result<NostrPublishOutcome, cgka_traits::TransportAdapterError> {
+        self.attempted_events.lock().unwrap().push(event.clone());
+        if self
+            .fail_publish_unavailable
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            return Err(cgka_traits::TransportAdapterError::PublishEndpoints(
+                cgka_traits::TransportPublishFailure::with_endpoint_failures(
+                    "relay unavailable",
+                    endpoints
+                        .iter()
+                        .cloned()
+                        .map(|endpoint| cgka_traits::TransportEndpointFailure {
+                            endpoint,
+                            reason: "relay unavailable".into(),
+                            kind: cgka_traits::TransportEndpointFailureKind::RetryableUnavailable,
+                            rejection_category: None,
+                        })
+                        .collect(),
+                ),
+            ));
+        }
         let block_counted_publish = self
             .block_publish_count
             .fetch_update(
@@ -14988,6 +15030,253 @@ async fn a_send_that_reaches_the_transport_reports_published() {
         summary.accept_disposition,
         cgka_traits::SendAcceptDisposition::Published,
         "the message reached the transport, so nothing is being held"
+    );
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn unavailable_send_retries_the_exact_event_after_transport_recovers() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("sender")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://send-recovery.example")
+        .with_test_relay_client(relay.clone());
+    let mut setup_client = app.client("sender").await.unwrap();
+    let group_id = setup_client
+        .create_group("send recovery", &[])
+        .await
+        .unwrap();
+    drop(setup_client);
+
+    let runtime = MarmotAppRuntime::new(app.clone());
+    runtime.reconcile_accounts().await.unwrap();
+    let attempts_before = relay.attempted_event_ids().len();
+    relay.fail_publishes_as_unavailable();
+
+    let summary = runtime
+        .send_message("sender", &group_id, b"recover exact event".to_vec())
+        .await
+        .expect("a temporary transport failure must retain the send");
+    assert_eq!(
+        summary.accept_disposition,
+        cgka_traits::SendAcceptDisposition::CompletionUnknown
+    );
+    let failed_event_id = relay
+        .attempted_event_ids()
+        .get(attempts_before)
+        .cloned()
+        .expect("the initial transport attempt must expose its signed event id");
+
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let pending = app
+        .timeline_messages_with_query(
+            "sender",
+            TimelineMessageQuery {
+                group_id_hex: Some(group_id_hex.clone()),
+                ..TimelineMessageQuery::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(pending.messages.len(), 1);
+    assert!(pending.messages[0].source_message_id_hex.is_none());
+    assert!(pending.messages[0].invalidation_status.is_none());
+
+    relay.allow_publishes();
+    let recovery = tokio::time::timeout(std::time::Duration::from_secs(12), async {
+        loop {
+            let timeline = app
+                .timeline_messages_with_query(
+                    "sender",
+                    TimelineMessageQuery {
+                        group_id_hex: Some(group_id_hex.clone()),
+                        ..TimelineMessageQuery::default()
+                    },
+                )
+                .unwrap();
+            if timeline.messages[0].source_message_id_hex.is_some() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+    })
+    .await;
+    assert!(
+        recovery.is_ok(),
+        "the retained send must publish promptly after connectivity returns; attempts={:?}; published={:?}",
+        relay.attempted_event_ids(),
+        relay.published_event_ids()
+    );
+
+    let recovered = app
+        .timeline_messages_with_query(
+            "sender",
+            TimelineMessageQuery {
+                group_id_hex: Some(group_id_hex),
+                ..TimelineMessageQuery::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(
+        recovered.messages[0].source_message_id_hex.as_deref(),
+        Some(failed_event_id.as_str()),
+        "recovery must reuse the exact signed transport event"
+    );
+    assert_eq!(
+        relay
+            .published_event_ids()
+            .iter()
+            .filter(|event_id| *event_id == &failed_event_id)
+            .count(),
+        1,
+        "the retained event must be accepted exactly once"
+    );
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn two_unavailable_sends_retry_once_in_order_after_transport_recovers() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("sender")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://ordered-recovery.example")
+        .with_test_relay_client(relay.clone());
+    let mut setup_client = app.client("sender").await.unwrap();
+    let group_id = setup_client
+        .create_group("ordered recovery", &[])
+        .await
+        .unwrap();
+    drop(setup_client);
+
+    let runtime = MarmotAppRuntime::new(app.clone());
+    runtime.reconcile_accounts().await.unwrap();
+    let attempts_before = relay.attempted_event_ids().len();
+    relay.fail_publishes_as_unavailable();
+
+    for plaintext in ["first retained", "second retained"] {
+        let summary = runtime
+            .send_message("sender", &group_id, plaintext.as_bytes().to_vec())
+            .await
+            .expect("each temporary failure must remain accepted");
+        assert_eq!(
+            summary.accept_disposition,
+            cgka_traits::SendAcceptDisposition::CompletionUnknown
+        );
+    }
+    let failed_ids = relay.attempted_event_ids()[attempts_before..].to_vec();
+    assert_eq!(failed_ids.len(), 2);
+
+    relay.allow_publishes();
+    let group_id_hex = hex::encode(group_id.as_slice());
+    tokio::time::timeout(std::time::Duration::from_secs(12), async {
+        loop {
+            let timeline = app
+                .timeline_messages_with_query(
+                    "sender",
+                    TimelineMessageQuery {
+                        group_id_hex: Some(group_id_hex.clone()),
+                        ..TimelineMessageQuery::default()
+                    },
+                )
+                .unwrap();
+            if timeline.messages.len() == 2
+                && timeline
+                    .messages
+                    .iter()
+                    .all(|message| message.source_message_id_hex.is_some())
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("one recovered drain must finalize both retained sends");
+
+    let published_in_order = relay
+        .published_event_ids()
+        .into_iter()
+        .filter(|event_id| failed_ids.contains(event_id))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        published_in_order, failed_ids,
+        "recovery must accept each exact event once in original send order"
+    );
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn unavailable_group_invite_retries_the_exact_commit_after_transport_recovers() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    home.create_account("sender").unwrap();
+    let invited = home.create_account("invited").unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://invite-recovery.example")
+        .with_test_relay_client(relay.clone());
+    let runtime = MarmotAppRuntime::new(app);
+    runtime.reconcile_accounts().await.unwrap();
+    runtime.catch_up_accounts().await.unwrap();
+    let group_id = runtime
+        .create_group("sender", "invite recovery", &[], None)
+        .await
+        .unwrap();
+
+    let attempts_before = relay.attempted_event_ids().len();
+    relay.fail_publishes_as_unavailable();
+    let summary = runtime
+        .invite_members("sender", &group_id, &[invited.account_id_hex])
+        .await
+        .expect("a temporary invite publish failure must retain the exact commit");
+    assert_eq!(
+        summary.accept_disposition,
+        cgka_traits::SendAcceptDisposition::CompletionUnknown
+    );
+    let failed_commit_id = relay
+        .attempted_event_ids()
+        .get(attempts_before)
+        .cloned()
+        .expect("the invite commit must reach the transport boundary");
+
+    relay.allow_publishes();
+    tokio::time::timeout(std::time::Duration::from_secs(12), async {
+        loop {
+            if relay
+                .published_event_ids()
+                .iter()
+                .any(|event_id| event_id == &failed_commit_id)
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("the retained invite commit must finalize after connectivity returns");
+
+    assert_eq!(
+        runtime
+            .group_members("sender", &group_id)
+            .await
+            .expect("the confirmed group remains readable")
+            .len(),
+        2
+    );
+
+    assert_eq!(
+        relay
+            .published_event_ids()
+            .iter()
+            .filter(|event_id| *event_id == &failed_commit_id)
+            .count(),
+        1,
+        "group recovery must accept the original commit exactly once"
     );
 
     runtime.shutdown().await;

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -13394,6 +13394,11 @@ async fn assert_mixed_publish_batch_finalizes_successful_message(
         result.is_err(),
         "the unrelated hard failure must still surface"
     );
+    assert_eq!(
+        client.take_pending_projection_updates().len(),
+        1,
+        "a committed pending-to-sent flip must remain available for runtime broadcast after the batch errors"
+    );
 
     let row = app
         .timeline_messages_with_query(
@@ -15473,6 +15478,15 @@ async fn eventless_drain_projects_every_retained_send_it_publishes() {
         summary.projection_updates.len(),
         2,
         "both pending-to-sent transitions must reach runtime subscribers"
+    );
+    assert!(
+        client
+            .runtime
+            .session()
+            .outbound_fanouts()
+            .unwrap()
+            .is_empty(),
+        "durably projected publications must acknowledge and retire their recovery fanouts"
     );
 
     let recovered = app

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -15788,7 +15788,11 @@ async fn unavailable_group_invite_retries_the_exact_commit_after_transport_recov
         .notify_connectivity_restored()
         .await
         .expect("the host connectivity signal must wake the retained invite");
-    tokio::time::timeout(std::time::Duration::from_millis(750), async {
+    // Keep the end-to-end allowance below the five-second unavailable-target
+    // backoff while leaving enough headroom for MLS and SQLite work on a busy
+    // CI runner. The scheduler's immediate deadline reset is covered
+    // deterministically in `connectivity_restore_wakes_pending_outbound_before_durable_cutoff`.
+    tokio::time::timeout(std::time::Duration::from_secs(3), async {
         loop {
             if relay
                 .published_event_ids()

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -13321,6 +13321,118 @@ async fn a_publish_failure_after_scheduled_convergence_still_arms_recovery() {
     );
 }
 
+#[derive(Clone, Copy)]
+enum MixedPublishObservation {
+    Drained,
+    Scheduled,
+    Retry,
+}
+
+async fn assert_mixed_publish_batch_finalizes_successful_message(
+    observation: MixedPublishObservation,
+) {
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://mixed-publish.example")
+        .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client.create_group("mixed publish", &[]).await.unwrap();
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let app_event_id = "successful-app-message";
+
+    app.record_account_app_event(
+        "alice",
+        &AppMessageProjection {
+            message_id_hex: app_event_id.to_owned(),
+            source_message_id_hex: None,
+            direction: "sent".to_owned(),
+            group_id_hex: group_id_hex.clone(),
+            sender: account.account_id_hex,
+            plaintext: "successful sibling publish".to_owned(),
+            kind: MARMOT_APP_EVENT_KIND_CHAT,
+            tags: Vec::new(),
+            source_epoch: Some(1),
+            retention: None,
+            recorded_at: Some(10),
+            origin_commit_id: None,
+            moderation_grant: false,
+        },
+    )
+    .unwrap();
+
+    let published_message_id = cgka_traits::MessageId::new(vec![0xcd; 32]);
+    let retention = AppMessageRetentionDecision::new(10, 0);
+    let effects = marmot_account::AccountDeviceEffects {
+        published_app_messages: vec![marmot_account::PublishedApplicationMessage {
+            group_id: group_id.clone(),
+            app_event_id: app_event_id.to_owned(),
+            message_id: published_message_id.clone(),
+            source_epoch: cgka_traits::EpochId(1),
+            retention,
+        }],
+        failures: vec![marmot_account::PublishFailure {
+            message_id: cgka_traits::MessageId::new(vec![0xee; 32]),
+            reason: "unrelated sibling publish failed".to_owned(),
+        }],
+        ..Default::default()
+    };
+
+    let result = match observation {
+        MixedPublishObservation::Drained => client.observe_drained_session_events(&effects).await,
+        MixedPublishObservation::Scheduled => {
+            client
+                .observe_scheduled_convergence_effects(&group_id, &effects)
+                .await
+        }
+        MixedPublishObservation::Retry => client
+            .observe_convergence_retry_effects(&group_id, &effects)
+            .map(|_| SyncSummary::default()),
+    };
+    assert!(
+        result.is_err(),
+        "the unrelated hard failure must still surface"
+    );
+
+    let row = app
+        .timeline_messages_with_query(
+            "alice",
+            storage_sqlite::TimelineMessageQuery {
+                group_id_hex: Some(group_id_hex),
+                ..storage_sqlite::TimelineMessageQuery::default()
+            },
+        )
+        .unwrap()
+        .messages
+        .into_iter()
+        .find(|message| message.message_id_hex == app_event_id)
+        .expect("successful local message remains in the timeline");
+    assert_eq!(
+        row.source_message_id_hex,
+        Some(hex::encode(published_message_id.as_slice())),
+        "the successful sibling must leave Sending before the batch errors"
+    );
+    assert_eq!(row.source_epoch, Some(1));
+    assert_eq!(row.retention_seconds, Some(retention.retention_seconds));
+}
+
+#[tokio::test]
+async fn drained_mixed_publish_batch_finalizes_success_before_failure() {
+    assert_mixed_publish_batch_finalizes_successful_message(MixedPublishObservation::Drained).await;
+}
+
+#[tokio::test]
+async fn scheduled_mixed_publish_batch_finalizes_success_before_failure() {
+    assert_mixed_publish_batch_finalizes_successful_message(MixedPublishObservation::Scheduled)
+        .await;
+}
+
+#[tokio::test]
+async fn retry_mixed_publish_batch_finalizes_success_before_failure() {
+    assert_mixed_publish_batch_finalizes_successful_message(MixedPublishObservation::Retry).await;
+}
+
 /// A resource refusal carried by a host-requested convergence retry must arm
 /// epoch-gap recovery even when that same pass's publish check fails it.
 ///

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -13323,6 +13323,7 @@ async fn a_publish_failure_after_scheduled_convergence_still_arms_recovery() {
 
 #[derive(Clone, Copy)]
 enum MixedPublishObservation {
+    DirectSend,
     Drained,
     Scheduled,
     Retry,
@@ -13380,6 +13381,14 @@ async fn assert_mixed_publish_batch_finalizes_successful_message(
     };
 
     let result = match observation {
+        MixedPublishObservation::DirectSend => client
+            .observe_recovery_evidence_then_gate_send_publish(&effects, &group_id, app_event_id)
+            .await
+            .and_then(|()| {
+                let updates = client.finalize_published_app_message_source_retention(&effects)?;
+                client.pending_projection_updates.extend(updates);
+                Ok(SyncSummary::default())
+            }),
         MixedPublishObservation::Drained => client.observe_drained_session_events(&effects).await,
         MixedPublishObservation::Scheduled => {
             client
@@ -13390,10 +13399,17 @@ async fn assert_mixed_publish_batch_finalizes_successful_message(
             .observe_convergence_retry_effects(&group_id, &effects)
             .map(|_| SyncSummary::default()),
     };
-    assert!(
-        result.is_err(),
-        "the unrelated hard failure must still surface"
-    );
+    if matches!(observation, MixedPublishObservation::DirectSend) {
+        assert!(
+            result.is_ok(),
+            "an unrelated sibling failure must not fail the current delivered send"
+        );
+    } else {
+        assert!(
+            result.is_err(),
+            "the unrelated hard failure must still surface to aggregate observers"
+        );
+    }
     assert_eq!(
         client.take_pending_projection_updates().len(),
         1,
@@ -13423,6 +13439,12 @@ async fn assert_mixed_publish_batch_finalizes_successful_message(
 }
 
 #[tokio::test]
+async fn direct_send_mixed_batch_preserves_the_current_delivered_message() {
+    assert_mixed_publish_batch_finalizes_successful_message(MixedPublishObservation::DirectSend)
+        .await;
+}
+
+#[tokio::test]
 async fn drained_mixed_publish_batch_finalizes_success_before_failure() {
     assert_mixed_publish_batch_finalizes_successful_message(MixedPublishObservation::Drained).await;
 }
@@ -13440,63 +13462,70 @@ async fn retry_mixed_publish_batch_finalizes_success_before_failure() {
 
 #[tokio::test]
 #[cfg(feature = "test-policy-overrides")]
-async fn published_message_delivery_update_survives_acknowledgement_failure() {
+async fn published_message_acknowledgement_failure_retries_cleanup_without_republishing() {
     let dir = tempfile::tempdir().unwrap();
-    let account = AccountHome::open(dir.path())
+    AccountHome::open(dir.path())
         .create_account("alice")
         .unwrap();
     let config = MarmotAppConfig::default().with_dev_fail_published_app_message_acknowledgement();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
     let app = MarmotApp::with_relay_and_config(
         dir.path(),
         "wss://ack-failure.example".to_owned(),
         config,
     )
-    .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+    .with_test_relay_client(relay.clone());
     let mut client = app.client("alice").await.unwrap();
     let group_id = client
         .create_group("acknowledgement failure", &[])
         .await
         .unwrap();
     let group_id_hex = hex::encode(group_id.as_slice());
-    let app_event_id = "delivered-before-acknowledgement";
-
-    app.record_account_app_event(
-        "alice",
-        &AppMessageProjection {
-            message_id_hex: app_event_id.to_owned(),
-            source_message_id_hex: None,
-            direction: "sent".to_owned(),
-            group_id_hex: group_id_hex.clone(),
-            sender: account.account_id_hex,
-            plaintext: "delivery survives cleanup failure".to_owned(),
-            kind: MARMOT_APP_EVENT_KIND_CHAT,
-            tags: Vec::new(),
-            source_epoch: Some(1),
-            retention: None,
-            recorded_at: Some(10),
-            origin_commit_id: None,
-            moderation_grant: false,
-        },
-    )
-    .unwrap();
-
-    let published_message_id = cgka_traits::MessageId::new(vec![0xac; 32]);
-    let effects = marmot_account::AccountDeviceEffects {
-        published_app_messages: vec![marmot_account::PublishedApplicationMessage {
-            group_id,
-            app_event_id: app_event_id.to_owned(),
-            message_id: published_message_id.clone(),
-            source_epoch: cgka_traits::EpochId(1),
-            retention: AppMessageRetentionDecision::new(10, 0),
-        }],
-        ..Default::default()
-    };
+    let publish_attempts_before = relay.attempted_event_ids().len();
 
     let summary = client
-        .observe_drained_session_events(&effects)
+        .send(&group_id, b"delivery survives cleanup failure")
         .await
-        .expect("fanout cleanup failure must not hide a committed delivery update");
-    assert_eq!(summary.projection_updates.len(), 1);
+        .expect("cleanup failure must not hide an accepted message");
+    assert_eq!(
+        summary.accept_disposition,
+        cgka_traits::SendAcceptDisposition::Published
+    );
+    let app_event_id = summary.message_ids[0].clone();
+    assert_eq!(
+        client.runtime.session().outbound_fanouts().unwrap().len(),
+        1,
+        "the accepted fanout must remain durable after the injected acknowledgement failure"
+    );
+    assert!(
+        client.take_pending_convergence_groups().contains(&group_id),
+        "acknowledgement failure must create its own cleanup scheduling edge"
+    );
+    assert!(matches!(
+        client.convergence_schedule_state(&group_id).unwrap(),
+        ConvergenceScheduleState::PendingOutbound {
+            retry_after_ms: None
+        }
+    ));
+
+    client
+        .retry_group_convergence(&group_id)
+        .await
+        .expect("the autonomous cleanup replay must succeed after the one-shot fault");
+    assert!(
+        client
+            .runtime
+            .session()
+            .outbound_fanouts()
+            .unwrap()
+            .is_empty(),
+        "the replayed publication metadata must be acknowledged and retired"
+    );
+    assert_eq!(
+        relay.attempted_event_ids().len(),
+        publish_attempts_before + 1,
+        "cleanup retry must not republish the already-accepted network event"
+    );
 
     let row = app
         .timeline_messages_with_query(
@@ -13511,10 +13540,7 @@ async fn published_message_delivery_update_survives_acknowledgement_failure() {
         .into_iter()
         .find(|message| message.message_id_hex == app_event_id)
         .expect("the finalized local message remains in the timeline");
-    assert_eq!(
-        row.source_message_id_hex,
-        Some(hex::encode(published_message_id.as_slice()))
-    );
+    assert!(row.source_message_id_hex.is_some());
 }
 
 /// A resource refusal carried by a host-requested convergence retry must arm
@@ -13612,7 +13638,7 @@ async fn a_publish_failure_on_the_send_path_still_arms_recovery() {
 
     let effects = a_refusal_riding_a_rolled_back_publish(&group_id);
     let result = client
-        .observe_recovery_evidence_then_gate_send_publish(&effects)
+        .observe_recovery_evidence_then_gate_send_publish(&effects, &group_id, "current-send")
         .await;
 
     assert!(
@@ -13652,7 +13678,7 @@ async fn a_confirmed_but_partial_send_publish_still_passes_the_arming_gate() {
 
     let effects = a_refusal_riding_a_confirmed_but_partial_publish(&group_id);
     let result = client
-        .observe_recovery_evidence_then_gate_send_publish(&effects)
+        .observe_recovery_evidence_then_gate_send_publish(&effects, &group_id, "current-send")
         .await;
 
     assert!(

--- a/crates/marmot-c/CHANGELOG.md
+++ b/crates/marmot-c/CHANGELOG.md
@@ -9,6 +9,8 @@ Versions track the workspace version; releases are tagged `marmotc-v<version>`.
 
 ### Added
 
+- `marmot_notify_connectivity_restored`, allowing C hosts to wake durable
+  outbound retries immediately after usable connectivity returns.
 - Initial C ABI over `marmot-uniffi`: client lifecycle, accounts, groups,
   messaging, media, notifications, push, relays/telemetry, audit logs,
   timeline reads, Markdown parsing, and the 8 subscription surfaces with

--- a/crates/marmot-c/include/marmot.h
+++ b/crates/marmot-c/include/marmot.h
@@ -4454,6 +4454,18 @@ MarmotStatus marmot_retry_hydrate_quarantined_group(const struct MarmotClient *c
                                                     bool *out);
 
 /**
+ * Interrupt retry backoff for durable outbound work after the host has
+ * observed usable connectivity.
+ *
+ * # Safety
+ * `client` must be a live handle; string arguments must be valid
+ * NUL-terminated strings (nullable ones may be NULL); array
+ * arguments must hold their stated length (or be NULL with
+ * length 0); out-pointers must be valid.
+ */
+MarmotStatus marmot_notify_connectivity_restored(const struct MarmotClient *client);
+
+/**
  * Flag a group archived (or restore it). Local-only projection
  * state. Free with `marmot_app_group_record_free`.
  *

--- a/crates/marmot-c/src/commands.rs
+++ b/crates/marmot-c/src/commands.rs
@@ -712,6 +712,10 @@ c_cmd! {
     /// quarantined. Unknown-group status if the id is not quarantined.
     async fn marmot_retry_hydrate_quarantined_group(account_ref: str, group_id_hex: str) -> scalar(bool) = retry_hydrate_quarantined_group;
 
+    /// Interrupt retry backoff for durable outbound work after the host has
+    /// observed usable connectivity.
+    async fn marmot_notify_connectivity_restored() -> unit = notify_connectivity_restored;
+
     /// Flag a group archived (or restore it). Local-only projection
     /// state. Free with `marmot_app_group_record_free`.
     async fn marmot_set_group_archived(account_ref: str, group_id_hex: str, archived: flag) -> rec(MarmotAppGroupRecord) = set_group_archived;

--- a/crates/marmot-uniffi/src/commands/notification.rs
+++ b/crates/marmot-uniffi/src/commands/notification.rs
@@ -47,6 +47,14 @@ impl Marmot {
         Ok(())
     }
 
+    /// Interrupt retry backoff for durable outbound work after the host has
+    /// observed usable connectivity. This is a scheduling signal only; it does
+    /// not recreate application events or weaken exact-replay guarantees.
+    pub async fn notify_connectivity_restored(&self) -> Result<(), MarmotKitError> {
+        self.runtime.notify_connectivity_restored().await?;
+        Ok(())
+    }
+
     pub async fn collect_notifications_after_wake(
         &self,
         max_wait_ms: u32,

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -1021,7 +1021,6 @@ pub(crate) fn chat_list_preview_order_desc(column_prefix: &str) -> String {
          END DESC,
          CASE
             WHEN {column_prefix}direction = 'sent'
-             AND {column_prefix}source_epoch IS NULL
              AND {column_prefix}source_message_id_hex IS NULL
              AND {column_prefix}invalidation_status IS NULL
              AND NOT EXISTS (
@@ -1035,7 +1034,6 @@ pub(crate) fn chat_list_preview_order_desc(column_prefix: &str) -> String {
                   AND accepted.invalidation_status IS NULL
                   AND NOT (
                       accepted.direction = 'sent'
-                      AND accepted.source_epoch IS NULL
                       AND accepted.source_message_id_hex IS NULL
                   )
                   AND accepted_source.insert_order > COALESCE((
@@ -1046,7 +1044,6 @@ pub(crate) fn chat_list_preview_order_desc(column_prefix: &str) -> String {
                   ), -1)
              ) THEN 2
             WHEN {column_prefix}direction = 'sent'
-             AND {column_prefix}source_epoch IS NULL
              AND {column_prefix}source_message_id_hex IS NULL
              AND {column_prefix}invalidation_status IS NULL THEN 0
             ELSE 1

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -1002,6 +1002,55 @@ pub(crate) fn chat_list_activity_filter_sql(column_prefix: &str) -> String {
     )
 }
 
+fn accepted_activity_insert_order_high_water_sql(group_id_expression: &str) -> String {
+    let accepted_activity_filter = chat_list_activity_filter_sql("accepted.");
+    format!(
+        "MAX(
+            COALESCE((
+                SELECT boundary.accepted_activity_insert_order
+                FROM chat_list_rows AS boundary
+                WHERE boundary.group_id_hex = {group_id_expression}
+            ), 0),
+            COALESCE((
+                SELECT MAX(accepted_source.insert_order)
+                FROM message_timeline AS accepted
+                JOIN app_events AS accepted_source
+                  ON accepted_source.group_id_hex = accepted.group_id_hex
+                 AND accepted_source.message_id_hex = accepted.message_id_hex
+                WHERE accepted.group_id_hex = {group_id_expression}
+                  AND {accepted_activity_filter}
+                  AND accepted.invalidation_status IS NULL
+                  AND NOT (
+                      accepted.direction = 'sent'
+                      AND accepted.source_message_id_hex IS NULL
+                  )
+            ), 0)
+         )"
+    )
+}
+
+/// SQL predicate excluding a pending local preview after later accepted
+/// activity has durably displaced it. The live accepted-row maximum covers a
+/// first rebuild; the persisted high-water mark preserves the decision after
+/// secure pruning removes that evidence.
+pub(crate) fn chat_list_preview_eligibility_sql(column_prefix: &str) -> String {
+    let accepted_high_water =
+        accepted_activity_insert_order_high_water_sql(&format!("{column_prefix}group_id_hex"));
+    format!(
+        "NOT (
+            {column_prefix}direction = 'sent'
+            AND {column_prefix}source_message_id_hex IS NULL
+            AND {column_prefix}invalidation_status IS NULL
+            AND COALESCE((
+                SELECT current_source.insert_order
+                FROM app_events AS current_source
+                WHERE current_source.group_id_hex = {column_prefix}group_id_hex
+                  AND current_source.message_id_hex = {column_prefix}message_id_hex
+            ), -1) < {accepted_high_water}
+         )"
+    )
+}
+
 /// One authoritative latest-preview order for rebuild, completeness, and
 /// secure-prune repair. A pending local send stays at the preview head only
 /// until accepted activity is first persisted later on this device. The stable
@@ -1093,6 +1142,8 @@ fn chat_list_projection_complete_tx(
 ) -> StorageResult<bool> {
     let activity_filter = chat_list_activity_filter_sql("mt.");
     let preview_order = chat_list_preview_order_desc("mt.");
+    let preview_eligibility = chat_list_preview_eligibility_sql("mt.");
+    let accepted_high_water = accepted_activity_insert_order_high_water_sql("ag.group_id_hex");
     if projection_has_rows_tx(
         tx,
         "SELECT EXISTS(
@@ -1200,6 +1251,7 @@ fn chat_list_projection_complete_tx(
                         FROM message_timeline AS mt
                         WHERE mt.group_id_hex = ag.group_id_hex
                           AND {activity_filter}
+                          AND {preview_eligibility}
                           AND (
                               mt.invalidation_status IS NULL
                               OR (
@@ -1237,6 +1289,7 @@ fn chat_list_projection_complete_tx(
                         ), 0),
                         ag.conversation_created_at
                      )
+                   OR row.accepted_activity_insert_order < {accepted_high_water}
              )"
         ),
         [],
@@ -1320,6 +1373,8 @@ fn rebuild_chat_list_row_for_group_tx(
 ) -> StorageResult<()> {
     let latest = latest_chat_list_activity_tx(tx, &group.group_id_hex)?;
     let latest_message = latest.as_ref().map(|latest| &latest.preview);
+    let accepted_activity_insert_order =
+        latest_accepted_activity_insert_order_tx(tx, &group.group_id_hex)?.unwrap_or(0);
     let read_state = read_state_tx(tx, &group.group_id_hex)?;
     let unread = unread_summary_tx(
         tx,
@@ -1351,12 +1406,12 @@ fn rebuild_chat_list_row_for_group_tx(
             first_unread_message_id_hex,
             last_read_message_id_hex, last_read_timeline_at,
             conversation_created_at, activity_sort_at, retained_activity_sort_at,
-            updated_at, self_membership
+            accepted_activity_insert_order, updated_at, self_membership
          )
          VALUES (
             ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
             ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20,
-            ?21, ?22, ?23, ?24, ?25, ?26, ?27, 0, ?28, ?29
+            ?21, ?22, ?23, ?24, ?25, ?26, ?27, 0, ?28, ?29, ?30
          )
          ON CONFLICT(group_id_hex) DO UPDATE SET
             archived = excluded.archived,
@@ -1389,6 +1444,10 @@ fn rebuild_chat_list_row_for_group_tx(
                 chat_list_rows.retained_activity_sort_at
             ),
             retained_activity_sort_at = chat_list_rows.retained_activity_sort_at,
+            accepted_activity_insert_order = MAX(
+                chat_list_rows.accepted_activity_insert_order,
+                excluded.accepted_activity_insert_order
+            ),
             updated_at = excluded.updated_at,
             self_membership = excluded.self_membership",
         params![
@@ -1452,6 +1511,7 @@ fn rebuild_chat_list_row_for_group_tx(
             )?,
             u64_to_i64(group.conversation_created_at)?,
             u64_to_i64(activity_sort_at)?,
+            accepted_activity_insert_order,
             u64_to_i64(now)?,
             group.self_membership.as_str(),
         ],
@@ -1680,6 +1740,7 @@ fn latest_chat_list_activity_tx(
 ) -> StorageResult<Option<LatestChatListMessage>> {
     let activity_filter = chat_list_activity_filter_sql("preview.");
     let preview_order = chat_list_preview_order_desc("preview.");
+    let preview_eligibility = chat_list_preview_eligibility_sql("preview.");
     let sql = format!(
         "SELECT preview.message_id_hex, preview.sender, preview.plaintext,
                 preview.kind, preview.timeline_at, preview.deleted,
@@ -1689,6 +1750,7 @@ fn latest_chat_list_activity_tx(
                 preview.timeline_order_phase, preview.timeline_order_at
          FROM message_timeline AS preview
          WHERE preview.group_id_hex = ?1 AND {activity_filter}
+           AND {preview_eligibility}
            AND (
                preview.invalidation_status IS NULL
                OR (
@@ -1711,6 +1773,32 @@ fn latest_chat_list_activity_tx(
         })
     })
     .optional()
+    .storage()
+}
+
+fn latest_accepted_activity_insert_order_tx(
+    tx: &Connection,
+    group_id_hex: &str,
+) -> StorageResult<Option<i64>> {
+    let activity_filter = chat_list_activity_filter_sql("accepted.");
+    tx.query_row(
+        &format!(
+            "SELECT MAX(accepted_source.insert_order)
+             FROM message_timeline AS accepted
+             JOIN app_events AS accepted_source
+               ON accepted_source.group_id_hex = accepted.group_id_hex
+              AND accepted_source.message_id_hex = accepted.message_id_hex
+             WHERE accepted.group_id_hex = ?1
+               AND {activity_filter}
+               AND accepted.invalidation_status IS NULL
+               AND NOT (
+                   accepted.direction = 'sent'
+                   AND accepted.source_message_id_hex IS NULL
+               )"
+        ),
+        params![group_id_hex],
+        |row| row.get(0),
+    )
     .storage()
 }
 

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -1003,18 +1003,61 @@ pub(crate) fn chat_list_activity_filter_sql(column_prefix: &str) -> String {
 }
 
 /// One authoritative latest-preview order for rebuild, completeness, and
-/// secure-prune repair. Failed local sends remain visible in the timeline but
-/// do not outrank accepted history in the chat-list projection.
-pub(crate) const CHAT_LIST_PREVIEW_ORDER_DESC: &str = "CASE
-        WHEN direction = 'sent'
-         AND invalidation_status = 'local_publish_failed' THEN 0
-        ELSE 1
-    END DESC,
-    timeline_order_class DESC,
-    timeline_order_primary DESC,
-    timeline_order_phase DESC,
-    timeline_order_at DESC,
-    message_id_hex DESC";
+/// secure-prune repair. A pending local send stays at the preview head only
+/// until accepted activity is first persisted later on this device. The stable
+/// `app_events.insert_order` boundary is intentional: relay replay can rewrite
+/// `received_at` on an older row and must not make old history look new. The
+/// canonical timeline deliberately keeps every unresolved local row at its
+/// head, but reusing that unconditional class here lets one orphaned send pin a
+/// chat-list preview forever. Failed local sends remain visible in the timeline
+/// without outranking accepted history.
+pub(crate) fn chat_list_preview_order_desc(column_prefix: &str) -> String {
+    let accepted_activity_filter = chat_list_activity_filter_sql("accepted.");
+    format!(
+        "CASE
+            WHEN {column_prefix}direction = 'sent'
+             AND {column_prefix}invalidation_status = 'local_publish_failed' THEN 0
+            ELSE 1
+         END DESC,
+         CASE
+            WHEN {column_prefix}direction = 'sent'
+             AND {column_prefix}source_epoch IS NULL
+             AND {column_prefix}source_message_id_hex IS NULL
+             AND {column_prefix}invalidation_status IS NULL
+             AND NOT EXISTS (
+                SELECT 1
+                FROM message_timeline AS accepted
+                JOIN app_events AS accepted_source
+                  ON accepted_source.group_id_hex = accepted.group_id_hex
+                 AND accepted_source.message_id_hex = accepted.message_id_hex
+                WHERE accepted.group_id_hex = {column_prefix}group_id_hex
+                  AND {accepted_activity_filter}
+                  AND accepted.invalidation_status IS NULL
+                  AND NOT (
+                      accepted.direction = 'sent'
+                      AND accepted.source_epoch IS NULL
+                      AND accepted.source_message_id_hex IS NULL
+                  )
+                  AND accepted_source.insert_order > COALESCE((
+                      SELECT current_source.insert_order
+                      FROM app_events AS current_source
+                      WHERE current_source.group_id_hex = {column_prefix}group_id_hex
+                        AND current_source.message_id_hex = {column_prefix}message_id_hex
+                  ), -1)
+             ) THEN 2
+            WHEN {column_prefix}direction = 'sent'
+             AND {column_prefix}source_epoch IS NULL
+             AND {column_prefix}source_message_id_hex IS NULL
+             AND {column_prefix}invalidation_status IS NULL THEN 0
+            ELSE 1
+         END DESC,
+         {column_prefix}timeline_order_class DESC,
+         {column_prefix}timeline_order_primary DESC,
+         {column_prefix}timeline_order_phase DESC,
+         {column_prefix}timeline_order_at DESC,
+         {column_prefix}message_id_hex DESC"
+    )
+}
 
 struct LatestChatListMessage {
     preview: ChatListMessagePreview,
@@ -1052,6 +1095,7 @@ fn chat_list_projection_complete_tx(
     mention_classifier: &MentionClassifier<'_>,
 ) -> StorageResult<bool> {
     let activity_filter = chat_list_activity_filter_sql("mt.");
+    let preview_order = chat_list_preview_order_desc("mt.");
     if projection_has_rows_tx(
         tx,
         "SELECT EXISTS(
@@ -1146,8 +1190,16 @@ fn chat_list_projection_complete_tx(
                         FROM message_timeline AS mt
                         WHERE mt.group_id_hex = ag.group_id_hex
                      ), 0)
-                   OR row.last_message_id_hex IS NOT (
-                        SELECT mt.message_id_hex
+                   OR (
+                        row.last_message_id_hex,
+                        row.last_message_sender,
+                        row.last_message_preview,
+                        row.last_message_kind,
+                        row.last_message_timeline_at,
+                        row.last_message_media_json
+                     ) IS NOT (
+                        SELECT mt.message_id_hex, mt.sender, mt.plaintext,
+                               mt.kind, mt.timeline_at, mt.media_json
                         FROM message_timeline AS mt
                         WHERE mt.group_id_hex = ag.group_id_hex
                           AND {activity_filter}
@@ -1158,99 +1210,15 @@ fn chat_list_projection_complete_tx(
                                   AND mt.invalidation_status = 'local_publish_failed'
                               )
                           )
-                        ORDER BY {CHAT_LIST_PREVIEW_ORDER_DESC}
-                        LIMIT 1
-                     )
-                   OR row.last_message_sender IS NOT (
-                        SELECT mt.sender
-                        FROM message_timeline AS mt
-                        WHERE mt.group_id_hex = ag.group_id_hex
-                          AND {activity_filter}
-                          AND (
-                              mt.invalidation_status IS NULL
-                              OR (
-                                  mt.direction = 'sent'
-                                  AND mt.invalidation_status = 'local_publish_failed'
-                              )
-                          )
-                        ORDER BY {CHAT_LIST_PREVIEW_ORDER_DESC}
-                        LIMIT 1
-                     )
-                   OR row.last_message_preview IS NOT (
-                        SELECT mt.plaintext
-                        FROM message_timeline AS mt
-                        WHERE mt.group_id_hex = ag.group_id_hex
-                          AND {activity_filter}
-                          AND (
-                              mt.invalidation_status IS NULL
-                              OR (
-                                  mt.direction = 'sent'
-                                  AND mt.invalidation_status = 'local_publish_failed'
-                              )
-                          )
-                        ORDER BY {CHAT_LIST_PREVIEW_ORDER_DESC}
-                        LIMIT 1
-                     )
-                   OR row.last_message_kind IS NOT (
-                        SELECT mt.kind
-                        FROM message_timeline AS mt
-                        WHERE mt.group_id_hex = ag.group_id_hex
-                          AND {activity_filter}
-                          AND (
-                              mt.invalidation_status IS NULL
-                              OR (
-                                  mt.direction = 'sent'
-                                  AND mt.invalidation_status = 'local_publish_failed'
-                              )
-                          )
-                        ORDER BY {CHAT_LIST_PREVIEW_ORDER_DESC}
-                        LIMIT 1
-                     )
-                   OR row.last_message_timeline_at IS NOT (
-                        SELECT mt.timeline_at
-                        FROM message_timeline AS mt
-                        WHERE mt.group_id_hex = ag.group_id_hex
-                          AND {activity_filter}
-                          AND (
-                              mt.invalidation_status IS NULL
-                              OR (
-                                  mt.direction = 'sent'
-                                  AND mt.invalidation_status = 'local_publish_failed'
-                              )
-                          )
-                        ORDER BY {CHAT_LIST_PREVIEW_ORDER_DESC}
+                        ORDER BY {preview_order}
                         LIMIT 1
                      )
                    OR row.last_message_deleted IS NOT COALESCE((
                         SELECT mt.deleted
                         FROM message_timeline AS mt
                         WHERE mt.group_id_hex = ag.group_id_hex
-                          AND {activity_filter}
-                          AND (
-                              mt.invalidation_status IS NULL
-                              OR (
-                                  mt.direction = 'sent'
-                                  AND mt.invalidation_status = 'local_publish_failed'
-                              )
-                          )
-                        ORDER BY {CHAT_LIST_PREVIEW_ORDER_DESC}
-                        LIMIT 1
+                          AND mt.message_id_hex = row.last_message_id_hex
                      ), 0)
-                   OR row.last_message_media_json IS NOT (
-                        SELECT mt.media_json
-                        FROM message_timeline AS mt
-                        WHERE mt.group_id_hex = ag.group_id_hex
-                          AND {activity_filter}
-                          AND (
-                              mt.invalidation_status IS NULL
-                              OR (
-                                  mt.direction = 'sent'
-                                  AND mt.invalidation_status = 'local_publish_failed'
-                              )
-                          )
-                        ORDER BY {CHAT_LIST_PREVIEW_ORDER_DESC}
-                        LIMIT 1
-                     )
                    OR row.last_message_delivery_state IS NOT COALESCE((
                         SELECT CASE
                             WHEN mt.direction != 'sent' THEN 'not_applicable'
@@ -1260,34 +1228,11 @@ fn chat_list_projection_complete_tx(
                         END
                         FROM message_timeline AS mt
                         WHERE mt.group_id_hex = ag.group_id_hex
-                          AND {activity_filter}
-                          AND (
-                              mt.invalidation_status IS NULL
-                              OR (
-                                  mt.direction = 'sent'
-                                  AND mt.invalidation_status = 'local_publish_failed'
-                              )
-                          )
-                        ORDER BY {CHAT_LIST_PREVIEW_ORDER_DESC}
-                        LIMIT 1
+                          AND mt.message_id_hex = row.last_message_id_hex
                      ), 'not_applicable')
                    OR row.activity_sort_at IS NOT MAX(
                         row.retained_activity_sort_at,
-                        COALESCE((
-                            SELECT mt.timeline_at
-                            FROM message_timeline AS mt
-                            WHERE mt.group_id_hex = ag.group_id_hex
-                              AND {activity_filter}
-                              AND (
-                                  mt.invalidation_status IS NULL
-                                  OR (
-                                      mt.direction = 'sent'
-                                      AND mt.invalidation_status = 'local_publish_failed'
-                                  )
-                              )
-                        ORDER BY {CHAT_LIST_PREVIEW_ORDER_DESC}
-                            LIMIT 1
-                        ), 0),
+                        COALESCE(row.last_message_timeline_at, 0),
                         COALESCE((
                             SELECT read_state.last_read_timeline_at
                             FROM conversation_read_state AS read_state
@@ -1736,19 +1681,25 @@ fn latest_chat_list_activity_tx(
     tx: &Connection,
     group_id_hex: &str,
 ) -> StorageResult<Option<LatestChatListMessage>> {
-    let activity_filter = chat_list_activity_filter_sql("");
+    let activity_filter = chat_list_activity_filter_sql("preview.");
+    let preview_order = chat_list_preview_order_desc("preview.");
     let sql = format!(
-        "SELECT message_id_hex, sender, plaintext, kind, timeline_at, deleted,
-                media_json, direction, source_message_id_hex, invalidation_status,
-                timeline_order_class, timeline_order_primary,
-                timeline_order_phase, timeline_order_at
-         FROM message_timeline
-         WHERE group_id_hex = ?1 AND {activity_filter}
+        "SELECT preview.message_id_hex, preview.sender, preview.plaintext,
+                preview.kind, preview.timeline_at, preview.deleted,
+                preview.media_json, preview.direction,
+                preview.source_message_id_hex, preview.invalidation_status,
+                preview.timeline_order_class, preview.timeline_order_primary,
+                preview.timeline_order_phase, preview.timeline_order_at
+         FROM message_timeline AS preview
+         WHERE preview.group_id_hex = ?1 AND {activity_filter}
            AND (
-               invalidation_status IS NULL
-               OR (direction = 'sent' AND invalidation_status = 'local_publish_failed')
+               preview.invalidation_status IS NULL
+               OR (
+                   preview.direction = 'sent'
+                   AND preview.invalidation_status = 'local_publish_failed'
+               )
            )
-         ORDER BY {CHAT_LIST_PREVIEW_ORDER_DESC}
+         ORDER BY {preview_order}
          LIMIT 1"
     );
     tx.query_row(&sql, params![group_id_hex], |row| {

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -1851,6 +1851,117 @@ fn chat_list_read_state_and_preview_follow_canonical_epoch_order() {
 }
 
 #[test]
+fn newer_authenticated_message_replaces_older_pending_preview() {
+    let store = setup_store();
+    let mut pending = chat("pending", LOCAL, 100, "older pending send");
+    pending.source_message_id_hex = None;
+    pending.source_epoch = None;
+    store.record_app_event(&pending).unwrap();
+
+    let mut delivered = chat("delivered", LOCAL, 100, "newer delivered send");
+    delivered.source_epoch = Some(7);
+    store.record_app_event(&delivered).unwrap();
+
+    let row = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    let preview = row.last_message.expect("latest preview");
+    assert_eq!(preview.message_id_hex, "delivered");
+    assert_eq!(
+        preview.delivery_state,
+        ChatListMessageDeliveryState::Delivered
+    );
+}
+
+#[test]
+fn newer_pending_message_replaces_older_authenticated_preview() {
+    let store = setup_store();
+    let mut delivered = chat("delivered", LOCAL, 100, "older delivered send");
+    delivered.source_epoch = Some(7);
+    store.record_app_event(&delivered).unwrap();
+
+    let mut pending = chat("pending", LOCAL, 100, "newer pending send");
+    pending.source_message_id_hex = None;
+    pending.source_epoch = None;
+    store.record_app_event(&pending).unwrap();
+
+    let row = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    let preview = row.last_message.expect("latest preview");
+    assert_eq!(preview.message_id_hex, "pending");
+    assert_eq!(
+        preview.delivery_state,
+        ChatListMessageDeliveryState::Pending
+    );
+}
+
+#[test]
+fn replayed_older_authenticated_message_does_not_replace_newer_pending_preview() {
+    let store = setup_store();
+    let mut delivered = chat("delivered", LOCAL, 100, "older delivered send");
+    delivered.source_epoch = Some(7);
+    store.record_app_event(&delivered).unwrap();
+
+    let mut pending = chat("pending", LOCAL, 150, "newer pending send");
+    pending.source_message_id_hex = None;
+    pending.source_epoch = None;
+    store.record_app_event(&pending).unwrap();
+
+    delivered.received_at = 200;
+    store.record_app_event(&delivered).unwrap();
+
+    let row = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(
+        row.last_message
+            .as_ref()
+            .map(|message| message.message_id_hex.as_str()),
+        Some("pending")
+    );
+}
+
+#[test]
+fn ensure_repairs_a_stale_pending_preview_after_newer_authenticated_activity() {
+    let store = setup_store();
+    let mut pending = chat("pending", LOCAL, 100, "older pending send");
+    pending.source_message_id_hex = None;
+    pending.source_epoch = None;
+    store.record_app_event(&pending).unwrap();
+    store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap();
+
+    let mut delivered = chat("delivered", LOCAL, 100, "newer delivered send");
+    delivered.source_epoch = Some(7);
+    store.record_app_event(&delivered).unwrap();
+    assert_eq!(
+        store
+            .chat_list_row(GROUP)
+            .unwrap()
+            .and_then(|row| row.last_message)
+            .map(|message| message.message_id_hex),
+        Some("pending".to_owned()),
+        "the fixture must start with the stale persisted preview"
+    );
+
+    store.ensure_chat_list_rows(LOCAL, &no_mentions).unwrap();
+
+    assert_eq!(
+        store
+            .chat_list_row(GROUP)
+            .unwrap()
+            .and_then(|row| row.last_message)
+            .map(|message| message.message_id_hex),
+        Some("delivered".to_owned())
+    );
+}
+
+#[test]
 fn group_system_read_marker_preserves_same_epoch_canonical_phase() {
     let store = setup_store();
     store

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -1899,6 +1899,33 @@ fn newer_pending_message_replaces_older_authenticated_preview() {
 }
 
 #[test]
+fn pending_send_with_source_epoch_uses_pending_preview_ordering() {
+    let store = setup_store();
+    let mut delivered = chat("delivered", LOCAL, 100, "older delivered send");
+    delivered.source_epoch = Some(8);
+    store.record_app_event(&delivered).unwrap();
+
+    // Source epoch is captured when the MLS message is encrypted, before a
+    // relay-assigned source id exists. The missing source id is therefore the
+    // authoritative pending signal even when the epoch is already present.
+    let mut pending = chat("pending", LOCAL, 100, "newer pending send");
+    pending.source_message_id_hex = None;
+    pending.source_epoch = Some(7);
+    store.record_app_event(&pending).unwrap();
+
+    let row = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    let preview = row.last_message.expect("latest preview");
+    assert_eq!(preview.message_id_hex, "pending");
+    assert_eq!(
+        preview.delivery_state,
+        ChatListMessageDeliveryState::Pending
+    );
+}
+
+#[test]
 fn replayed_older_authenticated_message_does_not_replace_newer_pending_preview() {
     let store = setup_store();
     let mut delivered = chat("delivered", LOCAL, 100, "older delivered send");

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -2202,6 +2202,64 @@ fn failed_local_send_does_not_replace_delivered_preview_after_prune_or_ensure() 
 }
 
 #[test]
+fn secure_prune_does_not_resurrect_a_pending_preview_displaced_by_accepted_activity() {
+    let store = setup_store();
+    let mut pending = chat("pending", LOCAL, 300, "older unresolved send");
+    pending.source_message_id_hex = None;
+    pending.source_epoch = None;
+    store.record_app_event(&pending).unwrap();
+
+    let mut accepted = chat("accepted", REMOTE, 10, "newer accepted activity");
+    accepted.source_epoch = Some(7);
+    store.record_app_event(&accepted).unwrap();
+
+    let before = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(
+        before
+            .last_message
+            .as_ref()
+            .map(|message| message.message_id_hex.as_str()),
+        Some("accepted")
+    );
+
+    store
+        .secure_prune_app_events_before(GROUP, 20, LOCAL, &no_mentions)
+        .unwrap();
+
+    let after_prune = store.chat_list_row(GROUP).unwrap().expect("chat row");
+    assert!(
+        after_prune.last_message.is_none(),
+        "the older pending send must stay displaced after its accepted witness is pruned"
+    );
+    let accepted_high_water = store
+        .lock()
+        .unwrap()
+        .query_row(
+            "SELECT accepted_activity_insert_order
+             FROM chat_list_rows
+             WHERE group_id_hex = ?1",
+            params![GROUP],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap();
+    assert!(accepted_high_water > 0);
+
+    store.ensure_chat_list_rows(LOCAL, &no_mentions).unwrap();
+    assert!(
+        store
+            .chat_list_row(GROUP)
+            .unwrap()
+            .expect("rebuilt chat row")
+            .last_message
+            .is_none(),
+        "projection repair must preserve the durable pending demotion"
+    );
+}
+
+#[test]
 fn secure_prune_keeps_chat_preview_on_canonical_latest_epoch() {
     let store = setup_store();
     let mut pruned = chat("pruned", REMOTE, 10, "old");

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -108,6 +108,8 @@ mod migration_0053_account_delivery_recovery;
 mod migration_0054_transport_reconciliation_items;
 #[path = "migrations/0055_epoch_stall_evidence.rs"]
 mod migration_0055_epoch_stall_evidence;
+#[path = "migrations/0056_chat_list_accepted_activity_high_water.rs"]
+mod migration_0056_chat_list_accepted_activity_high_water;
 #[cfg(test)]
 #[path = "migrations/test_support.rs"]
 mod test_support;
@@ -397,6 +399,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 55,
         name: "0055_epoch_stall_evidence",
         apply: migration_0055_epoch_stall_evidence::apply,
+    },
+    Migration {
+        version: 56,
+        name: "0056_chat_list_accepted_activity_high_water",
+        apply: migration_0056_chat_list_accepted_activity_high_water::apply,
     },
 ];
 
@@ -925,7 +932,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 55,
+                found: 56,
                 latest_supported: 46,
             }
         ));
@@ -981,7 +988,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 55,
+                found: 56,
                 latest_supported: 46,
             }
         ));
@@ -1285,7 +1292,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 55,
+                found: 56,
                 latest_supported: 46,
             }
         ));
@@ -1639,6 +1646,70 @@ mod tests {
             .refresh_chat_list_rows("local-account", &no_mentions)
             .unwrap();
         assert_eq!(semantic_chat_list_timestamps(&store), expected);
+    }
+
+    #[test]
+    fn accepted_activity_high_water_migration_backfills_existing_chat_history() {
+        let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.pragma_update(None, "foreign_keys", true).unwrap();
+        // Versions 1-55 are the schema immediately before the durable preview
+        // demotion boundary.
+        run(&mut conn, &MIGRATIONS[..55]).unwrap();
+        conn.execute(
+            "INSERT INTO account_groups (group_id_hex, endpoint, profile_name, updated_at)
+             VALUES ('active', 'relay', 'Migration group', 1)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO app_events (
+                group_id_hex, message_id_hex, source_message_id_hex, direction,
+                sender, plaintext, kind, tags_json, recorded_at, received_at
+             ) VALUES
+                ('active', 'pending', NULL, 'sent', 'alice', 'pending', 9, '[]', 20, 20),
+                ('active', 'accepted', 'source-accepted', 'received', 'bob',
+                 'accepted', 9, '[]', 10, 10)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message_timeline (
+                group_id_hex, message_id_hex, source_message_id_hex, direction,
+                sender, plaintext, kind, tags_json, timeline_at, received_at,
+                reactions_json
+             ) VALUES
+                ('active', 'pending', NULL, 'sent', 'alice', 'pending', 9, '[]', 20, 20, '[]'),
+                ('active', 'accepted', 'source-accepted', 'received', 'bob',
+                 'accepted', 9, '[]', 10, 10, '[]')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO chat_list_rows (group_id_hex, updated_at)
+             VALUES ('active', 1)",
+            [],
+        )
+        .unwrap();
+        let accepted_insert_order: i64 = conn
+            .query_row(
+                "SELECT insert_order FROM app_events
+                 WHERE group_id_hex = 'active' AND message_id_hex = 'accepted'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        run(&mut conn, MIGRATIONS).unwrap();
+
+        let high_water: i64 = conn
+            .query_row(
+                "SELECT accepted_activity_insert_order FROM chat_list_rows
+                 WHERE group_id_hex = 'active'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(high_water, accepted_insert_order);
     }
 
     #[test]

--- a/crates/storage-sqlite/src/migrations/0056_chat_list_accepted_activity_high_water.rs
+++ b/crates/storage-sqlite/src/migrations/0056_chat_list_accepted_activity_high_water.rs
@@ -19,26 +19,52 @@ ALTER TABLE chat_list_rows
     )
     .storage()?;
 
-    let activity_filter = crate::chat_list::chat_list_activity_filter_sql("accepted.");
-    tx.execute(
-        &format!(
-            "UPDATE chat_list_rows AS row
-             SET accepted_activity_insert_order = COALESCE((
-                 SELECT MAX(accepted_source.insert_order)
-                 FROM message_timeline AS accepted
-                 JOIN app_events AS accepted_source
-                   ON accepted_source.group_id_hex = accepted.group_id_hex
-                  AND accepted_source.message_id_hex = accepted.message_id_hex
-                 WHERE accepted.group_id_hex = row.group_id_hex
-                   AND {activity_filter}
-                   AND accepted.invalidation_status IS NULL
-                   AND NOT (
-                       accepted.direction = 'sent'
-                       AND accepted.source_message_id_hex IS NULL
-                   )
-             ), 0)"
-        ),
-        [],
+    // Keep the historical v56 activity predicate self-contained. Calling the
+    // live chat-list SQL helper here would let a future projection change
+    // alter migration results on fresh installs while already-migrated
+    // databases retain the old backfill.
+    tx.execute_batch(
+        r#"
+UPDATE chat_list_rows AS row
+SET accepted_activity_insert_order = COALESCE((
+    SELECT MAX(accepted_source.insert_order)
+    FROM message_timeline AS accepted
+    JOIN app_events AS accepted_source
+      ON accepted_source.group_id_hex = accepted.group_id_hex
+     AND accepted_source.message_id_hex = accepted.message_id_hex
+    WHERE accepted.group_id_hex = row.group_id_hex
+      AND (
+          accepted.kind = 9
+          OR (
+              accepted.kind = 1210
+              AND accepted.tags_json IN (
+                  '[["system","member_added"]]',
+                  '[["system","member_removed"]]',
+                  '[["system","member_left"]]',
+                  '[["system","admin_added"]]',
+                  '[["system","admin_removed"]]'
+              )
+              AND EXISTS (
+                  SELECT 1
+                  FROM account_groups AS activity_group
+                  WHERE activity_group.group_id_hex = accepted.group_id_hex
+                    AND (
+                        trim(activity_group.profile_name) != ''
+                        OR (
+                            activity_group.member_count IS NOT NULL
+                            AND activity_group.member_count != 2
+                        )
+                    )
+              )
+          )
+      )
+      AND accepted.invalidation_status IS NULL
+      AND NOT (
+          accepted.direction = 'sent'
+          AND accepted.source_message_id_hex IS NULL
+      )
+), 0);
+"#,
     )
     .storage()?;
 

--- a/crates/storage-sqlite/src/migrations/0056_chat_list_accepted_activity_high_water.rs
+++ b/crates/storage-sqlite/src/migrations/0056_chat_list_accepted_activity_high_water.rs
@@ -1,0 +1,46 @@
+//! Persist the accepted-activity insertion boundary used to demote stale
+//! optimistic chat previews.
+//!
+//! Secure plaintext pruning can remove every accepted timeline row newer than
+//! an unresolved local send. The insertion-order high-water mark preserves the
+//! fact that accepted activity already displaced that pending row, without
+//! retaining message content or identifiers.
+
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+ALTER TABLE chat_list_rows
+    ADD COLUMN accepted_activity_insert_order INTEGER NOT NULL DEFAULT 0;
+"#,
+    )
+    .storage()?;
+
+    let activity_filter = crate::chat_list::chat_list_activity_filter_sql("accepted.");
+    tx.execute(
+        &format!(
+            "UPDATE chat_list_rows AS row
+             SET accepted_activity_insert_order = COALESCE((
+                 SELECT MAX(accepted_source.insert_order)
+                 FROM message_timeline AS accepted
+                 JOIN app_events AS accepted_source
+                   ON accepted_source.group_id_hex = accepted.group_id_hex
+                  AND accepted_source.message_id_hex = accepted.message_id_hex
+                 WHERE accepted.group_id_hex = row.group_id_hex
+                   AND {activity_filter}
+                   AND accepted.invalidation_status IS NULL
+                   AND NOT (
+                       accepted.direction = 'sent'
+                       AND accepted.source_message_id_hex IS NULL
+                   )
+             ), 0)"
+        ),
+        [],
+    )
+    .storage()?;
+
+    Ok(())
+}

--- a/crates/storage-sqlite/src/storage/outbound.rs
+++ b/crates/storage-sqlite/src/storage/outbound.rs
@@ -203,8 +203,9 @@ mod tests {
     use cgka_traits::engine_state::PendingStateRef;
     use cgka_traits::storage::{GroupStorage, OutboundFanoutStorage, OutboundIntentStorage};
     use cgka_traits::{
-        MemberId, OutboundFanout, Timestamp, TransportEndpoint, TransportEnvelope,
-        TransportMessage, TransportPublishRequest, TransportPublishTarget, TransportSource,
+        AppMessageRetentionDecision, EpochId, MemberId, OutboundApplicationMessage, OutboundFanout,
+        Timestamp, TransportEndpoint, TransportEnvelope, TransportMessage, TransportPublishRequest,
+        TransportPublishTarget, TransportSource,
     };
 
     fn sample_fanout(id: u8) -> OutboundFanout {
@@ -274,7 +275,15 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("fanout.sqlite");
         let key = crate::SqlCipherKey::new("durable fanout key").unwrap();
-        let expected = sample_fanout(8);
+        let mut expected = sample_fanout(8);
+        expected
+            .set_application_message(OutboundApplicationMessage {
+                group_id: gid(1),
+                app_event_id: "durable-app-event".into(),
+                source_epoch: EpochId(7),
+                retention: AppMessageRetentionDecision::new(100, 30),
+            })
+            .unwrap();
         {
             let store = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
             store.put_group(&sample_group(gid(1), 0, 0)).unwrap();

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -1240,36 +1240,63 @@ fn retain_pruned_chat_activity_tx(
     group_id_hex: &str,
     pruned_message_ids: &BTreeSet<String>,
 ) -> StorageResult<()> {
-    let activity_filter = crate::chat_list::chat_list_activity_filter_sql("");
+    let activity_filter = crate::chat_list::chat_list_activity_filter_sql("timeline.");
     let sql = format!(
-        "SELECT timeline_at
-         FROM message_timeline
-         WHERE group_id_hex = ?1
-           AND message_id_hex = ?2
+        "SELECT timeline.timeline_at,
+                CASE
+                    WHEN timeline.invalidation_status IS NULL
+                     AND NOT (
+                         timeline.direction = 'sent'
+                         AND timeline.source_message_id_hex IS NULL
+                     ) THEN source.insert_order
+                    ELSE NULL
+                END
+         FROM message_timeline AS timeline
+         JOIN app_events AS source
+           ON source.group_id_hex = timeline.group_id_hex
+          AND source.message_id_hex = timeline.message_id_hex
+         WHERE timeline.group_id_hex = ?1
+           AND timeline.message_id_hex = ?2
            AND {activity_filter}
            AND (
-               invalidation_status IS NULL
-               OR (direction = 'sent' AND invalidation_status = 'local_publish_failed')
+               timeline.invalidation_status IS NULL
+               OR (
+                   timeline.direction = 'sent'
+                   AND timeline.invalidation_status = 'local_publish_failed'
+               )
            )"
     );
     let mut statement = tx.prepare(&sql).storage()?;
     let mut latest_pruned_activity = None;
+    let mut accepted_activity_insert_order = None;
     for message_id_hex in pruned_message_ids {
-        let timeline_at = statement
+        let retained = statement
             .query_row(params![group_id_hex, message_id_hex], |row| {
-                row.get::<_, i64>(0)
+                Ok((row.get::<_, i64>(0)?, row.get::<_, Option<i64>>(1)?))
             })
             .optional()
             .storage()?;
-        latest_pruned_activity = latest_pruned_activity.max(timeline_at);
+        if let Some((timeline_at, accepted_insert_order)) = retained {
+            latest_pruned_activity = latest_pruned_activity.max(Some(timeline_at));
+            accepted_activity_insert_order =
+                accepted_activity_insert_order.max(accepted_insert_order);
+        }
     }
-    if let Some(timeline_at) = latest_pruned_activity {
+    if latest_pruned_activity.is_some() || accepted_activity_insert_order.is_some() {
         tx.execute(
             "UPDATE chat_list_rows
              SET retained_activity_sort_at = MAX(retained_activity_sort_at, ?2),
-                 activity_sort_at = MAX(activity_sort_at, ?2)
+                 activity_sort_at = MAX(activity_sort_at, ?2),
+                 accepted_activity_insert_order = MAX(
+                     accepted_activity_insert_order,
+                     ?3
+                 )
              WHERE group_id_hex = ?1",
-            params![group_id_hex, timeline_at],
+            params![
+                group_id_hex,
+                latest_pruned_activity.unwrap_or(0),
+                accepted_activity_insert_order.unwrap_or(0)
+            ],
         )
         .storage()?;
     }
@@ -1282,6 +1309,7 @@ fn refresh_chat_list_last_message_after_secure_prune_tx(
 ) -> StorageResult<()> {
     let activity_filter = crate::chat_list::chat_list_activity_filter_sql("preview.");
     let preview_order = crate::chat_list::chat_list_preview_order_desc("preview.");
+    let preview_eligibility = crate::chat_list::chat_list_preview_eligibility_sql("preview.");
     let sql = format!(
         "SELECT preview.message_id_hex, preview.sender, preview.plaintext,
                 preview.kind, preview.timeline_at, preview.deleted,
@@ -1295,6 +1323,7 @@ fn refresh_chat_list_last_message_after_secure_prune_tx(
          FROM message_timeline AS preview
          WHERE preview.group_id_hex = ?1
            AND {activity_filter}
+           AND {preview_eligibility}
            AND (
                preview.invalidation_status IS NULL
                OR (

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -1280,26 +1280,30 @@ fn refresh_chat_list_last_message_after_secure_prune_tx(
     tx: &Connection,
     group_id_hex: &str,
 ) -> StorageResult<()> {
-    let activity_filter = crate::chat_list::chat_list_activity_filter_sql("");
+    let activity_filter = crate::chat_list::chat_list_activity_filter_sql("preview.");
+    let preview_order = crate::chat_list::chat_list_preview_order_desc("preview.");
     let sql = format!(
-        "SELECT message_id_hex, sender, plaintext, kind, timeline_at, deleted,
-                media_json,
+        "SELECT preview.message_id_hex, preview.sender, preview.plaintext,
+                preview.kind, preview.timeline_at, preview.deleted,
+                preview.media_json,
                 CASE
-                    WHEN direction != 'sent' THEN 'not_applicable'
-                    WHEN invalidation_status = 'local_publish_failed' THEN 'failed'
-                    WHEN source_message_id_hex IS NULL THEN 'pending'
+                    WHEN preview.direction != 'sent' THEN 'not_applicable'
+                    WHEN preview.invalidation_status = 'local_publish_failed' THEN 'failed'
+                    WHEN preview.source_message_id_hex IS NULL THEN 'pending'
                     ELSE 'delivered'
                 END
-         FROM message_timeline
-         WHERE group_id_hex = ?1
+         FROM message_timeline AS preview
+         WHERE preview.group_id_hex = ?1
            AND {activity_filter}
            AND (
-               invalidation_status IS NULL
-               OR (direction = 'sent' AND invalidation_status = 'local_publish_failed')
+               preview.invalidation_status IS NULL
+               OR (
+                   preview.direction = 'sent'
+                   AND preview.invalidation_status = 'local_publish_failed'
+               )
            )
-         ORDER BY {}
+         ORDER BY {preview_order}
          LIMIT 1",
-        crate::chat_list::CHAT_LIST_PREVIEW_ORDER_DESC,
     );
     let latest = tx
         .query_row(&sql, params![group_id_hex], |row| {

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -1241,6 +1241,11 @@ fn retain_pruned_chat_activity_tx(
     pruned_message_ids: &BTreeSet<String>,
 ) -> StorageResult<()> {
     let activity_filter = crate::chat_list::chat_list_activity_filter_sql("timeline.");
+    // Every id in this set was selected from `app_events` earlier in the
+    // caller's same IMMEDIATE transaction, and retention runs before the
+    // source rows are scrubbed or deleted. Source-row existence is therefore
+    // an invariant here; the inner join makes a violation visible instead of
+    // silently treating it like an orphan-tolerant read.
     let sql = format!(
         "SELECT timeline.timeline_at,
                 CASE

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -1244,8 +1244,8 @@ fn retain_pruned_chat_activity_tx(
     // Every id in this set was selected from `app_events` earlier in the
     // caller's same IMMEDIATE transaction, and retention runs before the
     // source rows are scrubbed or deleted. Source-row existence is therefore
-    // an invariant here; the inner join makes a violation visible instead of
-    // silently treating it like an orphan-tolerant read.
+    // an invariant here, so an inner join is intentional rather than an
+    // orphan-tolerant read.
     let sql = format!(
         "SELECT timeline.timeline_at,
                 CASE

--- a/crates/traits/src/lib.rs
+++ b/crates/traits/src/lib.rs
@@ -110,13 +110,13 @@ pub use transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
 };
 pub use transport_adapter::{
-    FanoutMlsState, FanoutPendingKind, FanoutTargetStatus, OutboundFanout, OutboundFanoutOutcome,
-    TransportAccountActivation, TransportAdapter, TransportAdapterError, TransportDelivery,
-    TransportDeliveryPlane, TransportDeliverySource, TransportEndpoint, TransportEndpointFailure,
-    TransportEndpointFailureKind, TransportEndpointReceipt, TransportEndpointRejectionCategory,
-    TransportGroupSubscription, TransportGroupSync, TransportPublishFailure,
-    TransportPublishReport, TransportPublishRequest, TransportPublishTarget, TransportWireMetadata,
-    collapse_publish_failure_summaries,
+    FanoutMlsState, FanoutPendingKind, FanoutTargetStatus, OutboundApplicationMessage,
+    OutboundFanout, OutboundFanoutOutcome, TransportAccountActivation, TransportAdapter,
+    TransportAdapterError, TransportDelivery, TransportDeliveryPlane, TransportDeliverySource,
+    TransportEndpoint, TransportEndpointFailure, TransportEndpointFailureKind,
+    TransportEndpointReceipt, TransportEndpointRejectionCategory, TransportGroupSubscription,
+    TransportGroupSync, TransportPublishFailure, TransportPublishReport, TransportPublishRequest,
+    TransportPublishTarget, TransportWireMetadata, collapse_publish_failure_summaries,
 };
 pub use types::{Backend, EpochId, GroupId, MemberId, MessageId};
 pub use welcome::PendingWelcome;

--- a/crates/traits/src/transport_adapter.rs
+++ b/crates/traits/src/transport_adapter.rs
@@ -466,6 +466,23 @@ impl OutboundFanout {
         self.target_last_attempt_at_ms.get(index).copied().flatten()
     }
 
+    /// Make targets whose last attempt was proven not to reach a relay
+    /// immediately eligible after the host observes restored connectivity.
+    /// Possibly-exposed targets deliberately retain their conservative retry
+    /// clock because replaying them early could duplicate an accepted event.
+    pub fn wake_retryable_unavailable_targets(&mut self) -> usize {
+        self.ensure_target_metadata_len();
+        let mut woken = 0;
+        for (index, status) in self.target_statuses.iter().enumerate() {
+            if *status == FanoutTargetStatus::RetryableUnavailable
+                && self.target_last_attempt_at_ms[index].take().is_some()
+            {
+                woken += 1;
+            }
+        }
+        woken
+    }
+
     pub fn possible_exposure(&self) -> bool {
         self.target_possible_exposure.iter().any(|exposed| *exposed)
             || self
@@ -1265,6 +1282,49 @@ mod tests {
         let restored: OutboundFanout =
             serde_json::from_slice(&serde_json::to_vec(&fanout).unwrap()).unwrap();
         assert_eq!(restored, fanout);
+    }
+
+    #[test]
+    fn connectivity_wake_only_clears_proven_unavailable_retry_clocks() {
+        let mut fanout = OutboundFanout::stage(
+            fanout_request(),
+            Some(crate::engine_state::PendingStateRef::new(9)),
+            Some(GroupId::new(vec![0xD4; 16])),
+            55,
+        )
+        .unwrap();
+        for (index, kind) in [
+            TransportEndpointFailureKind::PossiblyExposed,
+            TransportEndpointFailureKind::RetryableUnavailable,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            fanout.mark_attempt_started_at(index, 100).unwrap();
+            fanout
+                .record_target_failure(
+                    index,
+                    TransportEndpointFailure {
+                        endpoint: fanout.request().target.endpoints()[index].clone(),
+                        reason: "scripted failure".into(),
+                        kind,
+                        rejection_category: None,
+                    },
+                )
+                .unwrap();
+        }
+
+        assert_eq!(fanout.wake_retryable_unavailable_targets(), 1);
+        assert_eq!(fanout.target_last_attempt_at_ms(0), Some(100));
+        assert_eq!(fanout.target_last_attempt_at_ms(1), None);
+        assert_eq!(
+            fanout.target_status(0),
+            Some(FanoutTargetStatus::PossiblyExposed)
+        );
+        assert_eq!(
+            fanout.target_status(1),
+            Some(FanoutTargetStatus::RetryableUnavailable)
+        );
     }
 
     #[test]

--- a/crates/traits/src/transport_adapter.rs
+++ b/crates/traits/src/transport_adapter.rs
@@ -8,9 +8,10 @@
 //! boundary and remains the source of truth for commit ordering, branch
 //! selection, and application-message validity.
 
+use crate::app_event::AppMessageRetentionDecision;
 use crate::engine_state::PendingStateRef;
 use crate::transport::{Timestamp, TransportEnvelope, TransportMessage, TransportSource};
-use crate::types::{GroupId, MemberId, MessageId};
+use crate::types::{EpochId, GroupId, MemberId, MessageId};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -238,6 +239,10 @@ pub enum FanoutPendingKind {
 pub struct OutboundFanout {
     request: TransportPublishRequest,
     group_id: Option<GroupId>,
+    /// Durable app-layer identity needed to finalize an optimistic local row
+    /// when this exact frozen event is acknowledged by a later retry.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    application_message: Option<OutboundApplicationMessage>,
     #[serde(default)]
     pending_origin_message_id: Option<MessageId>,
     #[serde(default)]
@@ -261,6 +266,14 @@ pub struct OutboundFanout {
     post_confirmation_welcomes_pending: bool,
     mls_state: FanoutMlsState,
     created_at_ms: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutboundApplicationMessage {
+    pub group_id: GroupId,
+    pub app_event_id: String,
+    pub source_epoch: EpochId,
+    pub retention: AppMessageRetentionDecision,
 }
 
 impl OutboundFanout {
@@ -348,6 +361,7 @@ impl OutboundFanout {
         Ok(Self {
             request,
             group_id: target_group_id.or(pending_group_id),
+            application_message: None,
             pending_origin_message_id,
             pending_kind,
             published_message_id: None,
@@ -381,6 +395,31 @@ impl OutboundFanout {
 
     pub fn group_id(&self) -> Option<&GroupId> {
         self.group_id.as_ref()
+    }
+
+    pub fn application_message(&self) -> Option<&OutboundApplicationMessage> {
+        self.application_message.as_ref()
+    }
+
+    pub fn set_application_message(
+        &mut self,
+        application_message: OutboundApplicationMessage,
+    ) -> Result<(), TransportAdapterError> {
+        if self.group_id.as_ref() != Some(&application_message.group_id) {
+            return Err(TransportAdapterError::Other(
+                "application-message fanout group does not match publish target".into(),
+            ));
+        }
+        match &self.application_message {
+            None => {
+                self.application_message = Some(application_message);
+                Ok(())
+            }
+            Some(previous) if previous == &application_message => Ok(()),
+            Some(_) => Err(TransportAdapterError::Other(
+                "application-message fanout context changed".into(),
+            )),
+        }
     }
 
     /// Stored OpenMLS commit row used to restore this pending lifecycle.
@@ -634,6 +673,7 @@ impl OutboundFanout {
     pub fn validate_successor_of(&self, previous: &Self) -> Result<(), TransportAdapterError> {
         let immutable_matches = self.request == previous.request
             && self.group_id == previous.group_id
+            && self.application_message == previous.application_message
             && self.pending_origin_message_id == previous.pending_origin_message_id
             && self.pending_kind == previous.pending_kind
             && self.created_at_ms == previous.created_at_ms
@@ -1341,6 +1381,30 @@ mod tests {
         assert_eq!(restored.request().message.id, original_id);
         assert_eq!(restored.request().target.endpoints(), original_targets);
         assert_eq!(restored.outstanding_target_indexes(), vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn frozen_fanout_round_trip_preserves_application_message_context() {
+        let mut fanout = OutboundFanout::stage(fanout_request(), None, None, 55).unwrap();
+        let application = OutboundApplicationMessage {
+            group_id: GroupId::new(vec![0xD4; 16]),
+            app_event_id: "app-event-1".into(),
+            source_epoch: EpochId(7),
+            retention: AppMessageRetentionDecision::new(100, 30),
+        };
+        fanout.set_application_message(application.clone()).unwrap();
+
+        let encoded = serde_json::to_vec(&fanout).unwrap();
+        let restored: OutboundFanout = serde_json::from_slice(&encoded).unwrap();
+        assert_eq!(restored.application_message(), Some(&application));
+
+        let mut legacy = serde_json::to_value(fanout).unwrap();
+        legacy
+            .as_object_mut()
+            .unwrap()
+            .remove("application_message");
+        let legacy: OutboundFanout = serde_json::from_value(legacy).unwrap();
+        assert!(legacy.application_message().is_none());
     }
 
     #[test]

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -755,6 +755,7 @@ impl NostrSdkRelayClient {
         request: PreparedPublish,
         unavailable: &HashMap<RelayUrl, TransportEndpointFailure>,
         connect_before_send: bool,
+        deadline: tokio::time::Instant,
     ) -> Result<NostrPublishOutcome, TransportAdapterError> {
         // A configured threshold of zero relaxes the quorum but never permits
         // confirming work that no relay accepted.
@@ -783,7 +784,6 @@ impl NostrSdkRelayClient {
             });
         }
 
-        let deadline = tokio::time::Instant::now() + SDK_RELAY_PUBLISH_OVERALL_WAIT;
         let mut aborted_publishes = false;
         let mut timed_out = false;
         let (accepted, failed, timed_out) = loop {
@@ -860,8 +860,9 @@ impl NostrSdkRelayClient {
         // goal aborts relays that are still connecting. The multi-event path
         // below may pre-connect because it amortizes those connections across
         // the batch.
+        let deadline = tokio::time::Instant::now() + SDK_RELAY_PUBLISH_OVERALL_WAIT;
         let outcome = self
-            .publish_prepared_event(request, &unavailable, true)
+            .publish_prepared_event(request, &unavailable, true, deadline)
             .await;
         lease.release().await;
         outcome
@@ -872,7 +873,12 @@ impl NostrSdkRelayClient {
         requests: Vec<Result<PreparedPublish, TransportAdapterError>>,
         batch_started_at: std::time::Instant,
     ) -> NostrPublishBatch {
-        let deadline = tokio::time::Instant::now() + SDK_RELAY_BATCH_OVERALL_WAIT;
+        let publish_started_at = tokio::time::Instant::now();
+        // The first concurrent request window starts before shared relay
+        // connection. A bounded `try_connect_relay` must not silently extend
+        // the existing end-to-end event budget from 20s to 25s.
+        let mut request_window_deadline = publish_started_at + SDK_RELAY_PUBLISH_OVERALL_WAIT;
+        let batch_deadline = publish_started_at + SDK_RELAY_BATCH_OVERALL_WAIT;
         let mut unique_endpoints = Vec::new();
         let mut seen_endpoints = HashSet::new();
         for request in requests.iter().filter_map(|request| request.as_ref().ok()) {
@@ -908,7 +914,7 @@ impl NostrSdkRelayClient {
             connects.spawn(async move { client.connect_publish_relay(endpoint).await });
         }
         loop {
-            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            let remaining = batch_deadline.saturating_duration_since(tokio::time::Instant::now());
             if remaining.is_zero() {
                 connects.abort_all();
                 break;
@@ -946,19 +952,34 @@ impl NostrSdkRelayClient {
                         request_durations[index] = batch_started_at.elapsed();
                     }
                     Some((index, Ok(request))) => {
-                        if tokio::time::Instant::now() >= deadline {
+                        let now = tokio::time::Instant::now();
+                        if now >= batch_deadline {
                             outcomes[index] = Some(Err(TransportAdapterError::Publish(
                                 "publish batch timed out".to_owned(),
                             )));
                             request_durations[index] = batch_started_at.elapsed();
                             continue;
                         }
+                        // Requests admitted during one concurrency window share
+                        // its deadline. Once that window expires, later
+                        // backpressured requests receive the next bounded
+                        // window, capped by the whole-batch deadline.
+                        if now >= request_window_deadline {
+                            request_window_deadline =
+                                (now + SDK_RELAY_PUBLISH_OVERALL_WAIT).min(batch_deadline);
+                        }
+                        let request_deadline = request_window_deadline;
                         let client = self.clone();
                         let unavailable = unavailable.clone();
                         publishes.spawn(async move {
                             let outcome = match timeout_at(
-                                deadline,
-                                client.publish_prepared_event(request, &unavailable, false),
+                                batch_deadline,
+                                client.publish_prepared_event(
+                                    request,
+                                    &unavailable,
+                                    false,
+                                    request_deadline,
+                                ),
                             )
                             .await
                             {
@@ -2340,23 +2361,43 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn publish_event_cleans_one_shot_relay_after_overall_timeout() {
-        let silent = TransportEndpoint(silent_relay_url().await);
+        let stored_ids = Arc::new(Mutex::new(Vec::new()));
+        let endpoint = TransportEndpoint(storing_no_ack_relay_url(stored_ids.clone()).await);
         let keys = Keys::generate();
         let client = Client::builder().signer(keys).build();
         let sdk = NostrSdkRelayClient::new(client);
         // kind-445 events must arrive pre-signed by a fresh ephemeral key; the
         // publish path rejects unsigned 445s (spec/transports/nostr.md:64-66).
         let dto = signed_group_event_dto();
+        let expected_id = dto.id.clone();
+        let publish_sdk = sdk.clone();
+        let publish_endpoint = endpoint.clone();
+        let publish = tokio::spawn(async move {
+            publish_sdk
+                .publish_event(std::slice::from_ref(&publish_endpoint), &dto, 1)
+                .await
+        });
 
-        let err = sdk
-            .publish_event(std::slice::from_ref(&silent), &dto, 1)
+        for _ in 0..100 {
+            if stored_ids.lock().await.contains(&expected_id) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            stored_ids.lock().await.contains(&expected_id),
+            "the relay must receive the event before withholding OK"
+        );
+        advance(SDK_RELAY_PUBLISH_OVERALL_WAIT + Duration::from_secs(1)).await;
+        let err = publish
             .await
-            .expect_err("silent relay should miss the required ack deadline");
+            .expect("publish task must not panic")
+            .expect_err("a relay withholding OK should miss the required ack deadline");
 
         assert!(err.to_string().contains("publish timed out"));
         assert_eq!(
             err.publish_message_id().unwrap().as_slice(),
-            hex::decode(&dto.id).unwrap()
+            hex::decode(expected_id).unwrap()
         );
         assert!(
             err.publish_endpoint_failures()
@@ -2748,7 +2789,7 @@ mod tests {
         assert_eq!(outcomes.len(), 2);
         assert!(
             outcomes[0].is_err(),
-            "stalled request must fail in slot zero"
+            "unavailable request must fail in slot zero"
         );
         assert_eq!(
             outcomes[0]
@@ -2756,7 +2797,7 @@ mod tests {
                 .unwrap_err()
                 .publish_endpoint_failures()[0]
                 .kind,
-            TransportEndpointFailureKind::PossiblyExposed
+            TransportEndpointFailureKind::RetryableUnavailable
         );
         assert!(
             outcomes[1].is_ok(),
@@ -2790,7 +2831,8 @@ mod tests {
         assert!(outcomes.iter().all(Result::is_err));
         assert!(
             started_at.elapsed() <= SDK_RELAY_PUBLISH_OVERALL_WAIT + Duration::from_secs(1),
-            "all-unavailable latency must stay within one concurrent request window"
+            "all-unavailable latency {:?} must stay within one concurrent request window",
+            started_at.elapsed(),
         );
         assert_eq!(sdk.relay_health().await.total_relays, 0);
     }

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -656,27 +656,28 @@ impl NostrSdkRelayClient {
                 .or_default() += 1;
         }
         let transport_endpoint = TransportEndpoint(endpoint.to_string());
-        match timeout(
-            SDK_RELAY_CONNECT_WAIT,
-            self.client.connect_relay(endpoint.clone()),
-        )
-        .await
+        // `Client::connect_relay` only starts a background task and returns
+        // before the WebSocket handshake completes. Sending immediately after
+        // that call can therefore turn a proven offline connection failure
+        // into `PossiblyExposed`, putting a message behind the conservative
+        // ambiguity clock even though no relay could have received it. Await
+        // the SDK's bounded connection attempt so pre-send failures remain
+        // explicitly retryable and a host connectivity wake can replay them
+        // immediately.
+        match self
+            .client
+            .try_connect_relay(endpoint.clone(), SDK_RELAY_CONNECT_WAIT)
+            .await
         {
-            Ok(Ok(())) => Ok(endpoint),
+            Ok(()) => Ok(endpoint),
             // Failure reasons never embed the nostr-sdk error Display: it
             // commonly carries the relay URL, and these reasons flow into
             // `TransportAdapterError::Publish` Display (see
             // `finish_publish_outcome`), which upper layers may log. The
             // endpoint stays available on the structured failure record.
-            Ok(Err(_)) => Err(TransportEndpointFailure {
-                endpoint: transport_endpoint,
-                reason: "connect relay failed".to_owned(),
-                kind: TransportEndpointFailureKind::RetryableUnavailable,
-                rejection_category: None,
-            }),
             Err(_) => Err(TransportEndpointFailure {
                 endpoint: transport_endpoint,
-                reason: "connect relay timed out".to_owned(),
+                reason: "connect relay failed".to_owned(),
                 kind: TransportEndpointFailureKind::RetryableUnavailable,
                 rejection_category: None,
             }),
@@ -2307,6 +2308,32 @@ mod tests {
         assert!(
             outcome.failed.is_empty(),
             "aborted fan-out tasks must not add failures after quorum"
+        );
+        assert_eq!(sdk.relay_health().await.total_relays, 0);
+    }
+
+    #[tokio::test]
+    async fn publish_connection_failure_is_retryable_before_exposure() {
+        let reservation = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = TransportEndpoint(format!("ws://{}", reservation.local_addr().unwrap()));
+        drop(reservation);
+        let sdk = NostrSdkRelayClient::new(Client::builder().signer(Keys::generate()).build());
+        let dto = signed_group_event_dto();
+
+        let error = timeout(
+            Duration::from_secs(3),
+            sdk.publish_event(std::slice::from_ref(&endpoint), &dto, 1),
+        )
+        .await
+        .expect("a refused connection must fail promptly")
+        .expect_err("an event cannot be published without a relay connection");
+
+        let failures = error.publish_endpoint_failures();
+        assert_eq!(failures.len(), 1);
+        assert_eq!(
+            failures[0].kind,
+            TransportEndpointFailureKind::RetryableUnavailable,
+            "a failed connection proves the event was never exposed to the relay",
         );
         assert_eq!(sdk.relay_health().await.total_relays, 0);
     }

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -24,6 +24,10 @@ use crate::{
 };
 
 const SDK_RELAY_CONNECT_WAIT: Duration = Duration::from_secs(5);
+/// Keep the SDK's own reconnect sleep aligned with MDK's durable transport
+/// retry budget. The SDK default adaptively grows to 60 seconds, which leaves
+/// queued messages idle long after mobile connectivity has returned.
+const SDK_RELAY_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 // nostr-sdk 0.44 waits up to 10s for each relay's OK response. Keep this
 // wrapper above that so SDK endpoint-level success/failure results surface
 // instead of a MDK-level timeout masking them.
@@ -1000,17 +1004,55 @@ impl NostrSdkRelayClient {
         }
     }
 
+    /// Recreate a just-added, not-yet-connected relay with all SDK-composed
+    /// options preserved except for the reconnect interval. `Client` has no
+    /// supported in-place relay-option update API, so this is intentionally
+    /// limited to the caller that observed `add_*_relay == true` while holding
+    /// `publish_relay_refs`, before any connection task can start.
+    async fn pin_new_relay_retry_interval(&self, endpoint: &RelayUrl) -> Result<(), ()> {
+        let options = self
+            .client
+            .relays()
+            .await
+            .get(endpoint)
+            .map(|relay| relay.opts().clone())
+            .ok_or(())?
+            .retry_interval(SDK_RELAY_RETRY_INTERVAL)
+            .adjust_retry_interval(false);
+        self.client
+            .remove_relay(endpoint.clone())
+            .await
+            .map_err(|_| ())?;
+        match self
+            .client
+            .pool()
+            .add_relay(endpoint.clone(), options)
+            .await
+        {
+            Ok(true) => Ok(()),
+            Ok(false) | Err(_) => Err(()),
+        }
+    }
+
     async fn add_subscription_relay(
         &self,
         endpoint: RelayUrl,
     ) -> Result<(), TransportAdapterError> {
         let _relay_lifecycle = self.publish_relay_refs.lock().await;
-        self.client
-            .add_relay(endpoint)
+        let added = self
+            .client
+            .add_relay(endpoint.clone())
             .await
             // The sdk error Display can carry the relay URL; keep the error
             // operation-only so `TransportAdapterError` Display stays URL-free.
             .map_err(|_| TransportAdapterError::Subscription("add relay failed".to_owned()))?;
+        if added {
+            self.pin_new_relay_retry_interval(&endpoint)
+                .await
+                .map_err(|_| {
+                    TransportAdapterError::Subscription("configure relay failed".to_owned())
+                })?;
+        }
         Ok(())
     }
 
@@ -1035,6 +1077,14 @@ impl NostrSdkRelayClient {
         // delivery.
         match self.client.add_write_relay(endpoint.clone()).await {
             Ok(true) => {
+                if self.pin_new_relay_retry_interval(endpoint).await.is_err() {
+                    return Err(TransportEndpointFailure {
+                        endpoint: transport_endpoint,
+                        reason: "configure publish relay failed".to_owned(),
+                        kind: TransportEndpointFailureKind::RetryableUnavailable,
+                        rejection_category: None,
+                    });
+                }
                 publish_relay_refs.insert(endpoint.clone(), 1);
                 Ok(true)
             }
@@ -1554,6 +1604,12 @@ fn relay_rejection_endpoint_failure(
             rejection_category: Some(category),
         };
     }
+    // `nostr-sdk` uses the same `output.failed` map for a relay's NIP-20
+    // rejection and for local socket/pool failures such as a disconnected
+    // relay. Only a machine-readable prefix proves the former. Treat an
+    // unclassified value as ambiguous transport failure so upper layers keep
+    // the durable send queued and retry it after connectivity returns. Keep
+    // the SDK string out of the reason: it can contain relay URLs.
     TransportEndpointFailure {
         endpoint,
         reason: "publish acknowledgement unknown".to_owned(),
@@ -2965,6 +3021,63 @@ mod tests {
         // The privacy invariant forbids relay URLs in error Display: the bad
         // endpoint itself must not be echoed back.
         assert!(!rendered.contains("not a relay url"), "{rendered}");
+    }
+
+    #[tokio::test]
+    async fn subscription_relay_reconnects_within_durable_retry_budget() {
+        let reservation = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = reservation.local_addr().unwrap();
+        drop(reservation);
+
+        let endpoint = RelayUrl::parse(&format!("ws://{addr}")).unwrap();
+        let client = Client::builder().build();
+        let sdk = NostrSdkRelayClient::new(client.clone());
+        sdk.add_subscription_relay(endpoint.clone()).await.unwrap();
+        client.connect_relay(endpoint.clone()).await.unwrap();
+
+        timeout(Duration::from_secs(3), async {
+            loop {
+                let status = client
+                    .relays()
+                    .await
+                    .get(&endpoint)
+                    .expect("relay remains in the pool")
+                    .status();
+                if status == RelayStatus::Disconnected {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("the first unavailable connection attempt must fail promptly");
+
+        let listener = TcpListener::bind(addr).await.unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let _socket = tokio_tungstenite::accept_async(stream).await.unwrap();
+            std::future::pending::<()>().await;
+        });
+
+        timeout(Duration::from_secs(8), async {
+            loop {
+                let status = client
+                    .relays()
+                    .await
+                    .get(&endpoint)
+                    .expect("relay remains in the pool")
+                    .status();
+                if status == RelayStatus::Connected {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("relay must reconnect on the fixed five-second transport interval");
+
+        server.abort();
+        client.shutdown().await;
     }
 
     #[derive(Debug)]

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -1,5 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+#[cfg(test)]
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -142,6 +144,8 @@ pub struct NostrSdkRelayClient {
     publish_connect_attempts: Arc<Mutex<HashMap<RelayUrl, usize>>>,
     #[cfg(test)]
     publish_release_attempts: Arc<Mutex<HashMap<RelayUrl, usize>>>,
+    #[cfg(test)]
+    publish_relay_pin_failure_stage: Arc<AtomicU8>,
     /// Relays that explicitly rejected NIP-77 are skipped for the rest of this
     /// process. Transient connection failures are never cached here.
     reconciliation_unsupported_relays: Arc<RwLock<HashSet<RelayUrl>>>,
@@ -227,6 +231,8 @@ impl NostrSdkRelayClient {
             publish_connect_attempts: Arc::new(Mutex::new(HashMap::new())),
             #[cfg(test)]
             publish_release_attempts: Arc::new(Mutex::new(HashMap::new())),
+            #[cfg(test)]
+            publish_relay_pin_failure_stage: Arc::new(AtomicU8::new(0)),
             reconciliation_unsupported_relays: Arc::new(RwLock::new(HashSet::new())),
             registration_log: Arc::new(Mutex::new(HashMap::new())),
         }
@@ -1032,6 +1038,10 @@ impl NostrSdkRelayClient {
     /// limited to the caller that observed `add_*_relay == true` while holding
     /// `publish_relay_refs`, before any connection task can start.
     async fn pin_new_relay_retry_interval(&self, endpoint: &RelayUrl) -> Result<(), ()> {
+        #[cfg(test)]
+        if self.publish_relay_pin_failure_stage.load(Ordering::Relaxed) == 1 {
+            return Err(());
+        }
         let options = self
             .client
             .relays()
@@ -1045,6 +1055,10 @@ impl NostrSdkRelayClient {
             .remove_relay(endpoint.clone())
             .await
             .map_err(|_| ())?;
+        #[cfg(test)]
+        if self.publish_relay_pin_failure_stage.load(Ordering::Relaxed) == 2 {
+            return Err(());
+        }
         match self
             .client
             .pool()
@@ -1100,6 +1114,15 @@ impl NostrSdkRelayClient {
         match self.client.add_write_relay(endpoint.clone()).await {
             Ok(true) => {
                 if self.pin_new_relay_retry_interval(endpoint).await.is_err() {
+                    if self.client.relays().await.contains_key(endpoint) {
+                        tracing::warn!(
+                            target: "transport_nostr_adapter::sdk_client",
+                            method = "retain_publish_relay",
+                            "new publish relay kept SDK retry defaults after configuration failed"
+                        );
+                        publish_relay_refs.insert(endpoint.clone(), 1);
+                        return Ok(true);
+                    }
                     return Err(TransportEndpointFailure {
                         endpoint: transport_endpoint,
                         reason: "configure publish relay failed".to_owned(),
@@ -2611,6 +2634,61 @@ mod tests {
         assert_eq!(outcome.accepted.len(), 1);
         assert_eq!(outcome.accepted[0].endpoint, endpoint);
         assert_eq!(sdk.relay_health().await.total_relays, 0);
+    }
+
+    #[tokio::test]
+    async fn publish_relay_pin_failure_tracks_only_a_relay_that_remains_registered() {
+        let registered_endpoint = RelayUrl::parse("wss://registered-pin-failure.example").unwrap();
+        let registered_sdk = NostrSdkRelayClient::new(Client::builder().build());
+        registered_sdk
+            .publish_relay_pin_failure_stage
+            .store(1, Ordering::Relaxed);
+
+        assert!(
+            registered_sdk
+                .retain_publish_relay(&registered_endpoint)
+                .await
+                .expect("an unpinned relay that remains registered must stay cleanup-tracked")
+        );
+        assert_eq!(
+            registered_sdk
+                .publish_relay_refs
+                .lock()
+                .await
+                .get(&registered_endpoint),
+            Some(&1)
+        );
+        registered_sdk
+            .release_publish_relay(registered_endpoint.clone())
+            .await
+            .unwrap();
+        assert!(
+            !registered_sdk
+                .client
+                .relays()
+                .await
+                .contains_key(&registered_endpoint),
+            "the tracked degraded relay must still be removed at lease release"
+        );
+
+        let removed_endpoint = RelayUrl::parse("wss://removed-pin-failure.example").unwrap();
+        let removed_sdk = NostrSdkRelayClient::new(Client::builder().build());
+        removed_sdk
+            .publish_relay_pin_failure_stage
+            .store(2, Ordering::Relaxed);
+
+        removed_sdk
+            .retain_publish_relay(&removed_endpoint)
+            .await
+            .expect_err("a pin failure that removed the relay must remain unavailable");
+        assert!(removed_sdk.publish_relay_refs.lock().await.is_empty());
+        assert!(
+            !removed_sdk
+                .client
+                .relays()
+                .await
+                .contains_key(&removed_endpoint)
+        );
     }
 
     #[tokio::test]

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -1097,12 +1097,18 @@ impl NostrSdkRelayClient {
             // The sdk error Display can carry the relay URL; keep the error
             // operation-only so `TransportAdapterError` Display stays URL-free.
             .map_err(|_| TransportAdapterError::Subscription("add relay failed".to_owned()))?;
-        if added {
-            self.pin_new_relay_retry_interval(&endpoint)
-                .await
-                .map_err(|_| {
-                    TransportAdapterError::Subscription("configure relay failed".to_owned())
-                })?;
+        if added && self.pin_new_relay_retry_interval(&endpoint).await.is_err() {
+            if self.client.relays().await.contains_key(&endpoint) {
+                tracing::warn!(
+                    target: "transport_nostr_adapter::sdk_client",
+                    method = "add_subscription_relay",
+                    "new subscription relay kept SDK retry defaults after configuration failed"
+                );
+            } else {
+                return Err(TransportAdapterError::Subscription(
+                    "configure relay failed".to_owned(),
+                ));
+            }
         }
         Ok(())
     }
@@ -2697,6 +2703,47 @@ mod tests {
             .await
             .expect_err("a pin failure that removed the relay must remain unavailable");
         assert!(removed_sdk.publish_relay_refs.lock().await.is_empty());
+        assert!(
+            !removed_sdk
+                .client
+                .relays()
+                .await
+                .contains_key(&removed_endpoint)
+        );
+    }
+
+    #[tokio::test]
+    async fn subscription_relay_pin_failure_uses_registered_relay_defaults_only() {
+        let registered_endpoint =
+            RelayUrl::parse("wss://registered-subscription-pin-failure.example").unwrap();
+        let registered_sdk = NostrSdkRelayClient::new(Client::builder().build());
+        registered_sdk
+            .publish_relay_pin_failure_stage
+            .store(1, Ordering::Relaxed);
+
+        registered_sdk
+            .add_subscription_relay(registered_endpoint.clone())
+            .await
+            .expect("an unpinned subscription relay that remains registered is usable");
+        assert!(
+            registered_sdk
+                .client
+                .relays()
+                .await
+                .contains_key(&registered_endpoint)
+        );
+
+        let removed_endpoint =
+            RelayUrl::parse("wss://removed-subscription-pin-failure.example").unwrap();
+        let removed_sdk = NostrSdkRelayClient::new(Client::builder().build());
+        removed_sdk
+            .publish_relay_pin_failure_stage
+            .store(2, Ordering::Relaxed);
+
+        removed_sdk
+            .add_subscription_relay(removed_endpoint.clone())
+            .await
+            .expect_err("a pin failure that removed the subscription relay must fail");
         assert!(
             !removed_sdk
                 .client

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -883,7 +883,7 @@ impl NostrSdkRelayClient {
         // The first concurrent request window starts before shared relay
         // connection. A bounded `try_connect_relay` must not silently extend
         // the existing end-to-end event budget from 20s to 25s.
-        let mut request_window_deadline = publish_started_at + SDK_RELAY_PUBLISH_OVERALL_WAIT;
+        let initial_request_deadline = publish_started_at + SDK_RELAY_PUBLISH_OVERALL_WAIT;
         let batch_deadline = publish_started_at + SDK_RELAY_BATCH_OVERALL_WAIT;
         let mut unique_endpoints = Vec::new();
         let mut seen_endpoints = HashSet::new();
@@ -950,6 +950,7 @@ impl NostrSdkRelayClient {
             .collect::<Vec<Option<Result<NostrPublishOutcome, TransportAdapterError>>>>();
         let mut request_durations = vec![Duration::ZERO; request_count];
         let mut exhausted = false;
+        let mut admitted_network_requests = 0_usize;
         loop {
             while publishes.len() < SDK_RELAY_BATCH_MAX_IN_FLIGHT && !exhausted {
                 match pending.next() {
@@ -966,15 +967,13 @@ impl NostrSdkRelayClient {
                             request_durations[index] = batch_started_at.elapsed();
                             continue;
                         }
-                        // Requests admitted during one concurrency window share
-                        // its deadline. Once that window expires, later
-                        // backpressured requests receive the next bounded
-                        // window, capped by the whole-batch deadline.
-                        if now >= request_window_deadline {
-                            request_window_deadline =
-                                (now + SDK_RELAY_PUBLISH_OVERALL_WAIT).min(batch_deadline);
-                        }
-                        let request_deadline = request_window_deadline;
+                        let request_deadline = Self::batch_request_deadline(
+                            now,
+                            initial_request_deadline,
+                            batch_deadline,
+                            admitted_network_requests,
+                        );
+                        admitted_network_requests = admitted_network_requests.saturating_add(1);
                         let client = self.clone();
                         let unavailable = unavailable.clone();
                         publishes.spawn(async move {
@@ -1029,6 +1028,22 @@ impl NostrSdkRelayClient {
         NostrPublishBatch {
             outcomes,
             request_durations,
+        }
+    }
+
+    /// Preserve the first cohort's end-to-end budget while giving every
+    /// request admitted after backpressure a fresh per-event window, capped by
+    /// the whole-batch ceiling.
+    fn batch_request_deadline(
+        admitted_at: tokio::time::Instant,
+        initial_deadline: tokio::time::Instant,
+        batch_deadline: tokio::time::Instant,
+        admission_index: usize,
+    ) -> tokio::time::Instant {
+        if admission_index < SDK_RELAY_BATCH_MAX_IN_FLIGHT {
+            initial_deadline.min(batch_deadline)
+        } else {
+            (admitted_at + SDK_RELAY_PUBLISH_OVERALL_WAIT).min(batch_deadline)
         }
     }
 
@@ -2913,6 +2928,42 @@ mod tests {
             started_at.elapsed(),
         );
         assert_eq!(sdk.relay_health().await.total_relays, 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn fifth_batch_request_gets_a_fresh_deadline_after_backpressure() {
+        let started_at = tokio::time::Instant::now();
+        let initial_deadline = started_at + SDK_RELAY_PUBLISH_OVERALL_WAIT;
+        let batch_deadline = started_at + SDK_RELAY_BATCH_OVERALL_WAIT;
+
+        for admission_index in 0..SDK_RELAY_BATCH_MAX_IN_FLIGHT {
+            assert_eq!(
+                NostrSdkRelayClient::batch_request_deadline(
+                    started_at,
+                    initial_deadline,
+                    batch_deadline,
+                    admission_index,
+                ),
+                initial_deadline,
+                "the first four concurrent requests share the original end-to-end budget"
+            );
+        }
+
+        tokio::time::advance(SDK_RELAY_PUBLISH_OVERALL_WAIT - Duration::from_millis(1)).await;
+        let admitted_at = tokio::time::Instant::now();
+        let fifth_deadline = NostrSdkRelayClient::batch_request_deadline(
+            admitted_at,
+            initial_deadline,
+            batch_deadline,
+            SDK_RELAY_BATCH_MAX_IN_FLIGHT,
+        );
+
+        assert_eq!(
+            fifth_deadline,
+            admitted_at + SDK_RELAY_PUBLISH_OVERALL_WAIT,
+            "a refill must not inherit the first cohort's final millisecond"
+        );
+        assert!(fifth_deadline > initial_deadline);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

Temporary relay or network failures could leave outbound application messages and group-invite commits pending for too long, even after connectivity returned. Two offline messages could retry with a long interval between them, and a successfully published retry could remain visually stuck in `Sending` because the retry path lacked enough application-event context to finalize the optimistic timeline row.

The same failure family also caused startup/catch-up transport errors to surface too eagerly and allowed an older unresolved pending row to remain pinned as a chat-list preview after newer authenticated activity arrived.

## Root causes

- `nostr-sdk` relay connection startup is asynchronous. The previous adapter path could race the background connection task, classify an obviously unavailable pre-send failure as possibly exposed, and put it behind the conservative 30-second exponential ambiguity backoff.
- Durable fanout persistence kept the exact signed transport event and relay targets, but not the application-message identity needed to project an eventless retry acknowledgement back into the local timeline.
- Runtime scheduling treated convergence inputs and queued intents as work, but did not consistently wake already-frozen fanouts when the host observed restored connectivity or while an account worker was sleeping in reconnect backoff.
- Chat-list preview selection reused timeline ordering that intentionally favors unresolved local sends; this could let an old orphaned pending row hide newer authenticated activity indefinitely.

## Solution

### Durable outbound retry

- Persist optional `OutboundApplicationMessage` context with each frozen fanout: group id, application-event id, source epoch, and retention policy.
- Preserve and retry the exact original signed event bytes and targets; no replacement event is constructed during retry.
- Query pending fanouts by group and drain them before newer group work so multiple offline messages retry once and in order.
- When an acknowledged retry produces no new engine event, emit the stored application-message projection so every matching optimistic timeline row transitions out of `Sending`.
- Apply the same durable exact-fanout path to group-invite commit publication.

### Connectivity recovery and failure classification

- Add the additive host API `notify_connectivity_restored` through the runtime, UniFFI, and C surfaces.
- Wake account workers, interrupt reconnect sleep, clear scheduled transport backoff, and schedule durable group work immediately when usable connectivity returns.
- Only clear retry clocks for targets proven unavailable before exposure. Possibly-exposed failures retain the conservative ambiguity/duplicate-safety backoff.
- Use `try_connect_relay` to prove pre-send connection failures are retryable-unavailable, preserve relay options, and keep privacy-safe error text free of relay URLs.
- Pin SDK reconnect cadence to the durable retry budget.
- Retry startup/catch-up only for transient transport activation, subscription, and receive failures (250 ms, 1 s, 3 s). Protocol, crypto, storage, cancellation, closed-worker, and exhausted-budget failures remain terminal.

### Chat-list preview repair

- Select preview candidates using stable application-event insertion order so newer authenticated activity replaces an older unresolved pending preview.
- Preserve the expected behavior where a genuinely newer pending send remains the preview.
- Prevent replayed older authenticated events from leapfrogging newer activity.
- Use the same ordering for projection-completeness and secure-prune repair paths.

The unresolved timeline row itself is retained; this change repairs only which event is presented as the latest chat preview.

## Safety and compatibility

- No MLS/protocol wire-format change.
- Adds SQLite migration 0056: an additive, defaulted `accepted_activity_insert_order` column with a backfill of existing accepted activity.
- Existing persisted fanouts remain readable because the new application-message field is optional and serde-defaulted.
- The host connectivity notification is additive. Clients that do not call it retain timer-based retry behavior, so existing iOS, macOS, Linux, and other integrations do not break.
- Ambiguous publication failures keep their existing conservative retry protection.
- The checked-in C header is refreshed for the new C ABI entry point.
- Generated Kotlin/Swift/JNI bindings, native binaries, and Android changes are intentionally not included. Local Android bindings were used only for device validation; Android integration remains a separate change.

## Validation

Automated:

- `just check`
- `just clippy`
- `cargo test -p marmot-app recover`
- focused connectivity-wake, eventless-projection, catch-up, ordered retry, and group-invite retry tests
- focused chat-list pending/authenticated preview ordering and repair tests
- focused frozen-fanout serialization and retry-clock safety tests
- focused `nostr-sdk` pre-exposure classification and reconnect-budget tests
- `cargo test -p cgka-engine --test convergence_policy_pin --locked`
- `cargo test -p marmot-c --features alloc-audit --locked`
- C/UniFFI command parity gate
- generated `marmot.h` inspection and clean diff check

Manual device validation with locally generated, uncommitted bindings:

- queued two messages offline, force-stopped and cold-started without clearing app data, restored connectivity, and confirmed ordered automatic delivery
- confirmed the companion client received both messages and the reply returned successfully
- confirmed the latest-message preview remained correct after restart
- accepted a two-member group invite offline, force-stopped and reopened offline, restored connectivity, and confirmed membership plus successful messages in both directions

`just fast-ci` passed formatting, naming, C/UniFFI parity, convergence-ledger, and static campaign checks, then stopped in the unchanged campaign-toolchain shell test because its GNU `sed -i` syntax is incompatible with macOS BSD `sed`. The affected script is unchanged from `master`; the equivalent Rust checks and focused regression suites above pass locally, and the Linux CI run remains authoritative for that harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added connectivity-restored notifications for native and C integrations.
  * Added group-level visibility into pending outbound delivery work.
  * Preserved application-message metadata through delivery, retries, and restart recovery.

* **Bug Fixes**
  * Improved retry scheduling, reconnection handling, and ordered delivery recovery.
  * Chat previews now prioritize the most relevant accepted or pending activity.
  * Improved cleanup and retention updates after publishing or acknowledgement failures.

* **Tests**
  * Expanded coverage for retries, reconnection, ordering, previews, persistence, and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->