### PR TITLE
Use browser-safe time primitives in MDK libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,6 +928,7 @@ dependencies = [
  "tls_codec",
  "tokio",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
@@ -3425,6 +3426,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "web-time",
 ]
 
 [[package]]
@@ -6348,6 +6350,7 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 hex = "0.4"
 getrandom = "0.3"
+web-time = "1.1"
 hmac = "0.12"
 libc = "0.2"
 hkdf = "0.12"

--- a/crates/cgka-engine/Cargo.toml
+++ b/crates/cgka-engine/Cargo.toml
@@ -38,6 +38,7 @@ nostr.workspace = true
 rand.workspace = true
 sha2.workspace = true
 tokio = { workspace = true, features = ["time"] }
+web-time.workspace = true
 # Pure-Rust secp256k1 used only to validate that a Marmot credential identity
 # is a well-formed BIP-340 x-only public key (foundation/identity.md). Already
 # resolved transitively via openmls_rust_crypto -> hpke-rs-rust-crypto -> k256;

--- a/crates/cgka-engine/src/convergence_clock.rs
+++ b/crates/cgka-engine/src/convergence_clock.rs
@@ -7,7 +7,7 @@
 //! their existing clocks.
 
 use std::sync::{Arc, Mutex};
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use web_time::{Instant, SystemTime, UNIX_EPOCH};
 
 /// One paired convergence-clock observation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -43,7 +43,7 @@ use rand::RngCore;
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
-use tls_codec::{Deserialize as _, Serialize as _};
+use tls_codec::Serialize as _;
 use web_time::{SystemTime, UNIX_EPOCH};
 
 /// Default ciphersuite. MLS-1.0 mandatory-to-implement; TLS-ish naming.

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -43,8 +43,8 @@ use rand::RngCore;
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
-use tls_codec::Serialize as _;
+use tls_codec::{Deserialize as _, Serialize as _};
+use web_time::{SystemTime, UNIX_EPOCH};
 
 /// Default ciphersuite. MLS-1.0 mandatory-to-implement; TLS-ish naming.
 pub const DEFAULT_CIPHERSUITE: Ciphersuite =

--- a/crates/cgka-engine/src/identity.rs
+++ b/crates/cgka-engine/src/identity.rs
@@ -18,6 +18,7 @@ use openmls::prelude::{
 };
 use openmls_basic_credential::SignatureKeyPair;
 use openmls_traits::types::Ciphersuite;
