### PR TITLE
Batch app-component reads onto one MLS group load

### DIFF
--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -2941,21 +2941,27 @@ impl<S: StorageProvider> Engine<S> {
         self.update_stored_message_state(id, MessageState::Processed)
     }
 
-    /// Return the current Marmot admin policy keys mirrored from signed MLS
-    /// group state.
-    pub fn admin_pubkeys(&self, group_id: &GroupId) -> Result<Vec<[u8; 32]>, EngineError> {
+    /// One liveness-gated `MlsGroup::load` for read-only accessors. A missing
+    /// group maps to `UnknownGroup`.
+    fn live_mls_group(&self, group_id: &GroupId) -> Result<openmls::group::MlsGroup, EngineError> {
         self.ensure_group_live(group_id)?;
         let provider = crate::provider::EngineOpenMlsProvider::<S>::new(
             &self.crypto,
             self.storage.mls_storage(),
         );
         let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
-        let mls_group = openmls::group::MlsGroup::load(
+        openmls::group::MlsGroup::load(
             <crate::provider::EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(&provider),
             &mls_gid,
         )
         .map_err(|e| EngineError::Backend(format!("load: {e:?}")))?
-        .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
+        .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))
+    }
+
+    /// Return the current Marmot admin policy keys mirrored from signed MLS
+    /// group state.
+    pub fn admin_pubkeys(&self, group_id: &GroupId) -> Result<Vec<[u8; 32]>, EngineError> {
+        let mls_group = self.live_mls_group(group_id)?;
         let mut admins = crate::app_components::admins_of_group(&mls_group)?;
         admins.sort();
         admins.dedup();
@@ -3016,18 +3022,7 @@ impl<S: StorageProvider> Engine<S> {
         group_id: &GroupId,
         component_id: AppComponentId,
     ) -> Result<EpochId, EngineError> {
-        self.ensure_group_live(group_id)?;
-        let provider = crate::provider::EngineOpenMlsProvider::<S>::new(
-            &self.crypto,
-            self.storage.mls_storage(),
-        );
-        let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
-        let mls_group = openmls::group::MlsGroup::load(
-            <crate::provider::EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(&provider),
-            &mls_gid,
-        )
-        .map_err(|e| EngineError::Backend(format!("load: {e:?}")))?
-        .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
+        let mls_group = self.live_mls_group(group_id)?;
 
         let required_components =
             crate::app_components::required_app_components_of_group(&mls_group)?;
@@ -3308,22 +3303,27 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
         group_id: &GroupId,
         component_id: AppComponentId,
     ) -> Result<Option<Vec<u8>>, EngineError> {
-        self.ensure_group_live(group_id)?;
-        let provider = crate::provider::EngineOpenMlsProvider::<S>::new(
-            &self.crypto,
-            self.storage.mls_storage(),
-        );
-        let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
-        let mls_group = openmls::group::MlsGroup::load(
-            <crate::provider::EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(&provider),
-            &mls_gid,
-        )
-        .map_err(|e| EngineError::Backend(format!("load: {e:?}")))?
-        .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
+        let mls_group = self.live_mls_group(group_id)?;
         Ok(crate::app_components::app_component_data_of_group(
             &mls_group,
             component_id,
         ))
+    }
+
+    // One `MlsGroup::load` (13 storage reads + a ratchet-tree deserialize)
+    // answers every requested id, instead of one load per id.
+    fn app_components(
+        &self,
+        group_id: &GroupId,
+        component_ids: &[AppComponentId],
+    ) -> Result<Vec<Option<Vec<u8>>>, EngineError> {
+        let mls_group = self.live_mls_group(group_id)?;
+        Ok(component_ids
+            .iter()
+            .map(|component_id| {
+                crate::app_components::app_component_data_of_group(&mls_group, *component_id)
+            })
+            .collect())
     }
 
     fn own_leaf_index(&self, group_id: &GroupId) -> Result<u32, EngineError> {

--- a/crates/cgka-engine/tests/capabilities.rs
+++ b/crates/cgka-engine/tests/capabilities.rs
@@ -349,6 +349,53 @@ async fn optional_initial_component_state_is_not_a_membership_requirement() {
 }
 
 #[tokio::test]
+async fn batched_app_components_match_per_id_reads() {
+    const ABSENT_COMPONENT: u16 = 0x8102;
+    let mut supported = default_group_components();
+    supported.insert(TEST_APP_COMPONENT);
+    let mut alice = build_engine_with_components(b"alice", supported);
+    let state = vec![0x01, 0x02, 0x03];
+
+    let (group_id, _) = alice
+        .create_group_with_optional_app_components(
+            CreateGroupRequest {
+                name: "batched-reads".into(),
+                description: String::new(),
+                members: vec![],
+                required_features: vec![],
+                app_components: vec![],
+                initial_admins: vec![],
+            },
+            vec![AppComponentData {
+                component_id: TEST_APP_COMPONENT,
+                data: state,
+            }],
+        )
+        .await
+        .unwrap();
+
+    let ids = [
+        TEST_APP_COMPONENT,
+        ABSENT_COMPONENT,
+        GROUP_PROFILE_COMPONENT_ID,
+    ];
+    let batched = alice.app_components(&group_id, &ids).unwrap();
+    let individual: Vec<_> = ids
+        .iter()
+        .map(|id| alice.app_component(&group_id, *id).unwrap())
+        .collect();
+    assert_eq!(batched, individual);
+    assert!(batched[0].is_some());
+    assert!(batched[1].is_none());
+
+    let unknown = cgka_traits::GroupId::new(vec![0xAB; 16]);
+    assert!(matches!(
+        alice.app_components(&unknown, &ids),
+        Err(EngineError::UnknownGroup(_))
+    ));
+}
+
+#[tokio::test]
 async fn optional_initial_component_state_requires_creator_support() {
     let mut alice = build_engine_with_components(b"alice", default_group_components());
 

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -743,6 +743,15 @@ impl AccountDeviceSession {
         Ok(self.engine.app_component(group_id, component_id)?)
     }
 
+    /// Batched [`Self::app_component`]: one engine state load answers every id.
+    pub fn app_components(
+        &self,
+        group_id: &GroupId,
+        component_ids: &[AppComponentId],
+    ) -> SessionResult<Vec<Option<Vec<u8>>>> {
+        Ok(self.engine.app_components(group_id, component_ids)?)
+    }
+
     pub fn safe_export_secret(
         &mut self,
         group_id: &GroupId,

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -393,6 +393,15 @@ where
         Ok(self.session.app_component(group_id, component_id)?)
     }
 
+    /// Batched [`Self::app_component`]: one engine state load answers every id.
+    pub fn app_components(
+        &self,
+        group_id: &GroupId,
+        component_ids: &[AppComponentId],
+    ) -> AccountResult<Vec<Option<Vec<u8>>>> {
+        Ok(self.session.app_components(group_id, component_ids)?)
+    }
+
     pub fn safe_export_secret(
         &mut self,
         group_id: &GroupId,

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -219,19 +219,24 @@ impl AppClient {
         }
         let previous = self.state_group_record(group_id);
         let group_metadata = self.runtime.group_record(group_id).ok();
-        let Ok(nostr_routing) = self.nostr_routing_for_group(group_id) else {
+        let protocol_profile = group_metadata
+            .as_ref()
+            .map(|group| group.protocol_profile)
+            .unwrap_or(ProtocolProfile::Legacy);
+        let components = self.read_group_components(group_id, protocol_profile);
+        let Ok(nostr_routing) = components.nostr_routing else {
             return;
         };
         let projection = EventGroupProjection {
             nostr_routing,
             group_metadata: group_metadata.as_ref(),
-            profile: self.profile_for_group(group_id),
+            profile: components.profile,
             admin_policy: self.admin_policy_for_group(group_id),
-            message_retention: self.message_retention_for_group(group_id),
-            agent_text_stream: self.agent_text_stream_for_group(group_id),
-            avatar_url: self.avatar_url_for_group(group_id),
-            encrypted_media: self.encrypted_media_for_group(group_id),
-            image: self.image_for_group(group_id),
+            message_retention: components.message_retention,
+            agent_text_stream: components.agent_text_stream,
+            avatar_url: components.avatar_url,
+            encrypted_media: components.encrypted_media,
+            image: components.image,
         };
         add_group(
             &mut self.state,
@@ -247,17 +252,22 @@ impl AppClient {
     pub(crate) fn add_group(&mut self, group_id: &GroupId) -> Result<(), AppError> {
         let previous = self.state_group_record(group_id);
         let group_metadata = self.runtime.group_record(group_id).ok();
-        let nostr_routing = self.nostr_routing_for_group(group_id)?;
+        let protocol_profile = group_metadata
+            .as_ref()
+            .map(|group| group.protocol_profile)
+            .unwrap_or(ProtocolProfile::Legacy);
+        let components = self.read_group_components(group_id, protocol_profile);
+        let nostr_routing = components.nostr_routing?;
         let projection = EventGroupProjection {
             nostr_routing,
             group_metadata: group_metadata.as_ref(),
-            profile: self.profile_for_group(group_id),
+            profile: components.profile,
             admin_policy: self.admin_policy_for_group(group_id),
-            message_retention: self.message_retention_for_group(group_id),
-            agent_text_stream: self.agent_text_stream_for_group(group_id),
-            avatar_url: self.avatar_url_for_group(group_id),
-            encrypted_media: self.encrypted_media_for_group(group_id),
-            image: self.image_for_group(group_id),
+            message_retention: components.message_retention,
+            agent_text_stream: components.agent_text_stream,
+            avatar_url: components.avatar_url,
+            encrypted_media: components.encrypted_media,
+            image: components.image,
         };
         add_group(
             &mut self.state,
@@ -541,12 +551,52 @@ impl AppClient {
     }
 
     pub(crate) fn profile_for_group(&self, group_id: &GroupId) -> AppGroupProfileComponent {
-        self.runtime
-            .app_component(group_id, GROUP_PROFILE_COMPONENT_ID)
-            .ok()
-            .flatten()
-            .map(|bytes| AppGroupProfileComponent::from_bytes(&bytes))
-            .unwrap_or_else(AppGroupProfileComponent::absent)
+        parse_profile_component(
+            self.runtime
+                .app_component(group_id, GROUP_PROFILE_COMPONENT_ID)
+                .ok()
+                .flatten(),
+        )
+    }
+
+    /// One batched engine read for every component the group projection needs:
+    /// 7 components on a single engine state load instead of 7 loads.
+    /// Per-component fallbacks match the individual `*_for_group` helpers.
+    pub(crate) fn read_group_components(
+        &self,
+        group_id: &GroupId,
+        protocol_profile: ProtocolProfile,
+    ) -> GroupComponentReads {
+        let media_component_id = Self::encrypted_media_component_id(protocol_profile);
+        let component_ids = [
+            NOSTR_ROUTING_COMPONENT_ID,
+            GROUP_PROFILE_COMPONENT_ID,
+            GROUP_MESSAGE_RETENTION_COMPONENT_ID,
+            AGENT_TEXT_STREAM_QUIC_COMPONENT_ID,
+            GROUP_AVATAR_URL_COMPONENT_ID,
+            media_component_id,
+            GROUP_BLOSSOM_IMAGE_COMPONENT_ID,
+        ];
+        let components = match self.runtime.app_components(group_id, &component_ids) {
+            Ok(components) => components,
+            Err(error) => {
+                return GroupComponentReads::unavailable(error.into(), protocol_profile);
+            }
+        };
+
+        // `next()` consumes in `component_ids` order; struct-literal fields
+        // evaluate in source order, which matches.
+        let mut components = components.into_iter();
+        let mut next = || components.next().flatten();
+        GroupComponentReads {
+            nostr_routing: parse_routing_component(next()),
+            profile: parse_profile_component(next()),
+            message_retention: parse_retention_component(next()),
+            agent_text_stream: parse_agent_stream_component(next()),
+            avatar_url: parse_avatar_component(next()),
+            encrypted_media: parse_media_component(media_component_id, protocol_profile, next()),
+            image: parse_image_component(next()),
+        }
     }
 
     pub(crate) fn admin_policy_for_group(
@@ -563,12 +613,12 @@ impl AppClient {
         &self,
         group_id: &GroupId,
     ) -> AppGroupMessageRetentionComponent {
-        self.runtime
-            .app_component(group_id, GROUP_MESSAGE_RETENTION_COMPONENT_ID)
-            .ok()
-            .flatten()
-            .map(|bytes| AppGroupMessageRetentionComponent::from_bytes(&bytes))
-            .unwrap_or_else(AppGroupMessageRetentionComponent::disabled)
+        parse_retention_component(
+            self.runtime
+                .app_component(group_id, GROUP_MESSAGE_RETENTION_COMPONENT_ID)
+                .ok()
+                .flatten(),
+        )
     }
 
     pub(crate) fn finalize_published_app_message_source_retention(
@@ -683,21 +733,21 @@ impl AppClient {
         &self,
         group_id: &GroupId,
     ) -> AppAgentTextStreamComponent {
-        self.runtime
-            .app_component(group_id, AGENT_TEXT_STREAM_QUIC_COMPONENT_ID)
-            .ok()
-            .flatten()
-            .map(|bytes| AppAgentTextStreamComponent::from_bytes(&bytes))
-            .unwrap_or_else(AppAgentTextStreamComponent::disabled)
+        parse_agent_stream_component(
+            self.runtime
+                .app_component(group_id, AGENT_TEXT_STREAM_QUIC_COMPONENT_ID)
+                .ok()
+                .flatten(),
+        )
     }
 
     pub(crate) fn avatar_url_for_group(&self, group_id: &GroupId) -> AppGroupAvatarUrlComponent {
-        self.runtime
-            .app_component(group_id, GROUP_AVATAR_URL_COMPONENT_ID)
-            .ok()
-            .flatten()
-            .map(|bytes| AppGroupAvatarUrlComponent::from_bytes(&bytes))
-            .unwrap_or_else(AppGroupAvatarUrlComponent::absent)
+        parse_avatar_component(
+            self.runtime
+                .app_component(group_id, GROUP_AVATAR_URL_COMPONENT_ID)
+                .ok()
+                .flatten(),
+        )
     }
 
     pub(crate) fn encrypted_media_component_id(profile: ProtocolProfile) -> u16 {
@@ -717,14 +767,14 @@ impl AppClient {
             .map(|group| group.protocol_profile)
             .unwrap_or(ProtocolProfile::Legacy);
         let component_id = Self::encrypted_media_component_id(profile);
-        self.runtime
-            .app_component(group_id, component_id)
-            .ok()
-            .flatten()
-            .map(|bytes| AppGroupEncryptedMediaComponent::from_bytes(component_id, &bytes))
-            .unwrap_or_else(|| {
-                AppGroupEncryptedMediaComponent::disabled_for_profile(profile.into())
-            })
+        parse_media_component(
+            component_id,
+            profile,
+            self.runtime
+                .app_component(group_id, component_id)
+                .ok()
+                .flatten(),
+        )
     }
 
     /// Authoritative encrypted-media component lookup for the epoch-secret warm
@@ -750,12 +800,12 @@ impl AppClient {
     }
 
     pub(crate) fn image_for_group(&self, group_id: &GroupId) -> AppGroupImageInput {
-        self.runtime
-            .app_component(group_id, GROUP_BLOSSOM_IMAGE_COMPONENT_ID)
-            .ok()
-            .flatten()
-            .and_then(|bytes| AppGroupImageInput::from_component_bytes(&bytes))
-            .unwrap_or_default()
+        parse_image_component(
+            self.runtime
+                .app_component(group_id, GROUP_BLOSSOM_IMAGE_COMPONENT_ID)
+                .ok()
+                .flatten(),
+        )
     }
 
     /// Persist and queue kind-1210 system rows for our own authenticated commits.
@@ -887,16 +937,91 @@ impl AppClient {
         &self,
         group_id: &GroupId,
     ) -> Result<AppGroupNostrRoutingComponent, AppError> {
-        let bytes = self
-            .runtime
-            .app_component(group_id, NOSTR_ROUTING_COMPONENT_ID)?
-            .ok_or_else(|| {
-                AppError::InvalidNostrRouting(
-                    "group is missing marmot.transport.nostr.routing.v1".into(),
-                )
-            })?;
-        AppGroupNostrRoutingComponent::from_bytes(&bytes)
+        parse_routing_component(
+            self.runtime
+                .app_component(group_id, NOSTR_ROUTING_COMPONENT_ID)?,
+        )
     }
+}
+
+/// Every component the group projection reads, from one batched engine call.
+/// Only routing distinguishes error from absence; the rest fall back the way
+/// their `*_for_group` helpers do.
+pub(crate) struct GroupComponentReads {
+    pub(crate) nostr_routing: Result<AppGroupNostrRoutingComponent, AppError>,
+    pub(crate) profile: AppGroupProfileComponent,
+    pub(crate) message_retention: AppGroupMessageRetentionComponent,
+    pub(crate) agent_text_stream: AppAgentTextStreamComponent,
+    pub(crate) avatar_url: AppGroupAvatarUrlComponent,
+    pub(crate) encrypted_media: AppGroupEncryptedMediaComponent,
+    pub(crate) image: AppGroupImageInput,
+}
+
+impl GroupComponentReads {
+    fn unavailable(error: AppError, protocol_profile: ProtocolProfile) -> Self {
+        Self {
+            nostr_routing: Err(error),
+            profile: AppGroupProfileComponent::absent(),
+            message_retention: AppGroupMessageRetentionComponent::disabled(),
+            agent_text_stream: AppAgentTextStreamComponent::disabled(),
+            avatar_url: AppGroupAvatarUrlComponent::absent(),
+            encrypted_media: AppGroupEncryptedMediaComponent::disabled_for_profile(
+                protocol_profile.into(),
+            ),
+            image: AppGroupImageInput::default(),
+        }
+    }
+}
+
+fn parse_routing_component(
+    bytes: Option<Vec<u8>>,
+) -> Result<AppGroupNostrRoutingComponent, AppError> {
+    let bytes = bytes.ok_or_else(|| {
+        AppError::InvalidNostrRouting("group is missing marmot.transport.nostr.routing.v1".into())
+    })?;
+    AppGroupNostrRoutingComponent::from_bytes(&bytes)
+}
+
+fn parse_profile_component(bytes: Option<Vec<u8>>) -> AppGroupProfileComponent {
+    bytes
+        .map(|bytes| AppGroupProfileComponent::from_bytes(&bytes))
+        .unwrap_or_else(AppGroupProfileComponent::absent)
+}
+
+fn parse_retention_component(bytes: Option<Vec<u8>>) -> AppGroupMessageRetentionComponent {
+    bytes
+        .map(|bytes| AppGroupMessageRetentionComponent::from_bytes(&bytes))
+        .unwrap_or_else(AppGroupMessageRetentionComponent::disabled)
+}
+
+fn parse_agent_stream_component(bytes: Option<Vec<u8>>) -> AppAgentTextStreamComponent {
+    bytes
+        .map(|bytes| AppAgentTextStreamComponent::from_bytes(&bytes))
+        .unwrap_or_else(AppAgentTextStreamComponent::disabled)
+}
+
+fn parse_avatar_component(bytes: Option<Vec<u8>>) -> AppGroupAvatarUrlComponent {
+    bytes
+        .map(|bytes| AppGroupAvatarUrlComponent::from_bytes(&bytes))
+        .unwrap_or_else(AppGroupAvatarUrlComponent::absent)
+}
+
+fn parse_media_component(
+    component_id: u16,
+    protocol_profile: ProtocolProfile,
+    bytes: Option<Vec<u8>>,
+) -> AppGroupEncryptedMediaComponent {
+    bytes
+        .map(|bytes| AppGroupEncryptedMediaComponent::from_bytes(component_id, &bytes))
+        .unwrap_or_else(|| {
+            AppGroupEncryptedMediaComponent::disabled_for_profile(protocol_profile.into())
+        })
+}
+
+fn parse_image_component(bytes: Option<Vec<u8>>) -> AppGroupImageInput {
+    bytes
+        .and_then(|bytes| AppGroupImageInput::from_component_bytes(&bytes))
+        .unwrap_or_default()
 }
 
 /// Build the durable kind-1210 group system row projection for one

--- a/crates/traits/src/engine.rs
+++ b/crates/traits/src/engine.rs
@@ -915,6 +915,20 @@ pub trait CgkaEngine: Send + Sync {
         component_id: AppComponentId,
     ) -> Result<Option<Vec<u8>>, EngineError>;
 
+    /// Batched [`Self::app_component`]: one entry per requested id, in
+    /// request order. Implementations that load group state per read should
+    /// override this to answer every id from a single load.
+    fn app_components(
+        &self,
+        group_id: &GroupId,
+        component_ids: &[AppComponentId],
+    ) -> Result<Vec<Option<Vec<u8>>>, EngineError> {
+        component_ids
+            .iter()
+            .map(|component_id| self.app_component(group_id, *component_id))
+            .collect()
+    }
+
     /// Local client's current MLS leaf index in this group.
     ///
     /// This is the MLS tree leaf index, not the current roster enumeration


### PR DESCRIPTION
### Summary
Batch `app_component` lookups in `CgkaEngine` to avoid redundant `MlsGroup::load` calls during group projections.

### Context
`CgkaEngine::app_component` currently triggers a full `MlsGroup::load` (13 storage reads + ratchet tree deserialization) just to check a key on the already-parsed `app_data_dictionary`. 

Because `refresh_group` / `add_group` in `marmot-app` look up 7 components sequentially, every group refresh was paying for 7 separate group loads, plus an extra redundant group-record read in `encrypted_media_for_group`.

### What changed
- Added `CgkaEngine::app_components(group_id, &[ids])` to fetch multiple IDs in a single load (with fallback logic in the trait).
- Added corresponding wrappers in `cgka-session` and `marmot-account`.
- Updated `marmot-app` group projection to batch all 7 component reads via `read_group_components`. Shared parsing logic moved to `parse_*_component` helpers.
- Cleaned up duplicated liveness-gated `MlsGroup::load` boilerplate in `engine.rs` into a `live_mls_group` helper.

### Impact
Cuts group projection from **7 full `MlsGroup::load` calls (~91 storage reads + 7 tree deserializations) down to 1**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batched retrieval of multiple application components.
  * Group projections now load required components more efficiently in a single request.
  * Added support for component-specific fallback handling while preserving required routing errors.

* **Bug Fixes**
  * Improved consistency between batched and individual component lookups.
  * Unknown groups now return the appropriate error during component retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->