### PR TITLE
Apply the batched component read to the three projection sites the first pass missed

### DIFF
--- a/crates/cgka-engine/AGENTS.md
+++ b/crates/cgka-engine/AGENTS.md
@@ -428,8 +428,8 @@ epoch visibility through `support::epoch_sealed_peeler`), plus the `convergence-
   repair the apply.
 - **Hydration quarantine is enforced through `Engine::ensure_group_live`.** A quarantined group vanishes from every
   live surface (mdk#364 / #365): every public accessor that reads durable or MLS group state (`members`,
-  `group_record`, `group_context`, `admin_pubkeys`, `app_component`, `feature_status`, capability queries, the
-  safe-export family, `own_leaf_index`) calls `ensure_group_live` first and returns `UnknownGroup`; `do_send` and
+  `group_record`, `group_context`, `admin_pubkeys`, `app_component`, `app_components`, `feature_status`, capability
+  queries, the safe-export family, `own_leaf_index`) calls `ensure_group_live` first and returns `UnknownGroup`; `do_send` and
   `converge_and_drain_queued_outbound_intents` refuse to run; `ingest_group_message` retains inbound input as
   `PeelDeferred` and classifies it `Stale { reason: Quarantined }`; `converge_stored_openmls_messages` reports a
   `Blocked` run without touching state; `retry_deferred_peels` skips the group. When you add a new accessor or data

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -34,8 +34,8 @@ use zeroize::Zeroizing;
 
 use crate::app_telemetry::AppPerformanceOperation;
 use crate::groups::{
-    EventGroupProjection, GroupConfirmationProjection, add_group, fail_if_publish_failed,
-    publish_failure_error, send_summary_from_effects, validate_group_profile,
+    GroupConfirmationProjection, add_group, fail_if_publish_failed, publish_failure_error,
+    send_summary_from_effects, validate_group_profile,
 };
 use crate::ids::{admin_pubkey_from_account_id_hex, admin_pubkey_from_member_id};
 use crate::media::{
@@ -3970,18 +3970,7 @@ impl AppClient {
         self.record_human_action_succeeded(group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
         let group_metadata = self.runtime.group_record(group_id).ok();
-        let nostr_routing = self.nostr_routing_for_group(group_id)?;
-        let projection = EventGroupProjection {
-            nostr_routing,
-            group_metadata: group_metadata.as_ref(),
-            profile: self.profile_for_group(group_id),
-            admin_policy: self.admin_policy_for_group(group_id),
-            message_retention: self.message_retention_for_group(group_id),
-            agent_text_stream: self.agent_text_stream_for_group(group_id),
-            avatar_url: self.avatar_url_for_group(group_id),
-            encrypted_media: self.encrypted_media_for_group(group_id),
-            image: self.image_for_group(group_id),
-        };
+        let projection = self.event_group_projection(group_id, group_metadata.as_ref())?;
         add_group(
             &mut self.state,
             group_id,

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -268,24 +268,8 @@ impl AppClient {
         }
         let previous = self.state_group_record(group_id);
         let group_metadata = self.runtime.group_record(group_id).ok();
-        let protocol_profile = group_metadata
-            .as_ref()
-            .map(|group| group.protocol_profile)
-            .unwrap_or(ProtocolProfile::Legacy);
-        let components = self.read_group_components(group_id, protocol_profile);
-        let Ok(nostr_routing) = components.nostr_routing else {
+        let Ok(projection) = self.event_group_projection(group_id, group_metadata.as_ref()) else {
             return;
-        };
-        let projection = EventGroupProjection {
-            nostr_routing,
-            group_metadata: group_metadata.as_ref(),
-            profile: components.profile,
-            admin_policy: self.admin_policy_for_group(group_id),
-            message_retention: components.message_retention,
-            agent_text_stream: components.agent_text_stream,
-            avatar_url: components.avatar_url,
-            encrypted_media: components.encrypted_media,
-            image: components.image,
         };
         add_group(
             &mut self.state,
@@ -301,23 +285,7 @@ impl AppClient {
     pub(crate) fn add_group(&mut self, group_id: &GroupId) -> Result<(), AppError> {
         let previous = self.state_group_record(group_id);
         let group_metadata = self.runtime.group_record(group_id).ok();
-        let protocol_profile = group_metadata
-            .as_ref()
-            .map(|group| group.protocol_profile)
-            .unwrap_or(ProtocolProfile::Legacy);
-        let components = self.read_group_components(group_id, protocol_profile);
-        let nostr_routing = components.nostr_routing?;
-        let projection = EventGroupProjection {
-            nostr_routing,
-            group_metadata: group_metadata.as_ref(),
-            profile: components.profile,
-            admin_policy: self.admin_policy_for_group(group_id),
-            message_retention: components.message_retention,
-            agent_text_stream: components.agent_text_stream,
-            avatar_url: components.avatar_url,
-            encrypted_media: components.encrypted_media,
-            image: components.image,
-        };
+        let projection = self.event_group_projection(group_id, group_metadata.as_ref())?;
         add_group(
             &mut self.state,
             group_id,
@@ -599,23 +567,17 @@ impl AppClient {
         }
     }
 
-    pub(crate) fn profile_for_group(&self, group_id: &GroupId) -> AppGroupProfileComponent {
-        parse_profile_component(
-            self.runtime
-                .app_component(group_id, GROUP_PROFILE_COMPONENT_ID)
-                .ok()
-                .flatten(),
-        )
-    }
-
-    /// One batched engine read for every component the group projection needs:
-    /// 7 components on a single engine state load instead of 7 loads.
-    /// Per-component fallbacks match the individual `*_for_group` helpers.
-    pub(crate) fn read_group_components(
+    /// Build the full [`EventGroupProjection`] for one group: one batched
+    /// engine read answers all 7 components (instead of 7 state loads), plus
+    /// the admin-policy lookup. Per-component fallbacks match the individual
+    /// `*_for_group` helpers. Errs only when the routing component is missing
+    /// or unreadable — the projection is unusable without a route.
+    pub(crate) fn event_group_projection<'a>(
         &self,
         group_id: &GroupId,
-        protocol_profile: ProtocolProfile,
-    ) -> GroupComponentReads {
+        group_metadata: Option<&'a cgka_traits::group::Group>,
+    ) -> Result<EventGroupProjection<'a>, AppError> {
+        let protocol_profile = protocol_profile_of(group_metadata);
         let media_component_id = Self::encrypted_media_component_id(protocol_profile);
         let component_ids = [
             NOSTR_ROUTING_COMPONENT_ID,
@@ -626,26 +588,36 @@ impl AppClient {
             media_component_id,
             GROUP_BLOSSOM_IMAGE_COMPONENT_ID,
         ];
-        let components = match self.runtime.app_components(group_id, &component_ids) {
-            Ok(components) => components,
-            Err(error) => {
-                return GroupComponentReads::unavailable(error.into(), protocol_profile);
-            }
-        };
+        let components = self.runtime.app_components(group_id, &component_ids)?;
 
-        // `next()` consumes in `component_ids` order; struct-literal fields
-        // evaluate in source order, which matches.
-        let mut components = components.into_iter();
-        let mut next = || components.next().flatten();
-        GroupComponentReads {
-            nostr_routing: parse_routing_component(next()),
-            profile: parse_profile_component(next()),
-            message_retention: parse_retention_component(next()),
-            agent_text_stream: parse_agent_stream_component(next()),
-            avatar_url: parse_avatar_component(next()),
-            encrypted_media: parse_media_component(media_component_id, protocol_profile, next()),
-            image: parse_image_component(next()),
-        }
+        // Keyed by id, not positional consumption order, so reordering the
+        // struct literal below cannot mis-assign a component.
+        let mut by_id: std::collections::HashMap<u16, Vec<u8>> = component_ids
+            .iter()
+            .copied()
+            .zip(components)
+            .filter_map(|(id, bytes)| bytes.map(|bytes| (id, bytes)))
+            .collect();
+        let mut take = |id: u16| by_id.remove(&id);
+        Ok(EventGroupProjection {
+            nostr_routing: parse_routing_component(take(NOSTR_ROUTING_COMPONENT_ID))?,
+            group_metadata,
+            profile: parse_profile_component(take(GROUP_PROFILE_COMPONENT_ID)),
+            admin_policy: self.admin_policy_for_group(group_id),
+            message_retention: parse_retention_component(take(
+                GROUP_MESSAGE_RETENTION_COMPONENT_ID,
+            )),
+            agent_text_stream: parse_agent_stream_component(take(
+                AGENT_TEXT_STREAM_QUIC_COMPONENT_ID,
+            )),
+            avatar_url: parse_avatar_component(take(GROUP_AVATAR_URL_COMPONENT_ID)),
+            encrypted_media: parse_media_component(
+                media_component_id,
+                protocol_profile,
+                take(media_component_id),
+            ),
+            image: parse_image_component(take(GROUP_BLOSSOM_IMAGE_COMPONENT_ID)),
+        })
     }
 
     pub(crate) fn admin_policy_for_group(
@@ -656,18 +628,6 @@ impl AppClient {
             .admin_pubkeys(group_id)
             .map(AppGroupAdminPolicyComponent::new)
             .unwrap_or_else(|_| AppGroupAdminPolicyComponent::new(Vec::new()))
-    }
-
-    pub(crate) fn message_retention_for_group(
-        &self,
-        group_id: &GroupId,
-    ) -> AppGroupMessageRetentionComponent {
-        parse_retention_component(
-            self.runtime
-                .app_component(group_id, GROUP_MESSAGE_RETENTION_COMPONENT_ID)
-                .ok()
-                .flatten(),
-        )
     }
 
     pub(crate) fn finalize_published_app_message_source_retention(
@@ -778,27 +738,6 @@ impl AppClient {
         )
     }
 
-    pub(crate) fn agent_text_stream_for_group(
-        &self,
-        group_id: &GroupId,
-    ) -> AppAgentTextStreamComponent {
-        parse_agent_stream_component(
-            self.runtime
-                .app_component(group_id, AGENT_TEXT_STREAM_QUIC_COMPONENT_ID)
-                .ok()
-                .flatten(),
-        )
-    }
-
-    pub(crate) fn avatar_url_for_group(&self, group_id: &GroupId) -> AppGroupAvatarUrlComponent {
-        parse_avatar_component(
-            self.runtime
-                .app_component(group_id, GROUP_AVATAR_URL_COMPONENT_ID)
-                .ok()
-                .flatten(),
-        )
-    }
-
     pub(crate) fn encrypted_media_component_id(profile: ProtocolProfile) -> u16 {
         match profile {
             ProtocolProfile::Legacy => GROUP_ENCRYPTED_MEDIA_V1_COMPONENT_ID,
@@ -810,11 +749,7 @@ impl AppClient {
         &self,
         group_id: &GroupId,
     ) -> AppGroupEncryptedMediaComponent {
-        let profile = self
-            .runtime
-            .group_record(group_id)
-            .map(|group| group.protocol_profile)
-            .unwrap_or(ProtocolProfile::Legacy);
+        let profile = protocol_profile_of(self.runtime.group_record(group_id).ok().as_ref());
         let component_id = Self::encrypted_media_component_id(profile);
         parse_media_component(
             component_id,
@@ -996,33 +931,14 @@ impl AppClient {
     }
 }
 
-/// Every component the group projection reads, from one batched engine call.
-/// Only routing distinguishes error from absence; the rest fall back the way
-/// their `*_for_group` helpers do.
-pub(crate) struct GroupComponentReads {
-    pub(crate) nostr_routing: Result<AppGroupNostrRoutingComponent, AppError>,
-    pub(crate) profile: AppGroupProfileComponent,
-    pub(crate) message_retention: AppGroupMessageRetentionComponent,
-    pub(crate) agent_text_stream: AppAgentTextStreamComponent,
-    pub(crate) avatar_url: AppGroupAvatarUrlComponent,
-    pub(crate) encrypted_media: AppGroupEncryptedMediaComponent,
-    pub(crate) image: AppGroupImageInput,
-}
-
-impl GroupComponentReads {
-    fn unavailable(error: AppError, protocol_profile: ProtocolProfile) -> Self {
-        Self {
-            nostr_routing: Err(error),
-            profile: AppGroupProfileComponent::absent(),
-            message_retention: AppGroupMessageRetentionComponent::disabled(),
-            agent_text_stream: AppAgentTextStreamComponent::disabled(),
-            avatar_url: AppGroupAvatarUrlComponent::absent(),
-            encrypted_media: AppGroupEncryptedMediaComponent::disabled_for_profile(
-                protocol_profile.into(),
-            ),
-            image: AppGroupImageInput::default(),
-        }
-    }
+/// A group with no readable record keeps the legacy-profile fallbacks the
+/// individual component helpers have always used.
+pub(crate) fn protocol_profile_of(
+    group_metadata: Option<&cgka_traits::group::Group>,
+) -> ProtocolProfile {
+    group_metadata
+        .map(|group| group.protocol_profile)
+        .unwrap_or(ProtocolProfile::Legacy)
 }
 
 fn parse_routing_component(

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -570,8 +570,9 @@ impl AppClient {
     /// Build the full [`EventGroupProjection`] for one group: one batched
     /// engine read answers all 7 components (instead of 7 state loads), plus
     /// the admin-policy lookup. Per-component fallbacks match the individual
-    /// `*_for_group` helpers. Errs only when the routing component is missing
-    /// or unreadable — the projection is unusable without a route.
+    /// `*_for_group` helpers. Errs when the batched component read itself
+    /// fails, or when the routing component is missing or unparseable — the
+    /// projection is unusable without a route.
     pub(crate) fn event_group_projection<'a>(
         &self,
         group_id: &GroupId,

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -22,9 +22,8 @@ use crate::groups::{
 use crate::media::media_imeta_tags_are_valid;
 use crate::notifications;
 use crate::{
-    AccountState, AppError, AppGroupAdminPolicyComponent, AppMessageProjection,
-    AppPerformanceTelemetry, ClassifiedSyncFailure, EPOCH_BACKFILL_EOSE_WAIT,
-    EPOCH_BACKFILL_EXECUTION_QUANTUM, EPOCH_BACKFILL_RETRY_BACKOFF,
+    AccountState, AppError, AppMessageProjection, AppPerformanceTelemetry, ClassifiedSyncFailure,
+    EPOCH_BACKFILL_EOSE_WAIT, EPOCH_BACKFILL_EXECUTION_QUANTUM, EPOCH_BACKFILL_RETRY_BACKOFF,
     EPOCH_BACKFILL_RETRY_BACKOFF_CAP, SDK_DRAIN_WAIT, SDK_FIRST_SYNC_WAIT, SelfMembership,
     SyncFailure, SyncSummary, TRANSPORT_CURSOR_MAX_FUTURE_SKEW, unix_now_seconds,
 };
@@ -1331,22 +1330,7 @@ impl AppClient {
         if self.force_event_group_projection_unavailable {
             return None;
         }
-        let nostr_routing = self.nostr_routing_for_group(group_id).ok()?;
-        Some(EventGroupProjection {
-            nostr_routing,
-            group_metadata,
-            profile: self.profile_for_group(group_id),
-            admin_policy: self
-                .runtime
-                .admin_pubkeys(group_id)
-                .map(AppGroupAdminPolicyComponent::new)
-                .unwrap_or_else(|_| AppGroupAdminPolicyComponent::new(Vec::new())),
-            message_retention: self.message_retention_for_group(group_id),
-            agent_text_stream: self.agent_text_stream_for_group(group_id),
-            avatar_url: self.avatar_url_for_group(group_id),
-            encrypted_media: self.encrypted_media_for_group(group_id),
-            image: self.image_for_group(group_id),
-        })
+        self.event_group_projection(group_id, group_metadata).ok()
     }
 
     pub async fn next_event(&mut self) -> Result<SyncSummary, AppError> {
@@ -3947,23 +3931,7 @@ impl AppClient {
             let group_metadata =
                 event_group_id(event).and_then(|group_id| self.runtime.group_record(group_id).ok());
             let group_projection = event_group_id(event)
-                .map(|group_id| {
-                    Ok::<_, AppError>(EventGroupProjection {
-                        nostr_routing: self.nostr_routing_for_group(group_id)?,
-                        group_metadata: group_metadata.as_ref(),
-                        profile: self.profile_for_group(group_id),
-                        admin_policy: self
-                            .runtime
-                            .admin_pubkeys(group_id)
-                            .map(AppGroupAdminPolicyComponent::new)
-                            .unwrap_or_else(|_| AppGroupAdminPolicyComponent::new(Vec::new())),
-                        message_retention: self.message_retention_for_group(group_id),
-                        agent_text_stream: self.agent_text_stream_for_group(group_id),
-                        avatar_url: self.avatar_url_for_group(group_id),
-                        encrypted_media: self.encrypted_media_for_group(group_id),
-                        image: self.image_for_group(group_id),
-                    })
-                })
+                .map(|group_id| self.event_group_projection(group_id, group_metadata.as_ref()))
                 .transpose()?;
             if let Some(message) = observe_event(
                 &mut self.state,


### PR DESCRIPTION
### Summary
Apply the batched component read to the three projection sites the first pass missed, key batched results by component id, and fold the review nits.

### Context
Review on #1615 found three more places still building `EventGroupProjection` from 7 sequential `app_component` calls (the per-event observe path and `event_group_projection_best_effort` in `sync.rs`, and the post-publish projection in `client/mod.rs`). It also flagged that `read_group_components` assigned results by `next()` call order — correct today, but a reordered struct literal would silently mis-assign components — plus a 3×-duplicated `ProtocolProfile` fallback and a missing `app_components` entry in the engine's `ensure_group_live` doc list.

### What changed
- With five call sites building the same projection, the whole block moved into one `event_group_projection(group_id, group_metadata)` builder: one batched component read plus the admin-policy lookup. `GroupComponentReads` and the four now-dead single-component helpers (`profile_for_group`, `message_retention_for_group`, `agent_text_stream_for_group`, `avatar_url_for_group`) are deleted.
- Inside the builder, batched results zip with `component_ids` into an id-keyed map, so field order can't mis-assign.
- `protocol_profile_of(group_metadata)` replaces the three copies of the Legacy-default fallback.
- `app_components` added to the `ensure_group_live` accessor list in `cgka-engine/AGENTS.md`.

### Impact
The three fixed sites drop from 7 `MlsGroup::loads` per projection to 1, same as `refresh_group`/`add_group`. Net −127 lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Group information is now assembled consistently across group updates, refreshes, additions, and synchronization.
  - Component data retrieval is consolidated while preserving fallback handling for non-critical information.
  - Protocol profile handling is centralized for more consistent group and encrypted-media behavior.
  - Routing errors continue to propagate appropriately, while best-effort synchronization behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->