### PR TITLE
chore(release): prepare 0.9.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-connector"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "agent-control",
  "agent-stream-compose",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "agent-control"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "serde",
  "serde_json",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "agent-stream-compose"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -864,7 +864,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgka-conformance-simulator"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-engine"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-session"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-traits"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "async-trait",
  "criterion",
@@ -1192,7 +1192,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convergence-campaign-runner"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "async-trait",
  "cgka-conformance-simulator",
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "fs-private"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "libc",
  "tempfile",
@@ -2725,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "incident-replay"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "cgka-conformance-simulator",
  "fs-private",
@@ -3322,7 +3322,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-account"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-app"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-c"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "libc",
  "marmot-uniffi",
@@ -3410,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-forensics"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "fs-private",
  "serde",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-markdown"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "serde",
  "serde_json",
@@ -3428,7 +3428,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-terminal-harness"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "agent-control",
  "async-trait",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-uniffi"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "cgka-engine",
  "cgka-traits",
@@ -5668,7 +5668,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-sqlite"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "cgka-traits",
  "fs-private",
@@ -6285,7 +6285,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-adapter"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6305,7 +6305,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-peeler"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6322,7 +6322,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-broker"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "cgka-traits",
  "clap",
@@ -6341,7 +6341,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-stream"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
@@ -7408,7 +7408,7 @@ dependencies = [
 
 [[package]]
 name = "wn-cli"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "agent-stream-compose",
  "cgka-session",
@@ -7442,7 +7442,7 @@ dependencies = [
 
 [[package]]
 name = "wn-codex"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "async-trait",
  "clap",
@@ -7456,7 +7456,7 @@ dependencies = [
 
 [[package]]
 name = "wn-opencode"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "async-trait",
  "clap",
@@ -7471,7 +7471,7 @@ dependencies = [
 
 [[package]]
 name = "wn-pi"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.9.15"
+version = "0.9.16"
 license = "MIT"
 publish = false
 

--- a/crates/cgka-conformance-simulator/vectors/admin-handover.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-handover.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-handover/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "admin-handover/v1",

--- a/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-policy-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "admin-policy-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "concurrent-invite-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "concurrent-invite-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-committer-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "convergence-committer-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-witness-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "convergence-witness-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/conversation.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/conversation.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "conversation/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "conversation/v1",

--- a/crates/cgka-conformance-simulator/vectors/cross-route-own-commit-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/cross-route-own-commit-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "cross-route-own-commit-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "cross-route-own-commit-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "current-profile-required-set/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "application_profile": {
     "name": "current",

--- a/crates/cgka-conformance-simulator/vectors/deferred-tick-catchup.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/deferred-tick-catchup.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "deferred-tick-catchup/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "deferred-tick-catchup/v1",

--- a/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "delayed-past-epoch-app-message/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "delayed-past-epoch-app-message/v1",

--- a/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "drop-queued/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "drop-queued/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "group-data-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "group-data-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-profile-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-profile-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-profile-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "group-profile-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "convergence-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "membership-fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "membership-fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incremental-growth.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incremental-growth.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "incremental-growth/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "incremental-growth/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-member/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "invite-member/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "invite-publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/late-welcome-backfill.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/late-welcome-backfill.v1.json
@@ -1,7 +1,7 @@
 {
  "scenario_name": "late-welcome-backfill/v1",
  "vector_version": "1",
- "conformance_version": "0.9.15",
+ "conformance_version": "0.9.16",
  "seed": null,
  "scenario": {
   "name": "late-welcome-backfill/v1",

--- a/crates/cgka-conformance-simulator/vectors/latecomer-forward-secrecy.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/latecomer-forward-secrecy.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "latecomer-forward-secrecy/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "latecomer-forward-secrecy/v1",

--- a/crates/cgka-conformance-simulator/vectors/leaver-removal-secrecy.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/leaver-removal-secrecy.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "leaver-removal-secrecy/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "leaver-removal-secrecy/v1",

--- a/crates/cgka-conformance-simulator/vectors/multigroup-isolation.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/multigroup-isolation.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "multigroup-isolation/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "multigroup-isolation/v1",

--- a/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "partition-clear-leave/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "partition-clear-leave/v1",

--- a/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "queue-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "queue-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/readd-after-eviction.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/readd-after-eviction.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "readd-after-eviction/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "readd-after-eviction/v1",

--- a/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "restart-delivery-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "restart-delivery-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/route-equivalence.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/route-equivalence.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "route-equivalence/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "route-equivalence/v1",

--- a/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "three-client-message-exchange/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.15",
+  "conformance_version": "0.9.16",
   "seed": null,
   "scenario": {
     "name": "three-client-message-exchange/v1",

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,28 +9,123 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+## [0.9.16] - 2026-09-01
+
+### Added
+
+- The new `marmot-c` track exposes the app runtime through a generated,
+  allocation-audited C ABI, including lifecycle, accounts, groups, messages,
+  media, notifications, push, relays, telemetry, audit logs, timeline reads,
+  Markdown parsing, subscriptions, host-owned secret storage, connectivity
+  recovery, and relay-list reads for arbitrary account ids.
+  ([#1545](https://github.com/marmot-protocol/mdk/pull/1545),
+  [#1575](https://github.com/marmot-protocol/mdk/pull/1575),
+  [#1603](https://github.com/marmot-protocol/mdk/pull/1603),
+  [#1605](https://github.com/marmot-protocol/mdk/pull/1605))
+
+- Apps can send custom chat events with any non-reserved kind and fetch them
+  again by kind. `wn messages send-event <group> <kind> [content]` publishes
+  one, while CLI and MarmotKit list/subscription APIs accept kind filters.
+  Reserved protocol-owned kinds remain rejected.
+  ([#1544](https://github.com/marmot-protocol/mdk/pull/1544))
+
+- WN Agent terminal harnesses add shared chat-management commands, backend
+  artifact delivery through the encrypted media path, and ordered inbound
+  attachment batches for agent turns.
+  ([#1573](https://github.com/marmot-protocol/mdk/pull/1573),
+  [#1574](https://github.com/marmot-protocol/mdk/pull/1574),
+  [#1587](https://github.com/marmot-protocol/mdk/pull/1587))
+
+### Changed
+
+- Account databases advance through schema migrations 52–56 for durable epoch
+  backfill, account delivery recovery, transport reconciliation, stall
+  evidence, and accepted chat-activity ordering. Upgrades are transactional;
+  downgrade is unsupported, so re-upgrade or restore a pre-upgrade backup
+  instead of removing migration rows. Devices upgrading from before `0.9.15`
+  also cross migration 47 and should back up first with at least 3.25 times the
+  account database size free. The 2,048-row release benchmark measured a
+  4,676 ms migration, 4,584 ms gradual promotion, 92 ms maximum 32-row batch,
+  and a 4.01-times peak footprint (3.01 times additional space). See the
+  [storage-format contract](../../docs/marmot-architecture/storage-format-v2.md).
+
+- Audit logging is now privacy-safe by construction: the sensitive-data mode
+  and its runtime configuration were removed, leaving only the redacted audit
+  schema and aggregate diagnostics.
+  ([#1580](https://github.com/marmot-protocol/mdk/pull/1580))
+
+- Group projection and convergence recovery do less repeated work: app
+  components are read with one MLS group load, candidate-branch peel contexts
+  are reused only across matching durable state, and replay guards restore
+  canonical group state without rewriting live message and outbound queues.
+  ([#1563](https://github.com/marmot-protocol/mdk/pull/1563),
+  [#1564](https://github.com/marmot-protocol/mdk/pull/1564),
+  [#1615](https://github.com/marmot-protocol/mdk/pull/1615))
+
+- A disbanded group now emits its host-facing disband event once, with at most
+  one compatibility replay for an older tombstone. Account open still heals
+  terminal projections from the durable guard row without repeating events on
+  every launch.
+  ([#1604](https://github.com/marmot-protocol/mdk/pull/1604))
+
 ### Fixed
 
 - Multi-relay full-history recovery now requires end-of-stored-events from
   every endpoint in the activation's frozen route snapshot. A fast, empty
   relay or repeated unavailability can no longer falsely complete replay and
   clear its durable recovery intent.
-  ([#1578](https://github.com/marmot-protocol/mdk/issues/1578))
+  Recovery also reconciles history below cursor floors and rejects stale EOSE
+  signals from superseded subscription attempts.
+  ([#1578](https://github.com/marmot-protocol/mdk/issues/1578),
+  [#1581](https://github.com/marmot-protocol/mdk/pull/1581),
+  [#1583](https://github.com/marmot-protocol/mdk/pull/1583),
+  [#1584](https://github.com/marmot-protocol/mdk/pull/1584),
+  [#1586](https://github.com/marmot-protocol/mdk/pull/1586),
+  [#1607](https://github.com/marmot-protocol/mdk/pull/1607))
+
+- Capacity-refused or unknown-group ingests remain fetchable instead of being
+  marked seen below the relay cursor. Epoch recovery now persists and resumes
+  bounded work, re-arms only affected groups after fruitless drains, paces
+  failures, and distinguishes contested-fork evidence from ordinary lag.
+  ([#1565](https://github.com/marmot-protocol/mdk/pull/1565),
+  [#1566](https://github.com/marmot-protocol/mdk/pull/1566),
+  [#1569](https://github.com/marmot-protocol/mdk/pull/1569),
+  [#1590](https://github.com/marmot-protocol/mdk/pull/1590),
+  [#1591](https://github.com/marmot-protocol/mdk/pull/1591),
+  [#1593](https://github.com/marmot-protocol/mdk/pull/1593),
+  [#1602](https://github.com/marmot-protocol/mdk/pull/1602))
+
+- Durable outbound messages and invite commits retry their exact signed event
+  and targets after connectivity returns, wake promptly from reconnect
+  backoff, and finalize optimistic timeline rows without duplicate sends.
+  Relay queue overflow, ambiguous publish timeouts, and stale relay sockets now
+  retain enough state for safe recovery.
+  ([#1567](https://github.com/marmot-protocol/mdk/pull/1567),
+  [#1582](https://github.com/marmot-protocol/mdk/pull/1582),
+  [#1588](https://github.com/marmot-protocol/mdk/pull/1588),
+  [#1589](https://github.com/marmot-protocol/mdk/pull/1589),
+  [#1603](https://github.com/marmot-protocol/mdk/pull/1603))
+
+- Invite acceptance now refuses stale invitations after the account has
+  already observed terminal removal from that group.
+  ([#1614](https://github.com/marmot-protocol/mdk/pull/1614))
+
+- Preview mutations, terminal-harness result delivery, and Hermes inbound
+  queue shedding are recoverable without duplicating completed work or
+  permanently suppressing replayable messages.
+  ([#1555](https://github.com/marmot-protocol/mdk/pull/1555),
+  [#1568](https://github.com/marmot-protocol/mdk/pull/1568),
+  [#1571](https://github.com/marmot-protocol/mdk/pull/1571))
+
+- Incident replay detects and classifies rolled-back devices using their
+  current timed epoch instead of understating divergence with a high-water
+  mark.
+  ([#1559](https://github.com/marmot-protocol/mdk/pull/1559))
 
 ## [0.9.15] - 2026-08-25
 
 ### Added
 
-- Apps can send custom chat events with any non-reserved kind and fetch them
-  again by kind. `wn messages send-event <group> <kind> [content]` publishes
-  one (with repeatable `--tag '["name","value"]'` options), while `messages
-  list` and `messages subscribe` take repeatable `--kind` filters. MarmotKit
-  adds `send_custom_event` and a `kinds` filter on `messages` and
-  `subscribe_messages`. Custom kinds materialize as standalone timeline rows
-  with the new `CustomEvent` update trigger; kinds MDK owns (chat, reactions,
-  edits, deletes, agent, group system, push token) are rejected so apps cannot
-  forge protocol events.
-  ([#1544](https://github.com/marmot-protocol/mdk/pull/1544))
 - Local notification projection and UniFFI `NotificationTrigger` now include
   `RemovedFromGroup`, `MadeAdmin`, and `RemovedAsAdmin` for authenticated
   self-affecting membership and admin-role changes. Kind 446 wake delivery
@@ -1869,7 +1964,8 @@ Initial release of the `dm` command-line app, the `dmd` background daemon, and t
 - Local installation docs for `cargo install --path crates/cli --locked --bins`.
 - Homebrew release checklist and namespaced tap packaging path for `marmot-protocol/tap/darkmatter`.
 
-[Unreleased]: https://github.com/marmot-protocol/mdk/compare/v0.9.15...HEAD
+[Unreleased]: https://github.com/marmot-protocol/mdk/compare/v0.9.16...HEAD
+[0.9.16]: https://github.com/marmot-protocol/mdk/compare/v0.9.15...v0.9.16
 [0.9.15]: https://github.com/marmot-protocol/mdk/compare/v0.9.14...v0.9.15
 [0.9.14]: https://github.com/marmot-protocol/mdk/compare/v0.9.13...v0.9.14
 [0.9.13]: https://github.com/marmot-protocol/mdk/compare/v0.9.12...v0.9.13

--- a/crates/marmot-c/CHANGELOG.md
+++ b/crates/marmot-c/CHANGELOG.md
@@ -7,6 +7,8 @@ Versions track the workspace version; releases are tagged `marmotc-v<version>`.
 
 ## [Unreleased]
 
+## [0.9.16] - 2026-09-01
+
 ### Added
 
 - `marmot_notify_connectivity_restored`, allowing C hosts to wake durable
@@ -35,3 +37,6 @@ Versions track the workspace version; releases are tagged `marmotc-v<version>`.
   fetch the NIP-65 and inbox relay lists any account id has published, not
   just a local account's. Both return `MarmotAccountRelayLists`.
   ([#1605](https://github.com/marmot-protocol/mdk/pull/1605))
+
+[Unreleased]: https://github.com/marmot-protocol/mdk/compare/marmotc-v0.9.16...HEAD
+[0.9.16]: https://github.com/marmot-protocol/mdk/releases/tag/marmotc-v0.9.16

--- a/crates/marmot-c/c-bindings.sh
+++ b/crates/marmot-c/c-bindings.sh
@@ -30,7 +30,10 @@ cargo build --release --locked -p "$CRATE_NAME"
 
 # Darwin has no libdl: dlopen lives in libSystem.
 case "$(uname -s)" in
-  Darwin) DYLIB_EXT="dylib"; LIBS_PRIVATE="-lm -lpthread" ;;
+  Darwin)
+    DYLIB_EXT="dylib"
+    LIBS_PRIVATE="-lm -lpthread -framework Security -framework CoreFoundation -liconv"
+    ;;
   *) DYLIB_EXT="so"; LIBS_PRIVATE="-lm -lpthread -ldl" ;;
 esac
 

--- a/crates/marmot-c/c-smoke.sh
+++ b/crates/marmot-c/c-smoke.sh
@@ -27,7 +27,10 @@ CFLAGS=(-std=c11 -Wall -Wextra -Werror -I"$CRATE_DIR/include")
 # Darwin has no libdl (dlopen lives in libSystem) and looks up shared
 # libraries through DYLD_LIBRARY_PATH.
 case "$(uname -s)" in
-  Darwin) STATIC_LIBS=(-lm -pthread); LIB_PATH_VAR="DYLD_LIBRARY_PATH" ;;
+  Darwin)
+    STATIC_LIBS=(-lm -pthread -framework Security -framework CoreFoundation -liconv)
+    LIB_PATH_VAR="DYLD_LIBRARY_PATH"
+    ;;
   *) STATIC_LIBS=(-lm -pthread -ldl); LIB_PATH_VAR="LD_LIBRARY_PATH" ;;
 esac
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -23,7 +23,7 @@ Choose the runtime you already use:
 | Pi | Terminal harness | Repository and coding tasks through Pi |
 
 The guided installers prompt on the terminal for the White Noise account that
-may invite and message the agent. They install release `wn-agent-v0.9.15`, create
+may invite and message the agent. They install release `wn-agent-v0.9.16`, create
 an isolated White Noise identity for the selected connector, and start same-user
 services where supported. Download each installer with its adjacent checksum,
 verify it, and only then execute the local file:
@@ -50,7 +50,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
 ```
 
 ### Hermes
@@ -110,7 +110,7 @@ install_verified "$base_url/install-pi-marmot.sh" \
 
 ### Finish In White Noise
 
-Release 0.9.15 records the new agent's `npub` and `nprofile` in the
+Release 0.9.16 records the new agent's `npub` and `nprofile` in the
 `bootstrap.json` path printed at completion. Display them with:
 
 ```sh

--- a/integrations/codex/marmot/README.md
+++ b/integrations/codex/marmot/README.md
@@ -54,7 +54,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
 install_verified "$base_url/install-codex-marmot.sh" \
   "$base_url/install-codex-marmot.sh.sha256" \
   --yes --allow-welcomer npub1...

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -75,7 +75,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256"
 ```
@@ -92,7 +92,7 @@ repeated or given a comma-separated list to authorize multiple senders:
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256" \
   --yes \
@@ -108,7 +108,7 @@ with `--generate-identity`). To preserve an existing Nostr identity, place its
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256" \
   --yes \
@@ -138,7 +138,7 @@ To accept Marmot messages from any sender (explicit opt-in):
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256" \
   --yes --allow-all-users

--- a/integrations/openclaw/marmot/README.md
+++ b/integrations/openclaw/marmot/README.md
@@ -82,7 +82,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
 install_verified "$base_url/install-openclaw-marmot.sh" \
   "$base_url/install-openclaw-marmot.sh.sha256"
 ```
@@ -102,7 +102,7 @@ an `npub` or raw hex public key:
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
 install_verified "$base_url/install-openclaw-marmot.sh" \
   "$base_url/install-openclaw-marmot.sh.sha256" \
   --yes --allow-welcomer npub1...
@@ -116,7 +116,7 @@ with `--generate-identity`). To preserve an existing Nostr identity, place its
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
 install_verified "$base_url/install-openclaw-marmot.sh" \
   "$base_url/install-openclaw-marmot.sh.sha256" \
   --yes \

--- a/integrations/opencode/marmot/README.md
+++ b/integrations/opencode/marmot/README.md
@@ -56,7 +56,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
 install_verified "$base_url/install-opencode-marmot.sh" \
   "$base_url/install-opencode-marmot.sh.sha256"
 ```
@@ -67,7 +67,7 @@ as either an `npub` or raw hex public key:
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
 install_verified "$base_url/install-opencode-marmot.sh" \
   "$base_url/install-opencode-marmot.sh.sha256" \
   --yes --allow-welcomer npub1...

--- a/integrations/pi/marmot/README.md
+++ b/integrations/pi/marmot/README.md
@@ -48,7 +48,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
 install_verified "$base_url/install-pi-marmot.sh" \
   "$base_url/install-pi-marmot.sh.sha256"
 ```
@@ -58,7 +58,7 @@ For noninteractive setup, provide the allowed inviter and prompt sender:
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
 install_verified "$base_url/install-pi-marmot.sh" \
   "$base_url/install-pi-marmot.sh.sha256" \
   --yes --allow-welcomer npub1...

--- a/release.md
+++ b/release.md
@@ -189,12 +189,13 @@ storage artifact:
    MDK_STORAGE_OPS_ROWS=2048 just bench-storage-upgrade
    ```
 
-   The 2026-08-14 baseline peaked at 4.01 times the starting database footprint
-   and needed 3.01 times that footprint as additional temporary space. Release
-   notes should require at least 3.25 times the account database size free
-   before upgrade, report the newly measured duration, peak footprint, and
-   maximum 32-row batch latency, and explain that the estimate must be refreshed
-   if the format or journal policy changes.
+   The 2026-09-01 baseline used 2,048 rows and peaked at 4.01 times the starting
+   database footprint, needing 3.01 times that footprint as additional
+   temporary space. Migration took 4,676 ms, gradual promotion took 4,584 ms,
+   and the slowest 32-row promotion batch took 92 ms. Release notes should
+   require at least 3.25 times the account database size free before upgrade
+   and explain that the estimate must be refreshed if the format or journal
+   policy changes.
 6. Do not run `VACUUM` during automatic account open. If page reclamation is
    useful, expose it as explicit keyed-connection maintenance and report its
    expected duration and temporary free-space requirement.
@@ -353,7 +354,7 @@ workspace release looks like:
 ```sh
 (
 set -eu
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
 
 install_verified() (
   set -eu

--- a/scripts/install-hermes-marmot.sh
+++ b/scripts/install-hermes-marmot.sh
@@ -118,7 +118,7 @@ Hermes accepts after gateway restart via $HERMES_HOME/.env.
 
 Verified download (then choose one invocation below):
   set -eu
-  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15
+  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16
   tmpdir="$(mktemp -d)"
   trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
   installer_script=install-hermes-marmot.sh

--- a/scripts/install-openclaw-marmot.sh
+++ b/scripts/install-openclaw-marmot.sh
@@ -110,7 +110,7 @@ Environment:
 
 Verified download (then choose one invocation below):
   set -eu
-  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.15
+  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16
   tmpdir="$(mktemp -d)"
   trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
   installer_script=install-openclaw-marmot.sh

--- a/scripts/tests/test_campaign_toolchain.sh
+++ b/scripts/tests/test_campaign_toolchain.sh
@@ -28,47 +28,57 @@ expect_failure() {
     fi
 }
 
+rewrite_file() {
+    local expression="$1"
+    local file="$2"
+    local replacement="${file}.replacement"
+    sed "$expression" "$file" >"$replacement"
+    mv "$replacement" "$file"
+}
+
 cp "$tmp_root/Dockerfile.quic-broker" "$tmp_root/Dockerfile.quic-broker.clean"
-sed -i 's/rust:1\.97\.1-bookworm/rust:1.96.0-bookworm/' "$tmp_root/Dockerfile.quic-broker"
+rewrite_file 's/rust:1\.97\.1-bookworm/rust:1.96.0-bookworm/' "$tmp_root/Dockerfile.quic-broker"
 expect_failure 'quic broker builder uses rust:1.96.0-bookworm; expected rust:1.97.1-bookworm' \
     "$tmp_root/scripts/check_campaign_toolchain.sh"
 
 cp "$tmp_root/Dockerfile.quic-broker.clean" "$tmp_root/Dockerfile.quic-broker"
-sed -i 's/@sha256:[0-9a-f]\{64\} AS builder/ AS builder/' "$tmp_root/Dockerfile.quic-broker"
+rewrite_file 's/@sha256:[0-9a-f]\{64\} AS builder/ AS builder/' "$tmp_root/Dockerfile.quic-broker"
 expect_failure 'quic broker builder must use a digest-pinned rust image' \
     "$tmp_root/scripts/check_campaign_toolchain.sh"
 
 cp "$tmp_root/Dockerfile.quic-broker.clean" "$tmp_root/Dockerfile.quic-broker"
-sed -i '0,/rust:1\.97\.1-bookworm@sha256:[0-9a-f]\{64\} AS builder/s//rust:1.97.1-bookworm@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa AS builder/' \
+rewrite_file 's/^FROM rust:1\.97\.1-bookworm@sha256:[0-9a-f]\{64\} AS builder$/FROM rust:1.97.1-bookworm@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa AS builder/' \
     "$tmp_root/Dockerfile.quic-broker"
 expect_failure 'quic broker builder pin must match the campaign builder pin' \
     "$tmp_root/scripts/check_campaign_toolchain.sh"
 
 cp "$tmp_root/Dockerfile.quic-broker.clean" "$tmp_root/Dockerfile.quic-broker"
-sed -i 's/@sha256:[0-9a-f]\{64\}$/@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/' \
+rewrite_file 's/@sha256:[0-9a-f]\{64\}$/@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/' \
     "$tmp_root/Dockerfile.quic-broker"
 expect_failure 'quic broker runtime pin must match the campaign runtime pin' \
     "$tmp_root/scripts/check_campaign_toolchain.sh"
 
 cp "$tmp_root/Dockerfile.quic-broker.clean" "$tmp_root/Dockerfile.quic-broker"
-sed -i 's/^\(FROM debian:[^@ ]*\)@sha256:[0-9a-f]\{64\}$/\1/' \
+rewrite_file 's/^\(FROM debian:[^@ ]*\)@sha256:[0-9a-f]\{64\}$/\1/' \
     "$tmp_root/Dockerfile.quic-broker"
 expect_failure 'quic broker base images must be digest-pinned' \
     "$tmp_root/scripts/check_campaign_toolchain.sh"
 
 cp "$tmp_root/Dockerfile.quic-broker.clean" "$tmp_root/Dockerfile.quic-broker"
-sed -i '/^COPY integrations \.\/integrations$/d' "$tmp_root/Dockerfile.quic-broker"
+rewrite_file '/^COPY integrations \.\/integrations$/d' "$tmp_root/Dockerfile.quic-broker"
 expect_failure 'quic broker builder is missing required source coverage: COPY integrations ./integrations' \
     "$tmp_root/scripts/check_campaign_toolchain.sh"
 
 cp "$tmp_root/Dockerfile.quic-broker.clean" "$tmp_root/Dockerfile.quic-broker"
-sed -i '/^RUN cargo build/i ENV RUSTUP_TOOLCHAIN=1.97.1-x86_64-unknown-linux-gnu' \
+rewrite_file '/^RUN cargo build/i\
+ENV RUSTUP_TOOLCHAIN=1.97.1-x86_64-unknown-linux-gnu
+' \
     "$tmp_root/Dockerfile.quic-broker"
 expect_failure 'release images must use rust-toolchain.toml instead of a fixed RUSTUP_TOOLCHAIN override' \
     "$tmp_root/scripts/check_campaign_toolchain.sh"
 
 cp "$tmp_root/Dockerfile.quic-broker.clean" "$tmp_root/Dockerfile.quic-broker"
-sed -i '/snapshot\.debian\.org\/archive\/debian\/%s bookworm main/d' \
+rewrite_file '/snapshot\.debian\.org\/archive\/debian\/%s bookworm main/d' \
     "$tmp_root/Dockerfile.quic-broker"
 expect_failure 'quic broker runtime packages must use the dated Debian snapshot' \
     "$tmp_root/scripts/check_campaign_toolchain.sh"


### PR DESCRIPTION
## Summary

- bump the MDK workspace and conformance vectors to 0.9.16
- add the MDK and first Marmot C release notes and refresh WN Agent installer references
- record the current storage-upgrade benchmark
- make the campaign gate portable to BSD sed and include required Darwin frameworks in Marmot C static-link metadata

## Validation

- just fast-ci
- focused storage, conformance, UniFFI, Marmot C, WN Agent and terminal-harness tests
- just tamarin
- just c-smoke
- MarmotKit XCFramework and Kotlin/Android bindings (all four ABIs)
- all five WN Agent installer dry-runs
- MDK_STORAGE_OPS_ROWS=2048 just bench-storage-upgrade
- just release-all-dry-run 0.9.16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Released version 0.9.16 with updated changelogs and release references.
  - Updated installation instructions and verified download examples to use the 0.9.16 agent release.

- **Compatibility**
  - Improved macOS build and linking support for C library consumers.

- **Conformance**
  - Updated protocol conformance scenarios and validation fixtures for version 0.9.16.

- **Documentation**
  - Added migration performance measurements and refreshed installer guidance across supported integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->