### PR TITLE
Add a WASM compilation regression gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,43 @@ jobs:
       - name: Check all features
         run: RUSTFLAGS='-D warnings' cargo check --workspace --all-targets --all-features --locked
 
+  rust-wasm-check:
+    name: Rust WASM check
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        run: |
+          set -euo pipefail
+          toolchain="$(sed -n 's/^channel = "\(.*\)"/\1/p' rust-toolchain.toml)"
+          rustup toolchain install "$toolchain" --profile minimal
+          rustup default "$toolchain"
+          rustup target add wasm32-unknown-unknown
+          rustc --version
+          cargo --version
+          clang --version
+          clang --print-targets | grep wasm32
+
+      - name: Cache Cargo artifacts
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      # Compile-only regression gate. Browser runtime behavior belongs in
+      # downstream headless-browser acceptance tests.
+      - name: Build browser WASM libraries
+        env:
+          CC_wasm32_unknown_unknown: clang
+        run: |
+          cargo build --locked --target wasm32-unknown-unknown \
+            -p cgka-traits \
+            -p cgka-engine \
+            -p transport-nostr-peeler
+
   rust-clippy:
     name: Rust clippy
     needs: changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,6 +907,8 @@ dependencies = [
  "cgka-traits",
  "chacha20poly1305",
  "criterion",
+ "futures",
+ "gloo-timers",
  "hex",
  "insta",
  "k256",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,6 +908,7 @@ dependencies = [
  "chacha20poly1305",
  "criterion",
  "futures",
+ "getrandom 0.4.3",
  "gloo-timers",
  "hex",
  "insta",
@@ -1437,7 +1438,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hybrid-array",
  "rand_core 0.10.1",
 ]
@@ -1960,12 +1961,6 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -2143,16 +2138,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2234,22 +2229,13 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -2260,7 +2246,7 @@ checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -2669,12 +2655,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "id-set"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2756,8 +2736,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -2993,12 +2971,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -3446,7 +3418,7 @@ dependencies = [
  "agent-control",
  "async-trait",
  "fs-private",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "hex",
  "hmac 0.12.1",
  "libc",
@@ -3873,6 +3845,7 @@ name = "openmls"
 version = "0.8.1"
 source = "git+https://github.com/erskingardner/openmls.git?rev=59e7d3b27a7e95237879dd5478de1fd90eff7ada#59e7d3b27a7e95237879dd5478de1fd90eff7ada"
 dependencies = [
+ "getrandom 0.4.3",
  "log",
  "openmls_serialization_helpers",
  "openmls_traits",
@@ -3881,6 +3854,7 @@ dependencies = [
  "serde_bytes",
  "thiserror 2.0.18",
  "tls_codec",
+ "web-time",
  "zeroize",
 ]
 
@@ -4678,7 +4652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.1",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -5818,7 +5792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -6490,12 +6464,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "uniffi"
 version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6677,7 +6645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "atomic",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -6756,16 +6724,7 @@ version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -6824,28 +6783,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6856,18 +6793,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.13.0",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -6887,6 +6812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 
@@ -7349,97 +7275,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.13.0",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "wn-cli"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,6 +928,7 @@ dependencies = [
  "tls_codec",
  "tokio",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
@@ -3425,6 +3426,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "web-time",
 ]
 
 [[package]]
@@ -6348,6 +6350,7 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ openmls_traits = { git = "https://github.com/erskingardner/openmls.git", rev = "
 tls_codec = "~0.5"
 
 # async
-tokio = { version = "1", features = ["sync", "macros", "rt", "rt-multi-thread", "time"] }
+tokio = { version = "1", features = ["sync", "macros", "rt", "time"] }
 tokio-util = { version = "0.7", features = ["io"] }
 async-trait = "0.1"
 futures = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 hex = "0.4"
 getrandom = "0.3"
+web-time = "1.1"
 hmac = "0.12"
 libc = "0.2"
 hkdf = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 hex = "0.4"
-getrandom = "0.3"
+getrandom = "0.4.3"
 web-time = "1.1"
 hmac = "0.12"
 libc = "0.2"

--- a/crates/cgka-engine/Cargo.toml
+++ b/crates/cgka-engine/Cargo.toml
@@ -38,6 +38,7 @@ nostr.workspace = true
 rand.workspace = true
 sha2.workspace = true
 tokio = { workspace = true, features = ["time"] }
+web-time.workspace = true
 # Pure-Rust secp256k1 used only to validate that a Marmot credential identity
 # is a well-formed BIP-340 x-only public key (foundation/identity.md). Already
 # resolved transitively via openmls_rust_crypto -> hpke-rs-rust-crypto -> k256;

--- a/crates/cgka-engine/Cargo.toml
+++ b/crates/cgka-engine/Cargo.toml
@@ -28,6 +28,7 @@ openmls_rust_crypto.workspace = true
 openmls_traits.workspace = true
 tls_codec = { workspace = true, features = ["derive", "std"] }
 async-trait.workspace = true
+futures.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 serde = { workspace = true }
@@ -37,7 +38,6 @@ marmot-forensics.workspace = true
 nostr.workspace = true
 rand.workspace = true
 sha2.workspace = true
-tokio = { workspace = true, features = ["time"] }
 web-time.workspace = true
 # Pure-Rust secp256k1 used only to validate that a Marmot credential identity
 # is a well-formed BIP-340 x-only public key (foundation/identity.md). Already
@@ -45,9 +45,15 @@ web-time.workspace = true
 # enabling the `schnorr` feature here pulls in BIP-340 x-only point validation.
 k256 = { version = "0.13", default-features = false, features = ["schnorr"] }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { workspace = true, features = ["time"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+gloo-timers = { version = "0.3", features = ["futures"] }
+
 [dev-dependencies]
 storage-sqlite = { workspace = true, features = ["storage-format-benchmarks"] }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros"] }
 test-log.workspace = true
 insta.workspace = true
 tempfile.workspace = true
@@ -60,6 +66,9 @@ sha2.workspace = true
 # binding uses, so engine visibility in tests matches production.
 chacha20poly1305.workspace = true
 criterion.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [[bench]]
 name = "group_lifecycle"

--- a/crates/cgka-engine/Cargo.toml
+++ b/crates/cgka-engine/Cargo.toml
@@ -49,7 +49,9 @@ k256 = { version = "0.13", default-features = false, features = ["schnorr"] }
 tokio = { workspace = true, features = ["time"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { workspace = true, features = ["wasm_js"] }
 gloo-timers = { version = "0.3", features = ["futures"] }
+openmls = { workspace = true, features = ["js"] }
 
 [dev-dependencies]
 storage-sqlite = { workspace = true, features = ["storage-format-benchmarks"] }

--- a/crates/cgka-engine/Cargo.toml
+++ b/crates/cgka-engine/Cargo.toml
@@ -28,7 +28,6 @@ openmls_rust_crypto.workspace = true
 openmls_traits.workspace = true
 tls_codec = { workspace = true, features = ["derive", "std"] }
 async-trait.workspace = true
-futures.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 serde = { workspace = true }
@@ -45,13 +44,16 @@ web-time.workspace = true
 # enabling the `schnorr` feature here pulls in BIP-340 x-only point validation.
 k256 = { version = "0.13", default-features = false, features = ["schnorr"] }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dependencies]
 tokio = { workspace = true, features = ["time"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { workspace = true, features = ["wasm_js"] }
-gloo-timers = { version = "0.3", features = ["futures"] }
 openmls = { workspace = true, features = ["js"] }
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+futures.workspace = true
+gloo-timers = { version = "0.3", features = ["futures"] }
 
 [dev-dependencies]
 storage-sqlite = { workspace = true, features = ["storage-format-benchmarks"] }
@@ -68,6 +70,7 @@ sha2.workspace = true
 # binding uses, so engine visibility in tests matches production.
 chacha20poly1305.workspace = true
 criterion.workspace = true
+futures.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/crates/cgka-engine/src/convergence_clock.rs
+++ b/crates/cgka-engine/src/convergence_clock.rs
@@ -7,7 +7,7 @@
 //! their existing clocks.
 
 use std::sync::{Arc, Mutex};
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use web_time::{Instant, SystemTime, UNIX_EPOCH};
 
 /// One paired convergence-clock observation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/cgka-engine/src/deadline.rs
+++ b/crates/cgka-engine/src/deadline.rs
@@ -3,7 +3,7 @@ use std::{future::Future, time::Duration};
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct DeadlineElapsed;
 
-#[cfg(any(target_arch = "wasm32", test))]
+#[cfg(any(test, all(target_arch = "wasm32", target_os = "unknown")))]
 fn browser_timeout_milliseconds(duration: Duration) -> u32 {
     // Browser timers accept integer milliseconds. Round a fractional
     // millisecond up so conversion never expires a nonzero budget early, then
@@ -15,7 +15,7 @@ fn browser_timeout_milliseconds(duration: Duration) -> u32 {
         .min(i32::MAX as u128) as u32
 }
 
-#[cfg(any(target_arch = "wasm32", test))]
+#[cfg(any(test, all(target_arch = "wasm32", target_os = "unknown")))]
 async fn browser_timeout_with_timer<F, T>(
     operation: F,
     timer: T,
@@ -38,7 +38,7 @@ where
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 pub(crate) async fn timeout<F>(duration: Duration, future: F) -> Result<F::Output, DeadlineElapsed>
 where
     F: Future,
@@ -48,7 +48,7 @@ where
         .map_err(|_| DeadlineElapsed)
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) async fn timeout<F>(duration: Duration, future: F) -> Result<F::Output, DeadlineElapsed>
 where
     F: Future,

--- a/crates/cgka-engine/src/deadline.rs
+++ b/crates/cgka-engine/src/deadline.rs
@@ -1,0 +1,153 @@
+use std::{future::Future, time::Duration};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct DeadlineElapsed;
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn browser_timeout_milliseconds(duration: Duration) -> u32 {
+    // Browser timers accept integer milliseconds. Round a fractional
+    // millisecond up so conversion never expires a nonzero budget early, then
+    // stay within the signed delay range used by browser timer implementations.
+    let fractional_millisecond = !duration.subsec_nanos().is_multiple_of(1_000_000);
+    duration
+        .as_millis()
+        .saturating_add(u128::from(fractional_millisecond))
+        .min(i32::MAX as u128) as u32
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+async fn browser_timeout_with_timer<F, T>(
+    operation: F,
+    timer: T,
+) -> Result<F::Output, DeadlineElapsed>
+where
+    F: Future,
+    T: Future<Output = ()>,
+{
+    use futures::{FutureExt, pin_mut, select_biased};
+
+    let operation = operation.fuse();
+    let timer = timer.fuse();
+    pin_mut!(operation, timer);
+
+    // Match Tokio's timeout contract: if both branches are ready on the same
+    // poll, the operation completes instead of being reported as elapsed.
+    select_biased! {
+        output = operation => Ok(output),
+        _ = timer => Err(DeadlineElapsed),
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) async fn timeout<F>(duration: Duration, future: F) -> Result<F::Output, DeadlineElapsed>
+where
+    F: Future,
+{
+    tokio::time::timeout(duration, future)
+        .await
+        .map_err(|_| DeadlineElapsed)
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) async fn timeout<F>(duration: Duration, future: F) -> Result<F::Output, DeadlineElapsed>
+where
+    F: Future,
+{
+    let milliseconds = browser_timeout_milliseconds(duration);
+    let timer = gloo_timers::future::TimeoutFuture::new(milliseconds);
+    browser_timeout_with_timer(future, timer).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        time::Duration,
+    };
+
+    struct DropFlag(Arc<AtomicBool>);
+
+    impl Drop for DropFlag {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn cancels_a_pending_future() {
+        let result = timeout(Duration::from_millis(1), std::future::pending::<()>()).await;
+        assert_eq!(result, Err(DeadlineElapsed));
+    }
+
+    #[tokio::test]
+    async fn returns_a_ready_value() {
+        assert_eq!(timeout(Duration::from_secs(1), async { 7 }).await, Ok(7));
+    }
+
+    #[tokio::test]
+    async fn browser_selection_always_prefers_the_operation_when_both_are_ready() {
+        for _ in 0..64 {
+            assert_eq!(
+                browser_timeout_with_timer(async { 7 }, std::future::ready(())).await,
+                Ok(7)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn browser_selection_drops_the_pending_operation_when_the_timer_wins() {
+        let operation_dropped = Arc::new(AtomicBool::new(false));
+        let dropped = Arc::clone(&operation_dropped);
+        let operation = async move {
+            let _drop_flag = DropFlag(dropped);
+            std::future::pending::<()>().await;
+        };
+
+        assert_eq!(
+            browser_timeout_with_timer(operation, std::future::ready(())).await,
+            Err(DeadlineElapsed)
+        );
+        assert!(
+            operation_dropped.load(Ordering::SeqCst),
+            "the losing operation must be cancelled before timeout returns"
+        );
+    }
+
+    #[test]
+    fn browser_timeout_zero_stays_zero() {
+        assert_eq!(browser_timeout_milliseconds(Duration::ZERO), 0);
+    }
+
+    #[test]
+    fn browser_timeout_nonzero_submillisecond_rounds_up() {
+        assert_eq!(browser_timeout_milliseconds(Duration::from_nanos(1)), 1);
+    }
+
+    #[test]
+    fn browser_timeout_exact_millisecond_stays_exact() {
+        assert_eq!(browser_timeout_milliseconds(Duration::from_millis(1)), 1);
+    }
+
+    #[test]
+    fn browser_timeout_fractional_millisecond_rounds_up() {
+        assert_eq!(
+            browser_timeout_milliseconds(Duration::from_millis(1) + Duration::from_nanos(1)),
+            2
+        );
+    }
+
+    #[test]
+    fn browser_timeout_milliseconds_caps_at_signed_timer_maximum() {
+        let maximum = Duration::from_millis(i32::MAX as u64);
+        let first_out_of_range = maximum + Duration::from_millis(1);
+        assert_eq!(browser_timeout_milliseconds(maximum), i32::MAX as u32);
+        assert_eq!(
+            browser_timeout_milliseconds(first_out_of_range),
+            i32::MAX as u32
+        );
+    }
+}

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -3088,7 +3088,8 @@ impl<S: StorageProvider> Engine<S> {
 // Trait methods stay thin: validate the trait boundary, then delegate to
 // the module that owns the behavior.
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
     async fn ingest(&mut self, msg: TransportMessage) -> Result<IngestOutcome, EngineError> {
         self.ingest_with_audit_context(msg, None).await

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -43,7 +43,7 @@ use rand::RngCore;
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
-use tls_codec::{Deserialize as _, Serialize as _};
+use tls_codec::Serialize as _;
 use web_time::{SystemTime, UNIX_EPOCH};
 
 /// Default ciphersuite. MLS-1.0 mandatory-to-implement; TLS-ish naming.

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -43,8 +43,8 @@ use rand::RngCore;
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
-use tls_codec::Serialize as _;
+use tls_codec::{Deserialize as _, Serialize as _};
+use web_time::{SystemTime, UNIX_EPOCH};
 
 /// Default ciphersuite. MLS-1.0 mandatory-to-implement; TLS-ish naming.
 pub const DEFAULT_CIPHERSUITE: Ciphersuite =

--- a/crates/cgka-engine/src/identity.rs
+++ b/crates/cgka-engine/src/identity.rs
@@ -18,6 +18,7 @@ use openmls::prelude::{
 };
 use openmls_basic_credential::SignatureKeyPair;
 use openmls_traits::types::Ciphersuite;
+use web_time::{SystemTime, UNIX_EPOCH};
 
 /// Bundle of everything needed to sign + identify the local client.
 pub struct Identity {
@@ -102,8 +103,8 @@ impl Identity {
             credential: credential.into(),
             signature_key: signer.public().into(),
         };
-        let created_at = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
+        let created_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
             .map_err(|error| format!("system clock precedes Unix epoch: {error}"))?
             .as_secs();
         let account_identity_proof =

--- a/crates/cgka-engine/src/lib.rs
+++ b/crates/cgka-engine/src/lib.rs
@@ -46,6 +46,7 @@ pub mod conformance_snapshot;
 pub mod convergence;
 pub mod convergence_clock;
 pub(crate) mod convergence_input;
+mod deadline;
 pub mod disband;
 pub mod distributed_convergence;
 pub mod engine;

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -1934,7 +1934,7 @@ impl<S: StorageProvider> Engine<S> {
             attempted += 1;
             let reingest = self.reingest_deferred_peel_row(group_id, &record, sweep);
             let result = if let Some(remaining) = execution.remaining() {
-                match tokio::time::timeout(remaining, reingest).await {
+                match crate::deadline::timeout(remaining, reingest).await {
                     Ok(result) => result,
                     Err(_) => {
                         timed_out = true;

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -37,7 +37,8 @@ use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use web_time::Instant;
 
 pub(crate) const MAX_CONVERGENCE_REPROCESSING_PASSES: usize = 16;
 pub(crate) const SELF_REMOVE_AUTO_COMMIT_JITTER_MIN_MS: u64 = 10;

--- a/crates/cgka-engine/src/message_processor/store.rs
+++ b/crates/cgka-engine/src/message_processor/store.rs
@@ -813,7 +813,8 @@ mod tests {
 
     struct UnreachablePeeler;
 
-    #[async_trait]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     impl TransportPeeler for UnreachablePeeler {
         async fn peel_group_message(
             &self,

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -4586,7 +4586,8 @@ mod candidate_branch_peel_halt_tests {
     /// Transport is not under test here: every message is carried verbatim.
     struct PassthroughPeeler;
 
-    #[async_trait]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     impl TransportPeeler for PassthroughPeeler {
         async fn peel_group_message(
             &self,

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -36,7 +36,7 @@ ratatui-image.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["io-util", "net"] }
+tokio = { workspace = true, features = ["io-util", "net", "rt-multi-thread"] }
 transport-quic-broker.workspace = true
 transport-quic-stream.workspace = true
 unicode-properties.workspace = true

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -4170,7 +4170,7 @@ fn deferred_primary_epoch_backfill_rotates_behind_queued_older_operation() {
 }
 
 /// Run app-runtime integration chains on a stack large enough for debug
-/// OpenMLS group creation. Libtest's default 2 MiB stack is too small once a
+/// OpenMLS group creation. Smaller stacks are insufficient once a
 /// test composes the account worker with maintenance and push lifecycle work.
 fn run_composed_app_runtime_test<F, Fut>(thread_name: &str, body: F)
 where
@@ -4179,7 +4179,7 @@ where
 {
     let test_thread = std::thread::Builder::new()
         .name(thread_name.to_owned())
-        .stack_size(4 * 1024 * 1024)
+        .stack_size(8 * 1024 * 1024)
         .spawn(move || {
             let test_runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()

--- a/crates/marmot-c/Cargo.toml
+++ b/crates/marmot-c/Cargo.toml
@@ -18,7 +18,7 @@ alloc-audit = []
 
 [dependencies]
 marmot-uniffi.workspace = true
-tokio = { workspace = true, features = ["io-util", "net", "time"] }
+tokio = { workspace = true, features = ["io-util", "net", "rt-multi-thread", "time"] }
 libc.workspace = true
 # Holds a host-supplied secret-key hex only as long as the boundary needs it.
 zeroize.workspace = true

--- a/crates/marmot-forensics/Cargo.toml
+++ b/crates/marmot-forensics/Cargo.toml
@@ -9,6 +9,7 @@ publish.workspace = true
 fs-private.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+web-time.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -24,7 +24,7 @@ use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
+use web_time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/traits/src/engine.rs
+++ b/crates/traits/src/engine.rs
@@ -647,7 +647,8 @@ pub struct CreateGroupRequest {
 /// The application-facing contract of the engine.
 ///
 /// Method docs describe legal state transitions and error classes.
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait CgkaEngine: Send + Sync {
     // ── Inbound ─────────────────────────────────────────────────────────────
 

--- a/crates/traits/src/peeler.rs
+++ b/crates/traits/src/peeler.rs
@@ -109,7 +109,8 @@ impl GroupMessageMetadata {
 ///   harness asserts on this where applicable.
 /// - Implementations are `Send + Sync`; the `#[async_trait]` macro handles
 ///   the lifetime gymnastics.
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait TransportPeeler: Send + Sync {
     async fn peel_group_message(
         &self,

--- a/crates/traits/src/transport_adapter.rs
+++ b/crates/traits/src/transport_adapter.rs
@@ -1109,7 +1109,8 @@ impl TransportAdapterError {
 }
 
 /// Account-aware network adapter that moves wrapped transport messages.
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait TransportAdapter: Send + Sync {
     /// Activate inbox and group subscriptions for an account.
     async fn activate_account(

--- a/crates/traits/tests/async_send.rs
+++ b/crates/traits/tests/async_send.rs
@@ -1,0 +1,24 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+use cgka_traits::engine::CgkaEngine;
+use cgka_traits::peeler::TransportPeeler;
+use cgka_traits::transport::TransportMessage;
+use cgka_traits::transport_adapter::TransportAdapter;
+
+fn assert_send<T: Send>(_: T) {}
+
+#[test]
+fn native_async_trait_futures_are_send() {
+    fn assert_trait_futures(
+        engine: &mut dyn CgkaEngine,
+        peeler: &dyn TransportPeeler,
+        adapter: &dyn TransportAdapter,
+        msg: TransportMessage,
+    ) {
+        assert_send(engine.ingest(msg.clone()));
+        assert_send(peeler.peel_welcome(&msg));
+        assert_send(adapter.receive());
+    }
+
+    let _ = assert_trait_futures;
+}

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -891,7 +891,8 @@ impl NostrTransportAdapter {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl TransportAdapter for NostrTransportAdapter {
     async fn activate_account(
         &self,

--- a/crates/transport-nostr-peeler/Cargo.toml
+++ b/crates/transport-nostr-peeler/Cargo.toml
@@ -20,4 +20,7 @@ thiserror.workspace = true
 web-time.workspace = true
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/crates/transport-nostr-peeler/Cargo.toml
+++ b/crates/transport-nostr-peeler/Cargo.toml
@@ -17,6 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
+web-time.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/transport-nostr-peeler/src/event.rs
+++ b/crates/transport-nostr-peeler/src/event.rs
@@ -8,7 +8,7 @@ use nostr::{Event, JsonUtil};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use std::time::{SystemTime, UNIX_EPOCH};
+use web_time::{SystemTime, UNIX_EPOCH};
 
 /// Nostr event shape consumed and produced at the peeler boundary.
 ///

--- a/crates/transport-nostr-peeler/src/peeler.rs
+++ b/crates/transport-nostr-peeler/src/peeler.rs
@@ -20,6 +20,8 @@ use nostr::base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use nostr::{EventBuilder, Keys, Kind, NostrSigner, PublicKey, RelayUrl, Tag, UnsignedEvent};
 use rand::RngCore;
 use std::sync::Arc;
+#[cfg(test)]
+use web_time::{SystemTime, UNIX_EPOCH};
 
 const NONCE_LEN: usize = 12;
 const WELCOME_SIGNER_CONTEXT: &str = "nostr_welcome_signer";
@@ -749,8 +751,8 @@ mod tests {
             HashMap::from([(DEFAULT_EXPORTER_LABEL.to_string(), vec![0x7a; 32])]),
             Some(group_id),
         );
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
 

--- a/crates/transport-nostr-peeler/src/peeler.rs
+++ b/crates/transport-nostr-peeler/src/peeler.rs
@@ -183,7 +183,8 @@ impl Default for NostrMlsPeeler {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl TransportPeeler for NostrMlsPeeler {
     async fn peel_group_message(
         &self,

--- a/crates/transport-quic-broker/Cargo.toml
+++ b/crates/transport-quic-broker/Cargo.toml
@@ -20,7 +20,7 @@ rustls-platform-verifier.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["net", "signal", "sync", "time"] }
+tokio = { workspace = true, features = ["net", "rt-multi-thread", "signal", "sync", "time"] }
 transport-quic-stream.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

- add a dedicated Rust WASM check job to the existing CI workflow
- install wasm32-unknown-unknown and verify the runner Clang WASM backend
- build cgka-traits, cgka-engine, and transport-nostr-peeler with the locked dependency graph
- keep this explicitly compile-only; browser runtime acceptance remains downstream

## Stack status

Draft stacked PR. Depends on:

- #1610
- #1611
- #1612
- #1613

The branch is based on the verified combined portability head. Rebase this PR onto master after those four patches land so the final upstream diff is one CI commit.

## Verification

- cold locked wasm32 build of all three packages
- actionlint v1.7.12
- YAML parser
- full repository fast-ci-equivalent policy, workspace check, Clippy, and convergence pin gates

The WASM job intentionally does not set RUSTFLAGS=-D warnings. Native checks and Clippy continue to enforce warning cleanliness; this job specifically guards target compilation. Browser runtime support is not claimed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WebAssembly support across core engine, transport, and peeler components.
  * Added browser-compatible timing and asynchronous operation support.
  * Added notifications when previously withdrawn group state becomes canonical again.
  * Added batch retrieval of application components.

* **Bug Fixes**
  * Improved timeout handling and cancellation in browser environments.
  * Improved canonicalization efficiency and stale-state processing.

* **Tests**
  * Added WebAssembly compilation checks and timeout edge-case coverage.
  * Added verification of native asynchronous task guarantees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->