### PR TITLE
Cut the deferred-peel sweep's idle-poll cost

### DIFF
--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -1088,16 +1088,6 @@ impl<S: StorageProvider> Engine<S> {
             return Ok(waiting_result(epoch));
         }
 
-        let previous_group = self
-            .storage
-            .get_group(group_id)
-            .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
-        // Pre-apply admin/avatar component snapshot, mirroring the direct
-        // inbound seam's before-state capture so the reorg path can emit the
-        // same profile/admin state-change events. Best-effort: a group whose
-        // MLS state isn't loadable just skips those diffs.
-        let previous_components = self.reorg_component_snapshot(group_id);
-        let previous_name = previous_group.name.clone();
         let previous_tip = self.convergence_tip_epoch(group_id)?;
         let policy = self.convergence_policy_for_group(group_id)?;
         let (pass, opened) =
@@ -1192,6 +1182,21 @@ impl<S: StorageProvider> Engine<S> {
         if pass.phase == ConvergencePassPhase::Completed {
             return Ok(settled_empty_result(previous_tip.0));
         }
+        // Pre-apply captures for the reorg diff, taken only once a pass is
+        // actually resolving. Capturing them before the Collecting/no-input
+        // early returns above paid a group-record read plus a full
+        // `MlsGroup::load` (via `reorg_component_snapshot`) on every scheduler
+        // poll of a not-yet-frozen pass, for a result those returns discard.
+        let previous_group = self
+            .storage
+            .get_group(group_id)
+            .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
+        // Pre-apply admin/avatar component snapshot, mirroring the direct
+        // inbound seam's before-state capture so the reorg path can emit the
+        // same profile/admin state-change events. Best-effort: a group whose
+        // MLS state isn't loadable just skips those diffs.
+        let previous_components = self.reorg_component_snapshot(group_id);
+        let previous_name = previous_group.name.clone();
         let max_retained_anchor_rewind = policy.convergence.max_rewind_commits;
         let retained_anchor_epoch = previous_tip
             .0

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -34,7 +34,7 @@ use cgka_traits::storage::{
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
 use sha2::{Digest, Sha256};
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -174,6 +174,14 @@ pub(crate) struct DeferredPeelGroupState {
     /// logged, or copied into durable generation state, and process restart
     /// drops it naturally.
     candidate_cache: Option<DeferredPeelCandidateCacheEntry>,
+    /// Per-row verdicts backing `stored_convergence_commit_digests`: the
+    /// commit digest, or `None` for a row that is not an MLS-wire commit.
+    /// Sound to remember without invalidation because a row id never maps to
+    /// different wire bytes (content rows are keyed by their content dedup
+    /// id, and payload rewrites only attach metadata around the same wire
+    /// message). Rebuilt to the currently listed rows on every use, so it
+    /// cannot outgrow the group's stored history.
+    commit_digest_memo: HashMap<MessageId, Option<[u8; 32]>>,
 }
 
 struct DeferredPeelCandidateCacheEntry {
@@ -2218,7 +2226,7 @@ impl<S: StorageProvider> Engine<S> {
     /// While all three are unchanged, re-peeling a deferred row is guaranteed
     /// wasted work.
     fn deferred_peel_context_fingerprint(
-        &self,
+        &mut self,
         group_id: &GroupId,
     ) -> Result<[u8; 32], EngineError> {
         let epoch = self.epoch_manager.epoch(group_id).unwrap_or_default();
@@ -2251,12 +2259,27 @@ impl<S: StorageProvider> Engine<S> {
 
     /// Content digests of the stored commits that can contribute to this
     /// group's convergence graph, in a stable order.
+    ///
+    /// The fingerprint gate computes this set at least twice per sweep, so a
+    /// row's decode + TLS parse + digest is remembered in
+    /// `DeferredPeelGroupState::commit_digest_memo` and paid once per row
+    /// lifetime instead of once per computation. State membership is re-read
+    /// from the fresh listing every call; only the payload verdict is memoized.
     fn stored_convergence_commit_digests(
-        &self,
+        &mut self,
         group_id: &GroupId,
     ) -> Result<BTreeSet<[u8; 32]>, EngineError> {
+        let records = self.storage.list_messages(group_id, EpochId(0))?;
+        let mut memo = std::mem::take(
+            &mut self
+                .deferred_peel
+                .entry(group_id.clone())
+                .or_default()
+                .commit_digest_memo,
+        );
+        let mut next_memo = HashMap::with_capacity(records.len());
         let mut digests = BTreeSet::new();
-        for record in self.storage.list_messages(group_id, EpochId(0))? {
+        for record in records {
             // Share the graph's own membership predicate rather than restating
             // it: this set must describe exactly the commits a pass would build
             // candidate branches from, and a private copy of that match drifts
@@ -2266,14 +2289,23 @@ impl<S: StorageProvider> Engine<S> {
             ) {
                 continue;
             }
-            let Some((_message, projection)) = decode_openmls_wire_projection(&record.payload)
-            else {
-                continue;
+            let verdict = match memo.remove(&record.id) {
+                Some(verdict) => verdict,
+                None => decode_openmls_wire_projection(&record.payload)
+                    .filter(|(_message, projection)| {
+                        projection.kind == crate::openmls_projection::OpenMlsContentKind::Commit
+                    })
+                    .map(|(_message, projection)| projection.message_digest),
             };
-            if projection.kind == crate::openmls_projection::OpenMlsContentKind::Commit {
-                digests.insert(projection.message_digest);
+            if let Some(digest) = verdict {
+                digests.insert(digest);
             }
+            next_memo.insert(record.id, verdict);
         }
+        self.deferred_peel
+            .entry(group_id.clone())
+            .or_default()
+            .commit_digest_memo = next_memo;
         Ok(digests)
     }
 

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -175,13 +175,15 @@ pub(crate) struct DeferredPeelGroupState {
     /// drops it naturally.
     candidate_cache: Option<DeferredPeelCandidateCacheEntry>,
     /// Per-row verdicts backing `stored_convergence_commit_digests`: the
-    /// commit digest, or `None` for a row that is not an MLS-wire commit.
-    /// Sound to remember without invalidation because a row id never maps to
-    /// different wire bytes (content rows are keyed by their content dedup
-    /// id, and payload rewrites only attach metadata around the same wire
-    /// message). Rebuilt to the currently listed rows on every use, so it
-    /// cannot outgrow the group's stored history.
-    commit_digest_memo: HashMap<MessageId, Option<[u8; 32]>>,
+    /// stored payload's hash, plus the commit digest or `None` for a row that
+    /// is not an MLS-wire commit. A row id CAN map to different payload bytes
+    /// over its lifetime — `persist_stored_message_payload` overwrites a
+    /// same-id row stored under a different payload variant (e.g. RawTransport
+    /// re-persisted as OpenMlsWire, #369) — so each reuse revalidates the
+    /// cheap payload hash and only then skips the decode + TLS parse. Rebuilt
+    /// to the currently listed rows on every use, so it cannot outgrow the
+    /// group's stored history.
+    commit_digest_memo: HashMap<MessageId, ([u8; 32], Option<[u8; 32]>)>,
 }
 
 struct DeferredPeelCandidateCacheEntry {
@@ -2262,9 +2264,10 @@ impl<S: StorageProvider> Engine<S> {
     ///
     /// The fingerprint gate computes this set at least twice per sweep, so a
     /// row's decode + TLS parse + digest is remembered in
-    /// `DeferredPeelGroupState::commit_digest_memo` and paid once per row
-    /// lifetime instead of once per computation. State membership is re-read
-    /// from the fresh listing every call; only the payload verdict is memoized.
+    /// `DeferredPeelGroupState::commit_digest_memo` and paid once per stored
+    /// payload version instead of once per computation. State membership is
+    /// re-read from the fresh listing every call, and each reuse revalidates
+    /// the payload hash; only the payload verdict is memoized.
     fn stored_convergence_commit_digests(
         &mut self,
         group_id: &GroupId,
@@ -2289,9 +2292,14 @@ impl<S: StorageProvider> Engine<S> {
             ) {
                 continue;
             }
+            // The memo entry is valid only for the payload bytes it was
+            // computed from: a same-id row can be overwritten under a
+            // different payload variant (RawTransport re-persisted as
+            // OpenMlsWire, #369), which must re-classify.
+            let payload_hash: [u8; 32] = Sha256::digest(&record.payload).into();
             let verdict = match memo.remove(&record.id) {
-                Some(verdict) => verdict,
-                None => decode_openmls_wire_projection(&record.payload)
+                Some((memo_hash, verdict)) if memo_hash == payload_hash => verdict,
+                _ => decode_openmls_wire_projection(&record.payload)
                     .filter(|(_message, projection)| {
                         projection.kind == crate::openmls_projection::OpenMlsContentKind::Commit
                     })
@@ -2300,7 +2308,7 @@ impl<S: StorageProvider> Engine<S> {
             if let Some(digest) = verdict {
                 digests.insert(digest);
             }
-            next_memo.insert(record.id, verdict);
+            next_memo.insert(record.id, (payload_hash, verdict));
         }
         self.deferred_peel
             .entry(group_id.clone())

--- a/crates/cgka-engine/src/message_processor/store.rs
+++ b/crates/cgka-engine/src/message_processor/store.rs
@@ -794,13 +794,11 @@ mod tests {
         }
     }
 
-    /// Regression for mdk#369: the idempotency short-circuit must compare the
-    /// encoded payload, not just (group, epoch, state) — a second persist of
-    /// the same id under a different `StoredMessagePayload` variant must
-    /// overwrite, or a reader on the other processing path silently loses the
-    /// record.
-    #[test]
-    fn same_key_persist_with_different_payload_variant_overwrites() {
+    fn engine_with_stored_group() -> (
+        SqliteAccountStorage,
+        crate::engine::Engine<SqliteAccountStorage>,
+        GroupId,
+    ) {
         let storage = SqliteAccountStorage::in_memory().unwrap();
         let signing_key = test_signing_key();
         let identity = signing_key.verifying_key().to_bytes().to_vec();
@@ -828,6 +826,49 @@ mod tests {
                 join_epoch: EpochId(0),
             })
             .unwrap();
+        (storage, engine, group_id)
+    }
+
+    /// Genuine OpenMLS commit wire bytes from a standalone one-member group.
+    /// The projection only parses the wire format, so the group needs no
+    /// relation to the engine under test.
+    fn real_commit_wire_bytes() -> Vec<u8> {
+        use openmls::group::{MlsGroupCreateConfig, PURE_PLAINTEXT_WIRE_FORMAT_POLICY};
+        use openmls::prelude::{
+            BasicCredential, Ciphersuite, CredentialWithKey, LeafNodeParameters,
+        };
+        use openmls_basic_credential::SignatureKeyPair;
+        use tls_codec::Serialize as _;
+
+        let ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+        let provider = openmls_rust_crypto::OpenMlsRustCrypto::default();
+        let signer = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
+        let credential_with_key = CredentialWithKey {
+            credential: BasicCredential::new(b"memo-test-member".to_vec()).into(),
+            signature_key: signer.public().into(),
+        };
+        let config = MlsGroupCreateConfig::builder()
+            .ciphersuite(ciphersuite)
+            .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+            .build();
+        let mut group =
+            openmls::group::MlsGroup::new(&provider, &signer, &config, credential_with_key)
+                .unwrap();
+        let (commit_out, _welcome, _group_info) = group
+            .self_update(&provider, &signer, LeafNodeParameters::default())
+            .unwrap()
+            .into_contents();
+        commit_out.tls_serialize_detached().unwrap()
+    }
+
+    /// Regression for mdk#369: the idempotency short-circuit must compare the
+    /// encoded payload, not just (group, epoch, state) — a second persist of
+    /// the same id under a different `StoredMessagePayload` variant must
+    /// overwrite, or a reader on the other processing path silently loses the
+    /// record.
+    #[test]
+    fn same_key_persist_with_different_payload_variant_overwrites() {
+        let (storage, engine, group_id) = engine_with_stored_group();
         let msg = transport_message(b"colliding-id", b"wire-bytes");
 
         engine
@@ -886,6 +927,43 @@ mod tests {
             stored.as_staged_invite_welcome().map(|(_, origin)| origin),
             Some(&origin_commit_id),
             "own echo must preserve staged Welcome ownership"
+        );
+    }
+
+    /// The commit-digest memo behind `deferred_peel_context_fingerprint`
+    /// remembers a per-payload verdict keyed by `MessageId`. A same-id row
+    /// overwritten under a different payload variant (RawTransport re-persisted
+    /// as an OpenMLS-wire commit, the mdk#369 path above) must re-classify:
+    /// a stale `None` verdict would hide the stored commit from the
+    /// fingerprint and keep the deferred-peel gate armed.
+    #[test]
+    fn overwritten_payload_changes_peel_context_fingerprint() {
+        let (_storage, mut engine, group_id) = engine_with_stored_group();
+        let raw_row = transport_message(b"memo-overwritten-id", b"opaque-transport-bytes");
+        engine
+            .persist_transport_message(&raw_row, &group_id, EpochId(3), MessageState::Sent)
+            .unwrap();
+
+        let before = engine.deferred_peel_context_fingerprint(&group_id).unwrap();
+        // Second call runs against the now-populated memo; it must agree.
+        assert_eq!(
+            before,
+            engine.deferred_peel_context_fingerprint(&group_id).unwrap()
+        );
+
+        let commit_row = TransportMessage {
+            payload: real_commit_wire_bytes(),
+            ..raw_row
+        };
+        engine
+            .persist_openmls_wire_message(&commit_row, &group_id, EpochId(3), MessageState::Sent)
+            .unwrap();
+
+        let after = engine.deferred_peel_context_fingerprint(&group_id).unwrap();
+        assert_ne!(
+            before, after,
+            "a RawTransport row overwritten as an OpenMLS-wire commit must \
+             re-classify instead of reusing the memoized non-commit verdict"
         );
     }
 }


### PR DESCRIPTION
### Summary
Memoize the per-row commit digests behind the peel-sweep fingerprint, and stop loading the MLS group on convergence polls that return before resolving.

### Context
Two spots paid full-history or full-load work on paths that discard the result:

- `deferred_peel_context_fingerprint` runs at least twice per sweep (gate + final), and the sweep sits inside the up-to-16-pass drain loop, up to 32 computations per drain while a backlog exists. Each one re-listed the group's stored messages and re-ran decode + TLS parse + SHA-256 on every row via `stored_convergence_commit_digests`.
- `converge_stored_openmls_messages` captured `previous_group` and the reorg component snapshot (a full `MlsGroup::load`) before its early returns, so every scheduler poll of a still-collecting pass deserialized the group just to throw it away.

### What changed
- `DeferredPeelGroupState` gains a per-row commit-digest memo: a row id never maps to different wire bytes (content rows are keyed by their content dedup id), so its "commit digest or not a commit" verdict is computed once per row lifetime. State membership is still re-read from the fresh listing on every call; the memo is rebuilt to the listed rows each time, so it can't outgrow the stored history.
- The pre-apply captures for the reorg diff moved below the generation-barrier / no-input / still-collecting / completed early returns, to where a pass is actually resolving.

### Impact
Fingerprint computation drops from O(rows) parses per call to parses for new rows only (the listing walk and digest hash remain). A scheduler poll of an unfrozen pass no longer costs a group-record read + 13-read `MlsGroup::load` + tree deserialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved deferred message processing by reusing previously computed commit information when message contents are unchanged.

* **Reliability**
  * Updated message handling to detect and reclassify messages when stored payloads change.
  * Ensured cached information reflects currently available message data, including removed entries.
  * Preserved snapshot contents and error handling while capturing convergence state at the appropriate processing stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->