+use web_time::{SystemTime, UNIX_EPOCH};
 
 /// Bundle of everything needed to sign + identify the local client.
 pub struct Identity {
@@ -102,8 +103,8 @@ impl Identity {
             credential: credential.into(),
             signature_key: signer.public().into(),
         };
-        let created_at = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
+        let created_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
             .map_err(|error| format!("system clock precedes Unix epoch: {error}"))?
             .as_secs();
         let account_identity_proof =

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -37,7 +37,8 @@ use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use web_time::Instant;
 
 pub(crate) const MAX_CONVERGENCE_REPROCESSING_PASSES: usize = 16;
 pub(crate) const SELF_REMOVE_AUTO_COMMIT_JITTER_MIN_MS: u64 = 10;

--- a/crates/marmot-forensics/Cargo.toml
+++ b/crates/marmot-forensics/Cargo.toml
@@ -9,6 +9,7 @@ publish.workspace = true
 fs-private.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+web-time.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -24,7 +24,7 @@ use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
+use web_time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/transport-nostr-peeler/Cargo.toml
+++ b/crates/transport-nostr-peeler/Cargo.toml
@@ -17,6 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
+web-time.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/transport-nostr-peeler/src/event.rs
+++ b/crates/transport-nostr-peeler/src/event.rs
@@ -8,7 +8,7 @@ use nostr::{Event, JsonUtil};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use std::time::{SystemTime, UNIX_EPOCH};
+use web_time::{SystemTime, UNIX_EPOCH};
 
 /// Nostr event shape consumed and produced at the peeler boundary.
 ///

--- a/crates/transport-nostr-peeler/src/peeler.rs
+++ b/crates/transport-nostr-peeler/src/peeler.rs
@@ -20,6 +20,8 @@ use nostr::base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use nostr::{EventBuilder, Keys, Kind, NostrSigner, PublicKey, RelayUrl, Tag, UnsignedEvent};
 use rand::RngCore;
 use std::sync::Arc;
+#[cfg(test)]
+use web_time::{SystemTime, UNIX_EPOCH};
 
 const NONCE_LEN: usize = 12;
 const WELCOME_SIGNER_CONTEXT: &str = "nostr_welcome_signer";
@@ -749,8 +751,8 @@ mod tests {
             HashMap::from([(DEFAULT_EXPORTER_LABEL.to_string(), vec![0x7a; 32])]),
             Some(group_id),
         );
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
 


### PR DESCRIPTION
## Summary

Replace browser-reachable std::time clock reads with web_time::{Instant, SystemTime, UNIX_EPOCH} in the engine, Nostr peeler, and forensics crates.

### Pre-patch evidence

At upstream base 876bdf3c408df0658c158da6a6521745cd0abde5, the exact hot-path source audit printed 8 unsupported std::time clock occurrences across convergence_clock.rs, engine.rs, identity.rs, message_processor/mod.rs, event.rs, peeler.rs, and audit.rs.

### Native semantics

Only clock types change. Native Duration, timestamp units, saturation, error handling, public APIs, and convergence/event behavior are unchanged; web-time uses native time behavior on native targets.

### Verification

    rg -n 'use std::time::\{.*(Instant|SystemTime|UNIX_EPOCH)|std::time::(Instant|SystemTime|UNIX_EPOCH)' \
      crates/cgka-engine/src/convergence_clock.rs \
      crates/cgka-engine/src/engine.rs \
      crates/cgka-engine/src/identity.rs \
      crates/cgka-engine/src/message_processor/mod.rs \
      crates/transport-nostr-peeler/src/event.rs \
      crates/transport-nostr-peeler/src/peeler.rs \
      crates/marmot-forensics/src/audit.rs
    cargo fmt --all --check
    cargo test -p cgka-engine --features test-policy-overrides
    cargo test -p transport-nostr-peeler -p marmot-forensics

Results: the audit returned zero matches (expected rg exit 1); formatting passed; the complete engine suite passed with policy overrides; transport-nostr-peeler passed 34 tests and marmot-forensics passed 21 tests, with zero failures and clean doc-tests.

### Scope boundary

This patch does not solve workspace Tokio/browser deadlines, wasm32-local async signer futures, or OpenMLS/getrandom WASM feature activation. It is one independently reviewable patch from the four-patch integration branch; it does not claim browser support.

- Upstream base: 876bdf3c408df0658c158da6a6521745cd0abde5
- Isolated head: 00c78c9cd4843980a9f09c0c9d58aa3cc2739ae1
- Reviewed integration context: [Epiphytic/deaddrop/wasm-portability](https://github.com/Epiphytic/mdk/tree/deaddrop/wasm-portability) at 7878ccd4347af25f6fefd377a6e263e9c245602f
- Design: [Patch A — Portable Time Primitives](https://github.com/Epiphytic/deaddrop/blob/67d2d4bd0d304c5f5949d918f72cfce9b6b3ae32/docs/superpowers/specs/2026-08-31-mdk-wasm-portability-design.md#4-patch-a-portable-time-primitives)

Target branch note: the requested upstream main branch does not exist. GitHub reports master as marmot-protocol/mdk's default branch, so this PR targets master as the factual branch-name correction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Improved time handling for WebAssembly environments.
  * Timestamps, expiration checks, convergence tracking, identity proofs, audit records, and event processing now use a browser-compatible clock source.
* **Tests**
  * Updated expiration test time handling to match the WebAssembly-compatible implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->