### PR TITLE
Fix/upsert invalidation revive

### DIFF
--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -2957,8 +2957,7 @@ impl AppClient {
 
         let should_project_locally = !notifications::is_push_gossip_kind(event.kind);
         if should_project_locally {
-            let update = self
-                .record_local_app_event_projection(group_id, &sender, &event, None, None, false)?;
+            let update = self.record_send_intent_projection(group_id, &sender, &event)?;
             on_local_projection(update);
         }
 

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -24,6 +24,42 @@ use crate::{
 use super::AppClient;
 
 impl AppClient {
+    /// Project a fresh send intent optimistically, before the publish is tried.
+    ///
+    /// Two things happen here, and the order matters. Inner app-event ids are
+    /// NIP-01 hashes over (pubkey, created_at, kind, tags, content) with
+    /// second-granular `created_at`, so a resend of identical text inside the
+    /// same second as a failed send mints that send's *exact* id — and lands on
+    /// the row `retract_failed_local_projection` tombstoned as
+    /// `local_publish_failed`. `record_app_event`'s upsert keeps invalidation
+    /// terminal by design (it cannot tell a retry from a relay redelivery, a
+    /// backfill replay, or a re-synthesized system row), so the retraction has
+    /// to be cleared explicitly first, and only where there is evidence to clear
+    /// it. A fresh send intent is that evidence: replay seams re-record rows
+    /// without ever reaching this function.
+    ///
+    /// Only the pre-publish projection clears. The post-publish one runs on a
+    /// row this call already revived, and anything that invalidated it *during*
+    /// the send — the terminal-group sweep, a convergence withdrawal — is a
+    /// verdict the send flow has no evidence to overturn.
+    ///
+    /// The clear's own projection update is dropped: the record below reprojects
+    /// the same row and returns that update, so forwarding both would emit the
+    /// same flip twice.
+    pub(crate) fn record_send_intent_projection(
+        &self,
+        group_id: &GroupId,
+        sender: &str,
+        event: &MarmotInnerEvent,
+    ) -> Result<crate::AppProjectionUpdate, AppError> {
+        let _revived = self.app.clear_timeline_local_publish_failure(
+            &self.state.label,
+            &hex::encode(group_id.as_slice()),
+            &event.id,
+        )?;
+        self.record_local_app_event_projection(group_id, sender, event, None, None, false)
+    }
+
     /// `advance_read_marker`: pre-publish projections must pass `false` so a
     /// failed publish never leaves the group read marker advanced past inbound
     /// unreads or pointing at an invalidated own message (#338); only the
@@ -732,10 +768,13 @@ impl AppClient {
     /// already dispatched each `GroupStateInvalidated` through
     /// [`MarmotApp::projection_update_for_invalidation_event`] — so by the time
     /// the upsert below runs, the batch's withdrawals are all applied and it
-    /// would be the last writer. The storage upsert clears `invalidated` on
-    /// conflict, so without this filter the tail either revives a row the batch
-    /// just tombstoned or synthesizes one for a change that canonically never
-    /// happened (the withdrawal swept a row that did not exist yet).
+    /// would be the last writer. Without this filter the tail synthesizes a row
+    /// for a change that canonically never happened: when no row existed yet,
+    /// the withdrawal swept nothing and the upsert INSERTs a *live* row.
+    ///
+    /// When the row does already exist, storage is the second line of defence —
+    /// its upsert preserves the withdrawal rather than clearing it — so that
+    /// shape is pinned at both layers by design, not by this filter alone.
     ///
     /// One batch carries both because the engine buffers convergence passes:
     /// `events_buf` has a single take site and

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -26,38 +26,51 @@ use super::AppClient;
 impl AppClient {
     /// Project a fresh send intent optimistically, before the publish is tried.
     ///
-    /// Two things happen here, and the order matters. Inner app-event ids are
-    /// NIP-01 hashes over (pubkey, created_at, kind, tags, content) with
-    /// second-granular `created_at`, so a resend of identical text inside the
-    /// same second as a failed send mints that send's *exact* id — and lands on
-    /// the row `retract_failed_local_projection` tombstoned as
-    /// `local_publish_failed`. `record_app_event`'s upsert keeps invalidation
-    /// terminal by design (it cannot tell a retry from a relay redelivery, a
-    /// backfill replay, or a re-synthesized system row), so the retraction has
-    /// to be cleared explicitly first, and only where there is evidence to clear
-    /// it. A fresh send intent is that evidence: replay seams re-record rows
-    /// without ever reaching this function.
+    /// Inner app-event ids are NIP-01 hashes over
+    /// (pubkey, created_at, kind, tags, content) with second-granular
+    /// `created_at`, so a resend of identical text inside the same second as a
+    /// failed send mints that send's *exact* id and lands on the row
+    /// `retract_failed_local_projection` tombstoned as `local_publish_failed`.
+    /// `record_app_event`'s upsert keeps invalidation terminal by design — it
+    /// cannot tell a retry from a relay redelivery, a backfill replay, or a
+    /// re-synthesized system row — so reviving that row needs an explicit clear
+    /// carrying evidence the upsert lacks. A fresh send intent is that evidence,
+    /// and only this function sees one: replay seams re-record rows without ever
+    /// entering a send.
+    ///
+    /// **Record first, then clear**, because the two writes commit separately
+    /// and only this order is truthful at every prefix. The record alone
+    /// preserves the tombstone, so a failing record, a failing clear, and a
+    /// crash between the two commits all leave the row `Failed` — the state the
+    /// user last saw, still retryable. Clearing first would commit a revival the
+    /// send never earned: a live `pending` row with no publish attempt behind
+    /// it, which nothing short of a terminal-group sweep re-invalidates. See
+    /// `docs/marmot-architecture/overview/multi-step-state-changes.md`.
+    ///
+    /// The clear reprojects the same row against the post-record snapshot, so
+    /// its update supersedes the record's and exactly one flip is forwarded;
+    /// with no tombstone to clear, the record's update is the only one.
     ///
     /// Only the pre-publish projection clears. The post-publish one runs on a
     /// row this call already revived, and anything that invalidated it *during*
     /// the send — the terminal-group sweep, a convergence withdrawal — is a
     /// verdict the send flow has no evidence to overturn.
-    ///
-    /// The clear's own projection update is dropped: the record below reprojects
-    /// the same row and returns that update, so forwarding both would emit the
-    /// same flip twice.
     pub(crate) fn record_send_intent_projection(
         &self,
         group_id: &GroupId,
         sender: &str,
         event: &MarmotInnerEvent,
     ) -> Result<crate::AppProjectionUpdate, AppError> {
-        let _revived = self.app.clear_timeline_local_publish_failure(
-            &self.state.label,
-            &hex::encode(group_id.as_slice()),
-            &event.id,
-        )?;
-        self.record_local_app_event_projection(group_id, sender, event, None, None, false)
+        let recorded =
+            self.record_local_app_event_projection(group_id, sender, event, None, None, false)?;
+        Ok(self
+            .app
+            .clear_timeline_local_publish_failure(
+                &self.state.label,
+                &hex::encode(group_id.as_slice()),
+                &event.id,
+            )?
+            .unwrap_or(recorded))
     }
 
     /// `advance_read_marker`: pre-publish projections must pass `false` so a

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -297,8 +297,10 @@ const DIRECT_CONVERSATION_MEMBERS_BACKFILL_MARKER: &str = "direct-conversation-m
 /// Invalidation reason for a sent app event that will never reach anyone,
 /// whether it was refused at send time or its group turned terminal while the
 /// engine still held it. The derived-state SQL keys the app-facing `Failed`
-/// delivery state off this exact literal, so both producers must share it.
-pub(crate) const LOCAL_PUBLISH_FAILED_REASON: &str = "local_publish_failed";
+/// delivery state off this exact literal, so both producers must share it —
+/// which is why storage owns the definition and this is a re-export rather than
+/// a second copy of the string.
+pub(crate) use storage_sqlite::LOCAL_PUBLISH_FAILED_REASON;
 const APP_CACHE_DB_FILE: &str = "app-cache.sqlite3";
 const SHARED_DB_FILE: &str = "shared.sqlite3";
 const KEY_PACKAGE_CUTOVER_RELAY_SCAN_LIMIT: usize = 1_024;
@@ -5269,6 +5271,32 @@ impl MarmotApp {
         let update = self
             .account_storage(label)?
             .invalidate_app_event_by_message_id(group_id_hex, message_id_hex, reason)?;
+        update
+            .map(|update| self.app_projection_update(label, update))
+            .transpose()
+    }
+
+    /// Clear a `local_publish_failed` retraction on one locally-sent row, so a
+    /// fresh send intent for an id a failed send already retracted starts from a
+    /// live pending row instead of a permanent tombstone.
+    ///
+    /// Inner app-event ids are NIP-01 hashes over
+    /// (pubkey, created_at, kind, tags, content) with second-granular
+    /// `created_at`, so a resend of identical text inside the same second as a
+    /// failed send reuses that send's id. `record_app_event`'s upsert keeps
+    /// invalidation terminal, so the revival has to be explicit and has to carry
+    /// evidence — and the send intent is the evidence. Only this path can
+    /// produce one: replay seams (`observe_drained_session_events`, backfill,
+    /// rejoin reprocessing) re-record rows without ever entering a send.
+    pub(crate) fn clear_timeline_local_publish_failure(
+        &self,
+        label: &str,
+        group_id_hex: &str,
+        message_id_hex: &str,
+    ) -> Result<Option<AppProjectionUpdate>, AppError> {
+        let update = self
+            .account_storage(label)?
+            .clear_local_publish_failure(group_id_hex, message_id_hex)?;
         update
             .map(|update| self.app_projection_update(label, update))
             .transpose()

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -12401,14 +12401,132 @@ async fn a_drained_state_change_synthesizes_the_system_row_the_live_seam_does() 
     );
 }
 
+/// A send that failed and is retried inside the same second must end delivered.
+///
+/// Inner app-event ids are NIP-01 hashes over
+/// (pubkey, created_at, kind, tags, content), and `created_at` is whole seconds
+/// (`unix_now_seconds`), with no nonce. So identical text resent inside the same
+/// second as a failed send is not a *similar* event — it is bit-for-bit the same
+/// event, under the same id, landing on the row the failure retracted. Hosts are
+/// told to do exactly this: `marmot-uniffi` prescribes an automatic retry for
+/// `StorageBusy` (milliseconds later) and a user resend for the rest.
+///
+/// `record_app_event`'s upsert keeps invalidation terminal, because it cannot
+/// tell this retry from a relay redelivery or a backfill replay. Left there, the
+/// second send publishes to the whole group while the sender's own row stays
+/// `Failed` forever — nothing else clears `invalidated`. The send intent is the
+/// missing evidence, so `record_send_intent_projection` clears the retraction.
+///
+/// The two sends are built at one fixed `created_at` rather than by sending
+/// twice through the relay harness: that is precisely what a same-second resend
+/// produces, and it pins the collision instead of racing a clock edge.
+#[tokio::test]
+async fn a_same_second_resend_revives_the_row_its_failed_send_retracted() {
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://same-second-resend.example")
+        .with_test_relay_client(relay);
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client
+        .create_group("same second resend", &[])
+        .await
+        .unwrap();
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let sender = account.account_id_hex.clone();
+
+    let chat = || AppMessageIntent::Chat {
+        content: "resent inside the same second".to_owned(),
+    };
+    let first = build_inner_event(&chat(), &sender, 1_700_000_000).unwrap();
+    let resend = build_inner_event(&chat(), &sender, 1_700_000_000).unwrap();
+    assert_eq!(
+        first.id, resend.id,
+        "the premise: a same-second resend of identical text is the same event id"
+    );
+
+    let status = |app: &MarmotApp| {
+        app.timeline_messages_with_query(
+            "alice",
+            storage_sqlite::TimelineMessageQuery {
+                group_id_hex: Some(group_id_hex.clone()),
+                ..storage_sqlite::TimelineMessageQuery::default()
+            },
+        )
+        .unwrap()
+        .messages
+        .into_iter()
+        .find(|row| row.message_id_hex == first.id)
+        .map(|row| (row.invalidation_status, row.source_message_id_hex))
+    };
+
+    // The first send projects optimistically, then its publish fails and
+    // `retract_failed_local_projection` withdraws the row.
+    client
+        .record_send_intent_projection(&group_id, &sender, &first)
+        .unwrap();
+    app.invalidate_timeline_app_event(
+        "alice",
+        &group_id_hex,
+        &first.id,
+        crate::LOCAL_PUBLISH_FAILED_REASON,
+    )
+    .unwrap()
+    .expect("the failed send is retracted");
+    assert_eq!(
+        status(&app),
+        Some((Some("local_publish_failed".to_owned()), None)),
+        "control: the failed send renders as a failed, sourceless row"
+    );
+
+    // The resend: same id, so the optimistic record lands on the tombstone.
+    client
+        .record_send_intent_projection(&group_id, &sender, &resend)
+        .unwrap();
+    assert_eq!(
+        status(&app),
+        Some((None, None)),
+        "a fresh send intent revives its own retracted row to pending"
+    );
+
+    // This time the publish lands, and the post-publish record stamps the source.
+    client
+        .record_local_app_event_projection(
+            &group_id,
+            &sender,
+            &resend,
+            Some("published-source-id".to_owned()),
+            Some((
+                7,
+                crate::AppMessageRetentionDecision::new(1_700_000_000, 300),
+            )),
+            true,
+        )
+        .unwrap();
+
+    assert_eq!(
+        status(&app),
+        Some((None, Some("published-source-id".to_owned()))),
+        "a message the group received must never keep rendering as Failed"
+    );
+}
+
 /// A batch that supersedes a commit must not leave that commit's kind-1210 row
 /// standing, whichever seam projects the batch.
 ///
 /// Both seams invalidate per event inside their projection loop and synthesize
 /// system rows once at the tail, so every `GroupStateInvalidated` in a batch has
-/// already been applied by the time the tail upserts. The storage upsert clears
-/// `invalidated` on conflict, so an unfiltered tail either revives a row the
-/// same batch just withdrew or creates one the batch never should have had.
+/// already been applied by the time the tail upserts. An unfiltered tail then
+/// creates a row the batch never should have had: with nothing to sweep, the
+/// upsert INSERTs a live row for a change that canonically never happened.
+///
+/// The shapes below pin both halves deliberately. Shape 1 is the filter's own
+/// job — storage cannot help when no row exists to preserve. Shape 2 is
+/// defence in depth: the filter withholds the upsert *and* storage would
+/// preserve the withdrawal if it ran, so the row stays dead even if one layer
+/// regresses.
 ///
 /// The engine reaches this by buffering two convergence passes into one batch:
 /// `events_buf` has a single take site, and
@@ -12538,7 +12656,9 @@ async fn a_drained_batch_leaves_no_live_system_row_for_a_commit_it_supersedes() 
     );
 
     // Shape 2 — the row already exists from an earlier batch. Here the sweep
-    // does withdraw it, and the tail's upsert would clear `invalidated` again.
+    // does withdraw it, and both layers must keep it withdrawn: the filter
+    // withholds the tail's upsert, and storage preserves the withdrawal even if
+    // the upsert did run.
     let synthesized = MessageId::new(vec![0xA1; 32]);
     client
         .observe_drained_session_events(&batch(vec![renamed(

--- a/crates/marmot-uniffi/src/commands/message.rs
+++ b/crates/marmot-uniffi/src/commands/message.rs
@@ -47,9 +47,11 @@ impl Marmot {
     /// event is created.
     ///
     /// (A resend after a send that *failed* is still safe and still supported:
-    /// the send path clears that row's `local_publish_failed` retraction before
-    /// re-recording it. This call is for sends that are pending, not failed.) Returns the delivery summary; `published == 0` means
-    /// nothing was pending or publishing is still failing.
+    /// the send path re-records that row and clears its `local_publish_failed`
+    /// retraction. This call is for sends that are pending, not failed.)
+    ///
+    /// Returns the delivery summary; `published == 0` means nothing was pending
+    /// or publishing is still failing.
     pub async fn retry_group_convergence(
         &self,
         account_ref: String,

--- a/crates/marmot-uniffi/src/commands/message.rs
+++ b/crates/marmot-uniffi/src/commands/message.rs
@@ -38,11 +38,17 @@ impl Marmot {
     /// An own send commits and projects locally *before* it publishes, so a
     /// message sent while offline (or when the relay was unreachable) lands in
     /// the timeline with `source_message_id_hex == null` — committed, not yet
-    /// delivered. Re-sending the same text would mint a fresh commit and event
-    /// id, duplicating the bubble. This drives the existing pending commit to
-    /// the relays via convergence instead, so the original timeline row flips
-    /// to delivered (`source_message_id_hex == Some(..)`) on success and no new
-    /// event is created. Returns the delivery summary; `published == 0` means
+    /// delivered. Re-sending the same text mints a fresh commit, so it is the
+    /// wrong tool here: it either duplicates the bubble or — inside the same
+    /// second as the original, where the NIP-01 id collides — silently reuses
+    /// the same timeline row. This drives the existing pending commit to the
+    /// relays via convergence instead, so the original timeline row flips to
+    /// delivered (`source_message_id_hex == Some(..)`) on success and no new
+    /// event is created.
+    ///
+    /// (A resend after a send that *failed* is still safe and still supported:
+    /// the send path clears that row's `local_publish_failed` retraction before
+    /// re-recording it. This call is for sends that are pending, not failed.) Returns the delivery summary; `published == 0` means
     /// nothing was pending or publishing is still failing.
     pub async fn retry_group_convergence(
         &self,

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -1234,10 +1234,9 @@ fn latest_preview_carries_exact_media_and_delivery_projection() {
     assert_eq!(failed.message_id_hex, "pending");
     assert_eq!(failed.delivery_state, ChatListMessageDeliveryState::Failed);
 
-    // Re-recording the same durable app event — relay redelivery, backfill
-    // replay, rejoin reprocessing — is not evidence that the send reached the
-    // group, so the preview stays failed. A send that does publish is finalized
-    // through `finalize_app_event_source_retention`, which never re-records.
+    // A bare re-record — relay redelivery, backfill replay, rejoin
+    // reprocessing — is not evidence that the send reached the group, so the
+    // preview stays failed.
     pending.source_message_id_hex = Some("source-after-replay".to_owned());
     store.record_app_event(&pending).unwrap();
     let replayed = store
@@ -1250,6 +1249,30 @@ fn latest_preview_carries_exact_media_and_delivery_projection() {
     assert_eq!(
         replayed.delivery_state,
         ChatListMessageDeliveryState::Failed
+    );
+
+    // A successful retry does clear it. A resend inside the same second mints
+    // the same NIP-01 id, so the send path re-records this very row — but only
+    // after `clear_local_publish_failure`, because the fresh send intent is the
+    // evidence the bare re-record above lacks. The chat row must transition that
+    // exact preview back to delivered rather than waiting for a different
+    // message to replace it.
+    store
+        .clear_local_publish_failure(GROUP, "pending")
+        .unwrap()
+        .expect("a retracted local send clears");
+    pending.source_message_id_hex = Some("source-after-retry".to_owned());
+    store.record_app_event(&pending).unwrap();
+    let retried = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row")
+        .last_message
+        .expect("retried preview");
+    assert_eq!(retried.message_id_hex, "pending");
+    assert_eq!(
+        retried.delivery_state,
+        ChatListMessageDeliveryState::Delivered
     );
 
     store

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -1234,22 +1234,22 @@ fn latest_preview_carries_exact_media_and_delivery_projection() {
     assert_eq!(failed.message_id_hex, "pending");
     assert_eq!(failed.delivery_state, ChatListMessageDeliveryState::Failed);
 
-    // A successful retry re-records the same durable app event with its MLS
-    // source id, clearing the local publish invalidation. The chat row must
-    // transition that exact preview back to delivered rather than waiting for
-    // a different message to replace it.
-    pending.source_message_id_hex = Some("source-after-retry".to_owned());
+    // Re-recording the same durable app event — relay redelivery, backfill
+    // replay, rejoin reprocessing — is not evidence that the send reached the
+    // group, so the preview stays failed. A send that does publish is finalized
+    // through `finalize_app_event_source_retention`, which never re-records.
+    pending.source_message_id_hex = Some("source-after-replay".to_owned());
     store.record_app_event(&pending).unwrap();
-    let retried = store
+    let replayed = store
         .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
         .unwrap()
         .expect("chat row")
         .last_message
-        .expect("retried preview");
-    assert_eq!(retried.message_id_hex, "pending");
+        .expect("replayed preview");
+    assert_eq!(replayed.message_id_hex, "pending");
     assert_eq!(
-        retried.delivery_state,
-        ChatListMessageDeliveryState::Delivered
+        replayed.delivery_state,
+        ChatListMessageDeliveryState::Failed
     );
 
     store

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -1252,17 +1252,18 @@ fn latest_preview_carries_exact_media_and_delivery_projection() {
     );
 
     // A successful retry does clear it. A resend inside the same second mints
-    // the same NIP-01 id, so the send path re-records this very row — but only
-    // after `clear_local_publish_failure`, because the fresh send intent is the
-    // evidence the bare re-record above lacks. The chat row must transition that
-    // exact preview back to delivered rather than waiting for a different
-    // message to replace it.
+    // the same NIP-01 id, so the send path re-records this very row and only
+    // then calls `clear_local_publish_failure` — that order, because the fresh
+    // send intent is the evidence the bare re-record above lacks, and the
+    // tombstone must stand until the revival itself commits. The chat row must
+    // transition that exact preview back to delivered rather than waiting for a
+    // different message to replace it.
+    pending.source_message_id_hex = Some("source-after-retry".to_owned());
+    store.record_app_event(&pending).unwrap();
     store
         .clear_local_publish_failure(GROUP, "pending")
         .unwrap()
         .expect("a retracted local send clears");
-    pending.source_message_id_hex = Some("source-after-retry".to_owned());
-    store.record_app_event(&pending).unwrap();
     let retried = store
         .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
         .unwrap()

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -60,10 +60,10 @@ pub use storage::messages::MessageFormatPromotionProgress;
 #[cfg(feature = "storage-format-benchmarks")]
 pub use storage::messages::StorageFormatBenchSizes;
 pub use timeline::{
-    MAX_TIMELINE_LIMIT, SecurePruneAppEventsResult, StoredAppEvent, TimelineMessageChange,
-    TimelineMessageQuery, TimelineMessageRecord, TimelineMessageTarget, TimelinePage,
-    TimelinePagination, TimelineProjectionUpdate, TimelineReactionSummary, TimelineRemoveReason,
-    TimelineReplyPreview, TimelineUpdateTrigger, TimelineUserReaction,
+    LOCAL_PUBLISH_FAILED_REASON, MAX_TIMELINE_LIMIT, SecurePruneAppEventsResult, StoredAppEvent,
+    TimelineMessageChange, TimelineMessageQuery, TimelineMessageRecord, TimelineMessageTarget,
+    TimelinePage, TimelinePagination, TimelineProjectionUpdate, TimelineReactionSummary,
+    TimelineRemoveReason, TimelineReplyPreview, TimelineUpdateTrigger, TimelineUserReaction,
 };
 pub use transport_reconciliation::{
     TRANSPORT_RECONCILIATION_MAX_ITEMS_PER_ROUTE, TRANSPORT_RECONCILIATION_RETENTION_SECS,

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -61,6 +61,17 @@ pub const MAX_TIMELINE_LIMIT: usize = 200;
 /// rather than vanishing), and because it is the one reason
 /// [`SqliteAccountStorage::clear_local_publish_failure`] may clear.
 pub const LOCAL_PUBLISH_FAILED_REASON: &str = "local_publish_failed";
+
+/// The one row shape [`SqliteAccountStorage::clear_local_publish_failure`] may
+/// revive, bound to `?1` group id, `?2` message id, `?3` reason. Its early-exit
+/// probe and its UPDATE interpolate this same fragment: the probe decides
+/// whether a revival happens, so a conjunct present in one and not the other
+/// would either skip a legitimate revival or report one that never landed.
+const CLEARABLE_LOCAL_PUBLISH_FAILURE_PREDICATE: &str = "group_id_hex = ?1
+       AND message_id_hex = ?2
+       AND direction = 'sent'
+       AND invalidated = 1
+       AND invalidation_reason = ?3";
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StoredAppEvent {
     pub group_id_hex: String,
@@ -586,7 +597,9 @@ impl SqliteAccountStorage {
                     -- send intent reusing the id of a send that failed in the
                     -- same second — and it carries evidence this statement does
                     -- not have. It goes through `clear_local_publish_failure`,
-                    -- which the send path calls before re-recording.
+                    -- which the send path calls immediately after re-recording,
+                    -- so this statement's preserved tombstone is what survives
+                    -- if the revival never commits.
                     invalidated = app_events.invalidated,
                     invalidation_reason = app_events.invalidation_reason",
                 params![
@@ -698,8 +711,10 @@ impl SqliteAccountStorage {
     /// `created_at`, so a user who resends identical text in the same second as
     /// a failed send mints the *same* id and re-enters the row that send just
     /// retracted. `record_app_event`'s upsert deliberately will not revive it,
-    /// so the send path calls this first: the fresh send intent is the evidence,
-    /// and only the local send path can produce one.
+    /// so the send path calls this *after* re-recording: the fresh send intent
+    /// is the evidence, only the local send path can produce one, and running
+    /// last keeps the tombstone standing until the revival itself commits (see
+    /// `AppClient::record_send_intent_projection`).
     ///
     /// The predicate is deliberately narrow, and every conjunct earns its place:
     ///
@@ -708,6 +723,11 @@ impl SqliteAccountStorage {
     ///   withdrawals (`LosingBranch`, `SupersededByBranchSelection`, ...) stay
     ///   terminal.
     /// - `invalidated = 1` — a live row is left untouched rather than rewritten.
+    ///
+    /// Because the send path re-records first, every ordinary send arrives here
+    /// on a row that exists and is live. A primary-key probe on the same
+    /// predicate ([`CLEARABLE_LOCAL_PUBLISH_FAILURE_PREDICATE`]) short-circuits
+    /// that case before the projection walk below.
     ///
     /// The reason literal is shared, by design, with the terminal-group sweep
     /// ([`Self::invalidate_pending_sent_app_events_for_group`]), so reason alone
@@ -725,6 +745,21 @@ impl SqliteAccountStorage {
     ) -> StorageResult<Option<TimelineProjectionUpdate>> {
         self.connection.with_transaction(|| {
             let conn = self.lock()?;
+            if conn
+                .query_row(
+                    &format!(
+                        "SELECT 1 FROM app_events
+                         WHERE {CLEARABLE_LOCAL_PUBLISH_FAILURE_PREDICATE}"
+                    ),
+                    params![group_id_hex, message_id_hex, LOCAL_PUBLISH_FAILED_REASON],
+                    |_| Ok(()),
+                )
+                .optional()
+                .storage()?
+                .is_none()
+            {
+                return Ok(None);
+            }
             let Some((kind, tags)) =
                 app_event_projection_parts_tx(&conn, group_id_hex, message_id_hex)?
             else {
@@ -741,16 +776,16 @@ impl SqliteAccountStorage {
                 timeline_records_by_ids_tx(&conn, group_id_hex, affected_message_ids.clone())?;
             let cleared = conn
                 .execute(
-                    "UPDATE app_events
-                     SET invalidated = 0, invalidation_reason = NULL
-                     WHERE group_id_hex = ?1
-                       AND message_id_hex = ?2
-                       AND direction = 'sent'
-                       AND invalidated = 1
-                       AND invalidation_reason = ?3",
+                    &format!(
+                        "UPDATE app_events
+                         SET invalidated = 0, invalidation_reason = NULL
+                         WHERE {CLEARABLE_LOCAL_PUBLISH_FAILURE_PREDICATE}"
+                    ),
                     params![group_id_hex, message_id_hex, LOCAL_PUBLISH_FAILED_REASON],
                 )
                 .storage()?;
+            // Unreachable while the probe above shares this predicate, and kept
+            // so a drift reports no revival rather than a phantom one.
             if cleared == 0 {
                 return Ok(None);
             }

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -568,8 +568,14 @@ impl SqliteAccountStorage {
                         WHEN app_events.retention_seconds IS NULL THEN excluded.retention_expires_at
                         ELSE app_events.retention_expires_at
                     END,
-                    invalidated = 0,
-                    invalidation_reason = NULL",
+                    -- Invalidation is terminal, and re-recording is not evidence
+                    -- that a withdrawn row reached the group: the same message
+                    -- arrives again from relay redelivery, backfill replay, or
+                    -- rejoin reprocessing, and a synthesized system row is
+                    -- re-derived under its deterministic id by any later batch.
+                    -- Only the invalidate_* primitives write these columns.
+                    invalidated = app_events.invalidated,
+                    invalidation_reason = app_events.invalidation_reason",
                 params![
                     &event.group_id_hex,
                     &event.message_id_hex,

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -54,6 +54,13 @@ const DEFAULT_TIMELINE_LIMIT: usize = 50;
 /// materialized window kept above this cannot be re-fetched in one query, so
 /// window owners should not exceed it.
 pub const MAX_TIMELINE_LIMIT: usize = 200;
+
+/// The invalidation reason a locally-sent row carries when its publish reached
+/// no one. Storage owns the literal because it is both a stored column value
+/// and a projection predicate (a retracted own send stays visible as `failed`
+/// rather than vanishing), and because it is the one reason
+/// [`SqliteAccountStorage::clear_local_publish_failure`] may clear.
+pub const LOCAL_PUBLISH_FAILED_REASON: &str = "local_publish_failed";
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StoredAppEvent {
     pub group_id_hex: String,
@@ -568,12 +575,18 @@ impl SqliteAccountStorage {
                         WHEN app_events.retention_seconds IS NULL THEN excluded.retention_expires_at
                         ELSE app_events.retention_expires_at
                     END,
-                    -- Invalidation is terminal, and re-recording is not evidence
-                    -- that a withdrawn row reached the group: the same message
-                    -- arrives again from relay redelivery, backfill replay, or
-                    -- rejoin reprocessing, and a synthesized system row is
-                    -- re-derived under its deterministic id by any later batch.
-                    -- Only the invalidate_* primitives write these columns.
+                    -- A withdrawal is terminal here, and re-recording is not
+                    -- evidence that a withdrawn row reached the group: the same
+                    -- message arrives again from relay redelivery, backfill
+                    -- replay, or rejoin reprocessing, and a synthesized system
+                    -- row is re-derived under its deterministic id by any later
+                    -- batch. This statement cannot tell those apart from a
+                    -- retry, so it never revives.
+                    -- There is exactly one legitimate revival — a fresh local
+                    -- send intent reusing the id of a send that failed in the
+                    -- same second — and it carries evidence this statement does
+                    -- not have. It goes through `clear_local_publish_failure`,
+                    -- which the send path calls before re-recording.
                     invalidated = app_events.invalidated,
                     invalidation_reason = app_events.invalidation_reason",
                 params![
@@ -674,6 +687,95 @@ impl SqliteAccountStorage {
             &[&group_id_hex, &message_id_hex],
             reason,
         )
+    }
+
+    /// Clear the `local_publish_failed` retraction on one locally-sent row.
+    ///
+    /// This is the **only** revival path for an invalidated app event, and it
+    /// exists because `local_publish_failed` is the one reason a later, wholly
+    /// legitimate event can contradict. Inner app-event ids are NIP-01 hashes
+    /// over (pubkey, created_at, kind, tags, content) with second-granular
+    /// `created_at`, so a user who resends identical text in the same second as
+    /// a failed send mints the *same* id and re-enters the row that send just
+    /// retracted. `record_app_event`'s upsert deliberately will not revive it,
+    /// so the send path calls this first: the fresh send intent is the evidence,
+    /// and only the local send path can produce one.
+    ///
+    /// The predicate is deliberately narrow, and every conjunct earns its place:
+    ///
+    /// - `direction = 'sent'` — only a local send can be retried at all.
+    /// - `invalidation_reason = 'local_publish_failed'` — convergence
+    ///   withdrawals (`LosingBranch`, `SupersededByBranchSelection`, ...) stay
+    ///   terminal.
+    /// - `invalidated = 1` — a live row is left untouched rather than rewritten.
+    ///
+    /// The reason literal is shared, by design, with the terminal-group sweep
+    /// ([`Self::invalidate_pending_sent_app_events_for_group`]), so reason alone
+    /// would not be a safe predicate anywhere the send intent is absent. That is
+    /// exactly why this is a primitive the send path calls explicitly and not a
+    /// carve-out in the upsert: replay seams re-record swept rows without ever
+    /// entering the send path, and an upsert-level carve-out would revive them.
+    ///
+    /// Returns `None` when no row matched, so a caller can tell a real revival
+    /// from a no-op without a second read.
+    pub fn clear_local_publish_failure(
+        &self,
+        group_id_hex: &str,
+        message_id_hex: &str,
+    ) -> StorageResult<Option<TimelineProjectionUpdate>> {
+        self.connection.with_transaction(|| {
+            let conn = self.lock()?;
+            let Some((kind, tags)) =
+                app_event_projection_parts_tx(&conn, group_id_hex, message_id_hex)?
+            else {
+                return Ok(None);
+            };
+            let affected_message_ids = affected_timeline_message_ids_for_parts_tx(
+                &conn,
+                group_id_hex,
+                message_id_hex,
+                kind,
+                &tags,
+            )?;
+            let before =
+                timeline_records_by_ids_tx(&conn, group_id_hex, affected_message_ids.clone())?;
+            let cleared = conn
+                .execute(
+                    "UPDATE app_events
+                     SET invalidated = 0, invalidation_reason = NULL
+                     WHERE group_id_hex = ?1
+                       AND message_id_hex = ?2
+                       AND direction = 'sent'
+                       AND invalidated = 1
+                       AND invalidation_reason = ?3",
+                    params![group_id_hex, message_id_hex, LOCAL_PUBLISH_FAILED_REASON],
+                )
+                .storage()?;
+            if cleared == 0 {
+                return Ok(None);
+            }
+            rebuild_message_timeline_for_group_tx(&conn, group_id_hex)?;
+            let messages =
+                timeline_records_by_ids_tx(&conn, group_id_hex, affected_message_ids.clone())?;
+            let mut changes =
+                timeline_changes_for_invalidation(message_id_hex, kind, &tags, &before, &messages);
+            // Only the revived row's own delivery state changed. Rows it merely
+            // affects (a reply preview, say) keep the trigger their own content
+            // warrants — the same split `finalize_app_event_source_retention`
+            // makes when a held send publishes.
+            for change in &mut changes {
+                if let TimelineMessageChange::Upsert { trigger, message } = change
+                    && message.message_id_hex == message_id_hex
+                {
+                    *trigger = TimelineUpdateTrigger::DeliveryOrSendStateChanged;
+                }
+            }
+            Ok(Some(TimelineProjectionUpdate {
+                group_id_hex: group_id_hex.to_owned(),
+                messages,
+                changes,
+            }))
+        })
     }
 
     /// Invalidate every app event whose `origin_commit_id` matches the given

--- a/crates/storage-sqlite/src/timeline/tests.rs
+++ b/crates/storage-sqlite/src/timeline/tests.rs
@@ -266,6 +266,16 @@ fn group_system(id: &str, system_type: &str, at: u64) -> StoredAppEvent {
     }
 }
 
+fn list_for_group(store: &SqliteAccountStorage, group_id_hex: &str) -> Vec<TimelineMessageRecord> {
+    store
+        .message_timeline(TimelineMessageQuery {
+            group_id_hex: Some(group_id_hex.to_owned()),
+            ..TimelineMessageQuery::default()
+        })
+        .unwrap()
+        .messages
+}
+
 fn list(store: &SqliteAccountStorage) -> Vec<TimelineMessageRecord> {
     store
         .message_timeline(TimelineMessageQuery {
@@ -2772,4 +2782,214 @@ fn finalizing_an_already_published_send_is_not_a_delivery_state_change() {
         })
         .expect("the finalized row must be reported as changed");
     assert_ne!(trigger, TimelineUpdateTrigger::DeliveryOrSendStateChanged);
+}
+
+#[test]
+fn clearing_a_local_publish_failure_revives_the_send() {
+    // A send that failed to publish is retracted as `local_publish_failed`. A
+    // same-second resend mints the *same* NIP-01 id, so the send path re-enters
+    // the row it just tombstoned. The upsert deliberately will not revive it —
+    // invalidation is terminal there — so the send intent clears the failure
+    // explicitly, and the row goes back to a live pending send.
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let group_id_hex = "11".repeat(32);
+    let event = pending_sent(&group_id_hex, "resent", 10);
+    store.record_app_event(&event).unwrap();
+    store
+        .invalidate_app_event_by_message_id(&group_id_hex, "resent", "local_publish_failed")
+        .unwrap()
+        .expect("retract");
+
+    let update = store
+        .clear_local_publish_failure(&group_id_hex, "resent")
+        .unwrap()
+        .expect("clearing a retracted send must project an update");
+
+    assert_eq!(
+        update
+            .messages
+            .iter()
+            .find(|message| message.message_id_hex == "resent")
+            .map(|message| message.invalidation_status.clone()),
+        Some(None),
+        "the revived send must project live"
+    );
+    assert!(
+        update.changes.iter().any(|change| matches!(
+            change,
+            TimelineMessageChange::Upsert {
+                trigger: TimelineUpdateTrigger::DeliveryOrSendStateChanged,
+                message,
+            } if message.message_id_hex == "resent"
+        )),
+        "reviving a retracted send is a delivery-state change, not new content"
+    );
+    let rows = list_for_group(&store, &group_id_hex);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].invalidation_status, None);
+}
+
+#[test]
+fn clearing_a_local_publish_failure_refuses_every_row_it_does_not_own() {
+    // Mutation strength: each arm below pins one conjunct of the WHERE clause.
+    // Widening the predicate — dropping the direction guard, the reason guard,
+    // or the invalidated guard — revives a row that no send intent owns. The
+    // reason literal is shared with the #1604 terminal-group sweep, so the
+    // direction and reason guards are not interchangeable.
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let group_id_hex = "11".repeat(32);
+
+    // A *received* row carrying the same reason: only a local send can be
+    // retried, so direction alone must disqualify it.
+    let mut received = chat("received-row", "bob", 10, "peer text");
+    received.group_id_hex = group_id_hex.clone();
+    store.record_app_event(&received).unwrap();
+    store
+        .invalidate_app_event_by_message_id(&group_id_hex, "received-row", "local_publish_failed")
+        .unwrap()
+        .expect("retract");
+
+    // A sent row withdrawn by convergence, not by a publish failure.
+    let losing = pending_sent(&group_id_hex, "losing-send", 11);
+    store.record_app_event(&losing).unwrap();
+    store
+        .invalidate_app_event_by_message_id(&group_id_hex, "losing-send", "LosingBranch")
+        .unwrap()
+        .expect("retract");
+
+    // A live sent row: nothing to clear.
+    let live = pending_sent(&group_id_hex, "live-send", 12);
+    store.record_app_event(&live).unwrap();
+
+    for message_id_hex in ["received-row", "losing-send", "live-send", "absent"] {
+        assert!(
+            store
+                .clear_local_publish_failure(&group_id_hex, message_id_hex)
+                .unwrap()
+                .is_none(),
+            "{message_id_hex} is not a retracted local send and must not be cleared"
+        );
+    }
+
+    let statuses = list_for_group(&store, &group_id_hex)
+        .into_iter()
+        .map(|row| (row.message_id_hex, row.invalidation_status))
+        .collect::<Vec<_>>();
+    assert!(statuses.contains(&(
+        "received-row".to_owned(),
+        Some("local_publish_failed".to_owned())
+    )));
+    assert!(statuses.contains(&("losing-send".to_owned(), Some("LosingBranch".to_owned()))));
+    assert!(statuses.contains(&("live-send".to_owned(), None)));
+}
+
+#[test]
+fn clearing_a_local_publish_failure_is_group_scoped() {
+    // Inner app-event ids carry no group binding, so the same account sending
+    // identical content to two groups in the same second produces one id in
+    // both. Clearing one group's retracted send must not revive the other's.
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let first = "11".repeat(32);
+    let second = "22".repeat(32);
+    for group_id_hex in [&first, &second] {
+        store
+            .record_app_event(&pending_sent(group_id_hex, "shared-id", 10))
+            .unwrap();
+        store
+            .invalidate_app_event_by_message_id(group_id_hex, "shared-id", "local_publish_failed")
+            .unwrap()
+            .expect("retract");
+    }
+
+    store
+        .clear_local_publish_failure(&first, "shared-id")
+        .unwrap()
+        .expect("the addressed group's send clears");
+
+    assert_eq!(list_for_group(&store, &first)[0].invalidation_status, None);
+    assert_eq!(
+        list_for_group(&store, &second)[0].invalidation_status,
+        Some("local_publish_failed".to_owned()),
+        "the unrelated group's copy must stay retracted"
+    );
+    // The assertion above reads the materialized projection, which the first
+    // call only rebuilds for the group it addressed — so an unscoped UPDATE
+    // would leave it stale and still passing. Ask the primitive itself: the
+    // second group's row must still be there to clear.
+    assert!(
+        store
+            .clear_local_publish_failure(&second, "shared-id")
+            .unwrap()
+            .is_some(),
+        "the unrelated group's row must still be retracted in app_events, not just in its projection"
+    );
+}
+
+#[test]
+fn rerecording_a_tombstone_under_a_new_kind_keeps_it_tombstoned() {
+    // A re-record may change kind and tags, which repoints the modifier edges
+    // and reprojects a different target set. None of that is evidence the
+    // withdrawn row came back, and the reaction must not re-apply to its target.
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    store
+        .record_app_event(&chat("target", "alice", 1, "hello"))
+        .unwrap();
+    store
+        .record_app_event(&reaction("modifier", "bob", "target", 2, "\u{1f44d}"))
+        .unwrap();
+    store
+        .invalidate_app_event_by_message_id(&"11".repeat(32), "modifier", "LosingBranch")
+        .unwrap()
+        .expect("retract");
+
+    // Same id, now a chat: kind and tags both change on conflict.
+    store
+        .record_app_event(&chat("modifier", "bob", 2, "no longer a reaction"))
+        .unwrap();
+
+    let rows = list(&store);
+    let modifier = rows
+        .iter()
+        .find(|row| row.message_id_hex == "modifier")
+        .expect("the tombstone still projects as its own row now that it is a chat");
+    assert_eq!(
+        modifier.invalidation_status.as_deref(),
+        Some("LosingBranch"),
+        "changing kind/tags is not evidence the withdrawn row came back"
+    );
+    let target = rows
+        .iter()
+        .find(|row| row.message_id_hex == "target")
+        .expect("target");
+    assert!(
+        target.reactions.user_reactions.is_empty(),
+        "a tombstoned modifier must never re-apply to its target"
+    );
+}
+
+#[test]
+fn rerecording_with_retention_keeps_the_tombstone() {
+    // `record_app_event_with_retention` shares `record_app_event_inner`, so the
+    // retention-carrying variant owes the same terminality.
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let event = chat("retained", "alice", 10, "hello");
+    store.record_app_event(&event).unwrap();
+    store
+        .invalidate_app_event_by_source("source-retained", "BeyondAppRetention")
+        .unwrap()
+        .expect("retract");
+
+    store
+        .record_app_event_with_retention(
+            &event,
+            Some(AppMessageRetentionDecision::new(event.recorded_at, 300)),
+        )
+        .unwrap();
+
+    let rows = list(&store);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].invalidation_status.as_deref(),
+        Some("BeyondAppRetention")
+    );
 }

--- a/crates/storage-sqlite/src/timeline/tests.rs
+++ b/crates/storage-sqlite/src/timeline/tests.rs
@@ -578,6 +578,138 @@ fn reupsert_with_none_origin_preserves_existing_commit_link() {
 }
 
 #[test]
+fn rerecording_an_origin_commit_invalidated_row_keeps_its_tombstone() {
+    // Fork recovery tombstones a kind-1210 row in one batch; a later batch
+    // (session replay, rejoin reprocessing) re-synthesizes the same
+    // deterministic id and re-records it. The re-record must not revive the row
+    // or erase the reason that explains it, or two members that agree on the
+    // CGKA state still render different histories.
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let event = group_system_from_commit("losing-added", "member_added", 10, "commit-losing");
+    store.record_app_event(&event).unwrap();
+    store
+        .invalidate_app_events_by_origin_commit("commit-losing", "SupersededByBranchSelection")
+        .unwrap()
+        .expect("matched rows should produce an update");
+
+    let update = store.record_app_event(&event).unwrap();
+
+    assert_eq!(
+        update
+            .messages
+            .iter()
+            .find(|message| message.message_id_hex == "losing-added")
+            .map(|message| message.invalidation_status.clone()),
+        Some(Some("SupersededByBranchSelection".to_owned())),
+        "the re-record must project the row as the tombstone it already is"
+    );
+    let rows = list(&store);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].invalidation_status.as_deref(),
+        Some("SupersededByBranchSelection")
+    );
+}
+
+#[test]
+fn rerecording_a_source_invalidated_message_keeps_its_tombstone() {
+    // A delivered app message the engine withdrew as a fork loser is
+    // redelivered by a relay and re-recorded under the same inner id in a later
+    // batch. `AppMessageInvalidated` is terminal by construction — the engine
+    // withholds it for retryable decrypt misses — so redelivery is never a
+    // reason to bring the message back.
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let event = chat("target", "alice", 1, "hello");
+    store.record_app_event(&event).unwrap();
+    store
+        .invalidate_app_event_by_source("source-target", "LosingBranch")
+        .unwrap()
+        .expect("projection update");
+
+    let update = store.record_app_event(&event).unwrap();
+
+    assert_eq!(
+        update
+            .messages
+            .iter()
+            .find(|message| message.message_id_hex == "target")
+            .map(|message| message.invalidation_status.clone()),
+        Some(Some("LosingBranch".to_owned()))
+    );
+    let rows = list(&store);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].invalidation_status.as_deref(), Some("LosingBranch"));
+}
+
+#[test]
+fn rerecording_a_message_id_invalidated_message_keeps_its_tombstone() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let event = chat("target", "alice", 1, "hello");
+    store.record_app_event(&event).unwrap();
+    store
+        .invalidate_app_event_by_message_id(
+            &"11".repeat(32),
+            "target",
+            "UndecryptableInCanonicalState",
+        )
+        .unwrap()
+        .expect("projection update");
+
+    store.record_app_event(&event).unwrap();
+
+    let rows = list(&store);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].invalidation_status.as_deref(),
+        Some("UndecryptableInCanonicalState")
+    );
+}
+
+#[test]
+fn rerecording_a_swept_pending_send_keeps_its_tombstone() {
+    // The terminal-group sweep withdraws sends the engine will never publish.
+    // The group is terminal, so nothing can legitimately publish those rows
+    // later; a re-record from any replay seam must leave them failed.
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let group_id_hex = "11".repeat(32);
+    let event = pending_sent(&group_id_hex, "held", 10);
+    store.record_app_event(&event).unwrap();
+    store
+        .invalidate_pending_sent_app_events_for_group(&group_id_hex, "local_publish_failed")
+        .unwrap()
+        .expect("held rows should produce an update");
+
+    store.record_app_event(&event).unwrap();
+
+    assert_eq!(
+        list(&store)
+            .into_iter()
+            .find(|row| row.message_id_hex == "held")
+            .map(|row| row.invalidation_status),
+        Some(Some("local_publish_failed".to_owned()))
+    );
+}
+
+#[test]
+fn rerecording_a_live_row_updates_it_and_leaves_it_live() {
+    // The common path: re-recording a row that was never invalidated still
+    // refreshes its content and leaves it delivered.
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    store
+        .record_app_event(&chat("target", "alice", 1, "first"))
+        .unwrap();
+
+    store
+        .record_app_event(&chat("target", "alice", 1, "reprojected"))
+        .unwrap();
+
+    let rows = list(&store);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].plaintext, "reprojected");
+    assert_eq!(rows[0].invalidation_status, None);
+}
+
+#[test]
 fn pagination_rejects_half_and_double_cursors() {
     let store = SqliteAccountStorage::in_memory().unwrap();
 


### PR DESCRIPTION
Two fixes to how app-event re-recording interacts with invalidation.

1. Storage: record_app_event's ON CONFLICT upsert unconditionally cleared invalidated and invalidation_reason, so a row tombstoned in one batch came back live in a later one. Relay redelivery, backfill replay, rejoin reprocessing, and synthesized kind-1210 rows (deterministic ids) all re-record the same (group, message_id). Fork-loser messages reappeared in timelines with their reason erased, so two members that agreed on CGKA state rendered different histories. #1593's synthesizer filter only closed the same-batch shape. The upsert now preserves both columns: every convergence withdrawal is terminal, and the upsert cannot tell a retry from a replay.
2. App: with the upsert terminal, the one legitimate revival needed an explicit path. Inner event ids are NIP-01 hashes with second-granular created_at and no nonce, so resending identical text in the same second as a failed send mints the same id and lands on the row retract_failed_local_projection just tombstoned as local_publish_failed. Without an escape hatch the retry publishes to the whole group while the sender's copy renders Failed forever (and a retried delete stays hidden for peers, visible locally). The send path now calls clear_local_publish_failure before the optimistic pre-publish record. The primitive is scoped to direction = sent, invalidated = 1, reason = local_publish_failed; the fresh send intent is the evidence, and replay seams never enter the send path, so terminal-group swept sends (#1604) stay dead.

Tests: cross-batch tombstone survival for all four invalidation flavors, a live-row control, kind/tags-changing re-record, the with_retention variant, mutation-verified scoping tests for the clear primitive, and an end-to-end same-second resend test at the app layer. The chat-list preview test now pins both directions: bare re-record stays failed, cleared retry goes delivered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Retrying a failed local message now correctly restores it to a delivered state after successful publication.
  * Resending an identical message shortly after a failed attempt avoids duplicate timeline entries.
  * Failed or withdrawn timeline messages remain excluded during replays, backfills, and ordinary updates unless explicitly recovered.
  * Recovery is limited to the original local message and its associated group, preventing unrelated messages from being revived.

* **Documentation**
  * Clarified retry behavior, delivery states, duplicate sends, and timeline invalidation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->