### PR TITLE
fix(transport): attempt-scoped subscription ids so a superseded EOSE cannot confirm a replay

### DIFF
--- a/crates/marmot-app/src/relay_plane/mod.rs
+++ b/crates/marmot-app/src/relay_plane/mod.rs
@@ -25,7 +25,7 @@ use transport_nostr_adapter::{
     AccountSubscriptionEose, NostrPublishOutcome, NostrReconciliationItem,
     NostrReconciliationSummary, NostrRelayClient, NostrSdkRelayClient, NostrSdkRelayHealth,
     NostrSubscription, NostrTransportAdapter, RelayExportConsent, RelayLabelResolution,
-    RelayRegistrationOutcome,
+    RelayRegistrationOutcome, SubscriptionAttempt,
 };
 
 use crate::config::RelayTelemetryExportConfig;
@@ -1766,6 +1766,9 @@ impl MarmotRelayPlaneAccountAdapter {
                     account_id: self.account_id.clone(),
                     endpoints: activation.inbox_endpoints,
                     since: None,
+                    // A one-shot reconciliation REQ is not owned by an account
+                    // activation and never feeds the replay-coverage gate.
+                    attempt: SubscriptionAttempt::INITIAL,
                 },
                 local_items,
                 reconcile_since,
@@ -1827,6 +1830,9 @@ impl MarmotRelayPlaneAccountAdapter {
                     transport_group_id: group.transport_group_id,
                     endpoints: group.endpoints,
                     since: None,
+                    // A one-shot reconciliation REQ is not owned by an account
+                    // activation and never feeds the replay-coverage gate.
+                    attempt: SubscriptionAttempt::INITIAL,
                 },
                 local_items,
                 reconcile_since,

--- a/crates/transport-nostr-adapter/AGENTS.md
+++ b/crates/transport-nostr-adapter/AGENTS.md
@@ -32,6 +32,11 @@ for reconnect/backoff and relay status mechanics.
 - Keep Nostr event DTO conversion delegated to `transport-nostr-peeler`.
 - Keep `TransportDeliverySource` metadata diagnostic only; do not feed it into consensus decisions.
 - Preserve account-scoped deliveries even when group subscriptions share relay endpoints.
