### PR TITLE
Allow local async trait futures on wasm32

### DIFF
--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -3088,7 +3088,8 @@ impl<S: StorageProvider> Engine<S> {
 // Trait methods stay thin: validate the trait boundary, then delegate to
 // the module that owns the behavior.
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
     async fn ingest(&mut self, msg: TransportMessage) -> Result<IngestOutcome, EngineError> {
         self.ingest_with_audit_context(msg, None).await

--- a/crates/cgka-engine/src/message_processor/store.rs
+++ b/crates/cgka-engine/src/message_processor/store.rs
@@ -813,7 +813,8 @@ mod tests {
 
     struct UnreachablePeeler;
 
-    #[async_trait]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     impl TransportPeeler for UnreachablePeeler {
         async fn peel_group_message(
             &self,

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -4586,7 +4586,8 @@ mod candidate_branch_peel_halt_tests {
     /// Transport is not under test here: every message is carried verbatim.
     struct PassthroughPeeler;
 
-    #[async_trait]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     impl TransportPeeler for PassthroughPeeler {
         async fn peel_group_message(
             &self,

--- a/crates/traits/src/engine.rs
+++ b/crates/traits/src/engine.rs
@@ -647,7 +647,8 @@ pub struct CreateGroupRequest {
 /// The application-facing contract of the engine.
 ///
 /// Method docs describe legal state transitions and error classes.
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait CgkaEngine: Send + Sync {
     // ── Inbound ─────────────────────────────────────────────────────────────
 

--- a/crates/traits/src/peeler.rs
+++ b/crates/traits/src/peeler.rs
@@ -109,7 +109,8 @@ impl GroupMessageMetadata {
 ///   harness asserts on this where applicable.
 /// - Implementations are `Send + Sync`; the `#[async_trait]` macro handles
 ///   the lifetime gymnastics.
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait TransportPeeler: Send + Sync {
     async fn peel_group_message(
         &self,

--- a/crates/traits/src/transport_adapter.rs
+++ b/crates/traits/src/transport_adapter.rs
@@ -1109,7 +1109,8 @@ impl TransportAdapterError {
 }
 
 /// Account-aware network adapter that moves wrapped transport messages.
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait TransportAdapter: Send + Sync {
     /// Activate inbox and group subscriptions for an account.
     async fn activate_account(

--- a/crates/traits/tests/async_send.rs
+++ b/crates/traits/tests/async_send.rs
@@ -1,0 +1,24 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+use cgka_traits::engine::CgkaEngine;
+use cgka_traits::peeler::TransportPeeler;
+use cgka_traits::transport::TransportMessage;
+use cgka_traits::transport_adapter::TransportAdapter;
+
+fn assert_send<T: Send>(_: T) {}
+
+#[test]
+fn native_async_trait_futures_are_send() {
+    fn assert_trait_futures(
+        engine: &mut dyn CgkaEngine,
+        peeler: &dyn TransportPeeler,
+        adapter: &dyn TransportAdapter,
+        msg: TransportMessage,
+    ) {
+        assert_send(engine.ingest(msg.clone()));
+        assert_send(peeler.peel_welcome(&msg));
+        assert_send(adapter.receive());
+    }
+
+    let _ = assert_trait_futures;
+}

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -891,7 +891,8 @@ impl NostrTransportAdapter {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl TransportAdapter for NostrTransportAdapter {
     async fn activate_account(
         &self,

--- a/crates/transport-nostr-peeler/src/peeler.rs
+++ b/crates/transport-nostr-peeler/src/peeler.rs
@@ -181,7 +181,8 @@ impl Default for NostrMlsPeeler {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl TransportPeeler for NostrMlsPeeler {
     async fn peel_group_message(
         &self,


### PR DESCRIPTION
## Summary

Use normal async_trait on native targets and async_trait(?Send) on wasm32 for the public engine, peeler, and transport-adapter traits and their target-compiled implementations.

### Pre-patch evidence

With unrelated OpenMLS/randomness features activated in a disposable WASM consumer at upstream base 876bdf3c408df0658c158da6a6521745cd0abde5, transport-nostr-peeler produced 4 Future ... is not Send errors across welcome peel/wrap signer futures. This isolated the async boundary from the other portability blockers.

### Native semantics

Native targets still use ordinary async_trait, and a compile-time assertion proves engine ingest, welcome peeling, and adapter receive futures remain Send. Existing Send + Sync trait-object supertraits are unchanged. Only wasm32-returned futures become local/non-Send.

### Verification

    cargo test -p cgka-traits --test async_send
    cargo test -p cgka-engine -p transport-nostr-peeler -p transport-nostr-adapter \
      --features cgka-engine/test-policy-overrides
    cargo test -p cgka-traits

A file-by-file attribute audit also verified one adjacent native async_trait / wasm32 async_trait(?Send) pair in each of the 8 reviewed trait/implementation files.

Results: the native Send compile guard exited 0. The complete feature-enabled engine suite passed; transport-nostr-peeler passed 34 tests; transport-nostr-adapter passed 30 unit and 39 inbound-routing tests; and cgka-traits passed 106 unit, 4 error-display, 6 host-safety, and 24 snapshot tests, all with zero failures.

### Scope boundary

This standalone patch does not solve portable clocks, Tokio/browser deadline ownership, or OpenMLS/getrandom WASM feature activation, so a C-only full WASM build is not expected to pass. It is one independently reviewable patch from the four-patch integration branch; it does not claim browser support.

- Upstream base: 876bdf3c408df0658c158da6a6521745cd0abde5
- Isolated head: be36b78f4ca1bd1be054a09a50ed6312290c9543
- Reviewed integration context: [Epiphytic/deaddrop/wasm-portability](https://github.com/Epiphytic/mdk/tree/deaddrop/wasm-portability) at 7878ccd4347af25f6fefd377a6e263e9c245602f
- Design: [Patch C — Target-Dependent Async Send](https://github.com/Epiphytic/deaddrop/blob/67d2d4bd0d304c5f5949d918f72cfce9b6b3ae32/docs/superpowers/specs/2026-08-31-mdk-wasm-portability-design.md#6-patch-c-target-dependent-async-send)

Target branch note: the requested upstream main branch does not exist. GitHub reports master as marmot-protocol/mdk's default branch, so this PR targets master as the factual branch-name correction.
