### PR TITLE
Make MDK deadlines portable across native and browser runtimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,6 +907,8 @@ dependencies = [
  "cgka-traits",
  "chacha20poly1305",
  "criterion",
+ "futures",
+ "gloo-timers",
  "hex",
  "insta",
  "k256",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ openmls_traits = { git = "https://github.com/erskingardner/openmls.git", rev = "
 tls_codec = "~0.5"
 
 # async
-tokio = { version = "1", features = ["sync", "macros", "rt", "rt-multi-thread", "time"] }
+tokio = { version = "1", features = ["sync", "macros", "rt", "time"] }
 tokio-util = { version = "0.7", features = ["io"] }
 async-trait = "0.1"
 futures = "0.3"

--- a/crates/cgka-engine/Cargo.toml
+++ b/crates/cgka-engine/Cargo.toml
@@ -28,7 +28,6 @@ openmls_rust_crypto.workspace = true
 openmls_traits.workspace = true
 tls_codec = { workspace = true, features = ["derive", "std"] }
 async-trait.workspace = true
-futures.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 serde = { workspace = true }
@@ -44,10 +43,11 @@ sha2.workspace = true
 # enabling the `schnorr` feature here pulls in BIP-340 x-only point validation.
 k256 = { version = "0.13", default-features = false, features = ["schnorr"] }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dependencies]
 tokio = { workspace = true, features = ["time"] }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+futures.workspace = true
 gloo-timers = { version = "0.3", features = ["futures"] }
 
 [dev-dependencies]
@@ -65,6 +65,7 @@ sha2.workspace = true
 # binding uses, so engine visibility in tests matches production.
 chacha20poly1305.workspace = true
 criterion.workspace = true
+futures.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/crates/cgka-engine/Cargo.toml
+++ b/crates/cgka-engine/Cargo.toml
@@ -28,6 +28,7 @@ openmls_rust_crypto.workspace = true
 openmls_traits.workspace = true
 tls_codec = { workspace = true, features = ["derive", "std"] }
 async-trait.workspace = true
+futures.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 serde = { workspace = true }
@@ -37,16 +38,21 @@ marmot-forensics.workspace = true
 nostr.workspace = true
 rand.workspace = true
 sha2.workspace = true
-tokio = { workspace = true, features = ["time"] }
 # Pure-Rust secp256k1 used only to validate that a Marmot credential identity
 # is a well-formed BIP-340 x-only public key (foundation/identity.md). Already
 # resolved transitively via openmls_rust_crypto -> hpke-rs-rust-crypto -> k256;
 # enabling the `schnorr` feature here pulls in BIP-340 x-only point validation.
 k256 = { version = "0.13", default-features = false, features = ["schnorr"] }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { workspace = true, features = ["time"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+gloo-timers = { version = "0.3", features = ["futures"] }
+
 [dev-dependencies]
 storage-sqlite = { workspace = true, features = ["storage-format-benchmarks"] }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros"] }
 test-log.workspace = true
 insta.workspace = true
 tempfile.workspace = true
@@ -59,6 +65,9 @@ sha2.workspace = true
 # binding uses, so engine visibility in tests matches production.
 chacha20poly1305.workspace = true
 criterion.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [[bench]]
 name = "group_lifecycle"

--- a/crates/cgka-engine/src/deadline.rs
+++ b/crates/cgka-engine/src/deadline.rs
@@ -3,7 +3,7 @@ use std::{future::Future, time::Duration};
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct DeadlineElapsed;
 
-#[cfg(any(target_arch = "wasm32", test))]
+#[cfg(any(test, all(target_arch = "wasm32", target_os = "unknown")))]
 fn browser_timeout_milliseconds(duration: Duration) -> u32 {
     // Browser timers accept integer milliseconds. Round a fractional
     // millisecond up so conversion never expires a nonzero budget early, then
@@ -15,7 +15,7 @@ fn browser_timeout_milliseconds(duration: Duration) -> u32 {
         .min(i32::MAX as u128) as u32
 }
 
-#[cfg(any(target_arch = "wasm32", test))]
+#[cfg(any(test, all(target_arch = "wasm32", target_os = "unknown")))]
 async fn browser_timeout_with_timer<F, T>(
     operation: F,
     timer: T,
@@ -38,7 +38,7 @@ where
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 pub(crate) async fn timeout<F>(duration: Duration, future: F) -> Result<F::Output, DeadlineElapsed>
 where
     F: Future,
@@ -48,7 +48,7 @@ where
         .map_err(|_| DeadlineElapsed)
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) async fn timeout<F>(duration: Duration, future: F) -> Result<F::Output, DeadlineElapsed>
 where
     F: Future,

--- a/crates/cgka-engine/src/deadline.rs
+++ b/crates/cgka-engine/src/deadline.rs
@@ -1,0 +1,153 @@
+use std::{future::Future, time::Duration};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct DeadlineElapsed;
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn browser_timeout_milliseconds(duration: Duration) -> u32 {
+    // Browser timers accept integer milliseconds. Round a fractional
+    // millisecond up so conversion never expires a nonzero budget early, then
+    // stay within the signed delay range used by browser timer implementations.
+    let fractional_millisecond = !duration.subsec_nanos().is_multiple_of(1_000_000);
+    duration
+        .as_millis()
+        .saturating_add(u128::from(fractional_millisecond))
+        .min(i32::MAX as u128) as u32
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+async fn browser_timeout_with_timer<F, T>(
+    operation: F,
+    timer: T,
+) -> Result<F::Output, DeadlineElapsed>
+where
+    F: Future,
+    T: Future<Output = ()>,
+{
+    use futures::{FutureExt, pin_mut, select_biased};
+
+    let operation = operation.fuse();
+    let timer = timer.fuse();
+    pin_mut!(operation, timer);
+
+    // Match Tokio's timeout contract: if both branches are ready on the same
+    // poll, the operation completes instead of being reported as elapsed.
+    select_biased! {
+        output = operation => Ok(output),
+        _ = timer => Err(DeadlineElapsed),
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) async fn timeout<F>(duration: Duration, future: F) -> Result<F::Output, DeadlineElapsed>
+where
+    F: Future,
+{
+    tokio::time::timeout(duration, future)
+        .await
+        .map_err(|_| DeadlineElapsed)
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) async fn timeout<F>(duration: Duration, future: F) -> Result<F::Output, DeadlineElapsed>
+where
+    F: Future,
+{
+    let milliseconds = browser_timeout_milliseconds(duration);
+    let timer = gloo_timers::future::TimeoutFuture::new(milliseconds);
+    browser_timeout_with_timer(future, timer).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        time::Duration,
+    };
+
+    struct DropFlag(Arc<AtomicBool>);
+
+    impl Drop for DropFlag {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn cancels_a_pending_future() {
+        let result = timeout(Duration::from_millis(1), std::future::pending::<()>()).await;
+        assert_eq!(result, Err(DeadlineElapsed));
+    }
+
+    #[tokio::test]
+    async fn returns_a_ready_value() {
+        assert_eq!(timeout(Duration::from_secs(1), async { 7 }).await, Ok(7));
+    }
+
+    #[tokio::test]
+    async fn browser_selection_always_prefers_the_operation_when_both_are_ready() {
+        for _ in 0..64 {
+            assert_eq!(
+                browser_timeout_with_timer(async { 7 }, std::future::ready(())).await,
+                Ok(7)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn browser_selection_drops_the_pending_operation_when_the_timer_wins() {
+        let operation_dropped = Arc::new(AtomicBool::new(false));
+        let dropped = Arc::clone(&operation_dropped);
+        let operation = async move {
+            let _drop_flag = DropFlag(dropped);
+            std::future::pending::<()>().await;
+        };
+
+        assert_eq!(
+            browser_timeout_with_timer(operation, std::future::ready(())).await,
+            Err(DeadlineElapsed)
+        );
+        assert!(
+            operation_dropped.load(Ordering::SeqCst),
+            "the losing operation must be cancelled before timeout returns"
+        );
+    }
+
+    #[test]
+    fn browser_timeout_zero_stays_zero() {
+        assert_eq!(browser_timeout_milliseconds(Duration::ZERO), 0);
+    }
+
+    #[test]
+    fn browser_timeout_nonzero_submillisecond_rounds_up() {
+        assert_eq!(browser_timeout_milliseconds(Duration::from_nanos(1)), 1);
+    }
+
+    #[test]
+    fn browser_timeout_exact_millisecond_stays_exact() {
+        assert_eq!(browser_timeout_milliseconds(Duration::from_millis(1)), 1);
+    }
+
+    #[test]
+    fn browser_timeout_fractional_millisecond_rounds_up() {
+        assert_eq!(
+            browser_timeout_milliseconds(Duration::from_millis(1) + Duration::from_nanos(1)),
+            2
+        );
+    }
+
+    #[test]
+    fn browser_timeout_milliseconds_caps_at_signed_timer_maximum() {
+        let maximum = Duration::from_millis(i32::MAX as u64);
+        let first_out_of_range = maximum + Duration::from_millis(1);
+        assert_eq!(browser_timeout_milliseconds(maximum), i32::MAX as u32);
+        assert_eq!(
+            browser_timeout_milliseconds(first_out_of_range),
+            i32::MAX as u32
+        );
+    }
+}

--- a/crates/cgka-engine/src/lib.rs
+++ b/crates/cgka-engine/src/lib.rs
@@ -46,6 +46,7 @@ pub mod conformance_snapshot;
 pub mod convergence;
 pub mod convergence_clock;
 pub(crate) mod convergence_input;
+mod deadline;
 pub mod disband;
 pub mod distributed_convergence;
 pub mod engine;

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -1933,7 +1933,7 @@ impl<S: StorageProvider> Engine<S> {
             attempted += 1;
             let reingest = self.reingest_deferred_peel_row(group_id, &record, sweep);
             let result = if let Some(remaining) = execution.remaining() {
-                match tokio::time::timeout(remaining, reingest).await {
+                match crate::deadline::timeout(remaining, reingest).await {
                     Ok(result) => result,
                     Err(_) => {
                         timed_out = true;

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -36,7 +36,7 @@ ratatui-image.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["io-util", "net"] }
+tokio = { workspace = true, features = ["io-util", "net", "rt-multi-thread"] }
 transport-quic-broker.workspace = true
 transport-quic-stream.workspace = true
 unicode-properties.workspace = true

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -4170,7 +4170,7 @@ fn deferred_primary_epoch_backfill_rotates_behind_queued_older_operation() {
 }
 
 /// Run app-runtime integration chains on a stack large enough for debug
-/// OpenMLS group creation. Libtest's default 2 MiB stack is too small once a
+/// OpenMLS group creation. Smaller stacks are insufficient once a
 /// test composes the account worker with maintenance and push lifecycle work.
 fn run_composed_app_runtime_test<F, Fut>(thread_name: &str, body: F)
 where
@@ -4179,7 +4179,7 @@ where
 {
     let test_thread = std::thread::Builder::new()
         .name(thread_name.to_owned())
-        .stack_size(4 * 1024 * 1024)
+        .stack_size(8 * 1024 * 1024)
         .spawn(move || {
             let test_runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()

--- a/crates/marmot-c/Cargo.toml
+++ b/crates/marmot-c/Cargo.toml
@@ -18,7 +18,7 @@ alloc-audit = []
 
 [dependencies]
 marmot-uniffi.workspace = true
-tokio = { workspace = true, features = ["io-util", "net", "time"] }
+tokio = { workspace = true, features = ["io-util", "net", "rt-multi-thread", "time"] }
 libc.workspace = true
 # Holds a host-supplied secret-key hex only as long as the boundary needs it.
 zeroize.workspace = true

--- a/crates/transport-nostr-peeler/Cargo.toml
+++ b/crates/transport-nostr-peeler/Cargo.toml
@@ -19,4 +19,7 @@ sha2.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/crates/transport-quic-broker/Cargo.toml
+++ b/crates/transport-quic-broker/Cargo.toml
@@ -20,7 +20,7 @@ rustls-platform-verifier.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["net", "signal", "sync", "time"] }
+tokio = { workspace = true, features = ["net", "rt-multi-thread", "signal", "sync", "time"] }
 transport-quic-stream.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

Move Tokio's multithread runtime feature to native runtime owners and introduce a target-specific cancellable deadline for deferred-peel reingest.

The browser backend uses operation-first select_biased!, rounds nonzero fractional milliseconds up, and caps delays at i32::MAX before calling gloo-timers. Engine and peeler rt-multi-thread test dependencies are native-only.

### Pre-patch evidence

At upstream base 876bdf3c408df0658c158da6a6521745cd0abde5:

- the browser dependency graph inherited workspace-wide Tokio rt-multi-thread;
- the deadline contract test failed to compile because timeout was absent;
- the unchanged deferred-peel lifecycle contract required cancellation during a pending row, not only between rows;
- review of gloo-timers 0.3.0 showed its u32 delay is cast to i32, so a u32::MAX cap could wrap negative;
- Duration::as_millis() flooring would turn 1ns into 0ms and 1ms + 1ns into 1ms;
- unbiased select! could choose a ready timer over a simultaneously ready operation, unlike Tokio's operation-first polling.

### Native semantics

Native timeout delegates to tokio::time::timeout; the existing mid-await cancellation and timed_out = true; break; behavior remain. Native runtime owners explicitly retain rt-multi-thread, and native engine/peeler test graphs retain it through native-only dev-dependencies.

The browser backend drops the losing future, prefers the operation when both branches are ready, never expires a nonzero fractional-millisecond budget early, and safely caps long delays at approximately 24.8 days.

### Verification

    cargo test -p cgka-engine deadline::tests
    cargo test -p cgka-engine --features test-policy-overrides --test deferred_peel_lifecycle cancelled_sweep_keeps_untried_rows_eligible_and_reuses_enumeration
    cargo test -p cgka-engine --features test-policy-overrides --test deferred_peel_lifecycle foreground_send_budget_queues_47_and_64_row_notify_gated_backlogs
    cargo check -p marmot-c -p wn-cli -p transport-quic-broker
    rg -n 'new_multi_thread|#\[tokio::main|flavor = "multi_thread"' crates integrations --glob '*.rs'
    rg -n 'rt-multi-thread' . --glob 'Cargo.toml'
    cargo tree --target aarch64-apple-darwin -e features -p cgka-engine -i tokio
    cargo tree --target aarch64-apple-darwin -e features -p transport-nostr-peeler -i tokio
    cargo tree --target wasm32-unknown-unknown -e features -p cgka-engine -p transport-nostr-peeler -i tokio

Results: 9/9 deadline tests passed, including operation-first ready ties, loser cancellation, zero/exact/fractional millisecond conversion, nonzero submillisecond ceiling, and the signed cap. Both named lifecycle tests passed 1/1 with policy overrides. All three runtime owners checked successfully. Native feature trees contain rt-multi-thread for engine and peeler tests; the combined WASM tree contains none.

### Scope boundary

This standalone patch intentionally does not solve portable time reads, wasm32-local signer futures, or OpenMLS/getrandom browser features, so a B-only full WASM build is not expected to pass. It is one independently reviewable patch from the four-patch integration branch; it does not claim browser support.

- Upstream base: 876bdf3c408df0658c158da6a6521745cd0abde5
- Isolated head: 9bbedec3574ac9df77c6b67bd2331e2da4bba949
- Reviewed integration context: [Epiphytic/deaddrop/wasm-portability](https://github.com/Epiphytic/mdk/tree/deaddrop/wasm-portability) at e2ccf70dbd12f329dd6f11c3a0911865fb023b8b
- Design: [Patch B — Tokio and Deferred-Peel Timing](https://github.com/Epiphytic/deaddrop/blob/67d2d4bd0d304c5f5949d918f72cfce9b6b3ae32/docs/superpowers/specs/2026-08-31-mdk-wasm-portability-design.md#5-patch-b-tokio-and-deferred-peel-timing)

Target branch note: the requested upstream main branch does not exist. GitHub reports master as marmot-protocol/mdk's default branch, so this PR targets master as the factual branch-name correction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deadline handling across native and WebAssembly environments.
  * Added browser-compatible timers with safe duration handling.

* **Bug Fixes**
  * Ensured deferred processing attempts are consistently bounded by deadlines.
  * Improved cancellation and timeout behavior for deferred operations.

* **Tests**
  * Added coverage for cancellation, readiness, timer conversion, and boundary conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->