### PR TITLE
fix(engine,app): announce a disband once, and heal terminal groups from the guard row

### DIFF
--- a/crates/cgka-engine/src/conformance_snapshot.rs
+++ b/crates/cgka-engine/src/conformance_snapshot.rs
@@ -880,6 +880,7 @@ mod tests {
             commit_digest: [0xd4; 32],
             local_was_committer_leaf: true,
             former_members: vec![bob.clone(), alice.clone(), bob],
+            announced: false,
         };
         let sibling_device = DisbandTombstone {
             local_was_committer_leaf: false,

--- a/crates/cgka-engine/src/disband.rs
+++ b/crates/cgka-engine/src/disband.rs
@@ -537,6 +537,12 @@ impl<S: StorageProvider> Engine<S> {
             commit_digest: selected.commit_digest,
             local_was_committer_leaf: selected.local_was_committer_leaf,
             former_members: selected.former_members.clone(),
+            // The live `GroupDisbanded` this settle emits reaches the
+            // application through a later, non-transactional drain that can
+            // drop the whole batch (a failed publish gate, or a crash). Marking
+            // here would suppress the one hydration replay that reconciles
+            // exactly that loss, so the guard is born unannounced.
+            announced: false,
         };
 
         self.storage

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -1316,14 +1316,18 @@ impl<S: StorageProvider> Engine<S> {
             {
                 continue;
             }
-            let tombstone = group
-                .disbanded
-                .clone()
-                .or_else(|| tombstones.remove(&group.id));
+            // The guard row is the authority on the `announced` marker: the
+            // group record's mirror is written once at settle and never
+            // updated, and the row outlives the record when the user deletes
+            // local history. The mirror is the payload fallback only.
+            let tombstone = tombstones
+                .remove(&group.id)
+                .or_else(|| group.disbanded.clone());
             if let Some(tombstone) = tombstone {
-                // Reconcile the single deterministic system row after a
-                // crash. The application projection canonicalizes this event,
-                // so replaying it on open is idempotent.
+                // Reconcile the single deterministic system row after a crash.
+                // The replay is idempotent (the application projection
+                // canonicalizes it) *and* announced-once, so an already
+                // announced guard restores its epoch entry in silence.
                 self.restore_disband_tombstone(group.id, tombstone)?;
                 continue;
             }
@@ -1464,6 +1468,32 @@ impl<S: StorageProvider> Engine<S> {
             .collect())
     }
 
+    /// Restore one terminal guard's epoch entry, and replay its
+    /// `GroupDisbanded` to the application at most once ever.
+    ///
+    /// The epoch entry is in-memory and is restored unconditionally on every
+    /// open; only the replay is marked. The marking moment is *here*, when the
+    /// replay is produced, and deliberately not at settle time. A settle
+    /// commits the guard durably, but the live `GroupDisbanded` it emits only
+    /// reaches the application through a later drain that can drop the whole
+    /// batch without a crash — `observe_drained_session_events` runs
+    /// `fail_if_publish_failed(effects)?` before it projects any event — so a
+    /// marker written at settle could suppress an announcement the application
+    /// never received. Marking at replay time instead guarantees live delivery
+    /// plus exactly one belt-and-braces replay, then silence.
+    ///
+    /// Residual crash window: the process can die (or the drain can fail its
+    /// publish gate) after this replay is buffered and marked, losing both the
+    /// live delivery and the one replay. What survives that is bounded, because
+    /// the user-visible terminal projection is derived from the guard row on
+    /// every read rather than accumulated from this event: `Group::disbanded`,
+    /// the chat-list terminal flag, the unread-aggregate exclusion, and the
+    /// transport-route exclusion all re-derive from `cgka_disband_tombstones`.
+    /// What is lost is the kind-1210 system row and the terminal push-token
+    /// sweep — the group can never resurface as live, routable, or unread. An
+    /// application-acknowledged marker would close even that, but no ack seam
+    /// covers `GroupStateChanged` today (only `MessageReceived` /
+    /// `GroupJoined`), so the plumbing is not proportionate to the residual.
     fn restore_disband_tombstone(
         &mut self,
         group_id: GroupId,
@@ -1471,13 +1501,32 @@ impl<S: StorageProvider> Engine<S> {
     ) -> Result<(), EngineError> {
         self.epoch_manager
             .restore_disbanded(group_id.clone(), tombstone.epoch)?;
+        if tombstone.announced {
+            return Ok(());
+        }
         self.events_buf.push_back(GroupEvent::GroupStateChanged {
-            group_id,
+            group_id: group_id.clone(),
             epoch: tombstone.epoch,
             actor: Some(tombstone.actor),
             change: GroupStateChange::GroupDisbanded,
             origin_commit_id: tombstone.origin_commit_id,
         });
+        // Best-effort by design. A failed mark leaves the guard unannounced, so
+        // the next open replays again — the pre-fix behavior, and the safe
+        // direction. Propagating instead would quarantine a terminal group over
+        // a deduplication write.
+        if self
+            .storage
+            .mark_disband_tombstone_announced(&group_id)
+            .is_err()
+        {
+            tracing::debug!(
+                target: "cgka_engine::hydrate",
+                method = "restore_disband_tombstone",
+                error_kind = "mark_disband_tombstone_announced_failed",
+                "terminal guard replayed but not marked announced; the next open replays it again"
+            );
+        }
         Ok(())
     }
 
@@ -1541,17 +1590,17 @@ impl<S: StorageProvider> Engine<S> {
             .storage
             .get_group(group_id)
             .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
-        let tombstone = match group.disbanded.clone() {
-            Some(tombstone) => Some(tombstone),
-            None => self
-                .storage
-                .disband_tombstone(group_id)
-                .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?,
-        };
+        // Same guard-row-first precedence as the cheap hydration pass, for the
+        // same reason. Live groups already paid this lookup, so the query count
+        // is unchanged for them; a terminal group gains one indexed read.
+        let tombstone = self
+            .storage
+            .disband_tombstone(group_id)
+            .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?
+            .or_else(|| group.disbanded.clone());
         if let Some(tombstone) = tombstone {
-            // Reconcile the single deterministic system row after a crash. The
-            // application projection canonicalizes this event, so replaying it
-            // on open is idempotent.
+            // Same once-only reconciliation as the cheap pass: idempotent if it
+            // does replay, and silent once the guard is marked announced.
             let epoch = tombstone.epoch;
             self.restore_disband_tombstone(group_id.clone(), tombstone)
                 .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -1472,28 +1472,63 @@ impl<S: StorageProvider> Engine<S> {
     /// `GroupDisbanded` to the application at most once ever.
     ///
     /// The epoch entry is in-memory and is restored unconditionally on every
-    /// open; only the replay is marked. The marking moment is *here*, when the
-    /// replay is produced, and deliberately not at settle time. A settle
-    /// commits the guard durably, but the live `GroupDisbanded` it emits only
-    /// reaches the application through a later drain that can drop the whole
-    /// batch without a crash — `observe_drained_session_events` runs
-    /// `fail_if_publish_failed(effects)?` before it projects any event — so a
-    /// marker written at settle could suppress an announcement the application
-    /// never received. Marking at replay time instead guarantees live delivery
-    /// plus exactly one belt-and-braces replay, then silence.
+    /// open; only the replay is marked.
     ///
-    /// Residual crash window: the process can die (or the drain can fail its
-    /// publish gate) after this replay is buffered and marked, losing both the
-    /// live delivery and the one replay. What survives that is bounded, because
-    /// the user-visible terminal projection is derived from the guard row on
-    /// every read rather than accumulated from this event: `Group::disbanded`,
-    /// the chat-list terminal flag, the unread-aggregate exclusion, and the
-    /// transport-route exclusion all re-derive from `cgka_disband_tombstones`.
-    /// What is lost is the kind-1210 system row and the terminal push-token
-    /// sweep — the group can never resurface as live, routable, or unread. An
-    /// application-acknowledged marker would close even that, but no ack seam
-    /// covers `GroupStateChanged` today (only `MessageReceived` /
-    /// `GroupJoined`), so the plumbing is not proportionate to the residual.
+    /// # Why the mark happens here and not at settle
+    ///
+    /// A settle commits the guard durably, but the live `GroupDisbanded` it
+    /// emits only reaches the application through a later drain that can drop
+    /// the whole batch without a crash — `observe_drained_session_events` runs
+    /// `fail_if_publish_failed(effects)?` before it projects any event. A
+    /// settle-time marker could therefore suppress an announcement the
+    /// application never received. Marking at replay time instead guarantees
+    /// live delivery plus exactly one belt-and-braces replay, then silence.
+    ///
+    /// # The loss window
+    ///
+    /// This runs inside `AccountDeviceSession::open`, so the mark is durable at
+    /// *account open* — before any drain exists to consume the event it
+    /// announces. The window in which the replay can be lost is therefore
+    /// `[account open, first successful drained projection]`: it spans app
+    /// startup, and **one** process death (or one drained batch that fails its
+    /// publish gate) is enough to close it with the event unprojected. That is
+    /// wider than a same-drain window, which is exactly why the consequences
+    /// below have to be reconciled from durable state rather than from this
+    /// event.
+    ///
+    /// # What a lost replay costs
+    ///
+    /// Re-derived from the guard row on every read, so unaffected:
+    ///
+    /// - `Group::disbanded` (`MarmotApp::visible_groups`, via
+    ///   `list_disband_tombstones`)
+    /// - transport-route exclusion (`MarmotApp::routing_for`, same source)
+    /// - chat-list terminal flag and the account unread-aggregate exclusion
+    ///   (correlated `EXISTS`/`NOT EXISTS` over `cgka_disband_tombstones`)
+    ///
+    /// Reconciled from the guard row once per account open by
+    /// `AppClient::sweep_terminal_groups_from_guards`, so also unaffected:
+    ///
+    /// - held-send resolution (`invalidate_pending_sent_app_events_for_group`)
+    ///   — the mdk#1177 reconciler, which would otherwise strand a send at
+    ///   "Sending…" permanently
+    /// - stale peer push tokens (`remove_stale_group_push_tokens`)
+    ///
+    /// Still event-only, and therefore the actual residual:
+    ///
+    /// - the durable kind-1210 "group disbanded" system row
+    ///   (`project_group_system_rows`) — a missing transcript entry
+    /// - `clear_terminal_local_group_deletion_frontiers` — an idempotent
+    ///   `DELETE` whose loss leaves a local-deletion marker lingering
+    /// - `queue_current_push_registration_removal_for_group` — deliberately
+    ///   left out of the open-time sweep because it is an upsert that arms an
+    ///   outbox publish, so sweeping it would re-queue work on every open and
+    ///   reintroduce exactly the per-open cost this marker removes
+    ///
+    /// None of those can make a terminal group look live, routable, unread, or
+    /// stuck sending. An application-acknowledged marker would close even them,
+    /// but no ack seam covers `GroupStateChanged` today (only `MessageReceived`
+    /// / `GroupJoined`), so the plumbing is not proportionate to what is left.
     fn restore_disband_tombstone(
         &mut self,
         group_id: GroupId,

--- a/crates/cgka-engine/tests/group_creation.rs
+++ b/crates/cgka-engine/tests/group_creation.rs
@@ -1646,6 +1646,189 @@ async fn solo_disband_is_durable_convergent_terminal_and_restart_safe() {
     );
 }
 
+/// Helper for the announce-once tests: drive one solo group all the way to a
+/// settled, durable disband and hand back the storage that outlives the engine.
+async fn settle_solo_disband(identity: &[u8]) -> (SqliteAccountStorage, cgka_traits::GroupId) {
+    let storage = SqliteAccountStorage::in_memory().unwrap();
+    let clock = ManualConvergenceClock::new(0, 10_000);
+    let mut alice = EngineBuilder::new(storage.clone())
+        .identity(pad32(identity))
+        .account_identity_proof_signer(proof_signer(identity))
+        .protocol_profile(ProtocolProfile::Current)
+        .peeler(Box::new(MockPeeler::default()))
+        .convergence_clock(Arc::new(clock.clone()))
+        .build()
+        .expect("build current-profile engine");
+    let (group_id, _) = alice
+        .create_group(CreateGroupRequest {
+            name: "announce once".into(),
+            description: String::new(),
+            members: vec![],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    alice.drain_events();
+
+    alice
+        .send(cgka_traits::engine::SendIntent::Disband {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    let prepared = alice.advance_convergence(&group_id).await.unwrap();
+    let pending = match prepared.as_slice() {
+        [SendResult::GroupEvolution { pending, .. }] => *pending,
+        other => panic!("expected one prepared disband commit, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    assert!(
+        alice
+            .advance_convergence(&group_id)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    clock.advance_ms(1_000);
+    assert!(
+        alice
+            .advance_convergence(&group_id)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        matches!(
+            alice.epoch_state(&group_id),
+            Some(cgka_traits::EpochState::Disbanded(_))
+        ),
+        "disband did not settle within the bounded convergence pass"
+    );
+    // The live delivery the application receives in-session. Everything after
+    // this point is hydration's belt-and-braces reconciliation.
+    assert_eq!(
+        disband_replays(&mut alice),
+        1,
+        "the settling session owes exactly one live GroupDisbanded"
+    );
+    drop(alice);
+    (storage, group_id)
+}
+
+/// Count the terminal `GroupDisbanded` events one engine session hands the
+/// application.
+fn disband_replays(engine: &mut Engine<SqliteAccountStorage>) -> usize {
+    engine
+        .drain_events()
+        .into_iter()
+        .filter(|event| {
+            matches!(
+                event,
+                cgka_traits::engine::GroupEvent::GroupStateChanged {
+                    change: cgka_traits::engine::GroupStateChange::GroupDisbanded,
+                    ..
+                }
+            )
+        })
+        .count()
+}
+
+/// A disband tombstone is immortal, but its announcement is not: hydration
+/// owes the application exactly one belt-and-braces replay of `GroupDisbanded`
+/// — the reconciler for a live delivery the application never projected — and
+/// silence on every open after that.
+///
+/// Without the marker every open re-emits, and the application's terminal arm
+/// forces a no-op route-refreshing sync for every disbanded group, forever.
+#[tokio::test]
+async fn a_disbanded_group_announces_itself_once_across_repeated_opens() {
+    let identity = b"alice-announce-once-record";
+    let (storage, group_id) = settle_solo_disband(identity).await;
+
+    let mut first =
+        build_profile_client_on_storage(identity, storage.clone(), ProtocolProfile::Current);
+    first.hydrate_all_stored_groups().unwrap();
+    assert!(matches!(
+        first.epoch_state(&group_id),
+        Some(cgka_traits::EpochState::Disbanded(_))
+    ));
+    assert_eq!(
+        disband_replays(&mut first),
+        1,
+        "the first open owes the one reconciling replay"
+    );
+    drop(first);
+
+    for open in 2..=3 {
+        let mut later =
+            build_profile_client_on_storage(identity, storage.clone(), ProtocolProfile::Current);
+        later.hydrate_all_stored_groups().unwrap();
+        assert!(
+            matches!(
+                later.epoch_state(&group_id),
+                Some(cgka_traits::EpochState::Disbanded(_))
+            ),
+            "open {open} must still restore the terminal epoch entry"
+        );
+        assert_eq!(
+            disband_replays(&mut later),
+            0,
+            "open {open} must not re-announce an already announced disband"
+        );
+        assert!(later.quarantined_groups().is_empty());
+        drop(later);
+    }
+}
+
+/// Same contract on the orphan-tombstone path: after the user deletes local
+/// history the group record is gone and only the anti-resurrection guard
+/// remains, so hydration reaches the tombstone through the orphan sweep rather
+/// than through a stored group record. Both hydration call sites must agree.
+#[tokio::test]
+async fn a_tombstone_only_group_announces_itself_once_across_repeated_opens() {
+    let identity = b"alice-announce-once-orphan";
+    let (storage, group_id) = settle_solo_disband(identity).await;
+    assert!(
+        storage
+            .delete_local_group_data(&hex::encode(group_id.as_slice()))
+            .unwrap()
+            .did_delete(),
+        "terminal local deletion should remove history and the full group row"
+    );
+
+    let mut first =
+        build_profile_client_on_storage(identity, storage.clone(), ProtocolProfile::Current);
+    first.hydrate_all_stored_groups().unwrap();
+    assert_eq!(
+        disband_replays(&mut first),
+        1,
+        "the orphan sweep owes the same single reconciling replay"
+    );
+    assert!(first.live_group_ids().unwrap().is_empty());
+    drop(first);
+
+    for open in 2..=3 {
+        let mut later =
+            build_profile_client_on_storage(identity, storage.clone(), ProtocolProfile::Current);
+        later.hydrate_all_stored_groups().unwrap();
+        assert!(
+            matches!(
+                later.epoch_state(&group_id),
+                Some(cgka_traits::EpochState::Disbanded(_))
+            ),
+            "open {open} must still restore the terminal epoch entry from the guard alone"
+        );
+        assert_eq!(
+            disband_replays(&mut later),
+            0,
+            "open {open} must not re-announce an already announced orphan tombstone"
+        );
+        drop(later);
+    }
+}
+
 #[tokio::test]
 async fn current_configured_engine_reopens_and_uses_a_legacy_group() {
     let storage = SqliteAccountStorage::in_memory().unwrap();

--- a/crates/cgka-engine/tests/hydration_quarantine.rs
+++ b/crates/cgka-engine/tests/hydration_quarantine.rs
@@ -392,6 +392,7 @@ struct FlakyGroupRecordStorage {
     inner: SqliteAccountStorage,
     fail_get_group: Arc<AtomicBool>,
     fail_disband_tombstone: Arc<AtomicBool>,
+    fail_mark_disband_tombstone_announced: Arc<AtomicBool>,
     fail_list_queued_outbound_intents: Arc<AtomicBool>,
 }
 
@@ -401,6 +402,7 @@ impl FlakyGroupRecordStorage {
             inner,
             fail_get_group: Arc::new(AtomicBool::new(false)),
             fail_disband_tombstone: Arc::new(AtomicBool::new(false)),
+            fail_mark_disband_tombstone_announced: Arc::new(AtomicBool::new(false)),
             fail_list_queued_outbound_intents: Arc::new(AtomicBool::new(false)),
         }
     }
@@ -411,6 +413,11 @@ impl FlakyGroupRecordStorage {
 
     fn set_fail_disband_tombstone(&self, fail: bool) {
         self.fail_disband_tombstone.store(fail, Ordering::SeqCst);
+    }
+
+    fn set_fail_mark_disband_tombstone_announced(&self, fail: bool) {
+        self.fail_mark_disband_tombstone_announced
+            .store(fail, Ordering::SeqCst);
     }
 
     fn set_fail_list_queued_outbound_intents(&self, fail: bool) {
@@ -631,6 +638,17 @@ impl DisbandTombstoneStorage for FlakyGroupRecordStorage {
         &self,
     ) -> StorageResult<Vec<(GroupId, cgka_traits::DisbandTombstone)>> {
         self.inner.list_disband_tombstones()
+    }
+    fn mark_disband_tombstone_announced(&self, group_id: &GroupId) -> StorageResult<()> {
+        if self
+            .fail_mark_disband_tombstone_announced
+            .load(Ordering::SeqCst)
+        {
+            return Err(StorageError::Backend(
+                "injected mark_disband_tombstone_announced failure".into(),
+            ));
+        }
+        self.inner.mark_disband_tombstone_announced(group_id)
     }
 }
 
@@ -964,6 +982,82 @@ async fn tombstone_read_failure_quarantines_instead_of_hydrating_live_state() {
         reopened
             .retry_hydrate_quarantined_group(&group_id)
             .expect("retry succeeds")
+    );
+}
+
+/// The announce-once marker fails safe. If the mark cannot be written the
+/// terminal guard stays unannounced, so the next open replays `GroupDisbanded`
+/// again — the pre-marker behavior — and the group is never quarantined over a
+/// deduplication write. The opposite failure (a mark that sticks while the
+/// replay is lost) is the one the design forbids.
+#[tokio::test]
+async fn a_failed_announce_mark_replays_again_instead_of_quarantining() {
+    let storage = FlakyGroupRecordStorage::new(SqliteAccountStorage::in_memory().expect("storage"));
+    let mut initial = build_flaky_engine(storage.clone());
+    let group_id = create_confirmed_group_flaky(&mut initial).await;
+    let epoch = initial.group_record(&group_id).unwrap().epoch;
+    // The durable terminal guard a settled disband commits, born unannounced.
+    storage
+        .put_disband_tombstone(
+            &group_id,
+            &cgka_traits::DisbandTombstone {
+                epoch,
+                actor: MemberId::new(pad32(b"alice-hydration")),
+                origin_commit_id: None,
+                commit_digest: [0x7a; 32],
+                local_was_committer_leaf: true,
+                former_members: Vec::new(),
+                announced: false,
+            },
+        )
+        .expect("write terminal guard");
+    drop(initial);
+
+    let disband_replays = |engine: &mut Engine<FlakyGroupRecordStorage>| {
+        engine
+            .drain_events()
+            .into_iter()
+            .filter(|event| {
+                matches!(
+                    event,
+                    GroupEvent::GroupStateChanged {
+                        change: cgka_traits::engine::GroupStateChange::GroupDisbanded,
+                        ..
+                    }
+                )
+            })
+            .count()
+    };
+
+    storage.set_fail_mark_disband_tombstone_announced(true);
+    for open in 1..=2 {
+        let mut reopened = build_flaky_engine(storage.clone());
+        reopened
+            .hydrate_all_stored_groups()
+            .expect("an unmarkable guard must not fail account open");
+        assert!(
+            reopened.quarantined_groups().is_empty(),
+            "open {open} quarantined a terminal group over a deduplication write"
+        );
+        assert_eq!(
+            disband_replays(&mut reopened),
+            1,
+            "open {open} must keep replaying while the marker cannot be written"
+        );
+    }
+
+    storage.set_fail_mark_disband_tombstone_announced(false);
+    let mut recovering = build_flaky_engine(storage.clone());
+    recovering.hydrate_all_stored_groups().expect("open");
+    assert_eq!(disband_replays(&mut recovering), 1);
+    drop(recovering);
+
+    let mut settled = build_flaky_engine(storage.clone());
+    settled.hydrate_all_stored_groups().expect("open");
+    assert_eq!(
+        disband_replays(&mut settled),
+        0,
+        "once the mark lands the guard must go silent"
     );
 }
 

--- a/crates/cgka-engine/tests/hydration_quarantine.rs
+++ b/crates/cgka-engine/tests/hydration_quarantine.rs
@@ -1061,6 +1061,94 @@ async fn a_failed_announce_mark_replays_again_instead_of_quarantining() {
     );
 }
 
+/// `retry_hydrate_quarantined_group` goes through `hydrate_one_stored_group`,
+/// which is the call site where the guard row must be read *before* the group
+/// record's `disbanded` mirror.
+///
+/// The mirror is written once, at settle, and never updated again — marking a
+/// guard announced does not touch it. So a mirror-first read would re-announce
+/// on every single retry, forever, for any group that keeps failing and
+/// recovering. This pins the ordering: both copies start unannounced, the first
+/// retry announces and marks the guard row, and the second retry is silent even
+/// though the mirror still says otherwise.
+#[tokio::test]
+async fn retrying_a_quarantined_terminal_group_announces_once_despite_a_stale_mirror() {
+    let storage = FlakyGroupRecordStorage::new(SqliteAccountStorage::in_memory().expect("storage"));
+    let mut initial = build_flaky_engine(storage.clone());
+    let group_id = create_confirmed_group_flaky(&mut initial).await;
+    let mut record = initial.group_record(&group_id).unwrap();
+    let guard = cgka_traits::DisbandTombstone {
+        epoch: record.epoch,
+        actor: MemberId::new(pad32(b"alice-hydration")),
+        origin_commit_id: None,
+        commit_digest: [0x3c; 32],
+        local_was_committer_leaf: true,
+        former_members: Vec::new(),
+        announced: false,
+    };
+    // Both copies a settle writes, both unannounced — exactly what the durable
+    // transaction in `settle_disband_after_convergence` leaves behind.
+    storage
+        .put_disband_tombstone(&group_id, &guard)
+        .expect("write terminal guard");
+    record.disbanded = Some(guard);
+    storage.put_group(&record).expect("write mirror");
+    drop(initial);
+
+    let disband_replays = |engine: &mut Engine<FlakyGroupRecordStorage>| {
+        engine
+            .drain_events()
+            .into_iter()
+            .filter(|event| {
+                matches!(
+                    event,
+                    GroupEvent::GroupStateChanged {
+                        change: cgka_traits::engine::GroupStateChange::GroupDisbanded,
+                        ..
+                    }
+                )
+            })
+            .count()
+    };
+
+    let mut replays_per_retry = Vec::new();
+    for _ in 0..2 {
+        // A transiently unreadable record quarantines the group at open.
+        storage.set_fail_get_group(true);
+        let mut engine = build_flaky_engine(storage.clone());
+        engine.hydrate_all_stored_groups().expect("open");
+        assert_eq!(
+            engine.quarantined_groups(),
+            vec![(
+                group_id.clone(),
+                GroupHydrationQuarantineReason::GroupRecordLoadFailed,
+            )]
+        );
+        engine.drain_events();
+
+        storage.set_fail_get_group(false);
+        assert!(
+            engine
+                .retry_hydrate_quarantined_group(&group_id)
+                .expect("retry succeeds")
+        );
+        replays_per_retry.push(disband_replays(&mut engine));
+    }
+
+    assert_eq!(
+        replays_per_retry,
+        vec![1, 0],
+        "the retry path must read the guard row, not the never-updated mirror"
+    );
+    assert!(
+        storage
+            .disband_tombstone(&group_id)
+            .unwrap()
+            .expect("guard survives")
+            .announced
+    );
+}
+
 #[tokio::test]
 async fn pending_fanout_is_not_exposed_until_hydration_fully_succeeds() {
     let storage = FlakyGroupRecordStorage::new(SqliteAccountStorage::in_memory().expect("storage"));

--- a/crates/cgka-engine/tests/publish_lifecycle.rs
+++ b/crates/cgka-engine/tests/publish_lifecycle.rs
@@ -1211,6 +1211,10 @@ impl DisbandTombstoneStorage for FaultStorage {
     ) -> StorageResult<Vec<(GroupId, cgka_traits::DisbandTombstone)>> {
         self.inner.list_disband_tombstones()
     }
+
+    fn mark_disband_tombstone_announced(&self, group_id: &GroupId) -> StorageResult<()> {
+        self.inner.mark_disband_tombstone_announced(group_id)
+    }
 }
 
 impl WelcomeStorage for FaultStorage {

--- a/crates/cgka-engine/tests/record_write_atomicity.rs
+++ b/crates/cgka-engine/tests/record_write_atomicity.rs
@@ -501,6 +501,10 @@ impl DisbandTombstoneStorage for FaultStorage {
     ) -> StorageResult<Vec<(GroupId, cgka_traits::DisbandTombstone)>> {
         self.inner.list_disband_tombstones()
     }
+
+    fn mark_disband_tombstone_announced(&self, group_id: &GroupId) -> StorageResult<()> {
+        self.inner.mark_disband_tombstone_announced(group_id)
+    }
 }
 
 impl WelcomeStorage for FaultStorage {

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -1043,13 +1043,15 @@ impl AppClient {
         }
         let display_names = self.app.display_names_by_id()?;
         let source_received_at = unix_now_seconds();
-        // Hydration re-emits a stored group's `GroupDisbanded` on every open
-        // (`restore_disband_tombstone`), and that replay is the only reconciler
-        // left for a disband whose live-session projection never completed — a
-        // crash, or a batch that failed after the engine had already drained the
-        // event. So this seam owes the same terminal sweep as the inbound one,
-        // which it discharges by running the shared
-        // `observe_event_projection_effects` below rather than a copy of it.
+        // Hydration replays a stored group's `GroupDisbanded` once ever
+        // (`restore_disband_tombstone`), as the belt-and-braces reconciler for a
+        // disband whose live-session projection never completed — a crash, or a
+        // batch that failed after the engine had already drained the event. So
+        // this seam owes the same terminal sweep as the inbound one, which it
+        // discharges by running the shared `observe_event_projection_effects`
+        // below rather than a copy of it. The durable writes that must not
+        // depend on that one replay arriving are reconciled from the guard rows
+        // instead, by `sweep_terminal_groups_from_guards` at account open.
         let local_account_id_hex = self
             .app
             .account_home()
@@ -2498,6 +2500,84 @@ impl AppClient {
         }
     }
 
+    /// Reconcile every terminal group's durable projection from the guard rows
+    /// themselves, once per account open.
+    ///
+    /// This used to ride the `GroupDisbanded` event arm alone, which worked only
+    /// because hydration re-emitted that event on *every* open: the replay was
+    /// the reconciler. Now that a guard announces itself once
+    /// (`Engine::restore_disband_tombstone`), an event-only sweep would run
+    /// exactly once ever — and a process death in the window between the engine
+    /// marking the guard at account open and the app committing its projection
+    /// would strand the group's held sends at "Sending…" permanently.
+    ///
+    /// So the sweep reads its input from the immortal guard rows instead of
+    /// from an event that fires once. Both writes are idempotent, group-keyed,
+    /// and no-ops when clean —
+    /// `invalidate_pending_sent_app_events_for_group` returns `None` without
+    /// writing when no unresolved send remains, and the token removal is a
+    /// `DELETE` of rows that may already be gone — so a steady-state open costs
+    /// one indexed read per terminal group and produces no projection churn.
+    ///
+    /// Best-effort per guard: one unreadable group must not fail account open,
+    /// and the next open retries it.
+    pub(crate) fn sweep_terminal_groups_from_guards(&mut self) {
+        use cgka_traits::storage::DisbandTombstoneStorage;
+
+        let guards = match self
+            .app
+            .account_storage(&self.state.label)
+            .and_then(|storage| Ok(storage.list_disband_tombstones()?))
+        {
+            Ok(guards) => guards,
+            Err(error) => {
+                tracing::warn!(
+                    target: "marmot_app::terminal_sweep",
+                    method = "sweep_terminal_groups_from_guards",
+                    error_kind = error.privacy_safe_kind(),
+                    "could not enumerate terminal guards; skipping the open-time sweep"
+                );
+                return;
+            }
+        };
+        let guard_count = guards.len();
+        let mut reconciled = 0_u64;
+        let mut failed = 0_u64;
+        for (group_id, _) in guards {
+            let group_id_hex = hex::encode(group_id.as_slice());
+            match self
+                .app
+                .invalidate_timeline_pending_sends_for_group(&self.state.label, &group_id_hex)
+            {
+                Ok(Some(update)) => {
+                    reconciled = reconciled.saturating_add(1);
+                    self.pending_projection_updates.push(update);
+                }
+                Ok(None) => {}
+                Err(_) => failed = failed.saturating_add(1),
+            }
+            // A terminal group never advertises notification destinations
+            // again, so every cached peer token is stale by definition.
+            if self
+                .app
+                .remove_stale_group_push_tokens(&self.state.label, &group_id_hex, &[])
+                .is_err()
+            {
+                failed = failed.saturating_add(1);
+            }
+        }
+        if reconciled > 0 || failed > 0 {
+            tracing::debug!(
+                target: "marmot_app::terminal_sweep",
+                method = "sweep_terminal_groups_from_guards",
+                terminal_groups = guard_count,
+                reconciled,
+                failed,
+                "reconciled terminal group projections from durable guards"
+            );
+        }
+    }
+
     /// Rebuild the frozen-epoch evidence a previous process gathered.
     pub(crate) fn restore_persisted_epoch_stall_evidence(
         &mut self,
@@ -3666,9 +3746,10 @@ impl AppClient {
     /// the account unread aggregate stale.
     ///
     /// Replay-safe by construction, which is what lets the drained seam call it:
-    /// hydration re-emits a stored group's `GroupDisbanded` on every open, and a
-    /// crash replays pending application events the live seam may already have
-    /// projected. Token removal is a `DELETE` of rows that may be gone;
+    /// hydration replays a stored group's `GroupDisbanded` once after the
+    /// settling session, and a crash replays pending application events the live
+    /// seam may already have projected. Token removal is a `DELETE` of rows that
+    /// may be gone;
     /// `set_group_self_membership` writes an absolute value and no-ops when the
     /// group has no projection row; the queued registration removal is an upsert
     /// keyed on the group; and both invalidation sweeps skip rows they already

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1721,6 +1721,10 @@ impl MarmotApp {
         client.restore_persisted_epoch_backfill_intents(persisted_backfills);
         let persisted_evidence = self.epoch_stall_evidence(&client.state.label)?;
         client.restore_persisted_epoch_stall_evidence(persisted_evidence);
+        // Reads only the durable terminal guards, never live group state, so it
+        // runs on deferred opens too — and it must, because it is now the sole
+        // reconciler for a disband whose live projection never completed.
+        client.sweep_terminal_groups_from_guards();
         if !defer_group_hydration {
             // These repairs read live group state. Deferred runtime opens run
             // them after the account worker's hydration pipeline instead.

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -11728,6 +11728,91 @@ async fn a_drained_disband_sweeps_the_held_send_its_first_pass_never_reached() {
     );
 }
 
+/// A disband tombstone is immortal, but its announcement is not.
+///
+/// The application's terminal `GroupDisbanded` arm marks the transport routes
+/// dirty and synthesizes a durable kind-1210 system row, so an unconditional
+/// hydration replay bills every account open a no-op route-refreshing
+/// `sync_runtime_groups` plus a redundant projection for every group the user
+/// ever disbanded — forever. Hydration owes exactly one belt-and-braces replay
+/// (the reconciler for a live delivery the application never projected) and
+/// silence after that.
+#[tokio::test]
+async fn reopening_an_account_replays_a_disband_once_and_then_stays_silent() {
+    use cgka_traits::storage::DisbandTombstoneStorage;
+
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://announce-once.example")
+        .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client.create_group("announce once", &[]).await.unwrap();
+
+    // The durable terminal guard a settled disband commits. Written directly so
+    // the test pins the hydration seam instead of re-driving convergence.
+    app.account_storage("alice")
+        .unwrap()
+        .put_disband_tombstone(
+            &group_id,
+            &cgka_traits::DisbandTombstone {
+                epoch: cgka_traits::EpochId(1),
+                actor: MemberId::new(hex::decode(&account.account_id_hex).unwrap()),
+                origin_commit_id: None,
+                commit_digest: [0x11; 32],
+                local_was_committer_leaf: true,
+                former_members: Vec::new(),
+                announced: false,
+            },
+        )
+        .unwrap();
+    drop(client);
+
+    let mut replays_per_open = Vec::new();
+    let mut system_rows_per_open = Vec::new();
+    for _ in 0..3 {
+        let mut reopened = app.client("alice").await.unwrap();
+        let effects = reopened.runtime.drain().await.unwrap();
+        replays_per_open.push(
+            effects
+                .events
+                .iter()
+                .filter(|event| {
+                    matches!(
+                        event,
+                        cgka_traits::engine::GroupEvent::GroupStateChanged {
+                            change: cgka_traits::engine::GroupStateChange::GroupDisbanded,
+                            ..
+                        }
+                    )
+                })
+                .count(),
+        );
+        let summary = reopened
+            .observe_drained_session_events(&effects)
+            .await
+            .unwrap();
+        system_rows_per_open.push(summary.projection_updates.len());
+        drop(reopened);
+    }
+
+    assert_eq!(
+        replays_per_open,
+        vec![1, 0, 0],
+        "hydration owes one reconciling GroupDisbanded, then silence"
+    );
+    assert!(
+        system_rows_per_open[0] > 0,
+        "the one replay must still do its reconciling projection work: {system_rows_per_open:?}"
+    );
+    assert_eq!(
+        system_rows_per_open[1..],
+        [0, 0],
+        "a re-announced disband re-projects its terminal system row and dirties the routes"
+    );
+}
+
 fn drained_seam_push_token(
     group_id_hex: &str,
     member_id_hex: &str,

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -11793,6 +11793,14 @@ async fn reopening_an_account_replays_a_disband_once_and_then_stays_silent() {
             .observe_drained_session_events(&effects)
             .await
             .unwrap();
+        // The open-time guard sweep must be a no-op once the terminal group is
+        // already reconciled, or it would simply move the per-open churn this
+        // fix removes onto a different channel.
+        let swept = reopened.take_pending_projection_updates();
+        assert!(
+            swept.is_empty(),
+            "a steady-state open must produce no terminal-sweep churn: {swept:?}"
+        );
         system_rows_per_open.push(summary.projection_updates.len());
         drop(reopened);
     }
@@ -11810,6 +11818,114 @@ async fn reopening_an_account_replays_a_disband_once_and_then_stays_silent() {
         system_rows_per_open[1..],
         [0, 0],
         "a re-announced disband re-projects its terminal system row and dirties the routes"
+    );
+}
+
+/// mdk#1177's reconciler must survive announce-once.
+///
+/// A send held at "Sending…" when the group disbands is resolved by
+/// `invalidate_terminal_pending_sends`, whose sole production trigger used to
+/// be the `GroupDisbanded` event arm. That worked only because hydration
+/// re-emitted the event every open. With the guard announcing itself once, a
+/// process death between the engine marking the guard at account open and the
+/// app committing its projection would strand the send at "Sending…" forever.
+///
+/// So the sweep now reads the immortal guard rows instead: this test hands the
+/// next open an *already announced* guard — no replay is coming, ever — and
+/// still expects the held send to be resolved.
+#[tokio::test]
+async fn an_open_heals_a_held_send_from_an_already_announced_guard() {
+    use cgka_traits::storage::DisbandTombstoneStorage;
+
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://announced-guard-heals.example")
+        .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client.create_group("terminal", &[]).await.unwrap();
+    let group_id_hex = hex::encode(group_id.as_slice());
+
+    // A send the engine accepted and retained: no published source id, so it
+    // derives as pending until something resolves it.
+    app.record_account_app_event(
+        "alice",
+        &AppMessageProjection {
+            message_id_hex: "held".to_owned(),
+            source_message_id_hex: None,
+            direction: "sent".to_owned(),
+            group_id_hex: group_id_hex.clone(),
+            sender: account.account_id_hex.clone(),
+            plaintext: "hello".to_owned(),
+            kind: MARMOT_APP_EVENT_KIND_CHAT,
+            tags: Vec::new(),
+            source_epoch: Some(1),
+            retention: None,
+            recorded_at: Some(11),
+            origin_commit_id: None,
+            moderation_grant: false,
+        },
+    )
+    .unwrap();
+
+    // The state a crash leaves behind: the guard is durable and already marked
+    // announced by a previous open's hydration, but that open died before any
+    // drain projected the terminal event.
+    app.account_storage("alice")
+        .unwrap()
+        .put_disband_tombstone(
+            &group_id,
+            &cgka_traits::DisbandTombstone {
+                epoch: cgka_traits::EpochId(1),
+                actor: MemberId::new(hex::decode(&account.account_id_hex).unwrap()),
+                origin_commit_id: None,
+                commit_digest: [0x22; 32],
+                local_was_committer_leaf: true,
+                former_members: Vec::new(),
+                announced: true,
+            },
+        )
+        .unwrap();
+    drop(client);
+
+    let mut reopened = app.client("alice").await.unwrap();
+    let effects = reopened.runtime.drain().await.unwrap();
+    assert!(
+        !effects.events.iter().any(|event| matches!(
+            event,
+            cgka_traits::engine::GroupEvent::GroupStateChanged {
+                change: cgka_traits::engine::GroupStateChange::GroupDisbanded,
+                ..
+            }
+        )),
+        "an announced guard must not replay; the sweep is what has to heal this"
+    );
+
+    let held = app
+        .timeline_messages_with_query(
+            "alice",
+            storage_sqlite::TimelineMessageQuery {
+                group_id_hex: Some(group_id_hex.clone()),
+                ..storage_sqlite::TimelineMessageQuery::default()
+            },
+        )
+        .unwrap()
+        .messages
+        .into_iter()
+        .find(|row| row.message_id_hex == "held")
+        .expect("the held send must still be on the timeline");
+    assert_eq!(
+        held.invalidation_status,
+        Some("local_publish_failed".to_owned()),
+        "a terminal group with no replay left must still end its held send's wait"
+    );
+    let updates = reopened.take_pending_projection_updates();
+    assert!(
+        updates.iter().any(|update| {
+            update.group_id_hex == group_id_hex && !update.timeline_changes.is_empty()
+        }),
+        "the healing write must surface to hosts as a projection update: {updates:?}"
     );
 }
 

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -3243,6 +3243,7 @@ fn put_disband_tombstone_for(store: &SqliteAccountStorage, group_id_hex: &str) {
                 commit_digest: [0; 32],
                 local_was_committer_leaf: false,
                 former_members: Vec::new(),
+                announced: false,
             },
         )
         .unwrap();

--- a/crates/storage-sqlite/src/storage/disband_requests.rs
+++ b/crates/storage-sqlite/src/storage/disband_requests.rs
@@ -179,13 +179,38 @@ impl DisbandTombstoneStorage for SqliteAccountStorage {
         group_id: &GroupId,
         tombstone: &DisbandTombstone,
     ) -> StorageResult<()> {
-        self.lock()?
-            .execute(
-                "INSERT OR REPLACE INTO cgka_disband_tombstones (group_id, record)
-                 VALUES (?1, ?2)",
-                params![group_id.as_slice(), serialize(tombstone)?],
+        // Preserve-on-rewrite. This is an `INSERT OR REPLACE`, so a caller that
+        // rewrites an existing guard with a freshly constructed
+        // `announced: false` would silently clear the latch and resurrect the
+        // per-open replay. The marker is owned by
+        // `mark_disband_tombstone_announced`, never by the writer of the guard,
+        // so OR it forward from any row already present.
+        let conn = self.lock()?;
+        let previously_announced = conn
+            .query_row(
+                "SELECT record FROM cgka_disband_tombstones WHERE group_id = ?1",
+                params![group_id.as_slice()],
+                |row| row.get::<_, Vec<u8>>(0),
             )
-            .storage()?;
+            .optional()
+            .storage()?
+            .map(|record| deserialize::<DisbandTombstone>(&record))
+            .transpose()?
+            .is_some_and(|existing| existing.announced);
+        let record = if previously_announced && !tombstone.announced {
+            serialize(&DisbandTombstone {
+                announced: true,
+                ..tombstone.clone()
+            })?
+        } else {
+            serialize(tombstone)?
+        };
+        conn.execute(
+            "INSERT OR REPLACE INTO cgka_disband_tombstones (group_id, record)
+             VALUES (?1, ?2)",
+            params![group_id.as_slice(), record],
+        )
+        .storage()?;
         Ok(())
     }
 
@@ -415,6 +440,77 @@ mod tests {
             store.list_disband_tombstones().unwrap(),
             vec![(group_id, after)]
         );
+    }
+
+    /// `put_disband_tombstone` is an `INSERT OR REPLACE`, so a caller rewriting
+    /// an existing guard with a freshly built `announced: false` must not clear
+    /// the latch — that would resurrect the per-open replay silently. The
+    /// marker is owned by `mark_disband_tombstone_announced`, so it survives
+    /// any rewrite of the guard around it.
+    #[test]
+    fn rewriting_a_guard_cannot_clear_its_announced_marker() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let group_id = gid(11);
+        let guard = DisbandTombstone {
+            epoch: EpochId(3),
+            actor: member_id(5),
+            origin_commit_id: None,
+            commit_digest: [0x1d; 32],
+            local_was_committer_leaf: false,
+            former_members: Vec::new(),
+            announced: false,
+        };
+        store.put_disband_tombstone(&group_id, &guard).unwrap();
+        store.mark_disband_tombstone_announced(&group_id).unwrap();
+
+        // The dangerous rewrite: same guard value the settle path constructs.
+        store.put_disband_tombstone(&group_id, &guard).unwrap();
+        let after = store.disband_tombstone(&group_id).unwrap().unwrap();
+        assert!(
+            after.announced,
+            "a guard rewrite must not resurrect the per-open replay"
+        );
+        assert_eq!(
+            DisbandTombstone {
+                announced: false,
+                ..after
+            },
+            guard,
+            "everything except the marker must come from the rewritten value"
+        );
+    }
+
+    /// The first write of a guard is unannounced, and a rewrite that carries a
+    /// changed payload still lands: preserve-on-rewrite is an OR on one field,
+    /// not a refusal to update.
+    #[test]
+    fn a_first_guard_write_is_unannounced_and_rewrites_still_update_the_payload() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let group_id = gid(12);
+        let mut guard = DisbandTombstone {
+            epoch: EpochId(4),
+            actor: member_id(6),
+            origin_commit_id: None,
+            commit_digest: [0x2e; 32],
+            local_was_committer_leaf: false,
+            former_members: Vec::new(),
+            announced: false,
+        };
+        store.put_disband_tombstone(&group_id, &guard).unwrap();
+        assert!(
+            !store
+                .disband_tombstone(&group_id)
+                .unwrap()
+                .unwrap()
+                .announced
+        );
+
+        store.mark_disband_tombstone_announced(&group_id).unwrap();
+        guard.epoch = EpochId(5);
+        store.put_disband_tombstone(&group_id, &guard).unwrap();
+        let after = store.disband_tombstone(&group_id).unwrap().unwrap();
+        assert_eq!(after.epoch, EpochId(5));
+        assert!(after.announced);
     }
 
     /// Marking a group that has no guard is a no-op, not an error: hydration

--- a/crates/storage-sqlite/src/storage/disband_requests.rs
+++ b/crates/storage-sqlite/src/storage/disband_requests.rs
@@ -218,6 +218,34 @@ impl DisbandTombstoneStorage for SqliteAccountStorage {
             .map(|(group_id, record)| Ok((GroupId::new(group_id), deserialize(&record)?)))
             .collect()
     }
+
+    fn mark_disband_tombstone_announced(&self, group_id: &GroupId) -> StorageResult<()> {
+        // One connection guard spans the read and the write, so the
+        // read-modify-write cannot interleave with a concurrent caller.
+        let conn = self.lock()?;
+        let Some(record) = conn
+            .query_row(
+                "SELECT record FROM cgka_disband_tombstones WHERE group_id = ?1",
+                params![group_id.as_slice()],
+                |row| row.get::<_, Vec<u8>>(0),
+            )
+            .optional()
+            .storage()?
+        else {
+            return Ok(());
+        };
+        let mut tombstone: DisbandTombstone = deserialize(&record)?;
+        if tombstone.announced {
+            return Ok(());
+        }
+        tombstone.announced = true;
+        conn.execute(
+            "UPDATE cgka_disband_tombstones SET record = ?2 WHERE group_id = ?1",
+            params![group_id.as_slice(), serialize(&tombstone)?],
+        )
+        .storage()?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -305,6 +333,7 @@ mod tests {
             commit_digest: candidate.commit_digest,
             local_was_committer_leaf: true,
             former_members: candidate.former_members,
+            announced: false,
         };
         store.put_disband_tombstone(&group.id, &tombstone).unwrap();
         assert!(
@@ -328,5 +357,73 @@ mod tests {
             store.list_disband_tombstones().unwrap(),
             vec![(group.id, tombstone)]
         );
+    }
+
+    /// A guard written before the announce-once marker existed is stored as a
+    /// JSON record with no `announced` key. It must read back as unannounced,
+    /// take the mark, and — this is the part that matters — still be there
+    /// afterwards: the marker suppresses a replay, it never consumes the
+    /// anti-resurrection guard.
+    #[test]
+    fn an_old_guard_row_reads_unannounced_marks_once_and_survives_the_mark() {
+        use rusqlite::params;
+
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let group_id = gid(9);
+        let legacy = serde_json::json!({
+            "epoch": 8,
+            "actor": member_id(2),
+            "origin_commit_id": null,
+            "commit_digest": vec![0x5au8; 32],
+            "local_was_committer_leaf": true,
+            "former_members": []
+        });
+        store
+            .lock()
+            .unwrap()
+            .execute(
+                "INSERT INTO cgka_disband_tombstones (group_id, record) VALUES (?1, ?2)",
+                params![group_id.as_slice(), serde_json::to_vec(&legacy).unwrap()],
+            )
+            .unwrap();
+
+        let before = store.disband_tombstone(&group_id).unwrap().unwrap();
+        assert!(!before.announced, "an old row must read as unannounced");
+
+        store.mark_disband_tombstone_announced(&group_id).unwrap();
+        let after = store.disband_tombstone(&group_id).unwrap().unwrap();
+        assert!(after.announced);
+        assert_eq!(
+            DisbandTombstone {
+                announced: false,
+                ..after.clone()
+            },
+            before,
+            "marking must change nothing but the marker"
+        );
+
+        // Idempotent, and still listed: the guard outlives its announcement.
+        store.mark_disband_tombstone_announced(&group_id).unwrap();
+        assert!(
+            store
+                .disband_tombstone(&group_id)
+                .unwrap()
+                .unwrap()
+                .announced
+        );
+        assert_eq!(
+            store.list_disband_tombstones().unwrap(),
+            vec![(group_id, after)]
+        );
+    }
+
+    /// Marking a group that has no guard is a no-op, not an error: hydration
+    /// calls this on a best-effort path and must not turn a missing row into a
+    /// failed open.
+    #[test]
+    fn marking_a_group_without_a_guard_is_a_no_op() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store.mark_disband_tombstone_announced(&gid(4)).unwrap();
+        assert!(store.list_disband_tombstones().unwrap().is_empty());
     }
 }

--- a/crates/traits/src/group.rs
+++ b/crates/traits/src/group.rs
@@ -105,6 +105,22 @@ pub struct DisbandTombstone {
     pub local_was_committer_leaf: bool,
     /// Deduplicated account roster captured immediately before disbanding.
     pub former_members: Vec<Member>,
+    /// Whether hydration has already replayed this guard's terminal
+    /// `GroupDisbanded` to the application.
+    ///
+    /// The guard itself is immortal — nothing may consume or clear it — so
+    /// suppressing the *replay* is the only thing this marker does. Rows
+    /// written before the marker existed carry no field and default to
+    /// unannounced, which replays them exactly once more and then marks them.
+    ///
+    /// The failure direction is deliberate: losing the marker costs one
+    /// redundant replay (the application's terminal projection is replay-safe
+    /// by construction), while a marker set too early would suppress an
+    /// announcement the application never received. Only
+    /// `Engine::restore_disband_tombstone` sets it, and only after it has
+    /// produced the replay.
+    #[serde(default)]
+    pub announced: bool,
 }
 
 /// One member of a group, as storage sees it.

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -497,6 +497,14 @@ pub trait DisbandTombstoneStorage {
     fn list_disband_tombstones(
         &self,
     ) -> StorageResult<Vec<(GroupId, crate::group::DisbandTombstone)>>;
+
+    /// Flip this guard's `announced` marker so later opens stop replaying its
+    /// terminal `GroupDisbanded`.
+    ///
+    /// Not a destructive read: the guard row itself must survive, or a
+    /// disbanded MLS group id becomes joinable again. Idempotent, and a no-op
+    /// when no guard is stored for `group_id`.
+    fn mark_disband_tombstone_announced(&self, group_id: &GroupId) -> StorageResult<()>;
 }
 
 // ── WelcomeStorage ──────────────────────────────────────────────────────────

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -481,6 +481,13 @@ pub trait DisbandCandidateStorage {
 /// record this row deliberately has no foreign key, so deleting local history
 /// cannot make a disbanded MLS group id joinable again.
 pub trait DisbandTombstoneStorage {
+    /// Write or rewrite the guard for `group_id`.
+    ///
+    /// `DisbandTombstone::announced` is owned by
+    /// [`Self::mark_disband_tombstone_announced`], not by callers of this
+    /// method: implementations must preserve an already-set marker rather than
+    /// take it from `tombstone`. A rewrite that cleared it would resurrect the
+    /// per-open `GroupDisbanded` replay.
     fn put_disband_tombstone(
         &self,
         group_id: &GroupId,
@@ -504,6 +511,15 @@ pub trait DisbandTombstoneStorage {
     /// Not a destructive read: the guard row itself must survive, or a
     /// disbanded MLS group id becomes joinable again. Idempotent, and a no-op
     /// when no guard is stored for `group_id`.
+    ///
+    /// This is the first read-modify-write over a stored `DisbandTombstone`,
+    /// which makes the record's encoding lossy across versions in a way a
+    /// pure-append field never was: an older build re-marking a guard written
+    /// by a newer one deserializes into its own narrower struct and writes back
+    /// a record missing the newer fields. Every field added to
+    /// `DisbandTombstone` from here on must therefore be loss-safe — recoverable
+    /// or re-derivable if a downgrade strips it — or this method needs to
+    /// become a field-level update instead of a whole-record rewrite.
     fn mark_disband_tombstone_announced(&self, group_id: &GroupId) -> StorageResult<()>;
 }
 

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -18,7 +18,7 @@ use cgka_traits::engine::{
     KeyPackage, SendIntent, SendResult,
 };
 use cgka_traits::engine_state::PendingStateRef;
-use cgka_traits::group::{Group, Member, ProtocolProfile};
+use cgka_traits::group::{DisbandTombstone, Group, Member, ProtocolProfile};
 use cgka_traits::ingest::{
     DeferralLineage, InboundResourceLimit, IngestOutcome, PeeledContent, PeeledMessage, StaleReason,
 };
@@ -923,4 +923,23 @@ fn unrecoverable_defaults_false_for_old_records() {
     }))
     .unwrap();
     assert!(!legacy.unrecoverable);
+}
+
+/// A disband tombstone written before the announce-once marker existed carries
+/// no `announced` field. It must read back as unannounced so hydration replays
+/// it exactly once more and then marks it — the only safe default, because the
+/// opposite would silently swallow an announcement the application may never
+/// have received.
+#[test]
+fn disband_tombstone_announced_defaults_false_for_old_records() {
+    let legacy: DisbandTombstone = serde_json::from_value(serde_json::json!({
+        "epoch": 9,
+        "actor": [0xaa, 0xbb],
+        "origin_commit_id": null,
+        "commit_digest": vec![0u8; 32],
+        "local_was_committer_leaf": true,
+        "former_members": []
+    }))
+    .unwrap();
+    assert!(!legacy.announced);
 }


### PR DESCRIPTION
Announce a disband once, and heal terminal groups from the guard row

Every account open used to replay GroupDisbanded for every disbanded group, forever: restore_disband_tombstone re-emitted unconditionally on hydration, and the app's event arm then forced a no-op subscription sync per group (two encrypted-media warm passes, adapter locks, a spawn). Probe-verified: three opens, three replays each.

The tombstone now carries an announced marker (additive, serde-default, no migration — the row is a JSON blob) and one new non-destructive trait method to set it. The guard row itself stays immortal: it is what blocks re-joining a disbanded group id, so destructive-read shapes were rejected up front. Hydration replays at most once more per pre-existing tombstone, marks, and goes quiet. The marker is a true latch — one writer, nothing unsets it, and a rewrite of the guard row ORs the marker forward so a future caller cannot silently clear it.

The hard part was proving a lost replay is safe, and the first version's safety argument did not survive adversarial review. Two findings reshaped it. First, the loss window is one process death, not two: hydration runs inside account open, so the marker is durable before any drain exists — the window spans app startup. Second, not everything was derived-on-read as claimed: the terminal pending-send invalidation (the #1177 reconciler) was driven only by this event, so a message stuck at "Sending…" when its group disbanded would have stayed stuck forever after one badly-timed crash.

The fix makes the claim true instead of aspirational: account open now runs a guard-sourced sweep — one pass over list_disband_tombstones, per guard resolving held sends and clearing stale peer push tokens. Both writes are idempotent and no-op-when-clean, so a steady-state open does zero extra work and produces zero projection churn (asserted). Net per-open cost for a terminal group went down versus master: the sweep is a strict subset of what the per-open replay used to do. The consequence table on restore_disband_tombstone now states all three tiers honestly: derived-on-read, reconciled-at-open, and the genuine residual (a possibly-missing kind-1210 transcript row, a lingering local-deletion marker, and an inert relay-side push registration).

Host-visible behavior change: hosts previously received one group_disbanded event per disbanded group on every account open (UniFFI and agent-connector projections). They now receive it once ever — at the disband, plus at most one belt-and-braces replay on the next open. A host using the repeated event as an implicit per-open terminal signal should read Group.disbanded or the chat-list terminal flag; both derive from the durable guard row on every read and were always the authoritative source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disband notifications now replay only once when an account is reopened.
  * Lost or interrupted notification delivery is retried safely on a later open.
  * Reopening an account no longer produces duplicate disband events.
  * Terminal groups continue to receive necessary cleanup and synchronization updates even when notifications were already delivered.
  * Improved recovery ensures durable disband status is respected, preventing stale data from triggering repeated events.
* **Tests**
  * Added coverage for repeated opens, deleted local group data, interrupted recovery, and legacy records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->