### PR TITLE
Export per-account-id relay lists to the C ABI

### DIFF
--- a/crates/marmot-c/CHANGELOG.md
+++ b/crates/marmot-c/CHANGELOG.md
@@ -29,3 +29,7 @@ Versions track the workspace version; releases are tagged `marmotc-v<version>`.
   ([#1545](https://github.com/marmot-protocol/mdk/pull/1545))
 
   Closes [#328](https://github.com/marmot-protocol/mdk/issues/328)
+- `marmot_user_relay_lists` and `marmot_refresh_user_relay_lists`: read or
+  fetch the NIP-65 and inbox relay lists any account id has published, not
+  just a local account's. Both return `MarmotAccountRelayLists`.
+  ([#1605](https://github.com/marmot-protocol/mdk/pull/1605))

--- a/crates/marmot-c/include/marmot.h
+++ b/crates/marmot-c/include/marmot.h
@@ -5019,6 +5019,36 @@ MarmotStatus marmot_refresh_profile(const struct MarmotClient *client,
                                     uintptr_t relays_len);
 
 /**
+ * Cached NIP-65 and inbox relay lists for any account id; no network.
+ * Free with `marmot_account_relay_lists_free`.
+ *
+ * # Safety
+ * `client` must be a live handle; string arguments must be valid
+ * NUL-terminated strings (nullable ones may be NULL); array
+ * arguments must hold their stated length (or be NULL with
+ * length 0); out-pointers must be valid.
+ */
+MarmotStatus marmot_user_relay_lists(const struct MarmotClient *client,
+                                     const char *account_id_hex,
+                                     struct MarmotAccountRelayLists **out);
+
+/**
+ * Fetch an account's published relay lists from `relays`, updating
+ * the cache. Free with `marmot_account_relay_lists_free`.
+ *
+ * # Safety
+ * `client` must be a live handle; string arguments must be valid
+ * NUL-terminated strings (nullable ones may be NULL); array
+ * arguments must hold their stated length (or be NULL with
+ * length 0); out-pointers must be valid.
+ */
+MarmotStatus marmot_refresh_user_relay_lists(const struct MarmotClient *client,
+                                             const char *account_id_hex,
+                                             const char *const *relays,
+                                             uintptr_t relays_len,
+                                             struct MarmotAccountRelayLists **out);
+
+/**
  * The account ids this account follows (NIP-02). Free with
  * `marmot_string_list_free`.
  *

--- a/crates/marmot-c/src/commands.rs
+++ b/crates/marmot-c/src/commands.rs
@@ -868,6 +868,14 @@ c_cmd! {
     /// Refresh the cached profile for an account id from `relays`.
     async fn marmot_refresh_profile(account_id_hex: str, relays/relays_len: str_arr) -> unit = refresh_profile;
 
+    /// Cached NIP-65 and inbox relay lists for any account id; no network.
+    /// Free with `marmot_account_relay_lists_free`.
+    sync fn marmot_user_relay_lists(account_id_hex: str) -> rec(MarmotAccountRelayLists) = user_relay_lists;
+
+    /// Fetch an account's published relay lists from `relays`, updating
+    /// the cache. Free with `marmot_account_relay_lists_free`.
+    async fn marmot_refresh_user_relay_lists(account_id_hex: str, relays/relays_len: str_arr) -> rec(MarmotAccountRelayLists) = refresh_user_relay_lists;
+
     /// The account ids this account follows (NIP-02). Free with
     /// `marmot_string_list_free`.
     sync fn marmot_account_follows(account_ref: str) -> rec(MarmotStringList) = account_follows;

--- a/crates/marmot-uniffi/src/commands/directory.rs
+++ b/crates/marmot-uniffi/src/commands/directory.rs
@@ -10,7 +10,7 @@ use crate::conversions::{
 use crate::errors::MarmotKitError;
 use crate::markdown::{self, MarkdownDocumentFfi};
 use crate::subscriptions::UserSearchSubscription;
-use crate::{Marmot, endpoints};
+use crate::{Marmot, conversions, endpoints};
 
 #[uniffi::export(async_runtime = "tokio")]
 impl Marmot {
@@ -115,6 +115,35 @@ impl Marmot {
         Ok(())
     }
 
+    /// Cached NIP-65 and inbox relay lists for any account id — no network.
+    /// An account with nothing cached yet returns an empty status with both
+    /// kinds in `missing` rather than erroring; call
+    /// `refresh_user_relay_lists` to fetch.
+    pub fn user_relay_lists(
+        &self,
+        account_id_hex: String,
+    ) -> Result<conversions::AccountRelayListsFfi, MarmotKitError> {
+        Ok(self
+            .app
+            .account_relay_list_status_for_account_id(&account_id_hex)?
+            .into())
+    }
+
+    /// Fetch an account's published NIP-65 and inbox relay lists from
+    /// `relays`, updating the cache. An account with nothing published
+    /// reports both kinds in `missing` rather than erroring.
+    pub async fn refresh_user_relay_lists(
+        &self,
+        account_id_hex: String,
+        relays: Vec<String>,
+    ) -> Result<conversions::AccountRelayListsFfi, MarmotKitError> {
+        Ok(self
+            .app
+            .fetch_account_relay_list_status_for_account_id(&account_id_hex, endpoints(&relays))
+            .await?
+            .into())
+    }
+
     /// Search the searcher's web of trust, streaming matches as each radius
     /// resolves.
     ///
@@ -192,6 +221,79 @@ mod tests {
         })
         .await
         .expect("generated identity must become network-ready");
+    }
+
+    #[test]
+    fn user_relay_lists_cached_path_reads_without_network() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+        let runtime = app.runtime();
+        let kit = Marmot { app, runtime };
+
+        // Valid but unknown id: empty status reporting both kinds missing,
+        // not an error. The relay URL above is never dialed.
+        let unknown = format!("{:064x}", 47);
+        let status = kit.user_relay_lists(unknown).expect("unknown id");
+        assert!(!status.complete);
+        assert_eq!(status.missing.len(), 2);
+        assert!(status.nip65.relays.is_empty());
+        assert!(status.inbox.relays.is_empty());
+
+        let error = kit
+            .user_relay_lists("not-a-public-key".to_owned())
+            .expect_err("malformed id");
+        assert!(matches!(error, MarmotKitError::InvalidIdentity { .. }));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn user_relay_list_bindings_cover_published_missing_and_invalid_ids() {
+        let relay = MockRelay::run().await.expect("start mock relay");
+        let relay_url = relay.url().await.to_string();
+        let root = tempfile::tempdir().expect("tempdir");
+        let app = MarmotApp::with_relays(root.path(), vec![relay_url.clone()]);
+        let runtime = app.runtime();
+        let kit = Marmot { app, runtime };
+        let endpoint = TransportEndpoint(relay_url.clone());
+        let account = kit
+            .runtime
+            .create_identity(AccountSetupRequest {
+                default_relays: vec![endpoint.clone()],
+                bootstrap_relays: vec![endpoint],
+                publish_missing_relay_lists: true,
+                publish_initial_key_package: false,
+                ..AccountSetupRequest::default()
+            })
+            .await
+            .expect("create identity");
+        let account_id_hex = account.account.account_id_hex;
+        wait_for_network_ready(&kit.runtime, &account_id_hex).await;
+
+        let fetched = kit
+            .refresh_user_relay_lists(account_id_hex.clone(), vec![relay_url.clone()])
+            .await
+            .expect("fetch published lists");
+        assert!(fetched.complete);
+        assert!(!fetched.nip65.relays.is_empty());
+        assert!(!fetched.inbox.relays.is_empty());
+
+        let cached = kit
+            .user_relay_lists(account_id_hex)
+            .expect("cached read after fetch");
+        assert!(cached.complete);
+
+        let unknown = format!("{:064x}", 47);
+        let absent = kit
+            .refresh_user_relay_lists(unknown, vec![relay_url])
+            .await
+            .expect("unpublished id reports missing, not error");
+        assert!(!absent.complete);
+        assert_eq!(absent.missing.len(), 2);
+
+        let error = kit
+            .refresh_user_relay_lists("not-a-public-key".to_owned(), Vec::new())
+            .await
+            .expect_err("malformed id");
+        assert!(matches!(error, MarmotKitError::InvalidIdentity { .. }));
     }
 
     #[test]


### PR DESCRIPTION
A marmot on a desktop client wants a "relays in common" row for a contact: the relays that account publishes, intersected with its own. No FFI surface could answer it. Every relay-list export resolved a local account and errored on any other pubkey, while `MarmotApp` already held the data keyed by account id.

This adds two directory commands on the UniFFI surface and their C wrappers:

- `user_relay_lists(account_id_hex)`: cached read, no network.
- `refresh_user_relay_lists(account_id_hex, relays)`: fetches from the given relays and updates the cache.

Both return the existing `AccountRelayListsFfi` / `MarmotAccountRelayLists` record, so callers get the NIP-65 and inbox lists separately plus `complete` and the typed `missing` kinds from mdk#565.

No new `Runtime` method: per-account-id directory commands already call `MarmotApp` directly, and a `Runtime` wrapper would only forward its arguments. The existing FFI record and C mirror are reused; the only generated change is the cbindgen header.

Tests cover published lists, an account with nothing published (reports missing, no error), a malformed pubkey (`InvalidIdentity`), and the cached path with no reachable relay.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added relay-list access for any account.
  * Read cached NIP-65 and inbox relay lists without network access.
  * Refresh published relay lists from selected relays and update the cache.
  * Reports when relay lists are unavailable or unpublished.
  * Added support across C ABI and UniFFI interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->