### PR TITLE
Fold pass-admission scans into one member walk

### DIFF
--- a/crates/cgka-engine/src/convergence_input.rs
+++ b/crates/cgka-engine/src/convergence_input.rs
@@ -91,22 +91,18 @@ impl ConvergenceInputContext {
     ) -> Self {
         let mut context = Self::default();
         for member in members {
-            context.fold_member(member);
+            if member.role == ConvergencePassMemberRole::CommitEdge {
+                context
+                    .commit_edges_by_source_epoch
+                    .entry(member.source_epoch)
+                    .or_default()
+                    .insert(member.payload_digest);
+            }
         }
         context
     }
 
-    /// Fold one pass member's contribution, so a caller already walking the
-    /// member list builds the context in the same pass instead of rescanning.
-    pub(crate) fn fold_member(&mut self, member: &ConvergencePassMember) {
-        if member.role == ConvergencePassMemberRole::CommitEdge {
-            self.commit_edges_by_source_epoch
-                .entry(member.source_epoch)
-                .or_default()
-                .insert(member.payload_digest);
-        }
-    }
-
+    #[cfg(test)]
     fn has_commit_at(&self, source_epoch: u64) -> bool {
         self.commit_edges_by_source_epoch
             .get(&source_epoch)
@@ -127,6 +123,10 @@ impl ConvergenceInputContext {
     /// proposal is only potentially relevant when a commit at the same source
     /// epoch may depend on it. Authentication and actual dependency/witness
     /// contribution are still proven by OpenMLS during frozen resolution.
+    ///
+    /// Test-only since pass admission moved to [`scan_selection_relevance`]:
+    /// this stays as the map-based oracle the parity test compares against.
+    #[cfg(test)]
     pub(crate) fn is_potentially_selection_relevant(
         &self,
         input: ClassifiedConvergenceInput,
@@ -179,9 +179,103 @@ impl ConvergenceInputContext {
     }
 }
 
+/// One input's [`ConvergenceInputContext::is_potentially_selection_relevant`]
+/// verdict in a single member scan, without materializing the commit-edge
+/// map. Pass admission answers exactly one input per call, so building the
+/// full context there is wasted work; equivalence with the context-based
+/// verdict is pinned by `scan_relevance_matches_context_relevance`.
+pub(crate) fn scan_selection_relevance(
+    members: &[ConvergencePassMember],
+    input: ClassifiedConvergenceInput,
+) -> bool {
+    use std::collections::hash_map::Entry;
+
+    match input.role {
+        ConvergencePassMemberRole::CommitEdge => true,
+        ConvergencePassMemberRole::ProposalDependency => members.iter().any(|member| {
+            member.role == ConvergencePassMemberRole::CommitEdge
+                && member.source_epoch == input.source_epoch
+        }),
+        ConvergencePassMemberRole::AppWitnessCandidate => {
+            // Competing commit edges strictly before the witness epoch: two
+            // distinct digests sharing one source epoch. Short-circuits on
+            // the first competing pair.
+            let mut first_digest_by_epoch = std::collections::HashMap::new();
+            for member in members {
+                if member.role != ConvergencePassMemberRole::CommitEdge
+                    || member.source_epoch >= input.source_epoch
+                {
+                    continue;
+                }
+                match first_digest_by_epoch.entry(member.source_epoch) {
+                    Entry::Vacant(entry) => {
+                        entry.insert(member.payload_digest);
+                    }
+                    Entry::Occupied(entry) => {
+                        if *entry.get() != member.payload_digest {
+                            return true;
+                        }
+                    }
+                }
+            }
+            false
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cgka_traits::types::MessageId;
+
+    fn member(
+        role: ConvergencePassMemberRole,
+        source_epoch: u64,
+        digest_byte: u8,
+    ) -> ConvergencePassMember {
+        ConvergencePassMember {
+            message_id: MessageId::new(vec![digest_byte; 32]),
+            payload_digest: [digest_byte; 32],
+            role,
+            source_epoch,
+        }
+    }
+
+    #[test]
+    fn scan_relevance_matches_context_relevance() {
+        use ConvergencePassMemberRole::*;
+
+        // Competing commits at epoch 1, a lone commit at epoch 3, a proposal
+        // and an app scattered around them.
+        let member_sets: Vec<Vec<ConvergencePassMember>> = vec![
+            vec![],
+            vec![member(CommitEdge, 1, 1)],
+            vec![member(CommitEdge, 1, 1), member(CommitEdge, 1, 2)],
+            vec![
+                member(CommitEdge, 1, 1),
+                member(CommitEdge, 1, 2),
+                member(CommitEdge, 3, 3),
+                member(ProposalDependency, 1, 4),
+                member(AppWitnessCandidate, 2, 5),
+            ],
+            // Duplicate digest at one epoch is one edge, not a competition.
+            vec![member(CommitEdge, 2, 6), member(CommitEdge, 2, 6)],
+        ];
+
+        for members in &member_sets {
+            let context = ConvergenceInputContext::from_pass_members(members);
+            for role in [CommitEdge, ProposalDependency, AppWitnessCandidate] {
+                for source_epoch in 0..=4 {
+                    let candidate = input(role, source_epoch, MessageState::Created, 9);
+                    assert_eq!(
+                        scan_selection_relevance(members, candidate),
+                        context.is_potentially_selection_relevant(candidate),
+                        "verdicts diverge for {role:?} at epoch {source_epoch} over {members:?}"
+                    );
+                }
+            }
+        }
+    }
 
     fn input(
         role: ConvergencePassMemberRole,

--- a/crates/cgka-engine/src/convergence_input.rs
+++ b/crates/cgka-engine/src/convergence_input.rs
@@ -91,15 +91,20 @@ impl ConvergenceInputContext {
     ) -> Self {
         let mut context = Self::default();
         for member in members {
-            if member.role == ConvergencePassMemberRole::CommitEdge {
-                context
-                    .commit_edges_by_source_epoch
-                    .entry(member.source_epoch)
-                    .or_default()
-                    .insert(member.payload_digest);
-            }
+            context.fold_member(member);
         }
         context
+    }
+
+    /// Fold one pass member's contribution, so a caller already walking the
+    /// member list builds the context in the same pass instead of rescanning.
+    pub(crate) fn fold_member(&mut self, member: &ConvergencePassMember) {
+        if member.role == ConvergencePassMemberRole::CommitEdge {
+            self.commit_edges_by_source_epoch
+                .entry(member.source_epoch)
+                .or_default()
+                .insert(member.payload_digest);
+        }
     }
 
     fn has_commit_at(&self, source_epoch: u64) -> bool {

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -524,12 +524,16 @@ impl<S: StorageProvider> Engine<S> {
         if pass.phase != ConvergencePassPhase::Collecting {
             return Ok((ConvergenceAdmissionOutcome::Retained, opened));
         }
-        if pass
-            .members
-            .iter()
-            .any(|member| &member.message_id == message_id)
-        {
-            return Ok((ConvergenceAdmissionOutcome::Retained, opened));
+        // One walk answers both admission questions: is this id already a
+        // member, and what commit-edge context do the current members form.
+        // Previously the id check and `from_pass_members` each rescanned the
+        // whole member list per admitted input (O(members²) per pass).
+        let mut context = ConvergenceInputContext::default();
+        for member in &pass.members {
+            if &member.message_id == message_id {
+                return Ok((ConvergenceAdmissionOutcome::Retained, opened));
+            }
+            context.fold_member(member);
         }
         if now.monotonic_ms >= pass.cutoff_monotonic_ms() {
             self.freeze_collecting_convergence_pass(&mut pass, now)?;
@@ -566,7 +570,11 @@ impl<S: StorageProvider> Engine<S> {
         }
         let admitted_input = candidate.input;
         pass.members.push(candidate.member);
-        let context = ConvergenceInputContext::from_pass_members(&pass.members);
+        // The pre-push context is sufficient here: a CommitEdge is relevant
+        // unconditionally, and a Proposal/AppWitness member contributes no
+        // commit edge, so folding the new member in cannot change its own
+        // relevance verdict.
+        //
         // Restart quiescence only for an input role that can change this
         // batch's deterministic resolution. Ordinary app delivery never
         // reaches this path; a future app without competing candidate edges is

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -30,6 +30,7 @@ use crate::canonicalization::{
 use crate::convergence_clock::ConvergenceTime;
 use crate::convergence_input::{
     ClassifiedConvergenceInput, ConvergenceInputContext, role_for_content_kind,
+    scan_selection_relevance,
 };
 use crate::engine::Engine;
 use crate::openmls_projection::{
@@ -524,16 +525,12 @@ impl<S: StorageProvider> Engine<S> {
         if pass.phase != ConvergencePassPhase::Collecting {
             return Ok((ConvergenceAdmissionOutcome::Retained, opened));
         }
-        // One walk answers both admission questions: is this id already a
-        // member, and what commit-edge context do the current members form.
-        // Previously the id check and `from_pass_members` each rescanned the
-        // whole member list per admitted input (O(members²) per pass).
-        let mut context = ConvergenceInputContext::default();
-        for member in &pass.members {
-            if &member.message_id == message_id {
-                return Ok((ConvergenceAdmissionOutcome::Retained, opened));
-            }
-            context.fold_member(member);
+        if pass
+            .members
+            .iter()
+            .any(|member| &member.message_id == message_id)
+        {
+            return Ok((ConvergenceAdmissionOutcome::Retained, opened));
         }
         if now.monotonic_ms >= pass.cutoff_monotonic_ms() {
             self.freeze_collecting_convergence_pass(&mut pass, now)?;
@@ -569,17 +566,18 @@ impl<S: StorageProvider> Engine<S> {
             return Ok((ConvergenceAdmissionOutcome::Retained, opened));
         }
         let admitted_input = candidate.input;
+        // One scan of the pre-push members, no commit-edge map: the full
+        // `from_pass_members` context rebuild here was O(members) BTreeMap
+        // work per admitted input. Pre-push is sufficient for the new input's
+        // own verdict — a CommitEdge is relevant unconditionally, and a
+        // Proposal/AppWitness member contributes no commit edge.
+        let selection_relevant = scan_selection_relevance(&pass.members, admitted_input);
         pass.members.push(candidate.member);
-        // The pre-push context is sufficient here: a CommitEdge is relevant
-        // unconditionally, and a Proposal/AppWitness member contributes no
-        // commit edge, so folding the new member in cannot change its own
-        // relevance verdict.
-        //
         // Restart quiescence only for an input role that can change this
         // batch's deterministic resolution. Ordinary app delivery never
         // reaches this path; a future app without competing candidate edges is
         // retained but does not move the pass boundary.
-        if context.is_potentially_selection_relevant(admitted_input) {
+        if selection_relevant {
             pass.quiescence_deadline_monotonic_ms = now
                 .monotonic_ms
                 .saturating_add(policy.settlement_quiescence_ms);


### PR DESCRIPTION
## Problem

`admit_stored_message_to_convergence_pass` walked `pass.members` twice per admitted input: a linear duplicate-id scan, then a full `ConvergenceInputContext::from_pass_members` rebuild after pushing the new member O(members²) comparisons and BTreeMap rebuilds over a pass's lifetime.

## Change

The cheap checks (duplicate id, cutoff freeze, candidate fetch, horizon) stay first, then the one admitted input's relevance is answered by `scan_selection_relevance`: a single pre-push member scan with no commit-edge map materialization, short-circuiting on the first competing pair (review feedback — the earlier version built the context during the duplicate scan, so bail-out paths paid for it). Pre-push is equivalent for the new member: a `CommitEdge` is relevant unconditionally, and a `Proposal`/`AppWitness` member contributes no commit edge. `is_potentially_selection_relevant` stays as the test-only map-based oracle; `scan_relevance_matches_context_relevance` pins the two verdicts together.

Not changed: the per-admission `put_convergence_pass` rewrite — the retained row and pass membership are one durability boundary; splitting the pass blob into per-member rows would be a storage migration with no measured need.

## Count

Per admitted input: 2 full member walks + 1 BTreeMap rebuild → 1 walk with incremental folds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Performance
- Improved convergence admission efficiency by evaluating selection relevance directly from available pass information.
- Reduced redundant context reconstruction during convergence processing.
- Preserved quiescence reset behavior while streamlining convergence decisions.

## Refactor
- Simplified member-processing logic without changing convergence outcomes.
- Added coverage for representative selection-relevance scenarios, including competing commits and proposal dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