+- Keep account-inbox and group subscription ids scoped to the activation attempt that issued them
+  (`SubscriptionAttempt`, stored on the account's routes). A relay reports end-of-stored-events by subscription id and
+  nothing else, so a shared id would let a superseded attempt's in-flight EOSE satisfy the replay-coverage gate the next
+  activation just reset. Ids stay derived from account/group/endpoint state plus the attempt, never from `since`, which
+  is not recorded with the routes and so could not be reconstructed at eviction time.
 - Keep real relay clients behind `NostrRelayClient`.
 - Keep the `nostr-sdk` dependency behind the `sdk` feature.
 - Relay endpoints are host-safety filtered before any connect at the `RelaySafetyPolicy` chokepoint in `marmot-app`

--- a/crates/transport-nostr-adapter/AGENTS.md
+++ b/crates/transport-nostr-adapter/AGENTS.md
@@ -33,10 +33,17 @@ for reconnect/backoff and relay status mechanics.
 - Keep `TransportDeliverySource` metadata diagnostic only; do not feed it into consensus decisions.
 - Preserve account-scoped deliveries even when group subscriptions share relay endpoints.
 - Keep account-inbox and group subscription ids scoped to the activation attempt that issued them
-  (`SubscriptionAttempt`, stored on the account's routes). A relay reports end-of-stored-events by subscription id and
-  nothing else, so a shared id would let a superseded attempt's in-flight EOSE satisfy the replay-coverage gate the next
-  activation just reset. Ids stay derived from account/group/endpoint state plus the attempt, never from `since`, which
-  is not recorded with the routes and so could not be reconstructed at eviction time.
+  (`SubscriptionAttempt`). A relay reports end-of-stored-events by subscription id and nothing else, so a shared id
+  would let a superseded attempt's in-flight EOSE satisfy the replay-coverage gate the next activation just reset. Ids
+  stay derived from account/group/endpoint state plus the attempt, never from `since`, which is not recorded with the
+  routes and so could not be reconstructed at eviction time.
+- Keep the attempt ordinal in `AdapterState::activation_attempt_high_water` and never clear it — not on
+  `deactivate_account`, not on the failed-activation rollback. Both drop the account's routes without closing the relay
+  sockets the superseded attempt's REQs still stream on, so an ordinal recovered from the routes would re-issue ids that
+  are still live. `AccountRoutes.attempt` holds only the live copy that `account_subscription_ids` reconstructs from.
+- Keep `activate_account`'s opening `unsubscribe_account` unconditional. Attempt-scoped ids removed the relay-side
+  REQ-replace backstop, and a rolled-back activation can leave `accounts` empty while the relay client still holds this
+  account's subscriptions; an orphaned REQ double-delivers because routing is content-keyed.
 - Keep real relay clients behind `NostrRelayClient`.
 - Keep the `nostr-sdk` dependency behind the `sdk` feature.
 - Relay endpoints are host-safety filtered before any connect at the `RelaySafetyPolicy` chokepoint in `marmot-app`

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -100,6 +100,36 @@ fn unix_now_seconds() -> u64 {
         .as_secs()
 }
 
+/// Which account-activation attempt issued a subscription.
+///
+/// A relay reports end-of-stored-events by subscription id and nothing else
+/// (`RelayMessage::EndOfStoredEvents` carries only the id), so the id is the
+/// only identity an EOSE can carry back. Without an attempt in it, a report
+/// answering a REQ that has already been torn down is indistinguishable from a
+/// report answering the REQ that replaced it — and lands on the replacement's
+/// freshly reset replay coverage. Stamping the attempt into the id makes the
+/// superseded report simply not match.
+///
+/// [`Self::INITIAL`] marks a subscription that no account activation owns —
+/// one-shot reconciliation REQs and post-join maintenance. Activations count
+/// from one.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SubscriptionAttempt(u64);
+
+impl SubscriptionAttempt {
+    /// Not scoped to an account activation.
+    pub const INITIAL: Self = Self(0);
+
+    /// The attempt an account's next activation issues under.
+    fn next(self) -> Self {
+        Self(self.0.saturating_add(1))
+    }
+
+    fn to_be_bytes(self) -> [u8; 8] {
+        self.0.to_be_bytes()
+    }
+}
+
 /// Low-level relay subscription request emitted by [`NostrTransportAdapter`].
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum NostrSubscription {
@@ -107,6 +137,8 @@ pub enum NostrSubscription {
         account_id: MemberId,
         endpoints: Vec<TransportEndpoint>,
         since: Option<Timestamp>,
+        /// Activation attempt that issued this REQ; see [`SubscriptionAttempt`].
+        attempt: SubscriptionAttempt,
     },
     Group {
         account_id: MemberId,
@@ -114,6 +146,8 @@ pub enum NostrSubscription {
         transport_group_id: Vec<u8>,
         endpoints: Vec<TransportEndpoint>,
         since: Option<Timestamp>,
+        /// Activation attempt that issued this REQ; see [`SubscriptionAttempt`].
+        attempt: SubscriptionAttempt,
     },
     /// Temporary full-history subscription used only by post-join maintenance.
     ///
@@ -133,12 +167,14 @@ impl NostrSubscription {
             Self::AccountInbox {
                 account_id,
                 endpoints,
+                attempt,
                 ..
             } => compact_subscription_id(
                 "inbox",
                 &[
                     account_id.as_slice(),
                     endpoint_set_digest(endpoints).as_bytes(),
+                    &attempt.to_be_bytes(),
                 ],
             ),
             Self::Group {
@@ -146,6 +182,7 @@ impl NostrSubscription {
                 group_id,
                 transport_group_id,
                 endpoints,
+                attempt,
                 ..
             } => {
                 let h_tag = hex::encode(transport_group_id);
@@ -156,6 +193,7 @@ impl NostrSubscription {
                         group_id.as_slice(),
                         h_tag.as_bytes(),
                         endpoint_set_digest(endpoints).as_bytes(),
+                        &attempt.to_be_bytes(),
                     ],
                 )
             }
@@ -185,6 +223,15 @@ impl NostrSubscription {
             Self::AccountInbox { endpoints, .. }
             | Self::Group { endpoints, .. }
             | Self::GroupMaintenance { endpoints, .. } => endpoints,
+        }
+    }
+
+    /// Activation attempt this subscription was issued under. See
+    /// [`SubscriptionAttempt`].
+    pub fn attempt(&self) -> SubscriptionAttempt {
+        match self {
+            Self::AccountInbox { attempt, .. } | Self::Group { attempt, .. } => *attempt,
+            Self::GroupMaintenance { .. } => SubscriptionAttempt::INITIAL,
         }
     }
 
@@ -636,6 +683,19 @@ impl NostrTransportAdapter {
             .account_subscription_eose(account_id)
     }
 
+    /// The activation attempt an account's live subscriptions were issued
+    /// under, or [`SubscriptionAttempt::INITIAL`] for an account that is not
+    /// active.
+    ///
+    /// Subscription ids are attempt-scoped (see [`SubscriptionAttempt`]), so a
+    /// caller that rebuilds the id of a live subscription from route state —
+    /// rather than reading it off the [`NostrSubscription`] the adapter issued —
+    /// must stamp the same attempt. It reports an ordinal only: no ids,
+    /// endpoints, or routes cross the boundary.
+    pub async fn account_subscription_attempt(&self, account_id: &MemberId) -> SubscriptionAttempt {
+        self.state.read().await.activation_attempt(account_id)
+    }
+
     /// Install the temporary, full-history subscription used by the post-join
     /// maintenance gate. The caller owns its eventual removal.
     pub async fn install_group_maintenance_subscription(
@@ -830,13 +890,21 @@ impl TransportAdapter for NostrTransportAdapter {
             group_subscription_count = activation.group_subscriptions.len(),
             "activating transport account"
         );
-        let replaced_count = {
+        // Read the replaced route count and the attempt this activation issues
+        // under together, under the subscription lock that serializes every
+        // activate/sync/deactivate. Stamping the attempt into the re-issued ids
+        // is what keeps a superseded attempt's in-flight EOSE from landing on
+        // the coverage this activation is about to reset.
+        let (replaced_count, attempt) = {
             let state = self.state.read().await;
-            state
-                .accounts
-                .get(&account_id)
-                .map(|routes| 1 + routes.groups.len())
-                .unwrap_or_default()
+            (
+                state
+                    .accounts
+                    .get(&account_id)
+                    .map(|routes| 1 + routes.groups.len())
+                    .unwrap_or_default(),
+                state.next_activation_attempt(&account_id),
+            )
         };
         if replaced_count > 0 {
             self.relay_client.unsubscribe_account(&account_id).await?;
@@ -847,16 +915,17 @@ impl TransportAdapter for NostrTransportAdapter {
             &account_id,
             activation.inbox_endpoints.clone(),
             inbox_since(activation.since),
+            attempt,
         ));
         let prior_route_keys = prior_group_route_keys(&account_id, &activation.group_subscriptions);
         for group in &activation.group_subscriptions {
-            let route_key = group_subscription(&account_id, group, None).route_key();
+            let route_key = group_route_key(&account_id, group);
             let since = if prior_route_keys.contains(&route_key) {
                 None
             } else {
                 activation.since
             };
-            issued.push(group_subscription(&account_id, group, since));
+            issued.push(group_subscription(&account_id, group, since, attempt));
         }
         // Register routing/telemetry state BEFORE the relay REQs go out: a
         // relay may stream stored events the moment it sees a subscription,
@@ -877,7 +946,7 @@ impl TransportAdapter for NostrTransportAdapter {
             }
             state.record_subscription_starts(&issued, now_ms);
             state.record_account_replay_start(&account_id, &issued);
-            state.activate(activation, replaced_count);
+            state.activate(activation, replaced_count, attempt);
         }
 
         if let Err(error) = self.subscribe_all("activate_account", &issued).await {
@@ -935,6 +1004,10 @@ impl TransportAdapter for NostrTransportAdapter {
 
         let (to_add, to_remove) = {
             let state = self.state.read().await;
+            // A sync amends the live activation's route set; it does not open a
+            // new attempt, so both sides of the diff carry the activation's own
+            // attempt and the ids stay stable across it.
+            let attempt = state.activation_attempt(&sync.account_id);
             let current_groups = state
                 .accounts
                 .get(&sync.account_id)
@@ -945,6 +1018,7 @@ impl TransportAdapter for NostrTransportAdapter {
                 current_groups,
                 &sync.group_subscriptions,
                 sync.since,
+                attempt,
             )
         };
 
@@ -1173,6 +1247,11 @@ struct AccountRoutes {
     /// arm's `by_transport_group` entries.
     inbox_endpoints: Vec<CanonicalEndpoint>,
     groups: Vec<TransportGroupSubscription>,
+    /// Attempt the live subscriptions for this account were issued under. Held
+    /// here so `account_subscription_ids` can rebuild exactly the ids that went
+    /// on the wire, and so a group sync reuses the activation's attempt rather
+    /// than minting a new one.
+    attempt: SubscriptionAttempt,
 }
 
 /// Immutable endpoint coverage for the most recent account activation.
@@ -1367,7 +1446,12 @@ impl AdapterState {
         }
     }
 
-    fn activate(&mut self, activation: TransportAccountActivation, replaced: usize) {
+    fn activate(
+        &mut self,
+        activation: TransportAccountActivation,
+        replaced: usize,
+        attempt: SubscriptionAttempt,
+    ) {
         self.metrics.subscriptions_created += 1 + activation.group_subscriptions.len();
         self.metrics.subscriptions_removed += replaced;
         self.accounts.insert(
@@ -1379,6 +1463,7 @@ impl AdapterState {
                     .map(CanonicalEndpoint::new)
                     .collect(),
                 groups: activation.group_subscriptions,
+                attempt,
             },
         );
         self.rebuild_transport_group_index();
@@ -1438,7 +1523,7 @@ impl AdapterState {
                 routes
                     .groups
                     .iter()
-                    .map(|group| group_subscription(account_id, group, None).route_key())
+                    .map(|group| group_route_key(account_id, group))
             })
             .collect()
     }
@@ -1452,6 +1537,25 @@ impl AdapterState {
 
     fn record_confirmed_unsubscribes(&mut self, count: usize) {
         self.metrics.subscriptions_removed += count;
+    }
+
+    /// Attempt ordinal the account's next activation issues under. Monotonic
+    /// per account for the lifetime of this adapter, so a re-issued
+    /// subscription never reuses a superseded attempt's id.
+    fn next_activation_attempt(&self, account_id: &MemberId) -> SubscriptionAttempt {
+        self.accounts
+            .get(account_id)
+            .map(|routes| routes.attempt)
+            .unwrap_or(SubscriptionAttempt::INITIAL)
+            .next()
+    }
+
+    /// Attempt the account's live subscriptions were issued under.
+    fn activation_attempt(&self, account_id: &MemberId) -> SubscriptionAttempt {
+        self.accounts
+            .get(account_id)
+            .map(|routes| routes.attempt)
+            .unwrap_or(SubscriptionAttempt::INITIAL)
     }
 
     fn deactivate(&mut self, account_id: &MemberId, removed_count: usize) {
@@ -1542,9 +1646,16 @@ impl AdapterState {
     }
 
     /// Subscription ids implied by an account's stored routes: its inbox plus
-    /// one per group. Ids are derived from account/group/endpoint state, never
-    /// `since`, so the reconstructed ids match the ones recorded at subscribe
-    /// time. Empty for an account with no stored routes.
+    /// one per group.
+    ///
+    /// Ids are derived from account/group/endpoint state plus the activation
+    /// attempt stored alongside those routes — never `since`. `since` is not
+    /// recorded with the routes and could not be reconstructed here, which is
+    /// why it stays out of the id; the attempt is recorded, so it can. That
+    /// keeps the reconstructed ids byte-identical to the ones recorded at
+    /// subscribe time while still separating one attempt's REQs from the next
+    /// attempt's over the same routes. Empty for an account with no stored
+    /// routes.
     fn account_subscription_ids(&self, account_id: &MemberId) -> Vec<String> {
         let Some(routes) = self.accounts.get(account_id) else {
             return Vec::new();
@@ -1559,11 +1670,12 @@ impl AdapterState {
                     .map(|endpoint| endpoint.verbatim.clone())
                     .collect(),
                 None,
+                routes.attempt,
             )
             .subscription_id(),
         );
         for group in &routes.groups {
-            ids.push(group_subscription(account_id, group, None).subscription_id());
+            ids.push(group_subscription(account_id, group, None, routes.attempt).subscription_id());
         }
         ids
     }
@@ -1696,11 +1808,13 @@ fn account_inbox_subscription(
     account_id: &MemberId,
     endpoints: Vec<TransportEndpoint>,
     since: Option<Timestamp>,
+    attempt: SubscriptionAttempt,
 ) -> NostrSubscription {
     NostrSubscription::AccountInbox {
         account_id: account_id.clone(),
         endpoints,
         since,
+        attempt,
     }
 }
 
@@ -1708,6 +1822,7 @@ fn group_subscription(
     account_id: &MemberId,
     group: &TransportGroupSubscription,
     since: Option<Timestamp>,
+    attempt: SubscriptionAttempt,
 ) -> NostrSubscription {
     NostrSubscription::Group {
         account_id: account_id.clone(),
@@ -1715,6 +1830,22 @@ fn group_subscription(
         transport_group_id: group.transport_group_id.clone(),
         endpoints: group.endpoints.clone(),
         since,
+        attempt,
+    }
+}
+
+/// Route identity of a group subscription, independent of both the `since`
+/// floor and the issuing attempt. Route comparison spans activations, so it
+/// must not see either.
+fn group_route_key(
+    account_id: &MemberId,
+    group: &TransportGroupSubscription,
+) -> NostrSubscriptionRouteKey {
+    NostrSubscriptionRouteKey::Group {
+        account_id: account_id.clone(),
+        group_id: group.group_id.clone(),
+        transport_group_id: group.transport_group_id.clone(),
+        endpoints: normalized_endpoints(&group.endpoints),
     }
 }
 
@@ -1723,23 +1854,24 @@ fn diff_group_subscriptions(
     current: &[TransportGroupSubscription],
     desired: &[TransportGroupSubscription],
     since: Option<Timestamp>,
+    attempt: SubscriptionAttempt,
 ) -> (Vec<NostrSubscription>, Vec<NostrSubscription>) {
     let current_subscriptions = current
         .iter()
-        .map(|group| group_subscription(account_id, group, None))
+        .map(|group| group_subscription(account_id, group, None, attempt))
         .collect::<Vec<_>>();
     let current_prior_keys = prior_group_route_keys(account_id, current);
     let desired_prior_keys = prior_group_route_keys(account_id, desired);
     let desired_subscriptions = desired
         .iter()
         .map(|group| {
-            let route_key = group_subscription(account_id, group, None).route_key();
+            let route_key = group_route_key(account_id, group);
             let since = if desired_prior_keys.contains(&route_key) {
                 None
             } else {
                 since
             };
-            group_subscription(account_id, group, since)
+            group_subscription(account_id, group, since, attempt)
         })
         .collect::<Vec<_>>();
     let current_keys = current_subscriptions
@@ -1780,7 +1912,7 @@ fn prior_group_route_keys(
     let mut prior_route_keys = HashSet::new();
     for group in groups {
         if !seen_groups.insert(group.group_id.clone()) {
-            prior_route_keys.insert(group_subscription(account_id, group, None).route_key());
+            prior_route_keys.insert(group_route_key(account_id, group));
         }
     }
     prior_route_keys

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -113,7 +113,10 @@ fn unix_now_seconds() -> u64 {
 /// [`Self::INITIAL`] marks a subscription that no account activation owns —
 /// one-shot reconciliation REQs and post-join maintenance. Activations count
 /// from one.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+///
+/// Deliberately not [`Default`]: a silently zero-valued attempt on an account's
+/// routes is the exact shape of the bug this type exists to prevent.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SubscriptionAttempt(u64);
 
 impl SubscriptionAttempt {
@@ -684,15 +687,18 @@ impl NostrTransportAdapter {
     }
 
     /// The activation attempt an account's live subscriptions were issued
-    /// under, or [`SubscriptionAttempt::INITIAL`] for an account that is not
-    /// active.
+    /// under, or `None` when the account is not active.
     ///
     /// Subscription ids are attempt-scoped (see [`SubscriptionAttempt`]), so a
     /// caller that rebuilds the id of a live subscription from route state —
     /// rather than reading it off the [`NostrSubscription`] the adapter issued —
-    /// must stamp the same attempt. It reports an ordinal only: no ids,
-    /// endpoints, or routes cross the boundary.
-    pub async fn account_subscription_attempt(&self, account_id: &MemberId) -> SubscriptionAttempt {
+    /// must stamp the same attempt. `None` keeps "unknown account" distinct from
+    /// [`SubscriptionAttempt::INITIAL`], which means "not activation-owned". It
+    /// reports an ordinal only: no ids, endpoints, or routes cross the boundary.
+    pub async fn account_subscription_attempt(
+        &self,
+        account_id: &MemberId,
+    ) -> Option<SubscriptionAttempt> {
         self.state.read().await.activation_attempt(account_id)
     }
 
@@ -906,9 +912,13 @@ impl TransportAdapter for NostrTransportAdapter {
                 state.next_activation_attempt(&account_id),
             )
         };
-        if replaced_count > 0 {
-            self.relay_client.unsubscribe_account(&account_id).await?;
-        }
+        // Unconditional, not gated on live local routes. Attempt-scoped ids mean
+        // a re-issued REQ no longer replaces its predecessor relay-side, and a
+        // rolled-back activation can leave `accounts` empty while the relay
+        // client still holds this account's subscriptions. An orphaned REQ
+        // double-delivers, because routing is content-keyed rather than
+        // subscription-keyed. The SDK client is a no-op on an empty id list.
+        self.relay_client.unsubscribe_account(&account_id).await?;
 
         let mut issued = Vec::with_capacity(1 + activation.group_subscriptions.len());
         issued.push(account_inbox_subscription(
@@ -939,11 +949,9 @@ impl TransportAdapter for NostrTransportAdapter {
             // the old subscription ids first (before recording the new starts,
             // since unchanged endpoint sets reuse the same ids).
             state.forget_account_subscription_starts(&account_id);
-            if replaced_count > 0 {
-                // The blanket `unsubscribe_account` above supersedes any queued
-                // per-subscription unsubscribes for this account.
-                state.clear_pending_unsubscribes_for_account(&account_id);
-            }
+            // The blanket `unsubscribe_account` above supersedes any queued
+            // per-subscription unsubscribes for this account.
+            state.clear_pending_unsubscribes_for_account(&account_id);
             state.record_subscription_starts(&issued, now_ms);
             state.record_account_replay_start(&account_id, &issued);
             state.activate(activation, replaced_count, attempt);
@@ -1007,10 +1015,11 @@ impl TransportAdapter for NostrTransportAdapter {
             // A sync amends the live activation's route set; it does not open a
             // new attempt, so both sides of the diff carry the activation's own
             // attempt and the ids stay stable across it.
-            let attempt = state.activation_attempt(&sync.account_id);
-            let current_groups = state
-                .accounts
-                .get(&sync.account_id)
+            let routes = state.accounts.get(&sync.account_id);
+            let attempt = routes
+                .map(|routes| routes.attempt)
+                .unwrap_or(SubscriptionAttempt::INITIAL);
+            let current_groups = routes
                 .map(|routes| routes.groups.as_slice())
                 .unwrap_or_default();
             diff_group_subscriptions(
@@ -1240,7 +1249,7 @@ struct DeliveryRoute {
     plane: TransportDeliveryPlane,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 struct AccountRoutes {
     /// Pre-canonicalized so the Welcome/inbox arm of `routes_for` never re-parses
     /// the same stored inbox endpoint per event (#698/#752), mirroring the group
@@ -1362,6 +1371,15 @@ struct AdapterState {
     /// recent activation of each account. This is intentionally independent of
     /// `accounts`, whose live group routes may change during the drain.
     account_replay_coverage: HashMap<MemberId, AccountReplayCoverage>,
+    /// Highest activation attempt ever issued for each account in this process.
+    ///
+    /// Deliberately never cleared — not by `deactivate`, not by the failed
+    /// activation rollback. Both drop the account's routes while the relay
+    /// sockets stay open and the superseded attempt's REQs keep streaming, so
+    /// recovering the ordinal from the routes would hand the next activation
+    /// the ids its predecessor is still using. Bounded by the number of distinct
+    /// accounts activated in this process.
+    activation_attempt_high_water: HashMap<MemberId, SubscriptionAttempt>,
     /// Derived accelerator for `routes_for` group delivery (#698/#752): maps a
     /// `transport_group_id` to its candidate routes, so an inbound group event is
     /// resolved in O(matching groups) instead of scanning O(accounts × groups)
@@ -1454,6 +1472,11 @@ impl AdapterState {
     ) {
         self.metrics.subscriptions_created += 1 + activation.group_subscriptions.len();
         self.metrics.subscriptions_removed += replaced;
+        // Raise the high-water mark before the routes take a copy of it: the
+        // routes are the reconstruction source for `account_subscription_ids`,
+        // the high-water map is what survives their removal.
+        self.activation_attempt_high_water
+            .insert(activation.account_id.clone(), attempt);
         self.accounts.insert(
             activation.account_id,
             AccountRoutes {
@@ -1539,23 +1562,26 @@ impl AdapterState {
         self.metrics.subscriptions_removed += count;
     }
 
-    /// Attempt ordinal the account's next activation issues under. Monotonic
-    /// per account for the lifetime of this adapter, so a re-issued
-    /// subscription never reuses a superseded attempt's id.
+    /// Attempt ordinal the account's next activation issues under.
+    ///
+    /// Read from the high-water map rather than from the account's routes:
+    /// deactivation and the failed-activation rollback both remove the routes,
+    /// and neither closes the relay sockets the superseded attempt's REQs are
+    /// still streaming on. Strictly increasing per account for the lifetime of
+    /// this adapter, so a re-issued subscription never reuses a superseded
+    /// attempt's id.
     fn next_activation_attempt(&self, account_id: &MemberId) -> SubscriptionAttempt {
-        self.accounts
+        self.activation_attempt_high_water
             .get(account_id)
-            .map(|routes| routes.attempt)
+            .copied()
             .unwrap_or(SubscriptionAttempt::INITIAL)
             .next()
     }
 
-    /// Attempt the account's live subscriptions were issued under.
-    fn activation_attempt(&self, account_id: &MemberId) -> SubscriptionAttempt {
-        self.accounts
-            .get(account_id)
-            .map(|routes| routes.attempt)
-            .unwrap_or(SubscriptionAttempt::INITIAL)
+    /// Attempt the account's live subscriptions were issued under, or `None`
+    /// when the account is not active.
+    fn activation_attempt(&self, account_id: &MemberId) -> Option<SubscriptionAttempt> {
+        self.accounts.get(account_id).map(|routes| routes.attempt)
     }
 
     fn deactivate(&mut self, account_id: &MemberId, removed_count: usize) {

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -124,6 +124,11 @@ impl SubscriptionAttempt {
     pub const INITIAL: Self = Self(0);
 
     /// The attempt an account's next activation issues under.
+    ///
+    /// Saturating: monotonicity would silently stop at `u64::MAX`. Unreachable
+    /// in practice — that is one activation per nanosecond for ~584 years on a
+    /// single in-process adapter — and saturating beats wrapping back onto ids
+    /// a live attempt may still be using.
     fn next(self) -> Self {
         Self(self.0.saturating_add(1))
     }
@@ -450,6 +455,13 @@ pub trait NostrRelayClient: Send + Sync {
         subscription: NostrSubscription,
     ) -> Result<(), TransportAdapterError>;
 
+    /// Tear down every subscription this client holds for an account.
+    ///
+    /// Must be a no-op returning `Ok` for an account the client knows nothing
+    /// about: `activate_account` calls this unconditionally — before the first
+    /// activation as well as before a replacement — and propagates the error
+    /// with `?`, so an implementation that faulted on an unknown account would
+    /// make every first activation fail.
     async fn unsubscribe_account(&self, account_id: &MemberId)
     -> Result<(), TransportAdapterError>;
 
@@ -961,6 +973,13 @@ impl TransportAdapter for NostrTransportAdapter {
             // Some concurrent REQs may already have succeeded. Tear those
             // down best-effort, then always remove the pre-registered local
             // routes so callers never observe a half-active account.
+            //
+            // `state.activate` above already ran, so this activation's attempt
+            // is in the high-water map before `subscribe_all` was even tried.
+            // The retry depends on that ordering: `deactivate` below drops the
+            // routes but not the high-water mark, so the retry issues a fresh
+            // attempt rather than reusing the ids of REQs that did reach a
+            // relay and are still streaming.
             let relay_cleanup_failed = self
                 .relay_client
                 .unsubscribe_account(&account_id)
@@ -1012,16 +1031,18 @@ impl TransportAdapter for NostrTransportAdapter {
 
         let (to_add, to_remove) = {
             let state = self.state.read().await;
+            // The `AccountNotActive` guard above ran under the subscription
+            // lock this call holds, and only activate/sync/deactivate can
+            // remove an account's routes — all three serialize on that lock.
+            let routes = state
+                .accounts
+                .get(&sync.account_id)
+                .expect("the AccountNotActive guard above proved the account is active");
             // A sync amends the live activation's route set; it does not open a
             // new attempt, so both sides of the diff carry the activation's own
             // attempt and the ids stay stable across it.
-            let routes = state.accounts.get(&sync.account_id);
-            let attempt = routes
-                .map(|routes| routes.attempt)
-                .unwrap_or(SubscriptionAttempt::INITIAL);
-            let current_groups = routes
-                .map(|routes| routes.groups.as_slice())
-                .unwrap_or_default();
+            let attempt = routes.attempt;
+            let current_groups = routes.groups.as_slice();
             diff_group_subscriptions(
                 &sync.account_id,
                 current_groups,

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -539,6 +539,9 @@ impl NostrSdkRelayClient {
                 account_id,
                 endpoints,
                 since,
+                // The issuing attempt reaches the wire through
+                // `subscription_id()` below; the filter does not carry it.
+                ..
             } => {
                 let pubkey = member_id_to_pubkey(account_id, "account inbox subscription")?;
                 let mut filter = Filter::new().kind(Kind::GiftWrap).pubkey(pubkey);
@@ -559,6 +562,7 @@ impl NostrSdkRelayClient {
                 transport_group_id,
                 endpoints,
                 since,
+                ..
             } => {
                 let h_tag = hex::encode(transport_group_id);
                 let mut filter = Filter::new()
@@ -1565,7 +1569,7 @@ fn relay_rejection_endpoint_failure(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::NostrKeyPackagePublication;
+    use crate::{NostrKeyPackagePublication, SubscriptionAttempt};
     use cgka_traits::Timestamp;
     use cgka_traits::engine::KeyPackage;
     use futures::{SinkExt, StreamExt};
@@ -1835,6 +1839,7 @@ mod tests {
             transport_group_id: transport_group_id.clone(),
             endpoints: vec![endpoint.clone()],
             since: Some(Timestamp(1_700_000_000)),
+            attempt: SubscriptionAttempt::INITIAL,
         };
         let expected_subscription_id = SubscriptionId::new(subscription.subscription_id());
         let plan = NostrSdkRelayClient::plan_subscription(&subscription).expect("plan");
@@ -2031,6 +2036,7 @@ mod tests {
             account_id: account_id.clone(),
             endpoints: vec![endpoint.clone()],
             since: None,
+            attempt: SubscriptionAttempt::INITIAL,
         };
         let expected_subscription_id = SubscriptionId::new(subscription.subscription_id());
         let plan = NostrSdkRelayClient::plan_subscription(&subscription).expect("plan");
@@ -2063,6 +2069,7 @@ mod tests {
             transport_group_id: transport_group_id.clone(),
             endpoints: vec![endpoint_a.clone(), endpoint_b.clone()],
             since: None,
+            attempt: SubscriptionAttempt::INITIAL,
         })
         .expect("first plan");
         let second = NostrSdkRelayClient::plan_subscription(&NostrSubscription::Group {
@@ -2071,6 +2078,7 @@ mod tests {
             transport_group_id,
             endpoints: vec![endpoint_b, endpoint_a],
             since: None,
+            attempt: SubscriptionAttempt::INITIAL,
         })
         .expect("second plan");
 
@@ -2957,6 +2965,7 @@ mod tests {
             transport_group_id: vec![0xC3; 32],
             endpoints: vec![TransportEndpoint("not a relay url".into())],
             since: None,
+            attempt: SubscriptionAttempt::INITIAL,
         })
         .unwrap_err();
 

--- a/crates/transport-nostr-adapter/tests/inbound_routing.rs
+++ b/crates/transport-nostr-adapter/tests/inbound_routing.rs
@@ -232,6 +232,16 @@ struct FakeRelayClient {
     published: Mutex<Vec<(Vec<TransportEndpoint>, NostrTransportEvent, usize)>>,
 }
 
+impl FakeRelayClient {
+    /// Subscriptions the adapter has actually put on the wire since the last
+    /// call, in issue order. Tests read issued ids from here rather than
+    /// re-deriving them from route state, because a subscription id is scoped
+    /// to the activation attempt that issued it.
+    fn take_issued_subscriptions(&self) -> Vec<NostrSubscription> {
+        self.subscriptions.lock().unwrap().drain(..).collect()
+    }
+}
+
 #[async_trait]
 impl NostrRelayClient for FakeRelayClient {
     async fn subscribe(
@@ -631,6 +641,7 @@ async fn group_subscription_id_fans_out_to_matching_accounts_and_replays_route_a
         transport_group_id: transport_group_id.clone(),
         endpoints: vec![endpoint.clone()],
         since: None,
+        attempt: adapter.account_subscription_attempt(&alice).await,
     }
     .subscription_id();
     let bob_subscription_id = NostrSubscription::Group {
@@ -639,6 +650,7 @@ async fn group_subscription_id_fans_out_to_matching_accounts_and_replays_route_a
         transport_group_id: transport_group_id.clone(),
         endpoints: vec![endpoint.clone()],
         since: None,
+        attempt: adapter.account_subscription_attempt(&bob).await,
     }
     .subscription_id();
 
@@ -1077,12 +1089,14 @@ async fn reissued_live_subscription_keeps_synchronous_callbacks() {
         .await
         .expect("group sync succeeds");
 
+    let attempt = adapter.account_subscription_attempt(&account_id).await;
     let old_subscription_id = NostrSubscription::Group {
         account_id: account_id.clone(),
         group_id: group_id.clone(),
         transport_group_id: old_transport_group_id,
         endpoints: vec![endpoint.clone()],
         since: None,
+        attempt,
     }
     .subscription_id();
     let new_subscription_id = NostrSubscription::Group {
@@ -1091,6 +1105,7 @@ async fn reissued_live_subscription_keeps_synchronous_callbacks() {
         transport_group_id: new_transport_group_id,
         endpoints: vec![endpoint],
         since: None,
+        attempt,
     }
     .subscription_id();
     assert_eq!(relay.replayed_deliveries.load(Ordering::SeqCst), 2);
@@ -1153,6 +1168,7 @@ async fn failed_group_sync_rolls_back_staged_routes_and_telemetry() {
         transport_group_id: old_transport_group_id.clone(),
         endpoints: vec![endpoint.clone()],
         since: None,
+        attempt: adapter.account_subscription_attempt(&account_id).await,
     }
     .subscription_id();
     adapter
@@ -1253,6 +1269,7 @@ async fn cancelled_group_sync_rolls_back_staged_routes_and_telemetry() {
         transport_group_id: new_transport_group_id.clone(),
         endpoints: vec![endpoint.clone()],
         since: None,
+        attempt: adapter.account_subscription_attempt(&account_id).await,
     }
     .subscription_id();
 
@@ -1346,23 +1363,6 @@ async fn cancelled_reissues_preserve_live_gates_and_apply_eose_on_rollback() {
         transport_group_id: vec![0xC3; 32],
         endpoints: vec![endpoint.clone()],
     };
-    let synced_old_subscription_id = NostrSubscription::Group {
-        account_id: account_id.clone(),
-        group_id: synced_group_id.clone(),
-        transport_group_id: synced_old.transport_group_id.clone(),
-        endpoints: vec![endpoint.clone()],
-        since: None,
-    }
-    .subscription_id();
-    let unsynced_old_subscription_id = NostrSubscription::Group {
-        account_id: account_id.clone(),
-        group_id: unsynced_group_id.clone(),
-        transport_group_id: unsynced_old.transport_group_id.clone(),
-        endpoints: vec![endpoint.clone()],
-        since: None,
-    }
-    .subscription_id();
-
     adapter
         .activate_account(TransportAccountActivation {
             account_id: account_id.clone(),
@@ -1372,6 +1372,25 @@ async fn cancelled_reissues_preserve_live_gates_and_apply_eose_on_rollback() {
         })
         .await
         .expect("activation succeeds");
+    let attempt = adapter.account_subscription_attempt(&account_id).await;
+    let synced_old_subscription_id = NostrSubscription::Group {
+        account_id: account_id.clone(),
+        group_id: synced_group_id.clone(),
+        transport_group_id: synced_old.transport_group_id.clone(),
+        endpoints: vec![endpoint.clone()],
+        since: None,
+        attempt,
+    }
+    .subscription_id();
+    let unsynced_old_subscription_id = NostrSubscription::Group {
+        account_id: account_id.clone(),
+        group_id: unsynced_group_id.clone(),
+        transport_group_id: unsynced_old.transport_group_id.clone(),
+        endpoints: vec![endpoint.clone()],
+        since: None,
+        attempt,
+    }
+    .subscription_id();
     adapter
         .handle_relay_eose(endpoint.clone(), synced_old_subscription_id.clone())
         .await;
@@ -1691,13 +1710,16 @@ async fn initial_sync_gate_closes_only_after_every_endpoint_eoses() {
         .await
         .expect("activation succeeds");
 
-    // Reconstruct the group subscription id the adapter issued.
+    // Reconstruct the group subscription id the adapter issued, stamped with
+    // the attempt that issued it.
+    let attempt = adapter.account_subscription_attempt(&account_id).await;
     let sub_id = NostrSubscription::Group {
         account_id,
         group_id,
         transport_group_id: transport_group_id.clone(),
         endpoints: vec![endpoint_a.clone(), endpoint_b.clone()],
         since: None,
+        attempt,
     }
     .subscription_id();
 
@@ -1790,6 +1812,9 @@ async fn synced_group_subscriptions_replace_old_routes() {
     let delivery = adapter.receive().await.unwrap().unwrap();
     assert_eq!(delivery.group_id_hint, Some(new_group_id));
 
+    let attempt = adapter
+        .account_subscription_attempt(&MemberId::new(vec![0xA1; 32]))
+        .await;
     let unsubscribed = relay.unsubscribed.lock().unwrap();
     assert_eq!(
         unsubscribed.as_slice(),
@@ -1799,6 +1824,7 @@ async fn synced_group_subscriptions_replace_old_routes() {
             transport_group_id: old_transport_group_id,
             endpoints: vec![TransportEndpoint("wss://group.example".into())],
             since: None,
+            attempt,
         }]
     );
 }
@@ -1918,6 +1944,9 @@ async fn rotating_current_route_reissues_the_displaced_route_for_full_backfill_o
         .await
         .expect("route rotation sync succeeds");
 
+    // A sync amends the live activation rather than opening a new attempt, so
+    // the re-issued routes carry the activation's own attempt.
+    let attempt = adapter.account_subscription_attempt(&account_id).await;
     let issued_after_rotation = relay
         .subscriptions
         .lock()
@@ -1935,6 +1964,7 @@ async fn rotating_current_route_reissues_the_displaced_route_for_full_backfill_o
                 transport_group_id: route_b.transport_group_id.clone(),
                 endpoints: route_b.endpoints.clone(),
                 since,
+                attempt,
             },
             NostrSubscription::Group {
                 account_id: account_id.clone(),
@@ -1942,6 +1972,7 @@ async fn rotating_current_route_reissues_the_displaced_route_for_full_backfill_o
                 transport_group_id: route_a.transport_group_id.clone(),
                 endpoints: route_a.endpoints.clone(),
                 since: None,
+                attempt,
             },
         ],
         "the new current route is bounded while the displaced route is reissued without a cursor"
@@ -2079,6 +2110,7 @@ async fn failed_unsubscribe_is_retried_and_drained_on_next_sync() {
         .await
         .expect("retry sync succeeds");
 
+    let attempt = adapter.account_subscription_attempt(&account_id).await;
     {
         let unsubscribed = relay.unsubscribed.lock().unwrap();
         assert_eq!(
@@ -2089,6 +2121,7 @@ async fn failed_unsubscribe_is_retried_and_drained_on_next_sync() {
                 transport_group_id: old_transport_group_id,
                 endpoints: vec![endpoint],
                 since: None,
+                attempt,
             }],
             "the failed unsubscribe is replayed exactly once"
         );
@@ -2124,22 +2157,26 @@ async fn cancelled_sync_drain_retries_unsubscribe_and_metrics_converge() {
         transport_group_id: new_transport_group_id.clone(),
         endpoints: vec![endpoint.clone()],
     };
-    let expected_unsubscribes = [
-        NostrSubscription::Group {
-            account_id: account_id.clone(),
-            group_id: old_group_a.group_id.clone(),
-            transport_group_id: old_group_a.transport_group_id.clone(),
-            endpoints: old_group_a.endpoints.clone(),
-            since: None,
-        },
-        NostrSubscription::Group {
-            account_id: account_id.clone(),
-            group_id: old_group_b.group_id.clone(),
-            transport_group_id: old_group_b.transport_group_id.clone(),
-            endpoints: old_group_b.endpoints.clone(),
-            since: None,
-        },
-    ];
+    let expected_unsubscribes = |attempt| {
+        [
+            NostrSubscription::Group {
+                account_id: account_id.clone(),
+                group_id: old_group_a.group_id.clone(),
+                transport_group_id: old_group_a.transport_group_id.clone(),
+                endpoints: old_group_a.endpoints.clone(),
+                since: None,
+                attempt,
+            },
+            NostrSubscription::Group {
+                account_id: account_id.clone(),
+                group_id: old_group_b.group_id.clone(),
+                transport_group_id: old_group_b.transport_group_id.clone(),
+                endpoints: old_group_b.endpoints.clone(),
+                since: None,
+                attempt,
+            },
+        ]
+    };
 
     adapter
         .activate_account(TransportAccountActivation {
@@ -2234,11 +2271,12 @@ async fn cancelled_sync_drain_retries_unsubscribe_and_metrics_converge() {
     .expect("retry sync must complete before timeout")
     .expect("retry sync succeeds");
 
+    let attempt = adapter.account_subscription_attempt(&account_id).await;
     {
         let unsubscribed = relay.unsubscribed.lock().unwrap();
         assert_eq!(
             unsubscribed.as_slice(),
-            &expected_unsubscribes,
+            &expected_unsubscribes(attempt),
             "both old subscription teardowns are recorded exactly once in vector order"
         );
     }
@@ -2915,6 +2953,7 @@ async fn sync_telemetry_tracks_only_live_subscriptions_across_churn() {
         transport_group_id: vec![1; 32],
         endpoints: vec![TransportEndpoint("wss://relay-1.example".into())],
         since: None,
+        attempt: adapter.account_subscription_attempt(&account_id).await,
     }
     .subscription_id();
     assert_eq!(adapter.subscription_synced(&stale_group_id).await, None);
@@ -2959,19 +2998,25 @@ async fn account_subscription_eose_follows_the_latest_activation_snapshot() {
         endpoints: vec![TransportEndpoint(format!("wss://group-{index}.example"))],
     };
     let group_endpoint = |index: u8| TransportEndpoint(format!("wss://group-{index}.example"));
-    let inbox_id = NostrSubscription::AccountInbox {
-        account_id: account_id.clone(),
-        endpoints: vec![inbox.clone()],
-        since: None,
-    }
-    .subscription_id();
-    let group_id_for = |index: u8| {
+    // Ids are scoped to the activation attempt that issued them, so both
+    // reconstructions take the attempt they belong to.
+    let inbox_id = |attempt| {
+        NostrSubscription::AccountInbox {
+            account_id: account_id.clone(),
+            endpoints: vec![inbox.clone()],
+            since: None,
+            attempt,
+        }
+        .subscription_id()
+    };
+    let group_id_for = |index: u8, attempt| {
         NostrSubscription::Group {
             account_id: account_id.clone(),
             group_id: cgka_traits::GroupId::new(vec![index; 32]),
             transport_group_id: vec![index; 32],
             endpoints: vec![group_endpoint(index)],
             since: None,
+            attempt,
         }
         .subscription_id()
     };
@@ -2985,13 +3030,14 @@ async fn account_subscription_eose_follows_the_latest_activation_snapshot() {
     };
 
     activate(group_for(1)).await.expect("activation succeeds");
+    let first = adapter.account_subscription_attempt(&account_id).await;
     let progress = adapter.account_subscription_eose(&account_id).await;
     assert_eq!(progress.subscriptions, 2);
     assert!(!progress.any(), "no relay has reported yet");
     assert!(!progress.complete());
 
     adapter
-        .handle_relay_eose(inbox.clone(), inbox_id.clone())
+        .handle_relay_eose(inbox.clone(), inbox_id(first))
         .await;
     let progress = adapter.account_subscription_eose(&account_id).await;
     assert!(progress.any());
@@ -3001,7 +3047,7 @@ async fn account_subscription_eose_follows_the_latest_activation_snapshot() {
     );
 
     adapter
-        .handle_relay_eose(group_endpoint(1), group_id_for(1))
+        .handle_relay_eose(group_endpoint(1), group_id_for(1, first))
         .await;
     assert!(
         adapter
@@ -3015,6 +3061,8 @@ async fn account_subscription_eose_follows_the_latest_activation_snapshot() {
     // must be evicted rather than left tracked, and both re-issued ids must be
     // confirmed again.
     activate(group_for(2)).await.expect("reactivation succeeds");
+    let second = adapter.account_subscription_attempt(&account_id).await;
+    assert_ne!(first, second, "reactivation opens a new attempt");
     assert_eq!(
         adapter.relay_sync().await.tracked_subscriptions,
         2,
@@ -3027,19 +3075,28 @@ async fn account_subscription_eose_follows_the_latest_activation_snapshot() {
         "a re-issued subscription must be confirmed again"
     );
 
-    // A report for the retired route cannot stand in for the live one.
+    // A report for the retired route cannot stand in for the live one, and
+    // neither can the superseded attempt's report for a route that survived.
     adapter
-        .handle_relay_eose(group_endpoint(1), group_id_for(1))
+        .handle_relay_eose(group_endpoint(1), group_id_for(1, second))
         .await;
     adapter
-        .handle_relay_eose(inbox.clone(), inbox_id.clone())
+        .handle_relay_eose(inbox.clone(), inbox_id(first))
+        .await;
+    let progress = adapter.account_subscription_eose(&account_id).await;
+    assert_eq!(
+        progress.with_eose, 0,
+        "neither the retired route nor the superseded attempt may count"
+    );
+    adapter
+        .handle_relay_eose(inbox.clone(), inbox_id(second))
         .await;
     let progress = adapter.account_subscription_eose(&account_id).await;
     assert_eq!(progress.with_eose, 1, "the retired route must not count");
     assert!(!progress.complete());
 
     adapter
-        .handle_relay_eose(group_endpoint(2), group_id_for(2))
+        .handle_relay_eose(group_endpoint(2), group_id_for(2, second))
         .await;
     assert!(
         adapter
@@ -3089,21 +3146,6 @@ async fn account_subscription_eose_requires_the_frozen_relay_coverage() {
         transport_group_id: vec![0x44; 32],
         endpoints: vec![group_a.clone(), group_b.clone()],
     };
-    let inbox_id = NostrSubscription::AccountInbox {
-        account_id: account_id.clone(),
-        endpoints: vec![inbox_a.clone(), inbox_b.clone()],
-        since: None,
-    }
-    .subscription_id();
-    let group_id = NostrSubscription::Group {
-        account_id: account_id.clone(),
-        group_id: group.group_id.clone(),
-        transport_group_id: group.transport_group_id.clone(),
-        endpoints: group.endpoints.clone(),
-        since: None,
-    }
-    .subscription_id();
-
     adapter
         .activate_account(TransportAccountActivation {
             account_id: account_id.clone(),
@@ -3113,6 +3155,23 @@ async fn account_subscription_eose_requires_the_frozen_relay_coverage() {
         })
         .await
         .expect("activation succeeds");
+    let attempt = adapter.account_subscription_attempt(&account_id).await;
+    let inbox_id = NostrSubscription::AccountInbox {
+        account_id: account_id.clone(),
+        endpoints: vec![inbox_a.clone(), inbox_b.clone()],
+        since: None,
+        attempt,
+    }
+    .subscription_id();
+    let group_id = NostrSubscription::Group {
+        account_id: account_id.clone(),
+        group_id: group.group_id.clone(),
+        transport_group_id: group.transport_group_id.clone(),
+        endpoints: group.endpoints.clone(),
+        since: None,
+        attempt,
+    }
+    .subscription_id();
 
     // Relay A is fast but empty. Its EOSE covers neither subscription on B.
     adapter
@@ -3189,6 +3248,8 @@ async fn account_subscription_eose_requires_the_frozen_relay_coverage() {
         transport_group_id: shrunk_group.transport_group_id,
         endpoints: shrunk_group.endpoints,
         since: None,
+        // A sync does not open a new attempt.
+        attempt,
     }
     .subscription_id();
     adapter.handle_relay_eose(group_a, shrunk_group_id).await;
@@ -3208,6 +3269,114 @@ async fn account_subscription_eose_requires_the_frozen_relay_coverage() {
             .complete(),
         "the frozen snapshot completes once B serves its relevant EOSE"
     );
+}
+
+/// A superseded activation's end-of-stored-events report must not satisfy the
+/// replay gate the next activation opened.
+///
+/// Reactivation tears the previous REQs down, zeroes the account's replay
+/// coverage, and re-issues. A relay's EOSE for a torn-down attempt can still be
+/// in flight and land after that reset. It answered a different REQ — here the
+/// `since`-floored live subscription, superseded by an unfloored history replay
+/// over the same routes — so it is no evidence that the replay reached the end
+/// of the relay's stored history.
+#[tokio::test]
+async fn superseded_activation_eose_does_not_satisfy_the_replay_gate() {
+    let relay = Arc::new(FakeRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay.clone() as Arc<dyn NostrRelayClient>);
+    let account_id = MemberId::new(vec![0xD4; 32]);
+    let inbox = TransportEndpoint("wss://inbox.example".to_owned());
+    let group_endpoint = TransportEndpoint("wss://group.example".to_owned());
+    let group = TransportGroupSubscription {
+        group_id: cgka_traits::GroupId::new(vec![0x55; 16]),
+        transport_group_id: vec![0x66; 32],
+        endpoints: vec![group_endpoint.clone()],
+    };
+    let activate = |since: Option<Timestamp>| {
+        adapter.activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![inbox.clone()],
+            group_subscriptions: vec![group.clone()],
+            since,
+        })
+    };
+
+    activate(Some(Timestamp(1_700_000_000)))
+        .await
+        .expect("floored activation succeeds");
+    let superseded = relay.take_issued_subscriptions();
+    assert!(
+        superseded
+            .iter()
+            .all(|subscription| subscription_since(subscription).is_some()),
+        "the superseded attempt must be the floored one"
+    );
+
+    activate(None).await.expect("unfloored replay succeeds");
+    let replay = relay.take_issued_subscriptions();
+    assert!(
+        replay
+            .iter()
+            .all(|subscription| subscription_since(subscription).is_none()),
+        "the replay attempt must be unfloored"
+    );
+
+    assert!(
+        superseded
+            .iter()
+            .zip(&replay)
+            .all(|(old, new)| old.attempt() != new.attempt()),
+        "reactivation must re-issue under a new attempt"
+    );
+
+    let progress = adapter.account_subscription_eose(&account_id).await;
+    assert_eq!(progress.subscriptions, 2);
+    assert!(!progress.any(), "the replay has not been served yet");
+
+    // The superseded attempt's buffered EOSEs are delivered after the reset.
+    for subscription in &superseded {
+        adapter
+            .handle_relay_eose(
+                subscription.endpoints()[0].clone(),
+                subscription.subscription_id(),
+            )
+            .await;
+    }
+    let progress = adapter.account_subscription_eose(&account_id).await;
+    assert!(
+        !progress.any(),
+        "an EOSE answering the superseded REQ is not replay evidence"
+    );
+    assert!(
+        !progress.complete(),
+        "a stale EOSE must not complete the unfloored replay gate"
+    );
+
+    // The live attempt's own reports still complete the gate.
+    for subscription in &replay {
+        adapter
+            .handle_relay_eose(
+                subscription.endpoints()[0].clone(),
+                subscription.subscription_id(),
+            )
+            .await;
+    }
+    assert!(
+        adapter
+            .account_subscription_eose(&account_id)
+            .await
+            .complete(),
+        "the replay attempt's own EOSEs complete its coverage"
+    );
+}
+
+fn subscription_since(subscription: &NostrSubscription) -> Option<Timestamp> {
+    match subscription {
+        NostrSubscription::AccountInbox { since, .. } | NostrSubscription::Group { since, .. } => {
+            *since
+        }
+        NostrSubscription::GroupMaintenance { .. } => None,
+    }
 }
 
 fn group_event(id_byte: &str, transport_group_id: &[u8]) -> NostrTransportEvent {

--- a/crates/transport-nostr-adapter/tests/inbound_routing.rs
+++ b/crates/transport-nostr-adapter/tests/inbound_routing.rs
@@ -224,6 +224,65 @@ impl NostrRelayClient for StoredReplayRelayClient {
     }
 }
 
+/// Models the production shape the activation rollback comment admits: some
+/// REQs of a failing activation already reached the relay. Records every
+/// subscription it sees, then fails the group REQ while armed.
+#[derive(Default)]
+struct PartialFailureRelayClient {
+    fail_group_subscribes: AtomicBool,
+    subscriptions: Mutex<Vec<NostrSubscription>>,
+}
+
+impl PartialFailureRelayClient {
+    fn take_issued_subscriptions(&self) -> Vec<NostrSubscription> {
+        self.subscriptions.lock().unwrap().drain(..).collect()
+    }
+}
+
+#[async_trait]
+impl NostrRelayClient for PartialFailureRelayClient {
+    async fn subscribe(
+        &self,
+        subscription: NostrSubscription,
+    ) -> Result<(), cgka_traits::TransportAdapterError> {
+        self.subscriptions
+            .lock()
+            .unwrap()
+            .push(subscription.clone());
+        if self.fail_group_subscribes.load(Ordering::SeqCst)
+            && matches!(subscription, NostrSubscription::Group { .. })
+        {
+            return Err(cgka_traits::TransportAdapterError::Subscription(
+                "injected group subscribe failure".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    async fn unsubscribe(
+        &self,
+        _subscription: NostrSubscription,
+    ) -> Result<(), cgka_traits::TransportAdapterError> {
+        Ok(())
+    }
+
+    async fn unsubscribe_account(
+        &self,
+        _account_id: &MemberId,
+    ) -> Result<(), cgka_traits::TransportAdapterError> {
+        Ok(())
+    }
+
+    async fn publish_event(
+        &self,
+        endpoints: &[TransportEndpoint],
+        _event: &NostrTransportEvent,
+        _required_acks: usize,
+    ) -> Result<NostrPublishOutcome, cgka_traits::TransportAdapterError> {
+        Ok(NostrPublishOutcome::accepted(endpoints.to_vec()))
+    }
+}
+
 #[derive(Default)]
 struct FakeRelayClient {
     subscriptions: Mutex<Vec<transport_nostr_adapter::NostrSubscription>>,
@@ -641,7 +700,10 @@ async fn group_subscription_id_fans_out_to_matching_accounts_and_replays_route_a
         transport_group_id: transport_group_id.clone(),
         endpoints: vec![endpoint.clone()],
         since: None,
-        attempt: adapter.account_subscription_attempt(&alice).await,
+        attempt: adapter
+            .account_subscription_attempt(&alice)
+            .await
+            .expect("the account is active"),
     }
     .subscription_id();
     let bob_subscription_id = NostrSubscription::Group {
@@ -650,7 +712,10 @@ async fn group_subscription_id_fans_out_to_matching_accounts_and_replays_route_a
         transport_group_id: transport_group_id.clone(),
         endpoints: vec![endpoint.clone()],
         since: None,
-        attempt: adapter.account_subscription_attempt(&bob).await,
+        attempt: adapter
+            .account_subscription_attempt(&bob)
+            .await
+            .expect("the account is active"),
     }
     .subscription_id();
 
@@ -796,7 +861,8 @@ async fn failed_activation_rolls_back_routes_and_can_retry() {
     assert_eq!(metrics.active_group_subscriptions, 0);
     assert_eq!(
         relay.unsubscribed_accounts.lock().unwrap().as_slice(),
-        &[account_id]
+        &[account_id.clone(), account_id],
+        "every activation opens with a blanket teardown; the rollback adds its own"
     );
 
     relay.fail_subscribes.store(false, Ordering::SeqCst);
@@ -1089,7 +1155,10 @@ async fn reissued_live_subscription_keeps_synchronous_callbacks() {
         .await
         .expect("group sync succeeds");
 
-    let attempt = adapter.account_subscription_attempt(&account_id).await;
+    let attempt = adapter
+        .account_subscription_attempt(&account_id)
+        .await
+        .expect("the account is active");
     let old_subscription_id = NostrSubscription::Group {
         account_id: account_id.clone(),
         group_id: group_id.clone(),
@@ -1168,7 +1237,10 @@ async fn failed_group_sync_rolls_back_staged_routes_and_telemetry() {
         transport_group_id: old_transport_group_id.clone(),
         endpoints: vec![endpoint.clone()],
         since: None,
-        attempt: adapter.account_subscription_attempt(&account_id).await,
+        attempt: adapter
+            .account_subscription_attempt(&account_id)
+            .await
+            .expect("the account is active"),
     }
     .subscription_id();
     adapter
@@ -1269,7 +1341,10 @@ async fn cancelled_group_sync_rolls_back_staged_routes_and_telemetry() {
         transport_group_id: new_transport_group_id.clone(),
         endpoints: vec![endpoint.clone()],
         since: None,
-        attempt: adapter.account_subscription_attempt(&account_id).await,
+        attempt: adapter
+            .account_subscription_attempt(&account_id)
+            .await
+            .expect("the account is active"),
     }
     .subscription_id();
 
@@ -1372,7 +1447,10 @@ async fn cancelled_reissues_preserve_live_gates_and_apply_eose_on_rollback() {
         })
         .await
         .expect("activation succeeds");
-    let attempt = adapter.account_subscription_attempt(&account_id).await;
+    let attempt = adapter
+        .account_subscription_attempt(&account_id)
+        .await
+        .expect("the account is active");
     let synced_old_subscription_id = NostrSubscription::Group {
         account_id: account_id.clone(),
         group_id: synced_group_id.clone(),
@@ -1712,7 +1790,10 @@ async fn initial_sync_gate_closes_only_after_every_endpoint_eoses() {
 
     // Reconstruct the group subscription id the adapter issued, stamped with
     // the attempt that issued it.
-    let attempt = adapter.account_subscription_attempt(&account_id).await;
+    let attempt = adapter
+        .account_subscription_attempt(&account_id)
+        .await
+        .expect("the account is active");
     let sub_id = NostrSubscription::Group {
         account_id,
         group_id,
@@ -1814,7 +1895,8 @@ async fn synced_group_subscriptions_replace_old_routes() {
 
     let attempt = adapter
         .account_subscription_attempt(&MemberId::new(vec![0xA1; 32]))
-        .await;
+        .await
+        .expect("the account is active");
     let unsubscribed = relay.unsubscribed.lock().unwrap();
     assert_eq!(
         unsubscribed.as_slice(),
@@ -1946,7 +2028,10 @@ async fn rotating_current_route_reissues_the_displaced_route_for_full_backfill_o
 
     // A sync amends the live activation rather than opening a new attempt, so
     // the re-issued routes carry the activation's own attempt.
-    let attempt = adapter.account_subscription_attempt(&account_id).await;
+    let attempt = adapter
+        .account_subscription_attempt(&account_id)
+        .await
+        .expect("the account is active");
     let issued_after_rotation = relay
         .subscriptions
         .lock()
@@ -2110,7 +2195,10 @@ async fn failed_unsubscribe_is_retried_and_drained_on_next_sync() {
         .await
         .expect("retry sync succeeds");
 
-    let attempt = adapter.account_subscription_attempt(&account_id).await;
+    let attempt = adapter
+        .account_subscription_attempt(&account_id)
+        .await
+        .expect("the account is active");
     {
         let unsubscribed = relay.unsubscribed.lock().unwrap();
         assert_eq!(
@@ -2271,7 +2359,10 @@ async fn cancelled_sync_drain_retries_unsubscribe_and_metrics_converge() {
     .expect("retry sync must complete before timeout")
     .expect("retry sync succeeds");
 
-    let attempt = adapter.account_subscription_attempt(&account_id).await;
+    let attempt = adapter
+        .account_subscription_attempt(&account_id)
+        .await
+        .expect("the account is active");
     {
         let unsubscribed = relay.unsubscribed.lock().unwrap();
         assert_eq!(
@@ -2416,7 +2507,8 @@ async fn deactivate_account_clears_pending_unsubscribes() {
         .expect("deactivation succeeds");
     assert_eq!(
         relay.unsubscribed_accounts.lock().unwrap().as_slice(),
-        std::slice::from_ref(&account_id)
+        &[account_id.clone(), account_id.clone()],
+        "the activation's opening teardown, then the deactivation's"
     );
     assert_eq!(adapter.metrics().await.unsubscribe_retries_pending, 0);
 }
@@ -2585,7 +2677,8 @@ async fn activating_existing_account_replaces_old_relay_state() {
 
     assert_eq!(
         relay.unsubscribed_accounts.lock().unwrap().as_slice(),
-        std::slice::from_ref(&account_id)
+        &[account_id.clone(), account_id.clone()],
+        "each activation opens with a blanket teardown of the account's REQs"
     );
     let old_delivered = adapter
         .handle_relay_event(NostrRelayEvent {
@@ -2953,7 +3046,10 @@ async fn sync_telemetry_tracks_only_live_subscriptions_across_churn() {
         transport_group_id: vec![1; 32],
         endpoints: vec![TransportEndpoint("wss://relay-1.example".into())],
         since: None,
-        attempt: adapter.account_subscription_attempt(&account_id).await,
+        attempt: adapter
+            .account_subscription_attempt(&account_id)
+            .await
+            .expect("the account is active"),
     }
     .subscription_id();
     assert_eq!(adapter.subscription_synced(&stale_group_id).await, None);
@@ -3030,7 +3126,10 @@ async fn account_subscription_eose_follows_the_latest_activation_snapshot() {
     };
 
     activate(group_for(1)).await.expect("activation succeeds");
-    let first = adapter.account_subscription_attempt(&account_id).await;
+    let first = adapter
+        .account_subscription_attempt(&account_id)
+        .await
+        .expect("the account is active");
     let progress = adapter.account_subscription_eose(&account_id).await;
     assert_eq!(progress.subscriptions, 2);
     assert!(!progress.any(), "no relay has reported yet");
@@ -3061,7 +3160,10 @@ async fn account_subscription_eose_follows_the_latest_activation_snapshot() {
     // must be evicted rather than left tracked, and both re-issued ids must be
     // confirmed again.
     activate(group_for(2)).await.expect("reactivation succeeds");
-    let second = adapter.account_subscription_attempt(&account_id).await;
+    let second = adapter
+        .account_subscription_attempt(&account_id)
+        .await
+        .expect("the account is active");
     assert_ne!(first, second, "reactivation opens a new attempt");
     assert_eq!(
         adapter.relay_sync().await.tracked_subscriptions,
@@ -3079,6 +3181,10 @@ async fn account_subscription_eose_follows_the_latest_activation_snapshot() {
     // neither can the superseded attempt's report for a route that survived.
     adapter
         .handle_relay_eose(group_endpoint(1), group_id_for(1, second))
+        .await;
+    // The retired route's genuinely-issued id does not count either.
+    adapter
+        .handle_relay_eose(group_endpoint(1), group_id_for(1, first))
         .await;
     adapter
         .handle_relay_eose(inbox.clone(), inbox_id(first))
@@ -3155,7 +3261,10 @@ async fn account_subscription_eose_requires_the_frozen_relay_coverage() {
         })
         .await
         .expect("activation succeeds");
-    let attempt = adapter.account_subscription_attempt(&account_id).await;
+    let attempt = adapter
+        .account_subscription_attempt(&account_id)
+        .await
+        .expect("the account is active");
     let inbox_id = NostrSubscription::AccountInbox {
         account_id: account_id.clone(),
         endpoints: vec![inbox_a.clone(), inbox_b.clone()],
@@ -3367,6 +3476,143 @@ async fn superseded_activation_eose_does_not_satisfy_the_replay_gate() {
             .await
             .complete(),
         "the replay attempt's own EOSEs complete its coverage"
+    );
+}
+
+/// Deactivation does not close the relay sockets, so an EOSE for the
+/// deactivated attempt can still arrive after the account is brought back up.
+/// Signing out and back in must not hand the new activation's replay gate the
+/// old attempt's evidence.
+#[tokio::test]
+async fn eose_from_a_deactivated_attempt_does_not_satisfy_the_next_activation() {
+    let relay = Arc::new(FakeRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay.clone() as Arc<dyn NostrRelayClient>);
+    let account_id = MemberId::new(vec![0xD5; 32]);
+    let inbox = TransportEndpoint("wss://inbox.example".to_owned());
+    let group_endpoint = TransportEndpoint("wss://group.example".to_owned());
+    let group = TransportGroupSubscription {
+        group_id: cgka_traits::GroupId::new(vec![0x57; 16]),
+        transport_group_id: vec![0x67; 32],
+        endpoints: vec![group_endpoint.clone()],
+    };
+    let activate = |since: Option<Timestamp>| {
+        adapter.activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![inbox.clone()],
+            group_subscriptions: vec![group.clone()],
+            since,
+        })
+    };
+
+    activate(Some(Timestamp(1_700_000_000)))
+        .await
+        .expect("first activation succeeds");
+    let superseded = relay.take_issued_subscriptions();
+    assert_eq!(superseded.len(), 2);
+
+    adapter
+        .deactivate_account(&account_id)
+        .await
+        .expect("deactivation succeeds");
+
+    activate(None).await.expect("reactivation succeeds");
+    let replay = relay.take_issued_subscriptions();
+    assert_eq!(replay.len(), 2);
+
+    for subscription in &superseded {
+        adapter
+            .handle_relay_eose(
+                subscription.endpoints()[0].clone(),
+                subscription.subscription_id(),
+            )
+            .await;
+    }
+    let progress = adapter.account_subscription_eose(&account_id).await;
+    assert!(
+        !progress.any(),
+        "an EOSE for the deactivated attempt is not evidence for the new one"
+    );
+    assert!(!progress.complete());
+
+    for subscription in &replay {
+        adapter
+            .handle_relay_eose(
+                subscription.endpoints()[0].clone(),
+                subscription.subscription_id(),
+            )
+            .await;
+    }
+    assert!(
+        adapter
+            .account_subscription_eose(&account_id)
+            .await
+            .complete(),
+        "the new activation's own EOSEs complete its coverage"
+    );
+}
+
+/// A failed activation rolls its local routes back, but REQs that already
+/// reached a relay keep streaming. The retry must not inherit their EOSEs.
+#[tokio::test]
+async fn eose_from_a_rolled_back_activation_does_not_satisfy_the_retry() {
+    let relay = Arc::new(PartialFailureRelayClient::default());
+    relay.fail_group_subscribes.store(true, Ordering::SeqCst);
+    let adapter = NostrTransportAdapter::new(relay.clone() as Arc<dyn NostrRelayClient>);
+    let account_id = MemberId::new(vec![0xD6; 32]);
+    let inbox = TransportEndpoint("wss://inbox.example".to_owned());
+    let group_endpoint = TransportEndpoint("wss://group.example".to_owned());
+    let group = TransportGroupSubscription {
+        group_id: cgka_traits::GroupId::new(vec![0x58; 16]),
+        transport_group_id: vec![0x68; 32],
+        endpoints: vec![group_endpoint.clone()],
+    };
+    let activate = |since: Option<Timestamp>| {
+        adapter.activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![inbox.clone()],
+            group_subscriptions: vec![group.clone()],
+            since,
+        })
+    };
+
+    activate(Some(Timestamp(1_700_000_000)))
+        .await
+        .expect_err("the group REQ fails, so the activation is rolled back");
+    let rolled_back = relay.take_issued_subscriptions();
+    let stranded_inbox = rolled_back
+        .iter()
+        .find(|subscription| matches!(subscription, NostrSubscription::AccountInbox { .. }))
+        .cloned()
+        .expect("the inbox REQ reached the relay before the group REQ failed");
+
+    relay.fail_group_subscribes.store(false, Ordering::SeqCst);
+    activate(None).await.expect("the retry succeeds");
+    let replay = relay.take_issued_subscriptions();
+    assert_eq!(replay.len(), 2);
+
+    adapter
+        .handle_relay_eose(inbox.clone(), stranded_inbox.subscription_id())
+        .await;
+    let progress = adapter.account_subscription_eose(&account_id).await;
+    assert!(
+        !progress.any(),
+        "the rolled-back attempt's stranded REQ is not evidence for the retry"
+    );
+
+    for subscription in &replay {
+        adapter
+            .handle_relay_eose(
+                subscription.endpoints()[0].clone(),
+                subscription.subscription_id(),
+            )
+            .await;
+    }
+    assert!(
+        adapter
+            .account_subscription_eose(&account_id)
+            .await
+            .complete(),
+        "the retry's own EOSEs complete its coverage"
     );
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account and group synchronization reliability during reconnects, retries, cancellations, and rollbacks.
  * Prevented outdated synchronization signals from being mistaken for current progress.
  * Ensured previous connections are fully cleared before a new activation begins.
  * Reduced the risk of duplicate updates or incomplete replay during subscription recovery.
  * Improved handling of partial connection failures so recovery can proceed cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->