### PR TITLE
fix(engine,app,account): announce branch-selection withdrawals once and take them back on re-adoption

### DIFF
--- a/crates/cgka-engine/AGENTS.md
+++ b/crates/cgka-engine/AGENTS.md
@@ -463,6 +463,16 @@ epoch visibility through `support::epoch_sealed_peeler`), plus the `convergence-
   is only half the obligation: the failed inbound apply must also hand the still-retained commit back to stored
   convergence via `schedule_pending_convergence_group`. Otherwise the group parks one epoch behind holding a durable
   commit nothing will ever apply.
+- **A branch-selection withdrawal is provisional, so it is announced once and can be taken back.** A losing commit is
+  parked `ConvergenceDeferred` — still a canonicalization input — precisely so a later pass holding deeper evidence can
+  re-adopt it. Both halves of `distributed_convergence.rs` therefore key on the commit's stored state as it was BEFORE
+  the pass's own disposition persistence ran (`pre_apply_commit_states`, captured outside the apply transaction):
+  `emit_rolled_back_commits` announces `CommitRolledBack` + `GroupStateInvalidated` only for a commit this pass is
+  parking, and `emit_revalidated_commits` emits `GroupStateRevalidated` when an accepted commit entered the pass parked.
+  Reading the state after the apply cannot tell those apart — the persistence has already written `ConvergenceDeferred`
+  for every deferral. The app side must mirror the asymmetry: its tombstone is terminal by default (#1608), and only the
+  explicitly evidenced `GroupStateRevalidated` path clears a `SupersededByBranchSelection` row. Withdrawals under every
+  other reason stay terminal on both sides.
 - **Only `EpochManager` may construct non-`Stable` `EpochState` variants.** This is enforced by visibility — the
   variants' fields are private. Don't add a public constructor for `Recovering` etc. somewhere else.
 - **`EpochManager::set_stable` only overwrites `Stable` and `Recovering`.** Every other state owes its exit to a

--- a/crates/cgka-engine/AGENTS.md
+++ b/crates/cgka-engine/AGENTS.md
@@ -473,6 +473,20 @@ epoch visibility through `support::epoch_sealed_peeler`), plus the `convergence-
   for every deferral. The app side must mirror the asymmetry: its tombstone is terminal by default (#1608), and only the
   explicitly evidenced `GroupStateRevalidated` path clears a `SupersededByBranchSelection` row. Withdrawals under every
   other reason stay terminal on both sides.
+- **Only `NonSelectedEligibleBranch` may drive a withdrawal.** `MissingCandidateParent` is the other commit deferral and
+  it does not mean "branch selection put this commit on the losing side": `handle_commit` also reaches it when the pass
+  selected NO branch at all, which is the case that actually occurs in practice. Withdrawing there would tombstone a
+  device's own applied history on a pass that decided nothing — the same hazard
+  `emit_superseded_processed_commits` guards with its `selected_tip.is_none()` early return.
+- **Announce-once is paid for by derived-state reconciliation, not by a durable event queue.** `events_buf` is
+  in-memory, so a crash between the convergence apply transaction and the app's projection loses an announcement that
+  announce-once will never repeat. The repair is not a queue: a commit's branch-selection tombstone state is fully
+  derivable from `cgka_messages.state`, and engine messages and `app_events` share one account database.
+  `SqliteAccountStorage::diverged_branch_selection_withdrawals` reports the disagreements (`ConvergenceDeferred` with
+  live rows owes a withdrawal; `Processed` with a `SupersededByBranchSelection` tombstone owes a revival) and
+  `AppClient::reconcile_branch_selection_withdrawals` applies them on every account open. Keep that derivation total:
+  if a future change makes a withdrawal mean something the stored disposition cannot express, it needs its own durable
+  evidence rather than a widened event.
 - **Only `EpochManager` may construct non-`Stable` `EpochState` variants.** This is enforced by visibility — the
   variants' fields are private. Don't add a public constructor for `Recovering` etc. somewhere else.
 - **`EpochManager::set_stable` only overwrites `Stable` and `Recovering`.** Every other state owes its exit to a

--- a/crates/cgka-engine/AGENTS.md
+++ b/crates/cgka-engine/AGENTS.md
@@ -487,6 +487,16 @@ epoch visibility through `support::epoch_sealed_peeler`), plus the `convergence-
   `AppClient::reconcile_branch_selection_withdrawals` applies them on every account open. Keep that derivation total:
   if a future change makes a withdrawal mean something the stored disposition cannot express, it needs its own durable
   evidence rather than a widened event.
+
+  The app timeline is not the only consumer that can lose the announcement. `GroupStateInvalidated` also retires the
+  maintenance `DurableGroupEvolution` behind a superseded commit, and that consumer sits *after* the account layer's
+  awaited relay publishes, so the window is network-wide rather than instantaneous.
+  `AccountDeviceRuntime::reconcile_superseded_maintenance_from_state` is the matching derived-state repair, keyed on the
+  same durable field: an evolution whose `signed_message_id` reads `ConvergenceDeferred` (parked) or `EpochInvalidated`
+  (retired) is superseded. Note that the *own-commit* emitter, `emit_superseded_processed_commits`, has always
+  announced once — it durably flips its record to `EpochInvalidated`, so a later pass no longer sees it as previously
+  applied. That half of the hole predates announce-once. Both repairs flip forward only; `GroupStateRevalidated` has no
+  account-layer consumer and neither reconciler un-marks a supersession.
 - **Only `EpochManager` may construct non-`Stable` `EpochState` variants.** This is enforced by visibility — the
   variants' fields are private. Don't add a public constructor for `Recovering` etc. somewhere else.
 - **`EpochManager::set_stable` only overwrites `Stable` and `Recovering`.** Every other state owes its exit to a

--- a/crates/cgka-engine/src/conformance_snapshot.rs
+++ b/crates/cgka-engine/src/conformance_snapshot.rs
@@ -798,6 +798,7 @@ fn event_group_id(event: &cgka_traits::engine::GroupEvent) -> &GroupId {
         | GroupEvent::EpochChanged { group_id, .. }
         | GroupEvent::CommitRolledBack { group_id, .. }
         | GroupEvent::GroupStateInvalidated { group_id, .. }
+        | GroupEvent::GroupStateRevalidated { group_id, .. }
         | GroupEvent::GroupUnrecoverable { group_id }
         | GroupEvent::PendingCommitRecovered { group_id, .. }
         | GroupEvent::GroupHydrationRecovered { group_id, .. } => group_id,

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -21,11 +21,11 @@
 //! our active membership. Outbound intents purged at realization stay purged
 //! — the app re-issues sends against the reopened send gate.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 
 use crate::canonicalization::{
     CanonicalizationError, CanonicalizationPolicy, CanonicalizationResult, CanonicalizationState,
-    ConvergenceStatus, InvalidatedAppMessageReason,
+    ConvergenceStatus, InvalidatedAppMessageReason, MessageKind,
 };
 use crate::convergence_clock::ConvergenceTime;
 use crate::convergence_input::{
@@ -1412,6 +1412,7 @@ impl<S: StorageProvider> Engine<S> {
         } else {
             Vec::new()
         };
+        let pre_apply_commit_states = self.pre_apply_commit_states(&result)?;
         let (observations, application_events) = self.storage.with_transaction(|storage| {
             let observations = apply_openmls_canonicalization_result_with_profile_policy(
                 storage,
@@ -1519,8 +1520,12 @@ impl<S: StorageProvider> Engine<S> {
         self.events_buf.extend(application_events);
         self.emit_invalidated_app_events(group_id, &result)?;
         self.emit_rejected_proposal_convergence_audits(group_id, &result);
-        self.emit_rolled_back_commits(group_id, &result)?;
+        self.emit_rolled_back_commits(group_id, &result, &pre_apply_commit_states)?;
         self.emit_superseded_processed_commits(group_id, &result)?;
+        // Last, so the revival lands on rows the re-adopted commit's own
+        // `GroupStateChanged` re-record has already restored — the ordering
+        // `clear_local_publish_failure` needs for the same reason.
+        self.emit_revalidated_commits(group_id, &result, &pre_apply_commit_states)?;
 
         // A selected branch reached the canonical state (Settled): the run is
         // applied/stable. With no selected branch the pass simply settled with
@@ -1888,6 +1893,52 @@ impl<S: StorageProvider> Engine<S> {
         }
     }
 
+    /// Stored `(state, epoch)` of every commit this pass is about to re-state,
+    /// read BEFORE the apply transaction overwrites it.
+    ///
+    /// `ConvergenceDeferred` has exactly one writer — a pass's own disposition
+    /// persistence — so it is the durable record of "a pass already parked this
+    /// commit". But that persistence runs inside the apply transaction, ahead
+    /// of every event emission, so by the time the withdrawal seam reads the
+    /// row it can no longer tell a commit this pass parked from one an earlier
+    /// pass parked and already announced. The pre-apply snapshot is where that
+    /// answer lives, and being durable state it survives the restart a
+    /// re-adoption days later depends on.
+    ///
+    /// Scoped to commits: proposals and application messages have their own
+    /// disposition seams and never carry a state-notification withdrawal.
+    fn pre_apply_commit_states(
+        &self,
+        result: &CanonicalizationResult,
+    ) -> Result<BTreeMap<String, (MessageState, EpochId)>, OpenMlsProjectionError> {
+        let deferred_commits = result
+            .deferred_messages
+            .iter()
+            .filter(|deferred| deferred.kind == MessageKind::Commit)
+            .map(|deferred| deferred.message_id.as_str());
+        let mut states = BTreeMap::new();
+        for message_id_hex in result
+            .accepted_commits
+            .iter()
+            .map(String::as_str)
+            .chain(deferred_commits)
+        {
+            let message_id = message_id_from_hex(message_id_hex)?;
+            match self.storage.get_message(&message_id) {
+                Ok(record) => {
+                    states.insert(message_id_hex.to_owned(), (record.state, record.epoch));
+                }
+                // No stored row: nothing was ever applied or parked under this
+                // id, so there is neither a withdrawal to suppress nor one to
+                // take back. Any other storage failure propagates — masking a
+                // locked or corrupt backend here would silently re-announce.
+                Err(StorageError::NotFound) => {}
+                Err(e) => return Err(OpenMlsProjectionError::Storage(format!("{e:?}"))),
+            }
+        }
+        Ok(states)
+    }
+
     /// Emit a [`GroupEvent::CommitRolledBack`] for every commit that this
     /// convergence pass deferred because its still-eligible branch lost
     /// selection: a commit that was previously applied through stored
@@ -1902,17 +1953,38 @@ impl<S: StorageProvider> Engine<S> {
     /// attributed to the superseded commit (convergence.md "Applying the
     /// selected branch"). This covers the client's own published-and-confirmed
     /// commit when it loses branch selection.
+    ///
+    /// Announced at most once per parking. A parked commit stays a
+    /// canonicalization input, so every later pass re-states it until it is
+    /// adopted or retired; re-announcing an unchanged withdrawal costs the app
+    /// a storage round trip per pass and makes announcement history unusable as
+    /// evidence of what was actually withdrawn. `pre_apply_states` says which
+    /// side of that line a commit is on — see
+    /// [`Self::emit_revalidated_commits`] for the other end of the lifecycle.
     fn emit_rolled_back_commits(
         &mut self,
         group_id: &GroupId,
         result: &CanonicalizationResult,
+        pre_apply_states: &BTreeMap<String, (MessageState, EpochId)>,
     ) -> Result<(), OpenMlsProjectionError> {
         for deferred in &result.deferred_messages {
-            if deferred.kind != crate::canonicalization::MessageKind::Commit {
+            if deferred.kind != MessageKind::Commit {
                 continue;
             }
+            let pre_apply = pre_apply_states.get(&deferred.message_id).copied();
+            // An earlier pass parked this commit and announced its withdrawal
+            // then. Nothing about that withdrawal changed by parking again.
+            if matches!(pre_apply, Some((MessageState::ConvergenceDeferred, _))) {
+                continue;
+            }
+            // `NonSelectedEligibleBranch` is a losing branch this device could
+            // materialize. A commit deferred for any other reason is merely
+            // unreplayable here — but if this device had already APPLIED it,
+            // its state notifications are live and losing the selected branch
+            // withdraws them just the same.
             if deferred.reason
                 != crate::canonicalization::DeferredMessageReason::NonSelectedEligibleBranch
+                && !matches!(pre_apply, Some((MessageState::Processed, _)))
             {
                 continue;
             }
@@ -1920,16 +1992,11 @@ impl<S: StorageProvider> Engine<S> {
             // The stored record's epoch is the commit's source epoch (the fork
             // it lost). A missing record falls back to the selected branch's
             // fork epoch — the id-matched withdrawal is what conformance
-            // requires; the epoch is presentation metadata. Any other storage
-            // failure propagates: masking a locked/corrupt backend here would
-            // emit a fabricated epoch and hide the failure from the caller.
-            let epoch = match self.storage.get_message(&invalidated_commit_id) {
-                Ok(record) => record.epoch,
-                Err(StorageError::NotFound) => {
-                    EpochId(result.selected_fork_epoch.unwrap_or(result.previous_tip))
-                }
-                Err(e) => return Err(OpenMlsProjectionError::Storage(format!("{e:?}"))),
-            };
+            // requires; the epoch is presentation metadata.
+            let epoch = pre_apply.map_or_else(
+                || EpochId(result.selected_fork_epoch.unwrap_or(result.previous_tip)),
+                |(_, epoch)| epoch,
+            );
             self.events_buf.push_back(GroupEvent::CommitRolledBack {
                 group_id: group_id.clone(),
                 invalidated_commit_id: invalidated_commit_id.clone(),
@@ -1940,6 +2007,48 @@ impl<S: StorageProvider> Engine<S> {
                     epoch,
                     invalidated_commit_id,
                     reason: GroupStateInvalidationReason::SupersededByBranchSelection,
+                });
+        }
+        Ok(())
+    }
+
+    /// Take back the withdrawal announced for a commit branch selection has
+    /// since RE-ADOPTED.
+    ///
+    /// A branch-selection withdrawal is provisional on the engine's side: the
+    /// pass parks the loser `ConvergenceDeferred`, still a canonicalization
+    /// input, precisely so a later pass holding deeper evidence can put it back
+    /// on the selected branch. On the app's side it is terminal — since #1608
+    /// the `app_events` upsert never revives a tombstone, because re-recording
+    /// the same row is not evidence that the withdrawal was reversed. So the
+    /// reversal has to arrive as its own explicit signal, or the re-adopted
+    /// commit's system rows stay dead under a branch decision that no longer
+    /// holds.
+    ///
+    /// An accepted commit whose pre-apply state was `ConvergenceDeferred` is
+    /// exactly that reversal. The signal is deliberately not narrowed further
+    /// to commits a withdrawal was actually announced for: revalidating a
+    /// commit that never had one is a scoped no-op on the app side (nothing
+    /// carries its `origin_commit_id` as a branch-selection tombstone), and
+    /// that is cheaper than a second durable mark that would have to agree with
+    /// this state for the life of the row.
+    fn emit_revalidated_commits(
+        &mut self,
+        group_id: &GroupId,
+        result: &CanonicalizationResult,
+        pre_apply_states: &BTreeMap<String, (MessageState, EpochId)>,
+    ) -> Result<(), OpenMlsProjectionError> {
+        for accepted in &result.accepted_commits {
+            let Some((MessageState::ConvergenceDeferred, epoch)) =
+                pre_apply_states.get(accepted).copied()
+            else {
+                continue;
+            };
+            self.events_buf
+                .push_back(GroupEvent::GroupStateRevalidated {
+                    group_id: group_id.clone(),
+                    epoch,
+                    revalidated_commit_id: message_id_from_hex(accepted)?,
                 });
         }
         Ok(())

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -1977,14 +1977,30 @@ impl<S: StorageProvider> Engine<S> {
             if matches!(pre_apply, Some((MessageState::ConvergenceDeferred, _))) {
                 continue;
             }
-            // `NonSelectedEligibleBranch` is a losing branch this device could
-            // materialize. A commit deferred for any other reason is merely
-            // unreplayable here — but if this device had already APPLIED it,
-            // its state notifications are live and losing the selected branch
-            // withdraws them just the same.
+            // `NonSelectedEligibleBranch` is the only deferral that means
+            // "branch selection put this commit on the losing side", which is
+            // the one thing a withdrawal is entitled to say.
+            //
+            // The other commit deferral, `MissingCandidateParent`, does NOT
+            // mean that, and widening to it — even restricted to commits this
+            // device had already applied — is unsound. `handle_commit` reaches
+            // it either when the commit's branch could not be materialized or
+            // when the pass selected NO branch at all
+            // (`selected_branch_id.is_none()`), and the second case is the one
+            // that actually occurs: nothing superseded the commit, because
+            // nothing was selected. Withdrawing there would tombstone a
+            // device's own applied history on a pass that decided nothing.
+            // `emit_superseded_processed_commits` guards the same hazard
+            // explicitly with its `selected_tip.is_none()` early return.
+            //
+            // A genuinely superseded commit that lands here anyway is not left
+            // standing: the apply persists it `ConvergenceDeferred`, and
+            // `SqliteAccountStorage::diverged_branch_selection_withdrawals`
+            // reconciles any parked commit whose rows are still live on the
+            // next account open, whatever reason parked it. Derived-state
+            // repair covers that residue without a speculative arm here.
             if deferred.reason
                 != crate::canonicalization::DeferredMessageReason::NonSelectedEligibleBranch
-                && !matches!(pre_apply, Some((MessageState::Processed, _)))
             {
                 continue;
             }

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -1979,26 +1979,34 @@ impl<S: StorageProvider> Engine<S> {
             }
             // `NonSelectedEligibleBranch` is the only deferral that means
             // "branch selection put this commit on the losing side", which is
-            // the one thing a withdrawal is entitled to say.
+            // the one thing a withdrawal is entitled to say. On the production
+            // path a stored commit reaches it through
+            // `classify_losing_materialized_candidate_commits`, which early
+            // returns unless a branch was actually selected.
             //
-            // The other commit deferral, `MissingCandidateParent`, does NOT
-            // mean that, and widening to it — even restricted to commits this
-            // device had already applied — is unsound. `handle_commit` reaches
-            // it either when the commit's branch could not be materialized or
-            // when the pass selected NO branch at all
-            // (`selected_branch_id.is_none()`), and the second case is the one
-            // that actually occurs: nothing superseded the commit, because
-            // nothing was selected. Withdrawing there would tombstone a
-            // device's own applied history on a pass that decided nothing.
-            // `emit_superseded_processed_commits` guards the same hazard
-            // explicitly with its `selected_tip.is_none()` early return.
+            // The other commit deferral, `MissingCandidateParent`, cannot mean
+            // that, and the reason is a state invariant rather than a judgement
+            // call. Production emits it from
+            // `append_missing_parent_deferred_commits`, over the stored commits
+            // the candidate-path BFS could not materialize; that set is filtered
+            // by `unresolved_commit_state`, which admits `Sent`, `Created`,
+            // `Retryable`, and `ConvergenceDeferred` and excludes `Processed`.
+            // So a `MissingCandidateParent` deferral can never name a commit
+            // this device previously applied — the commit has no applied
+            // notifications to withdraw, and widening this filter to it would
+            // reach nothing but rows that were never live.
             //
-            // A genuinely superseded commit that lands here anyway is not left
-            // standing: the apply persists it `ConvergenceDeferred`, and
+            // That invariant is what the branch's two state-derived reconcilers
+            // rest on. The only route from `Processed` to `ConvergenceDeferred`
+            // is losing to a *selected* branch, so a parked commit that was once
+            // applied is always a genuine branch-selection withdrawal whatever
+            // the pass recorded as its reason. Reason-agnostic repair is
+            // therefore sound, and it is how the residue is covered:
             // `SqliteAccountStorage::diverged_branch_selection_withdrawals`
-            // reconciles any parked commit whose rows are still live on the
-            // next account open, whatever reason parked it. Derived-state
-            // repair covers that residue without a speculative arm here.
+            // reconciles any parked commit whose rows are still live at the next
+            // account open, and `mark_evolution_superseded`'s state-derived
+            // caller does the same for the maintenance record behind it. Neither
+            // needs a speculative arm here.
             if deferred.reason
                 != crate::canonicalization::DeferredMessageReason::NonSelectedEligibleBranch
             {

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -698,6 +698,16 @@ impl<S: StorageProvider> Engine<S> {
     /// withdrawal seam announces once. The apply transaction already made the
     /// answer durable, and this exposes exactly that field so a consumer can
     /// re-derive it. Exposes no payload bytes and never affects processing.
+    ///
+    /// Ungated by the crate's accessor convention, not by omission: an id-keyed
+    /// read of durable metadata takes no group liveness gate, exactly like
+    /// [`Self::maintenance_obligation`] and [`Self::list_group_evolutions`].
+    /// `ensure_group_live` guards the group-keyed and payload-bearing
+    /// surfaces — [`Self::list_group_evolutions_for_group`],
+    /// [`Self::group_maintenance`], [`Self::own_leaf_hash`] — because those
+    /// answer questions about a group that may be quarantined or disbanded. A
+    /// single row's disposition is not such a question, and gating it would
+    /// break the repair precisely on the groups that need it.
     pub fn stored_message_state(
         &self,
         id: &MessageId,

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -689,6 +689,26 @@ impl<S: StorageProvider> Engine<S> {
         crate::conformance_snapshot::capture_structural_progress_snapshot(self, group_id)
     }
 
+    /// Read the durable disposition of one stored message, or `None` when no
+    /// row exists under that id.
+    ///
+    /// State-derived repair only. Engine events are in-memory, so a crash or an
+    /// error between the convergence apply transaction and the consumer that
+    /// acts on a `GroupStateInvalidated` loses the announcement for good — the
+    /// withdrawal seam announces once. The apply transaction already made the
+    /// answer durable, and this exposes exactly that field so a consumer can
+    /// re-derive it. Exposes no payload bytes and never affects processing.
+    pub fn stored_message_state(
+        &self,
+        id: &MessageId,
+    ) -> Result<Option<cgka_traits::MessageState>, EngineError> {
+        match self.storage.get_message(id) {
+            Ok(record) => Ok(Some(record.state)),
+            Err(cgka_traits::storage::StorageError::NotFound) => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+
     /// Read the durable state of one synthetic scenario input under either its
     /// transport or content-derived id.
     ///

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -4158,6 +4158,56 @@ mod reuse_scope_tests {
 }
 
 #[cfg(test)]
+mod unresolved_commit_state_tests {
+    use super::unresolved_commit_state;
+    use cgka_traits::message::MessageState;
+
+    /// `Processed` staying OUT of this set is load-bearing well past the BFS.
+    ///
+    /// `build_stored_openmls_candidate_paths` filters `unresolved_commit_ids`
+    /// through this predicate, and whatever the BFS then fails to materialize
+    /// becomes a `MissingCandidateParent` deferral in
+    /// `append_missing_parent_deferred_commits`. Excluding `Processed` is what
+    /// makes "a `MissingCandidateParent` deferral never names a previously
+    /// applied commit" true, and therefore what makes losing to a *selected*
+    /// branch the only route from `Processed` to `ConvergenceDeferred`.
+    ///
+    /// Two state-derived reconcilers rest on exactly that. Both treat a parked
+    /// commit as a genuine branch-selection withdrawal without consulting the
+    /// reason that parked it:
+    ///
+    /// - `marmot_app::AppClient::reconcile_branch_selection_withdrawals`, which
+    ///   tombstones the app rows a parked commit synthesized, and
+    /// - `marmot_account::AccountDeviceRuntime::reconcile_superseded_maintenance_from_state`,
+    ///   which retires the `DurableGroupEvolution` behind it and re-arms the
+    ///   self-update obligation it owed.
+    ///
+    /// Widening this set to admit `Processed` would let a pass that selected no
+    /// branch park an applied commit, and both reconcilers would then withdraw
+    /// history nothing superseded. That is the blast radius; this test is the
+    /// tripwire.
+    #[test]
+    fn processed_is_not_an_unresolved_commit_state() {
+        for state in [
+            MessageState::Sent,
+            MessageState::Created,
+            MessageState::Retryable,
+            MessageState::ConvergenceDeferred,
+        ] {
+            assert!(
+                unresolved_commit_state(state),
+                "{state:?} is an unresolved commit input and must stay one"
+            );
+        }
+        assert!(
+            !unresolved_commit_state(MessageState::Processed),
+            "an already-applied commit must never be reported unresolved: two \
+             state-derived reconcilers withdraw history on the strength of it"
+        );
+    }
+}
+
+#[cfg(test)]
 mod checkpoint_prefix_tests {
     use super::checkpoint_realizable_own_commit_prefix;
     use crate::canonicalization::{CanonicalizationResult, ConvergenceStatus};

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -3392,6 +3392,228 @@ async fn committers_losing_rival_is_reconsidered_onto_the_fleets_deeper_branch()
     );
 }
 
+/// RED (defects (a) + (e) on the rollback-announcement seam).
+///
+/// `emit_rolled_back_commits` announces the `CommitRolledBack` +
+/// `GroupStateInvalidated` withdrawal pair for every commit a pass parks
+/// `ConvergenceDeferred` / `NonSelectedEligibleBranch`. That state is
+/// *reconsiderable*, so the same commit can be parked by pass after pass and
+/// can later be RE-ADOPTED onto the selected branch. Neither is handled:
+///
+/// - (a) every pass that re-parks the same commit re-announces the identical
+///   withdrawal pair, so announcement history is not evidence of anything.
+/// - (e) the withdrawal is never taken back. Since #1608 made storage-side
+///   invalidation terminal, the re-adopted commit's kind-1210 rows stay
+///   tombstoned forever.
+///
+/// The scenario walks one commit through park → re-park → re-adoption on a
+/// single device.
+#[tokio::test]
+async fn reparked_and_readopted_commit_announces_once_and_is_revalidated() {
+    // A's identity must sort before the rival's so A's own commit wins the
+    // equal-depth ordering race in every pass below.
+    let first = b"wd-first".as_slice();
+    let second = b"wd-second".as_slice();
+    let (a_id, rival_id) = if pad32(first) < pad32(second) {
+        (first, second)
+    } else {
+        (second, first)
+    };
+    let (mut a, a_storage) = build_client_with_storage(a_id);
+    let mut rival = build_client(rival_id);
+    let mut eve = build_client(b"wd-eve");
+    let mut frank = build_client(b"wd-frank");
+
+    let rival_kp = rival.fresh_key_package().await.unwrap();
+    let (group_id, create) = a
+        .create_group(CreateGroupRequest {
+            name: "withdrawal-lifecycle".into(),
+            description: String::new(),
+            members: vec![rival_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![rival.self_id()],
+        })
+        .await
+        .unwrap();
+    let rival_welcome = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            a.confirm_published(pending).await.unwrap();
+            welcomes.remove(0)
+        }
+        _ => unreachable!(),
+    };
+    rival.join_welcome(rival_welcome).await.unwrap();
+    assert_eq!(a.epoch(&group_id).unwrap().0, 1);
+
+    let route = |msg: TransportMessage| TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..msg
+    };
+    let rename = |name: &str| SendIntent::UpdateGroupData {
+        group_id: group_id.clone(),
+        name: Some(name.to_owned()),
+        description: None,
+    };
+
+    // Rival branch root, authored from epoch 1 and never delivered to A until
+    // after A has committed its own epoch-1 rival.
+    let rival_root = match rival.send(rename("rival-branch")).await.unwrap() {
+        SendResult::GroupEvolution { msg, pending, .. } => {
+            rival.confirm_published(pending).await.unwrap();
+            msg
+        }
+        _ => unreachable!(),
+    };
+    let rival_root_id = MessageId::new(Sha256::digest(&rival_root.payload).to_vec());
+
+    let a_root = match a.send(rename("a-branch")).await.unwrap() {
+        SendResult::GroupEvolution { pending, msg, .. } => {
+            a.confirm_published(pending).await.unwrap();
+            msg
+        }
+        _ => unreachable!(),
+    };
+    let a_key = CommitOrderingKey::from_commit_bytes(
+        EpochId(1),
+        CommitOrderingPriority::Privileged,
+        MemberId::new(pad32(a_id)),
+        &a_root.payload,
+    );
+    let rival_key = CommitOrderingKey::from_commit_bytes(
+        EpochId(1),
+        CommitOrderingPriority::Privileged,
+        MemberId::new(pad32(rival_id)),
+        &rival_root.payload,
+    );
+    assert!(a_key < rival_key, "A must win the equal-depth ordering key");
+
+    // --- Pass 1: A parks the rival root and announces its withdrawal. -------
+    a.ingest(route(rival_root.clone())).await.unwrap();
+    a.converge_stored_openmls_messages_at(&group_id, u64::MAX)
+        .expect("the equal-depth fork settles on A");
+    assert_eq!(
+        a_storage.get_message(&rival_root_id).unwrap().state,
+        MessageState::ConvergenceDeferred
+    );
+    let pass_1 = a.drain_events();
+    assert_eq!(
+        withdrawals_naming(&pass_1, &rival_root_id),
+        1,
+        "pass 1 must announce the parked rival's withdrawal exactly once: {pass_1:?}"
+    );
+
+    // A deepens its own branch to depth 2 so the next pass re-parks the rival
+    // root (equal depth, A still wins the ordering key) instead of adopting it.
+    match a.send(rename("a-branch-2")).await.unwrap() {
+        SendResult::GroupEvolution { pending, .. } => a.confirm_published(pending).await.unwrap(),
+        _ => unreachable!(),
+    };
+    assert_eq!(a.epoch(&group_id).unwrap().0, 3);
+
+    // The rival branch grows two follow-ons; A learns them one at a time.
+    let eve_kp = eve.fresh_key_package().await.unwrap();
+    let follow_on_1 = match rival
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![eve_kp],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::GroupEvolution { msg, pending, .. } => {
+            rival.confirm_published(pending).await.unwrap();
+            msg
+        }
+        _ => unreachable!(),
+    };
+    let frank_kp = frank.fresh_key_package().await.unwrap();
+    let follow_on_2 = match rival
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![frank_kp],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::GroupEvolution { msg, pending, .. } => {
+            rival.confirm_published(pending).await.unwrap();
+            msg
+        }
+        _ => unreachable!(),
+    };
+
+    // --- Pass 2: the rival root is RE-parked. No second announcement. ------
+    a.ingest(route(follow_on_1)).await.unwrap();
+    a.converge_stored_openmls_messages_at(&group_id, u64::MAX)
+        .expect("the equal-depth fork settles again on A");
+    assert_eq!(
+        a_storage.get_message(&rival_root_id).unwrap().state,
+        MessageState::ConvergenceDeferred,
+        "pass 2 must re-park the rival root, not adopt it"
+    );
+    let pass_2 = a.drain_events();
+    assert_eq!(
+        withdrawals_naming(&pass_2, &rival_root_id),
+        0,
+        "(a) a re-parked commit must not re-announce a withdrawal: {pass_2:?}"
+    );
+
+    // --- Pass 3: the rival branch outgrows A's; the parked root is adopted. -
+    a.ingest(route(follow_on_2)).await.unwrap();
+    a.converge_stored_openmls_messages_at(&group_id, u64::MAX)
+        .expect("A reorgs onto the deeper rival branch");
+    assert_eq!(
+        a_storage.get_message(&rival_root_id).unwrap().state,
+        MessageState::Processed,
+        "the parked root must become canonical"
+    );
+    assert_eq!(
+        a_storage.get_group(&group_id).unwrap().name,
+        "rival-branch",
+        "A must surface the adopted branch's group data"
+    );
+    let pass_3 = a.drain_events();
+    assert_eq!(
+        pass_3
+            .iter()
+            .filter(|event| matches!(
+                event,
+                GroupEvent::GroupStateRevalidated { revalidated_commit_id, .. }
+                    if revalidated_commit_id == &rival_root_id
+            ))
+            .count(),
+        1,
+        "(e) re-adopting a withdrawn commit must take its withdrawal back: {pass_3:?}"
+    );
+    assert_eq!(
+        withdrawals_naming(&pass_3, &rival_root_id),
+        0,
+        "an adopted commit must never be named by a withdrawal: {pass_3:?}"
+    );
+}
+
+/// Number of `GroupStateInvalidated` withdrawals in `events` naming `commit_id`.
+fn withdrawals_naming(events: &[GroupEvent], commit_id: &MessageId) -> usize {
+    events
+        .iter()
+        .filter(|event| {
+            matches!(
+                event,
+                GroupEvent::GroupStateInvalidated { invalidated_commit_id, .. }
+                    if invalidated_commit_id == commit_id
+            )
+        })
+        .count()
+}
+
 // --- U4 event fidelity: what a convergence apply tells the app --------------
 //
 // `emit_rolled_back_commits` / `emit_superseded_processed_commits`

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -3392,22 +3392,24 @@ async fn committers_losing_rival_is_reconsidered_onto_the_fleets_deeper_branch()
     );
 }
 
-/// RED (defects (a) + (e) on the rollback-announcement seam).
+/// Pins both halves of the rollback-announcement seam (defects (a) + (e)).
 ///
 /// `emit_rolled_back_commits` announces the `CommitRolledBack` +
 /// `GroupStateInvalidated` withdrawal pair for every commit a pass parks
 /// `ConvergenceDeferred` / `NonSelectedEligibleBranch`. That state is
 /// *reconsiderable*, so the same commit can be parked by pass after pass and
-/// can later be RE-ADOPTED onto the selected branch. Neither is handled:
+/// can later be RE-ADOPTED onto the selected branch. Neither used to be handled:
 ///
-/// - (a) every pass that re-parks the same commit re-announces the identical
-///   withdrawal pair, so announcement history is not evidence of anything.
-/// - (e) the withdrawal is never taken back. Since #1608 made storage-side
-///   invalidation terminal, the re-adopted commit's kind-1210 rows stay
+/// - (a) every pass that re-parked the same commit re-announced the identical
+///   withdrawal pair, so announcement history was not evidence of anything.
+/// - (e) the withdrawal was never taken back. Since #1608 made storage-side
+///   invalidation terminal, the re-adopted commit's kind-1210 rows stayed
 ///   tombstoned forever.
 ///
-/// The scenario walks one commit through park → re-park → re-adoption on a
-/// single device.
+/// Both are fixed, and this test is what holds them fixed: the scenario walks
+/// one commit through park → re-park → re-adoption on a single device, and
+/// asserts one withdrawal across the two parkings plus a revalidation on the
+/// re-adoption.
 #[tokio::test]
 async fn reparked_and_readopted_commit_announces_once_and_is_revalidated() {
     // A's identity must sort before the rival's so A's own commit wins the

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -565,6 +565,15 @@ impl AccountDeviceSession {
         Ok(self.engine.delete_maintenance_obligation(id)?)
     }
 
+    /// Durable disposition of one stored message, for state-derived repair of
+    /// an announcement the engine's in-memory event buffer could not deliver.
+    pub fn stored_message_state(
+        &self,
+        id: &MessageId,
+    ) -> SessionResult<Option<cgka_traits::MessageState>> {
+        Ok(self.engine.stored_message_state(id)?)
+    }
+
     pub fn group_evolutions(&self) -> SessionResult<Vec<DurableGroupEvolution>> {
         Ok(self.engine.list_group_evolutions()?)
     }

--- a/crates/marmot-account/AGENTS.md
+++ b/crates/marmot-account/AGENTS.md
@@ -45,6 +45,12 @@ relay auth, or transport-specific relay discovery.
 - Keep `AccountDeviceSession` as the owner of engine state.
 - Keep CLI account-selection ergonomics and relay-list repair out of this crate; those belong in `wn` and `marmot-app`.
 - Confirm pending work only after the adapter reports enough acknowledgements.
+- Never let a durable maintenance record depend on an engine event alone. Engine events are in-memory, and this layer
+  consumes them *after* awaiting the batch's relay publishes, so the loss window is network-wide. `GroupStateInvalidated`
+  retires a `DurableGroupEvolution`, and `run_due_maintenance` re-derives that same retirement from the commit's stored
+  disposition (`ConvergenceDeferred`/`EpochInvalidated`) so a lost announcement cannot strand it. Both paths go through
+  `mark_evolution_superseded`; keep it the sole writer of `SupersededByConvergence`, and keep the derivation forward-only
+  — nothing here un-marks a supersession on re-adoption.
 - Roll back pending work when publication fails before any external exposure is possible. Once publication intent is durable and a relay may have accepted work, retain the journaled state and retry the exact or replaceable publication instead.
 - Do not log account ids, group ids, relay URLs, message ids, pubkeys, payloads, ciphertext, plaintext, or key material.
 

--- a/crates/marmot-account/AGENTS.md
+++ b/crates/marmot-account/AGENTS.md
@@ -50,7 +50,10 @@ relay auth, or transport-specific relay discovery.
   retires a `DurableGroupEvolution`, and `run_due_maintenance` re-derives that same retirement from the commit's stored
   disposition (`ConvergenceDeferred`/`EpochInvalidated`) so a lost announcement cannot strand it. Both paths go through
   `mark_evolution_superseded`; keep it the sole writer of `SupersededByConvergence`, and keep the derivation forward-only
-  — nothing here un-marks a supersession on re-adoption.
+  — nothing here un-marks a supersession on re-adoption. A supersession never revives a `Failed` obligation: that phase
+  is a terminal verdict (`local_member_removed` is the live one), and re-arming it would send a `SelfUpdate` into a group
+  the device has left, once per tick, uncounted by `MaintenanceRunSummary.failures`. `Complete` is deliberately not
+  guarded — a withdrawn commit un-completing the obligation it satisfied is the PCS re-arm this layer owes.
 - Roll back pending work when publication fails before any external exposure is possible. Once publication intent is durable and a relay may have accepted work, retain the journaled state and retry the exact or replaceable publication instead.
 - Do not log account ids, group ids, relay URLs, message ids, pubkeys, payloads, ciphertext, plaintext, or key material.
 

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -17,18 +17,19 @@ use cgka_traits::engine_state::PendingStateRef;
 use cgka_traits::group::{Group, Member};
 use cgka_traits::ingest::IngestOutcome;
 use cgka_traits::maintenance::{
-    DurableTransportFanout, GroupEvolutionPhase, GroupEvolutionSemantic, GroupMaintenanceStatus,
-    KeyPackageLifecycleState, MaintenanceObligation, MaintenancePhase, MaintenanceTrigger,
-    PeriodicMaintenancePolicy, RetainedKeyPackagePrivateMaterial, SendMaintenanceDisposition,
-    TransportFanoutAttemptState, TransportFanoutTarget,
+    DurableGroupEvolution, DurableTransportFanout, GroupEvolutionPhase, GroupEvolutionSemantic,
+    GroupMaintenanceStatus, KeyPackageLifecycleState, MaintenanceObligation, MaintenancePhase,
+    MaintenanceTrigger, PeriodicMaintenancePolicy, RetainedKeyPackagePrivateMaterial,
+    SendMaintenanceDisposition, TransportFanoutAttemptState, TransportFanoutTarget,
 };
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::{
-    EpochId, FanoutMlsState, FanoutPendingKind, GroupId, MemberId, OutboundApplicationMessage,
-    OutboundFanout, OutboundFanoutOutcome, StorageError, Timestamp, TransportAccountActivation,
-    TransportAdapter, TransportAdapterError, TransportDelivery, TransportEndpoint,
-    TransportEndpointFailure, TransportEndpointFailureKind, TransportEndpointReceipt,
-    TransportGroupSync, TransportPublishReport, TransportPublishRequest, TransportPublishTarget,
+    EpochId, FanoutMlsState, FanoutPendingKind, GroupId, MemberId, MessageState,
+    OutboundApplicationMessage, OutboundFanout, OutboundFanoutOutcome, StorageError, Timestamp,
+    TransportAccountActivation, TransportAdapter, TransportAdapterError, TransportDelivery,
+    TransportEndpoint, TransportEndpointFailure, TransportEndpointFailureKind,
+    TransportEndpointReceipt, TransportGroupSync, TransportPublishReport, TransportPublishRequest,
+    TransportPublishTarget,
 };
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
@@ -1277,6 +1278,11 @@ where
             output.absorb_account_effects(recovered);
         }
         let now = self.wall_clock.now();
+        // Before anything reads an evolution or an obligation: repair the
+        // supersessions whose announcement never reached
+        // `reconcile_superseded_maintenance`. This is the maintenance sweep, so
+        // it is where a stranded evolution would otherwise do its damage.
+        self.reconcile_superseded_maintenance_from_state(now)?;
         // Fanout of an already-acknowledged exact event is publication
         // recovery, not a new preparation, so it continues while paused.
         if self.key_package_has_pending_fanout()?
@@ -2461,46 +2467,114 @@ where
         let now = self.wall_clock.now();
         for (group_id, invalidated_commit_id) in superseded {
             let evolutions = self.session.group_evolutions_for_group(&group_id)?;
-            for mut evolution in evolutions.into_iter().filter(|evolution| {
+            for evolution in evolutions.into_iter().filter(|evolution| {
                 evolution.signed_message_id.as_ref() == Some(&invalidated_commit_id)
                     && evolution.phase != GroupEvolutionPhase::SupersededByConvergence
             }) {
-                evolution.phase = GroupEvolutionPhase::SupersededByConvergence;
-                self.session.put_group_evolution(&evolution)?;
-
-                let GroupEvolutionSemantic::SelfUpdate { obligation_id, .. } = evolution.semantic
-                else {
-                    continue;
-                };
-                let Some(obligation_id) = obligation_id else {
-                    continue;
-                };
-                let Some(mut obligation) = self.session.maintenance_obligation(&obligation_id)?
-                else {
-                    continue;
-                };
-                let selected_branch_rotated_own_leaf = evolution
-                    .own_leaf_before_hash
-                    .as_ref()
-                    .is_some_and(|before| {
-                        self.session
-                            .own_leaf_hash(&group_id)
-                            .is_ok_and(|current| current.as_slice() != before.as_slice())
-                    });
-                if selected_branch_rotated_own_leaf {
-                    self.complete_maintenance_obligation(&mut obligation, now)?;
-                } else {
-                    obligation.phase = MaintenancePhase::Quiet;
-                    obligation.quiet_since = Some(now);
-                    obligation.not_before = None;
-                    obligation.semantic_rearm_count =
-                        obligation.semantic_rearm_count.saturating_add(1);
-                    obligation.last_failure_code = Some("superseded_by_convergence".into());
-                    self.maintenance_quiet_monotonic
-                        .insert(obligation.id.clone(), self.monotonic_clock.elapsed());
-                    self.session.put_maintenance_obligation(&obligation)?;
-                }
+                self.mark_evolution_superseded(evolution, now)?;
             }
+        }
+        Ok(())
+    }
+
+    /// Re-derive a supersession whose `GroupStateInvalidated` announcement was
+    /// never consumed, from the disposition the engine already made durable.
+    ///
+    /// [`Self::reconcile_superseded_maintenance`] is purely event-driven, and
+    /// engine events live in an in-memory buffer. The convergence apply
+    /// transaction persists a superseded commit's disposition, and only *then*
+    /// does this layer publish the pass's outbound work — awaited transport
+    /// round trips, any of which can also return `Err` and abandon the batch —
+    /// before the event reconciler runs. A process death or an error anywhere in
+    /// that window loses the announcement, and both withdrawal emitters announce
+    /// at most once: `emit_rolled_back_commits` skips a commit an earlier pass
+    /// already parked, and `emit_superseded_processed_commits` durably retires
+    /// its record so no later pass sees it as previously applied.
+    ///
+    /// A stranded evolution is not inert. [`Self::run_due_maintenance`] takes
+    /// the first non-superseded `SelfUpdate` evolution behind an obligation: a
+    /// `Confirmed` one completes the obligation outright, so the leaf rotation it
+    /// owed is dropped and the next periodic rotation is rescheduled from a leaf
+    /// that never actually changed; a `Prepared`/`Attempting` one keeps
+    /// republishing the exact commit convergence already withdrew.
+    ///
+    /// Same philosophy as `AppClient::reconcile_branch_selection_withdrawals`,
+    /// and derivable for the same reason: an evolution and its commit's
+    /// disposition live in one account database, so the answer is a total
+    /// function of stored state rather than information this layer can lose.
+    /// `ConvergenceDeferred` (parked off the selected branch) and
+    /// `EpochInvalidated` (terminally retired) are exactly what the two
+    /// withdrawal emitters leave behind; every other state means the commit is
+    /// still live or still in flight, and is left alone.
+    ///
+    /// Flips forward only, exactly as the event path does. Re-adoption has no
+    /// account-layer consumer at all — `GroupStateRevalidated` is not handled
+    /// here — and the event path never un-marks a superseded evolution, so
+    /// neither does this. It is therefore a fixed point: a converged account
+    /// writes nothing, and a flipped evolution is skipped on every later run.
+    fn reconcile_superseded_maintenance_from_state(&mut self, now: Timestamp) -> AccountResult<()> {
+        for evolution in self.session.group_evolutions()? {
+            if evolution.phase == GroupEvolutionPhase::SupersededByConvergence {
+                continue;
+            }
+            let Some(commit_id) = evolution.signed_message_id.clone() else {
+                continue;
+            };
+            if !matches!(
+                self.session.stored_message_state(&commit_id)?,
+                Some(MessageState::ConvergenceDeferred | MessageState::EpochInvalidated)
+            ) {
+                continue;
+            }
+            self.mark_evolution_superseded(evolution, now)?;
+        }
+        Ok(())
+    }
+
+    /// Retire an evolution that branch selection superseded, and settle the
+    /// self-update obligation behind it.
+    ///
+    /// Sole writer of [`GroupEvolutionPhase::SupersededByConvergence`], shared
+    /// by the event-driven and state-derived reconcilers so the two cannot
+    /// disagree about what a supersession does.
+    fn mark_evolution_superseded(
+        &mut self,
+        mut evolution: DurableGroupEvolution,
+        now: Timestamp,
+    ) -> AccountResult<()> {
+        let group_id = evolution.group_id.clone();
+        evolution.phase = GroupEvolutionPhase::SupersededByConvergence;
+        self.session.put_group_evolution(&evolution)?;
+
+        let GroupEvolutionSemantic::SelfUpdate { obligation_id, .. } = evolution.semantic else {
+            return Ok(());
+        };
+        let Some(obligation_id) = obligation_id else {
+            return Ok(());
+        };
+        let Some(mut obligation) = self.session.maintenance_obligation(&obligation_id)? else {
+            return Ok(());
+        };
+        let selected_branch_rotated_own_leaf =
+            evolution
+                .own_leaf_before_hash
+                .as_ref()
+                .is_some_and(|before| {
+                    self.session
+                        .own_leaf_hash(&group_id)
+                        .is_ok_and(|current| current.as_slice() != before.as_slice())
+                });
+        if selected_branch_rotated_own_leaf {
+            self.complete_maintenance_obligation(&mut obligation, now)?;
+        } else {
+            obligation.phase = MaintenancePhase::Quiet;
+            obligation.quiet_since = Some(now);
+            obligation.not_before = None;
+            obligation.semantic_rearm_count = obligation.semantic_rearm_count.saturating_add(1);
+            obligation.last_failure_code = Some("superseded_by_convergence".into());
+            self.maintenance_quiet_monotonic
+                .insert(obligation.id.clone(), self.monotonic_clock.elapsed());
+            self.session.put_maintenance_obligation(&obligation)?;
         }
         Ok(())
     }

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -2555,6 +2555,30 @@ where
         let Some(mut obligation) = self.session.maintenance_obligation(&obligation_id)? else {
             return Ok(());
         };
+        // `Failed` is terminal here, and deliberately `Complete` is not.
+        //
+        // [`Self::reconcile_confirmed_own_leaf_rotations`] fails every live
+        // obligation in a group whose epoch change shows this device is no
+        // longer a member, stamping `local_member_removed`. There is no local
+        // leaf left to rotate, so no self-update can ever satisfy it. The same
+        // fork parks the commits it displaced, so the state-derived reconciler
+        // reaches that obligation with a genuine supersession — and re-arming it
+        // to `Quiet` would put `run_due_maintenance` back on a `SelfUpdate` in a
+        // group the device has left, failing once per tick forever and
+        // invisibly: `MaintenanceRunSummary.failures` counts only obligations
+        // sitting in `Failed`.
+        //
+        // A `Complete` obligation gets no such guard because un-completing it is
+        // the point. A withdrawn commit takes back the very rotation that
+        // completed the obligation behind it, and re-arming there is this
+        // branch's PCS re-arm mechanism, not a bug. Completion by some *other*
+        // rotation is already idempotent through the leaf-hash discriminator
+        // below: that rotation left `own_leaf_hash` different from the
+        // evolution's `own_leaf_before_hash`, so the branch taken is
+        // `complete_maintenance_obligation` again.
+        if obligation.phase == MaintenancePhase::Failed {
+            return Ok(());
+        }
         let selected_branch_rotated_own_leaf =
             evolution
                 .own_leaf_before_hash

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -4111,3 +4111,250 @@ async fn rejected_self_update_publication_rolls_back_instead_of_holding_pending_
         "the rotation the rejected publication owed must end up satisfied"
     );
 }
+
+type SelfUpdateRuntime =
+    AccountDeviceRuntime<RecordingAdapter, StaticTransportRouting, RecordingKeyPackages>;
+
+/// Stage a self-update whose exact commit is durably published-but-unconfirmed:
+/// the obligation sits in `PendingPublication`, the evolution is non-terminal,
+/// and the commit has not merged, so the local leaf still matches the
+/// evolution's `own_leaf_before_hash`.
+async fn staged_self_update_awaiting_publication(
+    database: std::path::PathBuf,
+    key: &SqlCipherKey,
+    adapter: RecordingAdapter,
+    wall: Arc<TestWallClock>,
+    monotonic: Arc<TestMonotonicClock>,
+) -> (SelfUpdateRuntime, GroupId, MessageId) {
+    let mut initial = current_session(database.clone(), key, b"alice");
+    let created = initial
+        .create_group(CreateGroupRequest {
+            name: "crash-lost withdrawal".into(),
+            description: String::new(),
+            members: Vec::new(),
+            required_features: Vec::new(),
+            app_components: Vec::new(),
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id;
+    drop(initial);
+
+    // The publish attempt errors after the bytes crossed the adapter boundary,
+    // so exposure cannot be disproved and the exact event is retained instead of
+    // rolled back. That is what leaves a live, non-terminal evolution behind.
+    adapter.error_next();
+    let mut runtime = AccountDeviceRuntime::new(
+        current_session(database, key, b"alice"),
+        adapter,
+        self_update_routing(&group_id),
+        RecordingKeyPackages::default(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        monotonic.clone(),
+        Arc::new(TestRandom::new(0)),
+    );
+
+    let obligation_id = runtime.schedule_manual_self_update(&group_id).unwrap();
+    runtime.run_due_maintenance().await.unwrap();
+    monotonic.set_millis(60_000);
+    wall.set(wall.now().0.saturating_add(60));
+    runtime.run_due_maintenance().await.unwrap();
+    let jittered = runtime
+        .session()
+        .maintenance_obligation(&obligation_id)
+        .unwrap()
+        .unwrap();
+    wall.set(jittered.not_before.unwrap().0);
+    runtime.run_due_maintenance().await.unwrap();
+    assert_eq!(
+        runtime
+            .session()
+            .maintenance_obligation(&obligation_id)
+            .unwrap()
+            .unwrap()
+            .phase,
+        cgka_traits::MaintenancePhase::PendingPublication
+    );
+    (runtime, group_id, obligation_id)
+}
+
+fn self_update_routing(group_id: &GroupId) -> StaticTransportRouting {
+    StaticTransportRouting::new(vec![TransportEndpoint("wss://inbox.example".into())])
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            vec![TransportEndpoint("wss://group.example".into())],
+        )
+}
+
+fn sole_evolution(
+    runtime: &SelfUpdateRuntime,
+    group_id: &GroupId,
+) -> cgka_traits::maintenance::DurableGroupEvolution {
+    let mut evolutions = runtime
+        .session()
+        .group_evolutions_for_group(group_id)
+        .unwrap();
+    assert_eq!(
+        evolutions.len(),
+        1,
+        "the harness stages exactly one evolution"
+    );
+    evolutions.remove(0)
+}
+
+// A convergence pass commits a superseded commit's disposition inside its apply
+// transaction, and only afterwards does the account layer publish the pass's
+// outbound work and reconcile `GroupStateInvalidated`. Engine events are
+// in-memory, so a crash — or any error — in that window drops the announcement,
+// and announce-once means no later pass repeats it. Without a state-derived
+// repair the evolution stays non-terminal forever and `run_due_maintenance`
+// keeps acting on a commit convergence already withdrew.
+#[tokio::test]
+async fn maintenance_supersedes_an_evolution_whose_withdrawal_announcement_was_lost() {
+    use cgka_traits::MessageStorage;
+    use cgka_traits::maintenance::GroupEvolutionPhase;
+    use storage_sqlite::SqliteAccountStorage;
+
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot crash-lost withdrawal key").unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let adapter = RecordingAdapter::default();
+    let wall = Arc::new(TestWallClock::new(120_000));
+    let monotonic = Arc::new(TestMonotonicClock::default());
+    let (runtime, group_id, obligation_id) = staged_self_update_awaiting_publication(
+        database.clone(),
+        &key,
+        adapter.clone(),
+        wall.clone(),
+        monotonic.clone(),
+    )
+    .await;
+
+    let evolution = sole_evolution(&runtime, &group_id);
+    assert_ne!(
+        evolution.phase,
+        GroupEvolutionPhase::SupersededByConvergence
+    );
+    let commit_id = evolution.signed_message_id.clone().unwrap();
+    drop(runtime);
+
+    // The pass's apply transaction parked the commit off the selected branch and
+    // committed. The `GroupStateInvalidated` it emitted was never consumed.
+    {
+        let storage = SqliteAccountStorage::open_encrypted(&database, &key).unwrap();
+        storage
+            .update_message_state(&commit_id, cgka_traits::MessageState::ConvergenceDeferred)
+            .unwrap();
+    }
+
+    let mut runtime = AccountDeviceRuntime::new(
+        current_session(database, &key, b"alice"),
+        adapter.clone(),
+        self_update_routing(&group_id),
+        RecordingKeyPackages::default(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(0)),
+    );
+
+    runtime.run_due_maintenance().await.unwrap();
+
+    assert_eq!(
+        sole_evolution(&runtime, &group_id).phase,
+        GroupEvolutionPhase::SupersededByConvergence,
+        "a maintenance run must re-derive the supersession from the stored disposition"
+    );
+    let rearmed = runtime
+        .session()
+        .maintenance_obligation(&obligation_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        rearmed.phase,
+        cgka_traits::MaintenancePhase::Quiet,
+        "the rotation the withdrawn commit owed must be re-armed, not left pending on it"
+    );
+    assert_eq!(rearmed.semantic_rearm_count, 1);
+    assert_eq!(
+        rearmed.last_failure_code.as_deref(),
+        Some("superseded_by_convergence"),
+        "the repair must settle the obligation exactly as the event path does"
+    );
+
+    // Fixed point: a second run has nothing left to disagree about.
+    let publishes_before = adapter.publishes().len();
+    runtime.run_due_maintenance().await.unwrap();
+    assert_eq!(
+        sole_evolution(&runtime, &group_id).phase,
+        GroupEvolutionPhase::SupersededByConvergence
+    );
+    let settled = runtime
+        .session()
+        .maintenance_obligation(&obligation_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        settled.semantic_rearm_count, 1,
+        "re-running the repair must not re-arm an obligation it already settled"
+    );
+    assert_eq!(settled.phase, cgka_traits::MaintenancePhase::Quiet);
+    assert_eq!(
+        adapter.publishes().len(),
+        publishes_before,
+        "a withdrawn commit must not be republished by the obligation behind it"
+    );
+}
+
+// The mirror case, and the one that keeps the repair from being a blanket
+// retirement: a commit whose stored disposition is not a withdrawal is still on
+// the selected branch (or still in flight), so its evolution must be left alone
+// and its obligation must keep driving the exact-event retry.
+#[tokio::test]
+async fn maintenance_leaves_an_evolution_alone_while_its_commit_is_still_live() {
+    use cgka_traits::maintenance::GroupEvolutionPhase;
+
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot live commit evolution key").unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let adapter = RecordingAdapter::default();
+    let wall = Arc::new(TestWallClock::new(120_000));
+    let monotonic = Arc::new(TestMonotonicClock::default());
+    let (mut runtime, group_id, obligation_id) = staged_self_update_awaiting_publication(
+        database,
+        &key,
+        adapter.clone(),
+        wall.clone(),
+        monotonic.clone(),
+    )
+    .await;
+
+    let before = sole_evolution(&runtime, &group_id);
+    assert_ne!(before.phase, GroupEvolutionPhase::SupersededByConvergence);
+
+    // No convergence pass withdrew anything, so the durable disposition still
+    // says the commit is live and the retry past the backoff lands it.
+    wall.set(wall.now().0.saturating_add(30));
+    runtime.run_due_maintenance().await.unwrap();
+
+    assert_eq!(
+        sole_evolution(&runtime, &group_id).phase,
+        GroupEvolutionPhase::Confirmed,
+        "a live commit's evolution must reach Confirmed, not be retired by the state-derived sweep"
+    );
+    assert_eq!(
+        runtime
+            .session()
+            .maintenance_obligation(&obligation_id)
+            .unwrap()
+            .unwrap()
+            .semantic_rearm_count,
+        0,
+        "nothing superseded this obligation, so it must not be re-armed"
+    );
+}

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -4213,6 +4213,17 @@ fn sole_evolution(
 // and announce-once means no later pass repeats it. Without a state-derived
 // repair the evolution stays non-terminal forever and `run_due_maintenance`
 // keeps acting on a commit convergence already withdrew.
+//
+// The headline shape, and the costliest one. The publish acknowledgement already
+// promoted this evolution to `Confirmed` and merged its commit `Processed`, so
+// the obligation behind it is one `run_due_maintenance` away from completing
+// outright. Convergence then parks that commit off the selected branch and rolls
+// this device back onto the branch that won, which did not touch its leaf: after
+// the rollback `own_leaf_hash` reads exactly the evolution's
+// `own_leaf_before_hash` again, the same relation the staged harness holds
+// pre-merge. Lose the announcement there and the obligation completes off a
+// rotation convergence took back, dropping the leaf rotation it owed and
+// rescheduling `next_periodic_rotation_at` from a leaf that never changed.
 #[tokio::test]
 async fn maintenance_supersedes_an_evolution_whose_withdrawal_announcement_was_lost() {
     use cgka_traits::MessageStorage;
@@ -4234,12 +4245,23 @@ async fn maintenance_supersedes_an_evolution_whose_withdrawal_announcement_was_l
     )
     .await;
 
-    let evolution = sole_evolution(&runtime, &group_id);
+    let mut evolution = sole_evolution(&runtime, &group_id);
     assert_ne!(
         evolution.phase,
         GroupEvolutionPhase::SupersededByConvergence
     );
     let commit_id = evolution.signed_message_id.clone().unwrap();
+    // The publish acknowledgement that promotes the evolution is durable; the
+    // obligation loop that would have settled the obligation behind it is not.
+    // That is the record pair a process death between the two leaves.
+    evolution.phase = GroupEvolutionPhase::Confirmed;
+    runtime.session().put_group_evolution(&evolution).unwrap();
+    assert_eq!(
+        runtime.session().own_leaf_hash(&group_id).unwrap(),
+        evolution.own_leaf_before_hash.clone().unwrap(),
+        "the rollback onto the winning branch leaves this device's leaf exactly \
+         where the evolution found it, so nothing satisfied the rotation"
+    );
     drop(runtime);
 
     // The pass's apply transaction parked the commit off the selected branch and
@@ -4275,10 +4297,15 @@ async fn maintenance_supersedes_an_evolution_whose_withdrawal_announcement_was_l
         .maintenance_obligation(&obligation_id)
         .unwrap()
         .unwrap();
+    assert_ne!(
+        rearmed.phase,
+        cgka_traits::MaintenancePhase::Complete,
+        "the obligation must not complete off a rotation convergence took back"
+    );
     assert_eq!(
         rearmed.phase,
         cgka_traits::MaintenancePhase::Quiet,
-        "the rotation the withdrawn commit owed must be re-armed, not left pending on it"
+        "the rotation the withdrawn commit owed must be re-armed, not settled by it"
     );
     assert_eq!(rearmed.semantic_rearm_count, 1);
     assert_eq!(
@@ -4356,5 +4383,210 @@ async fn maintenance_leaves_an_evolution_alone_while_its_commit_is_still_live() 
             .semantic_rearm_count,
         0,
         "nothing superseded this obligation, so it must not be re-armed"
+    );
+}
+
+// The other `run_due_maintenance` hazard behind the same repair: an evolution
+// still in flight, whose obligation would otherwise keep republishing the exact
+// commit convergence withdrew.
+//
+// The storage pairing staged here is synthetic, and says so: an `Attempting`
+// evolution whose commit is still `Sent`. A real pass cannot park a `Sent` own
+// commit — that state means a publish is outstanding, and a convergence pass
+// only opens while the epoch is stable — so production reaches this arm one
+// publish resolution later, with a `Prepared`/`Attempting` evolution whose
+// commit has since been parked. What the case pins is the code path, not the
+// pairing: the repair keys on the stored disposition alone, so an in-flight
+// evolution is retired and its obligation re-armed exactly as a confirmed one
+// is, and the commit is not republished.
+#[tokio::test]
+async fn maintenance_supersedes_an_in_flight_evolution_whose_commit_reads_parked() {
+    use cgka_traits::MessageStorage;
+    use cgka_traits::maintenance::GroupEvolutionPhase;
+    use storage_sqlite::SqliteAccountStorage;
+
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot in-flight withdrawal key").unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let adapter = RecordingAdapter::default();
+    let wall = Arc::new(TestWallClock::new(120_000));
+    let monotonic = Arc::new(TestMonotonicClock::default());
+    let (runtime, group_id, obligation_id) = staged_self_update_awaiting_publication(
+        database.clone(),
+        &key,
+        adapter.clone(),
+        wall.clone(),
+        monotonic.clone(),
+    )
+    .await;
+
+    let evolution = sole_evolution(&runtime, &group_id);
+    assert_ne!(
+        evolution.phase,
+        GroupEvolutionPhase::SupersededByConvergence
+    );
+    let commit_id = evolution.signed_message_id.clone().unwrap();
+    drop(runtime);
+
+    {
+        let storage = SqliteAccountStorage::open_encrypted(&database, &key).unwrap();
+        storage
+            .update_message_state(&commit_id, cgka_traits::MessageState::ConvergenceDeferred)
+            .unwrap();
+    }
+
+    let mut runtime = AccountDeviceRuntime::new(
+        current_session(database, &key, b"alice"),
+        adapter.clone(),
+        self_update_routing(&group_id),
+        RecordingKeyPackages::default(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(0)),
+    );
+
+    let publishes_before = adapter.publishes().len();
+    runtime.run_due_maintenance().await.unwrap();
+
+    assert_eq!(
+        sole_evolution(&runtime, &group_id).phase,
+        GroupEvolutionPhase::SupersededByConvergence,
+        "an in-flight evolution behind a parked commit must be retired too"
+    );
+    let rearmed = runtime
+        .session()
+        .maintenance_obligation(&obligation_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(rearmed.phase, cgka_traits::MaintenancePhase::Quiet);
+    assert_eq!(rearmed.semantic_rearm_count, 1);
+    assert_eq!(
+        adapter.publishes().len(),
+        publishes_before,
+        "the withdrawn commit must not be republished by the obligation behind it"
+    );
+}
+
+// `reconcile_confirmed_own_leaf_rotations` fails every live obligation in a
+// group whose epoch change shows this device is no longer a member, stamping
+// `local_member_removed`. That verdict is terminal by construction: there is no
+// local leaf left to rotate, so no self-update can ever satisfy the obligation.
+//
+// The evolution behind it is still non-terminal, and its commit can perfectly
+// well read `ConvergenceDeferred` — the fork that removed this device is exactly
+// the kind of adjudication that parks its commits. So the state-derived sweep
+// reaches the same obligation, and without a terminal guard
+// `mark_evolution_superseded` flips it `Failed` -> `Quiet`. `run_due_maintenance`
+// then attempts a `SelfUpdate` in a group this device has left, once per tick
+// forever — and invisibly, because `MaintenanceRunSummary.failures` counts only
+// obligations sitting in `Failed`.
+#[tokio::test]
+async fn maintenance_supersession_leaves_a_failed_obligation_terminal() {
+    use cgka_traits::MessageStorage;
+    use cgka_traits::maintenance::GroupEvolutionPhase;
+    use storage_sqlite::SqliteAccountStorage;
+
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot failed obligation key").unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let adapter = RecordingAdapter::default();
+    let wall = Arc::new(TestWallClock::new(120_000));
+    let monotonic = Arc::new(TestMonotonicClock::default());
+    let (runtime, group_id, obligation_id) = staged_self_update_awaiting_publication(
+        database.clone(),
+        &key,
+        adapter.clone(),
+        wall.clone(),
+        monotonic.clone(),
+    )
+    .await;
+
+    let evolution = sole_evolution(&runtime, &group_id);
+    assert_ne!(
+        evolution.phase,
+        GroupEvolutionPhase::SupersededByConvergence
+    );
+    let commit_id = evolution.signed_message_id.clone().unwrap();
+
+    // The fork removed this device, so the leaf-rotation reconciler failed the
+    // obligation terminally.
+    let mut failed = runtime
+        .session()
+        .maintenance_obligation(&obligation_id)
+        .unwrap()
+        .unwrap();
+    failed.phase = cgka_traits::MaintenancePhase::Failed;
+    failed.last_failure_code = Some("local_member_removed".into());
+    runtime
+        .session()
+        .put_maintenance_obligation(&failed)
+        .unwrap();
+    drop(runtime);
+
+    // ... and the same pass parked the commit behind it, with the
+    // `GroupStateInvalidated` never consumed.
+    {
+        let storage = SqliteAccountStorage::open_encrypted(&database, &key).unwrap();
+        storage
+            .update_message_state(&commit_id, cgka_traits::MessageState::ConvergenceDeferred)
+            .unwrap();
+    }
+
+    let mut runtime = AccountDeviceRuntime::new(
+        current_session(database, &key, b"alice"),
+        adapter.clone(),
+        self_update_routing(&group_id),
+        RecordingKeyPackages::default(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(0)),
+    );
+
+    let publishes_before = adapter.publishes().len();
+    runtime.run_due_maintenance().await.unwrap();
+
+    assert_eq!(
+        sole_evolution(&runtime, &group_id).phase,
+        GroupEvolutionPhase::SupersededByConvergence,
+        "the evolution is still retired: the commit behind it really was withdrawn"
+    );
+    let settled = runtime
+        .session()
+        .maintenance_obligation(&obligation_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        settled.phase,
+        cgka_traits::MaintenancePhase::Failed,
+        "a terminally failed obligation must not be re-armed by a supersession"
+    );
+    assert_eq!(
+        settled.last_failure_code.as_deref(),
+        Some("local_member_removed"),
+        "the terminal verdict must keep naming why it is terminal"
+    );
+    assert_eq!(
+        settled.semantic_rearm_count, 0,
+        "nothing re-armed, so nothing counted a semantic re-arm"
+    );
+
+    runtime.run_due_maintenance().await.unwrap();
+    assert_eq!(
+        runtime
+            .session()
+            .maintenance_obligation(&obligation_id)
+            .unwrap()
+            .unwrap()
+            .phase,
+        cgka_traits::MaintenancePhase::Failed
+    );
+    assert_eq!(
+        adapter.publishes().len(),
+        publishes_before,
+        "no self-update may be attempted in a group this device has left"
     );
 }

--- a/crates/marmot-app/src/client/epoch_stall.rs
+++ b/crates/marmot-app/src/client/epoch_stall.rs
@@ -493,11 +493,14 @@ impl GroupStall {
     /// mark to pace against, wedging [`Self::may_rearm_wedged`] shut for good on
     /// a group whose epoch never moves again — the exact failure the paced
     /// re-arm exists to prevent. Dropping the frozen-epoch evidence would hand a
-    /// recurring reorg the power to silence the wedge report, and reorgs do
-    /// recur: a losing commit is parked rather than consumed, so stored
-    /// convergence re-derives and re-announces the same withdrawal on every pass
-    /// it runs, and one unresolved fork plus ordinary member traffic produces a
-    /// reorg per pass indefinitely.
+    /// recurring reorg the power to silence the wedge report, and reorgs still
+    /// recur under announce-once. A withdrawal now arrives once per *parking*
+    /// rather than once per pass, so recurrence is bounded by genuinely new
+    /// adjudications instead of by pass count — but an unresolved fork keeps
+    /// attracting rival commits, and each fresh one this device parks is a new
+    /// adjudication that reaches this seam. Bounded recurrence is still
+    /// recurrence, and it is more than enough to keep clearing the evidence, so
+    /// the frozen-epoch retention argument is unchanged.
     fn end_arm_run_keeping_epoch_evidence(&mut self) {
         self.arms = 0;
         self.escalated = false;

--- a/crates/marmot-app/src/client/epoch_stall.rs
+++ b/crates/marmot-app/src/client/epoch_stall.rs
@@ -897,9 +897,25 @@ impl EpochStallDetector {
     /// The caller passes the group off the engine's own
     /// [`GroupEvent::GroupStateInvalidated`] withdrawal, once per superseded
     /// commit. Ending an already-ended arm run is a no-op, so a pass that
-    /// withdraws several commits decides as one that withdrew one — and so does
-    /// the *next* pass re-announcing the same withdrawal, which is the ordinary
-    /// case for a fork that has not resolved.
+    /// withdraws several commits decides as one that withdrew one.
+    ///
+    /// **A withdrawal now arrives once per parking, not once per pass.** The
+    /// engine announces a branch-selection withdrawal only on the transition
+    /// into `ConvergenceDeferred`; a later pass that re-parks the same commit
+    /// stays silent (`distributed_convergence::emit_rolled_back_commits`).
+    /// This used to read the other way — every pass re-announced, so an
+    /// unresolved fork fed this seam continuously and kept resetting the run
+    /// for as long as it stayed unresolved.
+    ///
+    /// The consequence is deliberate and observable: a *contested* group that
+    /// makes no epoch progress is no longer held below the escalation threshold
+    /// by the repeat. Its arms now accumulate like any other stall, so a fork
+    /// that parks a commit once and then wedges can reach
+    /// [`Self::escalation_arm_threshold`] and escalate to backfill. Only a
+    /// genuinely *new* adjudication — a fresh parking or a re-adoption — resets
+    /// the run now. `stalled_contested_group_escalates_after_announce_once`
+    /// pins that behavior; this note is a description of what the seam does,
+    /// not an argument that the threshold is tuned correctly for it.
     ///
     /// `get_mut` like [`Self::observe_epoch_passage`]: a reorg is evidence
     /// about a stall run, never the start of one, so a group with no stall
@@ -1766,9 +1782,12 @@ mod tests {
     /// resolves still escalates, off the relays' own verdict.
     ///
     /// Reorgs are not rare punctuation on a forked group — they recur. A losing
-    /// commit is parked rather than consumed, so every convergence pass
-    /// re-derives and re-announces the same withdrawal, and ordinary member
-    /// traffic is enough to run a pass per round indefinitely. If a reorg reset
+    /// commit is parked rather than consumed, so an unsettled fork keeps
+    /// producing fresh adjudications round after round: each pass can park a
+    /// *newly arrived* rival, and ordinary member traffic is enough to run a
+    /// pass per round indefinitely. (Re-parking the *same* commit is silent
+    /// since announce-once, so the repetition here is new parkings, not a
+    /// re-announcement of one.) If a reorg reset
     /// the frozen-epoch evidence along with the arm run, the count below would
     /// return to zero every round and this group — wedged at one epoch, relays
     /// confirming round after round that they hold nothing that moves it —
@@ -1797,8 +1816,8 @@ mod tests {
             // The relays serve the account's stored history in full and it
             // recovers nothing.
             reports.extend(detector.observe_fruitless_completion([&g]));
-            // And the unresolved fork is re-adjudicated, announcing the same
-            // withdrawal again.
+            // And the unresolved fork is re-adjudicated, parking another
+            // newly arrived rival.
             detector.observe_convergence_reorg(&g);
         }
 
@@ -1811,12 +1830,12 @@ mod tests {
         assert_eq!(reports[0].stalled_epoch, 10);
     }
 
-    /// Re-announcement is the ordinary case, not an edge one, so it must cost
-    /// the evidence nothing. The engine has no idempotence guard on the
-    /// withdrawal it derives from a parked losing commit; every pass emits the
-    /// same pair again.
+    /// A burst of withdrawal signals must cost the frozen-epoch evidence
+    /// nothing. One pass can park several commits and announce one withdrawal
+    /// each, and successive passes keep parking newly arrived rivals, so this
+    /// seam sees runs of reorg observations as the ordinary case.
     #[test]
-    fn re_announcing_the_same_withdrawal_does_not_reset_the_frozen_epoch_evidence() {
+    fn repeated_reorg_signals_do_not_reset_the_frozen_epoch_evidence() {
         let mut detector = EpochStallDetector::new(1, 3).with_fruitless_completion_threshold(3);
         let g = group(0x01);
 
@@ -1835,9 +1854,84 @@ mod tests {
         assert_eq!(
             reports.len(),
             1,
-            "ten re-announcements of one withdrawal must not spend the two completions already banked",
+            "ten withdrawal signals must not spend the two completions already banked",
         );
         assert_eq!(reports[0].completions, 3);
+    }
+
+    /// Announce-once made this seam quieter, and the escalation path felt it.
+    ///
+    /// A branch-selection withdrawal now arrives once per *parking*, not once
+    /// per pass: `emit_rolled_back_commits` skips a commit an earlier pass
+    /// already parked. Before that, a group whose fork never resolved fed a
+    /// withdrawal into `observe_convergence_reorg` on every pass, and each one
+    /// reset the arm run — so a contested group that also stopped making epoch
+    /// progress could be held below the escalation threshold indefinitely by
+    /// the repetition alone.
+    ///
+    /// Now the parking speaks once and then goes quiet, so a group that wedges
+    /// *after* being adjudicated accumulates arms like any other stall and
+    /// escalates. This test pins that outcome. It is deliberately a description
+    /// of current behavior, not a claim that escalating this group is the right
+    /// recovery — the arm threshold's tuning for contested groups is a separate
+    /// question from whether the signal reaches it.
+    #[test]
+    fn stalled_contested_group_escalates_after_announce_once() {
+        let mut detector = EpochStallDetector::new(1, 3);
+        let g = group(0x01);
+
+        // The fork is adjudicated once: one commit parked, one withdrawal. The
+        // run so far is ended by that signal, exactly as before.
+        assert_eq!(
+            detector.observe_undecryptable(g.clone(), "m0".into(), EpochId(10), T0),
+            BackfillDecision::Arm
+        );
+        detector.observe_convergence_reorg(&g);
+
+        // The device then limps: recovers a little, advances an epoch, stalls
+        // again, three times over — the ordinary escalation shape. Re-parking
+        // that same commit is silent now, so nothing interrupts the run.
+        assert_eq!(
+            detector.observe_undecryptable(g.clone(), "m1".into(), EpochId(11), T0),
+            BackfillDecision::Arm
+        );
+        assert_eq!(
+            detector.observe_undecryptable(g.clone(), "m2".into(), EpochId(12), T0),
+            BackfillDecision::Arm
+        );
+        assert_eq!(
+            detector.observe_undecryptable(g.clone(), "m3".into(), EpochId(13), T0),
+            BackfillDecision::ArmAndEscalate { arms: 3 },
+            "an adjudicated-then-stalling group now reaches escalation, because              the parking that adjudicated it no longer repeats",
+        );
+    }
+
+    /// The other half of the same seam, unchanged: a fork that keeps producing
+    /// *fresh* adjudications still suppresses escalation. Announce-once removed
+    /// the repeat of one parking, not the signal itself, so a device that is
+    /// still watching commits get adjudicated is still recognised as alive.
+    ///
+    /// Run this against the test above to see exactly what changed: identical
+    /// epoch progression, and the only difference is whether a withdrawal lands
+    /// between the arms.
+    #[test]
+    fn a_group_still_adjudicating_new_commits_stays_below_escalation() {
+        let mut detector = EpochStallDetector::new(1, 3);
+        let g = group(0x01);
+
+        for round in 0..6u64 {
+            assert_eq!(
+                detector.observe_undecryptable(
+                    g.clone(),
+                    format!("m{round}"),
+                    EpochId(11 + round),
+                    T0,
+                ),
+                BackfillDecision::Arm,
+                "round {round}: each newly parked rival ends the run before it can escalate",
+            );
+            detector.observe_convergence_reorg(&g);
+        }
     }
 
     /// A reorg is evidence about a run, never the start of one.

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -910,12 +910,26 @@ impl AppClient {
     ///
     /// Membership is the test rather than event order: a batch may carry the
     /// withdrawal before or after the change it names, and neither ordering
-    /// makes the change canonical.
+    /// makes the change canonical. For the same reason a commit the batch also
+    /// REVALIDATES is not withheld: a multi-pass batch can park a commit and
+    /// then re-adopt it, and the net verdict is that it is canonical. Withholding
+    /// it would leave no row at all — the withdrawal dispatch has nothing to
+    /// tombstone and the revalidation nothing to revive.
     pub(crate) fn project_group_system_rows(
         &self,
         events: &[cgka_traits::engine::GroupEvent],
         recorded_at: u64,
     ) -> Vec<crate::AppProjectionUpdate> {
+        let revalidated_commits: std::collections::HashSet<&[u8]> = events
+            .iter()
+            .filter_map(|event| match event {
+                cgka_traits::engine::GroupEvent::GroupStateRevalidated {
+                    revalidated_commit_id,
+                    ..
+                } => Some(revalidated_commit_id.as_slice()),
+                _ => None,
+            })
+            .collect();
         let superseded_commits: std::collections::HashSet<&[u8]> = events
             .iter()
             .filter_map(|event| match event {
@@ -925,6 +939,7 @@ impl AppClient {
                 } => Some(invalidated_commit_id.as_slice()),
                 _ => None,
             })
+            .filter(|commit_id| !revalidated_commits.contains(commit_id))
             .collect();
         let mut updates = Vec::new();
         for event in events {

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -908,38 +908,56 @@ impl AppClient {
     /// superseded emitter skips accepted commits — so the single-pass shape is
     /// not what this guards.
     ///
-    /// Membership is the test rather than event order: a batch may carry the
-    /// withdrawal before or after the change it names, and neither ordering
-    /// makes the change canonical. For the same reason a commit the batch also
-    /// REVALIDATES is not withheld: a multi-pass batch can park a commit and
-    /// then re-adopt it, and the net verdict is that it is canonical. Withholding
-    /// it would leave no row at all — the withdrawal dispatch has nothing to
-    /// tombstone and the revalidation nothing to revive.
+    /// Ordering matters here in exactly one place. Whether a batch carries the
+    /// withdrawal before or after the `GroupStateChanged` it names is
+    /// irrelevant — neither ordering makes the change canonical, so membership
+    /// decides that pairing. But a withdrawal and a REVALIDATION of the *same*
+    /// commit are opposite verdicts on one question, and a multi-pass batch can
+    /// carry several: pass A re-adopts a parked commit (its `GroupStateChanged`
+    /// plus `GroupStateRevalidated`), pass B parks it again
+    /// (`GroupStateInvalidated`). Only the last one is the batch's answer.
+    ///
+    /// So the verdict is resolved per commit, in event order, and the row is
+    /// withheld iff that commit's final verdict is a withdrawal. Membership
+    /// alone would get this wrong in both directions: treating any revalidation
+    /// as exonerating synthesizes a live row for a commit the batch ends by
+    /// withdrawing (with no pre-existing row there is nothing for the dispatch
+    /// loop to tombstone, so the tail's INSERT is the last writer and the row
+    /// survives — issue #1593's exact shape), and treating any withdrawal as
+    /// damning withholds the row a re-adoption is entitled to, leaving nothing
+    /// for the revalidation to revive.
+    ///
+    /// This also keeps the tail consistent with the dispatch loop that ran just
+    /// before it, which applies the same events *in order* against storage. The
+    /// two must agree on which verdict is final or they fight over the row.
     pub(crate) fn project_group_system_rows(
         &self,
         events: &[cgka_traits::engine::GroupEvent],
         recorded_at: u64,
     ) -> Vec<crate::AppProjectionUpdate> {
-        let revalidated_commits: std::collections::HashSet<&[u8]> = events
-            .iter()
-            .filter_map(|event| match event {
-                cgka_traits::engine::GroupEvent::GroupStateRevalidated {
-                    revalidated_commit_id,
-                    ..
-                } => Some(revalidated_commit_id.as_slice()),
-                _ => None,
-            })
-            .collect();
-        let superseded_commits: std::collections::HashSet<&[u8]> = events
-            .iter()
-            .filter_map(|event| match event {
+        // Last verdict wins, per commit. `true` = withdrawn, `false` = revalidated.
+        let mut final_verdict: std::collections::HashMap<&[u8], bool> =
+            std::collections::HashMap::new();
+        for event in events {
+            match event {
                 cgka_traits::engine::GroupEvent::GroupStateInvalidated {
                     invalidated_commit_id,
                     ..
-                } => Some(invalidated_commit_id.as_slice()),
-                _ => None,
-            })
-            .filter(|commit_id| !revalidated_commits.contains(commit_id))
+                } => {
+                    final_verdict.insert(invalidated_commit_id.as_slice(), true);
+                }
+                cgka_traits::engine::GroupEvent::GroupStateRevalidated {
+                    revalidated_commit_id,
+                    ..
+                } => {
+                    final_verdict.insert(revalidated_commit_id.as_slice(), false);
+                }
+                _ => {}
+            }
+        }
+        let superseded_commits: std::collections::HashSet<&[u8]> = final_verdict
+            .into_iter()
+            .filter_map(|(commit_id, withdrawn)| withdrawn.then_some(commit_id))
             .collect();
         let mut updates = Vec::new();
         for event in events {

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -2545,6 +2545,92 @@ impl AppClient {
         }
     }
 
+    /// Reconcile branch-selection tombstones against the engine's own commit
+    /// dispositions, once per account open.
+    ///
+    /// Same shape, and the same reason, as
+    /// [`Self::sweep_terminal_groups_from_guards`]: the engine announces a
+    /// branch-selection withdrawal exactly once (on the transition into
+    /// `ConvergenceDeferred`) and takes it back exactly once (on re-adoption),
+    /// but those announcements travel in the engine's in-memory `events_buf`.
+    /// A process death between the convergence apply transaction — which is
+    /// where the disposition becomes durable — and this app's projection commit
+    /// loses the announcement, and announce-once means no later pass re-derives
+    /// it. Before announce-once every later pass re-announced and the
+    /// already-invalidated filter turned the repeat into a no-op, which made the
+    /// old seam accidentally self-healing; this is the deliberate replacement.
+    ///
+    /// It can be a total reconciliation rather than a durable queue because both
+    /// sides live in the same account database, so the correct tombstone state
+    /// is *derivable*, never information the app can lose: a commit parked
+    /// `ConvergenceDeferred` owes its rows a withdrawal, and a commit back at
+    /// `Processed` owes them a revival. `diverged_branch_selection_withdrawals`
+    /// reports only the commits where the two disagree, so a converged account
+    /// performs no writes at all.
+    ///
+    /// Reads no live group state, only durable rows, so — like the terminal
+    /// sweep — it runs on deferred opens too. Best-effort per commit: one
+    /// failure must not fail account open, and the next open retries it.
+    pub(crate) fn reconcile_branch_selection_withdrawals(&mut self) {
+        let divergence = match self
+            .app
+            .account_storage(&self.state.label)
+            .and_then(|storage| Ok(storage.diverged_branch_selection_withdrawals()?))
+        {
+            Ok(divergence) => divergence,
+            Err(error) => {
+                tracing::warn!(
+                    target: "marmot_app::branch_selection_sweep",
+                    method = "reconcile_branch_selection_withdrawals",
+                    error_kind = error.privacy_safe_kind(),
+                    "could not enumerate branch-selection divergences; skipping the open-time sweep"
+                );
+                return;
+            }
+        };
+        if divergence.is_empty() {
+            return;
+        }
+        let mut withdrawn = 0_u64;
+        let mut revived = 0_u64;
+        let mut failed = 0_u64;
+        for origin_commit_id in &divergence.to_withdraw {
+            match self.app.invalidate_timeline_origin_commit(
+                &self.state.label,
+                origin_commit_id,
+                storage_sqlite::BRANCH_SELECTION_WITHDRAWAL_REASON,
+            ) {
+                Ok(Some(update)) => {
+                    withdrawn = withdrawn.saturating_add(1);
+                    self.pending_projection_updates.push(update);
+                }
+                Ok(None) => {}
+                Err(_) => failed = failed.saturating_add(1),
+            }
+        }
+        for origin_commit_id in &divergence.to_revive {
+            match self
+                .app
+                .revalidate_timeline_origin_commit(&self.state.label, origin_commit_id)
+            {
+                Ok(Some(update)) => {
+                    revived = revived.saturating_add(1);
+                    self.pending_projection_updates.push(update);
+                }
+                Ok(None) => {}
+                Err(_) => failed = failed.saturating_add(1),
+            }
+        }
+        tracing::debug!(
+            target: "marmot_app::branch_selection_sweep",
+            method = "reconcile_branch_selection_withdrawals",
+            withdrawn,
+            revived,
+            failed,
+            "reconciled branch-selection withdrawals against stored commit dispositions"
+        );
+    }
+
     /// Reconcile every terminal group's durable projection from the guard rows
     /// themselves, once per account open.
     ///

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -2594,6 +2594,7 @@ impl AppClient {
         let mut withdrawn = 0_u64;
         let mut revived = 0_u64;
         let mut failed = 0_u64;
+        let mut first_error_kind: Option<&'static str> = None;
         for origin_commit_id in &divergence.to_withdraw {
             match self.app.invalidate_timeline_origin_commit(
                 &self.state.label,
@@ -2605,7 +2606,10 @@ impl AppClient {
                     self.pending_projection_updates.push(update);
                 }
                 Ok(None) => {}
-                Err(_) => failed = failed.saturating_add(1),
+                Err(error) => {
+                    failed = failed.saturating_add(1);
+                    first_error_kind.get_or_insert(error.privacy_safe_kind());
+                }
             }
         }
         for origin_commit_id in &divergence.to_revive {
@@ -2618,7 +2622,10 @@ impl AppClient {
                     self.pending_projection_updates.push(update);
                 }
                 Ok(None) => {}
-                Err(_) => failed = failed.saturating_add(1),
+                Err(error) => {
+                    failed = failed.saturating_add(1);
+                    first_error_kind.get_or_insert(error.privacy_safe_kind());
+                }
             }
         }
         tracing::debug!(
@@ -2629,6 +2636,21 @@ impl AppClient {
             failed,
             "reconciled branch-selection withdrawals against stored commit dispositions"
         );
+        // A partial sweep leaves real divergence standing — a live row for a
+        // parked commit, or a tombstone over a re-adopted one — and nothing
+        // else notices until the next account open re-derives it. Say so above
+        // debug, with the first kind observed so the failure has a shape.
+        if failed > 0 {
+            tracing::warn!(
+                target: "marmot_app::branch_selection_sweep",
+                method = "reconcile_branch_selection_withdrawals",
+                withdrawn,
+                revived,
+                failed,
+                error_kind = first_error_kind.unwrap_or("unknown"),
+                "some branch-selection divergences stayed unreconciled; the next account open retries them"
+            );
+        }
     }
 
     /// Reconcile every terminal group's durable projection from the guard rows
@@ -2674,6 +2696,7 @@ impl AppClient {
         let guard_count = guards.len();
         let mut reconciled = 0_u64;
         let mut failed = 0_u64;
+        let mut first_error_kind: Option<&'static str> = None;
         for (group_id, _) in guards {
             let group_id_hex = hex::encode(group_id.as_slice());
             match self
@@ -2685,16 +2708,19 @@ impl AppClient {
                     self.pending_projection_updates.push(update);
                 }
                 Ok(None) => {}
-                Err(_) => failed = failed.saturating_add(1),
+                Err(error) => {
+                    failed = failed.saturating_add(1);
+                    first_error_kind.get_or_insert(error.privacy_safe_kind());
+                }
             }
             // A terminal group never advertises notification destinations
             // again, so every cached peer token is stale by definition.
-            if self
-                .app
-                .remove_stale_group_push_tokens(&self.state.label, &group_id_hex, &[])
-                .is_err()
+            if let Err(error) =
+                self.app
+                    .remove_stale_group_push_tokens(&self.state.label, &group_id_hex, &[])
             {
                 failed = failed.saturating_add(1);
+                first_error_kind.get_or_insert(error.privacy_safe_kind());
             }
         }
         if reconciled > 0 || failed > 0 {
@@ -2705,6 +2731,20 @@ impl AppClient {
                 reconciled,
                 failed,
                 "reconciled terminal group projections from durable guards"
+            );
+        }
+        // Same reasoning as the branch-selection sweep: a guard this open could
+        // not reconcile leaves a terminal group's held sends stuck at
+        // "Sending…", and only the next open retries it.
+        if failed > 0 {
+            tracing::warn!(
+                target: "marmot_app::terminal_sweep",
+                method = "sweep_terminal_groups_from_guards",
+                terminal_groups = guard_count,
+                reconciled,
+                failed,
+                error_kind = first_error_kind.unwrap_or("unknown"),
+                "some terminal group projections stayed unreconciled; the next account open retries them"
             );
         }
     }

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -2142,6 +2142,7 @@ pub(crate) fn event_group_id(event: &GroupEvent) -> Option<&GroupId> {
         | GroupEvent::EpochChanged { group_id, .. }
         | GroupEvent::CommitRolledBack { group_id, .. }
         | GroupEvent::GroupStateInvalidated { group_id, .. }
+        | GroupEvent::GroupStateRevalidated { group_id, .. }
         | GroupEvent::GroupUnrecoverable { group_id, .. }
         | GroupEvent::PendingCommitRecovered { group_id, .. }
         | GroupEvent::GroupHydrationQuarantined { group_id, .. }

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1732,6 +1732,11 @@ impl MarmotApp {
         // runs on deferred opens too — and it must, because it is now the sole
         // reconciler for a disband whose live projection never completed.
         client.sweep_terminal_groups_from_guards();
+        // Same durable-input rule as the terminal sweep: this reads stored
+        // commit dispositions and stored tombstones, never live group state, so
+        // it repairs a crash-lost branch-selection announcement on every open,
+        // deferred ones included.
+        client.reconcile_branch_selection_withdrawals();
         if !defer_group_hydration {
             // These repairs read live group state. Deferred runtime opens run
             // them after the account worker's hydration pipeline instead.

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -5324,6 +5324,30 @@ impl MarmotApp {
             .transpose()
     }
 
+    /// Restore every synthesized group system row a branch-selection withdrawal
+    /// tombstoned, after convergence re-adopted the commit that produced them.
+    ///
+    /// The inverse of [`Self::invalidate_timeline_origin_commit`], and scoped
+    /// the same way `clear_timeline_local_publish_failure` is: only the one
+    /// reason whose decision a later convergence pass can reverse is cleared,
+    /// and only for the named commit. The engine's
+    /// [`GroupEvent::GroupStateRevalidated`] is the evidence — re-recording the
+    /// rows is not, which is why the upsert keeps them tombstoned.
+    ///
+    /// [`GroupEvent::GroupStateRevalidated`]: cgka_traits::engine::GroupEvent::GroupStateRevalidated
+    pub(crate) fn revalidate_timeline_origin_commit(
+        &self,
+        label: &str,
+        origin_commit_id_hex: &str,
+    ) -> Result<Option<AppProjectionUpdate>, AppError> {
+        let update = self
+            .account_storage(label)?
+            .clear_branch_selection_withdrawal_by_origin_commit(origin_commit_id_hex)?;
+        update
+            .map(|update| self.app_projection_update(label, update))
+            .transpose()
+    }
+
     /// Withdraw every accepted-but-unpublished send in a group whose outbound
     /// queue the engine has permanently discarded.
     ///
@@ -5367,6 +5391,11 @@ impl MarmotApp {
     ///   pairs this event with the commit-rollback seam (`CommitRolledBack`),
     ///   so that commit-level event intentionally does NOT dispatch here: one
     ///   rollback must tombstone once, with one reason.
+    /// - [`GroupEvent::GroupStateRevalidated`] takes that withdrawal back when
+    ///   a later convergence pass re-adopts the commit. Storage-side
+    ///   invalidation is terminal by default (#1608), so this explicitly
+    ///   evidenced path is the only one that revives a branch-selection
+    ///   tombstone.
     ///
     /// Every other event carries no timeline invalidation and returns `None`.
     pub(crate) fn projection_update_for_invalidation_event(
@@ -5390,6 +5419,13 @@ impl MarmotApp {
                 label,
                 &hex::encode(invalidated_commit_id.as_slice()),
                 &format!("{reason:?}"),
+            ),
+            cgka_traits::engine::GroupEvent::GroupStateRevalidated {
+                revalidated_commit_id,
+                ..
+            } => self.revalidate_timeline_origin_commit(
+                label,
+                &hex::encode(revalidated_commit_id.as_slice()),
             ),
             _ => Ok(None),
         }

--- a/crates/marmot-app/src/runtime/event_routing.rs
+++ b/crates/marmot-app/src/runtime/event_routing.rs
@@ -130,6 +130,7 @@ pub(crate) fn chat_list_trigger_from_event(event: &MarmotAppEvent) -> ChatListUp
             | GroupEvent::EpochChanged { .. }
             | GroupEvent::CommitRolledBack { .. }
             | GroupEvent::GroupStateInvalidated { .. }
+            | GroupEvent::GroupStateRevalidated { .. }
             | GroupEvent::GroupUnrecoverable { .. }
             | GroupEvent::PendingCommitRecovered { .. }
             | GroupEvent::GroupHydrationQuarantined { .. }
@@ -164,6 +165,7 @@ fn group_id_from_event(event: &GroupEvent) -> &GroupId {
         | GroupEvent::EpochChanged { group_id, .. }
         | GroupEvent::CommitRolledBack { group_id, .. }
         | GroupEvent::GroupStateInvalidated { group_id, .. }
+        | GroupEvent::GroupStateRevalidated { group_id, .. }
         | GroupEvent::GroupUnrecoverable { group_id, .. }
         | GroupEvent::PendingCommitRecovered { group_id, .. }
         | GroupEvent::GroupHydrationQuarantined { group_id, .. }

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -11574,6 +11574,139 @@ fn group_state_invalidated_event_tombstones_origin_commit_system_rows() {
     );
 }
 
+/// The other end of the #363 withdrawal lifecycle: a branch-selection
+/// withdrawal is provisional, because the commit it names is parked
+/// reconsiderable and a later convergence pass can re-adopt it. The engine's
+/// `GroupStateRevalidated` must flip the tombstoned system rows back visible —
+/// and only those, and only for the one reason convergence can reverse.
+///
+/// The re-record in the middle is the #1608 evidence rule: replay re-deriving
+/// the same deterministic row id is not proof the withdrawal was reversed, so
+/// the row stays tombstoned until the revalidation itself arrives.
+#[test]
+fn group_state_revalidated_event_revives_the_readopted_commits_system_rows() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    let account = home.create_account("alice").unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    app.save_state(&AccountState {
+        label: "alice".to_owned(),
+        seen_events: Vec::new(),
+        last_transport_timestamp: None,
+        groups: vec![AppGroupRecord::new(
+            "aa".to_owned(),
+            AppGroupNostrRoutingComponent::new(
+                NostrRoutingV1::new([0xAA; 32], vec!["wss://relay.example".to_owned()]).unwrap(),
+            )
+            .unwrap(),
+            "alpha".to_owned(),
+            String::new(),
+            AppGroupImageInput::default(),
+            AppGroupAdminPolicyComponent::new(Vec::new()),
+            AppGroupMessageRetentionComponent::disabled(),
+        )],
+    })
+    .unwrap();
+
+    let parked_commit_id = cgka_traits::types::MessageId::new(vec![0xBE; 32]);
+    let parked_commit_hex = hex::encode(parked_commit_id.as_slice());
+    let system_row = |message_id_hex: &str, origin_commit_id: String| AppMessageProjection {
+        message_id_hex: message_id_hex.to_owned(),
+        source_message_id_hex: None,
+        direction: "system".to_owned(),
+        group_id_hex: "aa".to_owned(),
+        sender: account.account_id_hex.clone(),
+        plaintext: "renamed the group".to_owned(),
+        kind: MARMOT_APP_EVENT_KIND_GROUP_SYSTEM,
+        tags: Vec::new(),
+        source_epoch: Some(2),
+        retention: None,
+        recorded_at: Some(10),
+        origin_commit_id: Some(origin_commit_id),
+        moderation_grant: false,
+    };
+    let parked_row = system_row("parked-rename", parked_commit_hex.clone());
+    app.record_account_app_event("alice", &parked_row).unwrap();
+    app.record_account_app_event("alice", &system_row("other-rename", "cf".repeat(32)))
+        .unwrap();
+
+    let group_id = GroupId::new(vec![0xAA]);
+    app.projection_update_for_invalidation_event(
+        "alice",
+        &cgka_traits::engine::GroupEvent::GroupStateInvalidated {
+            group_id: group_id.clone(),
+            epoch: cgka_traits::EpochId(1),
+            invalidated_commit_id: parked_commit_id.clone(),
+            reason: cgka_traits::engine::GroupStateInvalidationReason::SupersededByBranchSelection,
+        },
+    )
+    .unwrap()
+    .expect("the park must tombstone the parked commit's row");
+    // The other commit is withdrawn under a reason convergence cannot reverse.
+    app.projection_update_for_invalidation_event(
+        "alice",
+        &cgka_traits::engine::GroupEvent::AppMessageInvalidated {
+            group_id: group_id.clone(),
+            message_id: cgka_traits::types::MessageId::new(vec![0xCF; 32]),
+            epoch: cgka_traits::EpochId(1),
+            reason: cgka_traits::engine::AppMessageInvalidationReason::LosingBranch,
+            decrypted_payload_ref: None,
+        },
+    )
+    .unwrap();
+
+    // Replay re-derives the row while the withdrawal still stands.
+    app.record_account_app_event("alice", &parked_row).unwrap();
+    assert_eq!(
+        invalidation_status(&app, "parked-rename"),
+        Some(Some("SupersededByBranchSelection".to_owned())),
+        "re-recording is not evidence the withdrawal was reversed"
+    );
+
+    let revalidation = cgka_traits::engine::GroupEvent::GroupStateRevalidated {
+        group_id,
+        epoch: cgka_traits::EpochId(1),
+        revalidated_commit_id: parked_commit_id,
+    };
+    let update = app
+        .projection_update_for_invalidation_event("alice", &revalidation)
+        .unwrap()
+        .expect("re-adoption must project an update");
+    assert_eq!(update.group_id_hex, "aa");
+    assert_eq!(
+        invalidation_status(&app, "parked-rename"),
+        Some(None),
+        "the re-adopted commit's row must be visible again"
+    );
+    assert_eq!(
+        invalidation_status(&app, "other-rename"),
+        Some(None),
+        "an unrelated live row is untouched"
+    );
+
+    assert!(
+        app.projection_update_for_invalidation_event("alice", &revalidation)
+            .unwrap()
+            .is_none(),
+        "a replayed revalidation must not produce another projection update"
+    );
+}
+
+fn invalidation_status(app: &MarmotApp, message_id_hex: &str) -> Option<Option<String>> {
+    app.timeline_messages_with_query(
+        "alice",
+        storage_sqlite::TimelineMessageQuery {
+            group_id_hex: Some("aa".to_owned()),
+            ..storage_sqlite::TimelineMessageQuery::default()
+        },
+    )
+    .unwrap()
+    .messages
+    .iter()
+    .find(|row| row.message_id_hex == message_id_hex)
+    .map(|row| row.invalidation_status.clone())
+}
+
 /// Issue #1177: a send the engine accepted but never published derives as
 /// `Pending`, which is truthful only while convergence can still release it.
 /// Once the group is terminal the queue is purged, so the sweep the sync loop

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -11627,7 +11627,9 @@ fn group_state_revalidated_event_revives_the_readopted_commits_system_rows() {
     };
     let parked_row = system_row("parked-rename", parked_commit_hex.clone());
     app.record_account_app_event("alice", &parked_row).unwrap();
-    app.record_account_app_event("alice", &system_row("other-rename", "cf".repeat(32)))
+    let other_commit_id = cgka_traits::types::MessageId::new(vec![0xCF; 32]);
+    let other_commit_hex = hex::encode(other_commit_id.as_slice());
+    app.record_account_app_event("alice", &system_row("other-rename", other_commit_hex))
         .unwrap();
 
     let group_id = GroupId::new(vec![0xAA]);
@@ -11642,18 +11644,25 @@ fn group_state_revalidated_event_revives_the_readopted_commits_system_rows() {
     )
     .unwrap()
     .expect("the park must tombstone the parked commit's row");
-    // The other commit is withdrawn under a reason convergence cannot reverse.
+    // A SECOND commit is parked in its own right, under the same reason. Only
+    // the commit scope separates its tombstone from the one being taken back
+    // below, so it is the row that catches a revalidation reaching too far.
     app.projection_update_for_invalidation_event(
         "alice",
-        &cgka_traits::engine::GroupEvent::AppMessageInvalidated {
+        &cgka_traits::engine::GroupEvent::GroupStateInvalidated {
             group_id: group_id.clone(),
-            message_id: cgka_traits::types::MessageId::new(vec![0xCF; 32]),
             epoch: cgka_traits::EpochId(1),
-            reason: cgka_traits::engine::AppMessageInvalidationReason::LosingBranch,
-            decrypted_payload_ref: None,
+            invalidated_commit_id: other_commit_id,
+            reason: cgka_traits::engine::GroupStateInvalidationReason::SupersededByBranchSelection,
         },
     )
-    .unwrap();
+    .unwrap()
+    .expect("the second park must tombstone its own row");
+    assert_eq!(
+        invalidation_status(&app, "other-rename"),
+        Some(Some("SupersededByBranchSelection".to_owned())),
+        "control: the second commit's row really is tombstoned"
+    );
 
     // Replay re-derives the row while the withdrawal still stands.
     app.record_account_app_event("alice", &parked_row).unwrap();
@@ -11680,8 +11689,8 @@ fn group_state_revalidated_event_revives_the_readopted_commits_system_rows() {
     );
     assert_eq!(
         invalidation_status(&app, "other-rename"),
-        Some(None),
-        "an unrelated live row is untouched"
+        Some(Some("SupersededByBranchSelection".to_owned())),
+        "another commit's withdrawal is not this commit's to take back"
     );
 
     assert!(
@@ -12748,6 +12757,18 @@ mod superseded_system_row_shapes {
         }
     }
 
+    pub(super) fn revalidated(
+        group_id: &GroupId,
+        epoch: u64,
+        revalidated_commit_id: &MessageId,
+    ) -> cgka_traits::engine::GroupEvent {
+        cgka_traits::engine::GroupEvent::GroupStateRevalidated {
+            group_id: group_id.clone(),
+            epoch: cgka_traits::EpochId(epoch),
+            revalidated_commit_id: revalidated_commit_id.clone(),
+        }
+    }
+
     pub(super) fn batch(
         events: Vec<cgka_traits::engine::GroupEvent>,
     ) -> marmot_account::AccountDeviceEffects {
@@ -12882,6 +12903,263 @@ async fn a_drained_batch_leaves_no_live_system_row_for_a_commit_it_supersedes() 
         system_row(&app, &group_id_hex, 4),
         Some(None),
         "a change attributed to a commit the batch did not withdraw stays live"
+    );
+}
+
+/// Crash repair, end to end: the window announce-once opened, and the derived
+/// state that closes it.
+///
+/// The engine persists a commit's parking inside the convergence apply
+/// transaction and announces the withdrawal afterwards, through the in-memory
+/// `events_buf`. A process death between the two loses the announcement, and
+/// announce-once guarantees no later pass repeats it — so before this repair the
+/// commit's kind-1210 rows stood forever, describing a change branch selection
+/// had already reversed. (Under the old always-re-announce behavior the next
+/// pass happened to fix it, which is the accidental self-healing announce-once
+/// removed.)
+///
+/// The repair is not a queue. Engine message state and `app_events` live in the
+/// same account database, so the correct tombstone state is *derivable*: a
+/// commit parked `ConvergenceDeferred` owes its rows a withdrawal, and one back
+/// at `Processed` owes them a revival. Account open reconciles both directions.
+///
+/// The crash is modelled the only way it can be — durable engine state advanced,
+/// announcement never delivered — by writing the disposition the apply
+/// transaction would have committed and never handing the app the event.
+#[tokio::test]
+async fn account_open_repairs_a_branch_selection_announcement_a_crash_lost() {
+    use cgka_traits::storage::MessageStorage;
+
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://crash-repair.example")
+        .with_test_relay_client(relay);
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client.create_group("crash repair", &[]).await.unwrap();
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let actor = MemberId::new(hex::decode(&account.account_id_hex).unwrap());
+
+    // Two commits the app has already projected system rows for, exactly as an
+    // accepted commit's `GroupStateChanged` would have.
+    let parked = MessageId::new(vec![0xBE; 32]);
+    let readopted = MessageId::new(vec![0xA1; 32]);
+    {
+        use superseded_system_row_shapes::{batch, renamed};
+        client
+            .observe_drained_session_events(&batch(vec![
+                renamed(&group_id, &actor, 2, "parked rename", Some(&parked)),
+                renamed(&group_id, &actor, 3, "re-adopted rename", Some(&readopted)),
+            ]))
+            .await
+            .unwrap();
+    }
+    // The re-adopted commit's rows are tombstoned by a withdrawal that DID
+    // arrive, so the row this test watches for revival is a real one.
+    app.projection_update_for_invalidation_event(
+        "alice",
+        &cgka_traits::engine::GroupEvent::GroupStateInvalidated {
+            group_id: group_id.clone(),
+            epoch: cgka_traits::EpochId(3),
+            invalidated_commit_id: readopted.clone(),
+            reason: cgka_traits::engine::GroupStateInvalidationReason::SupersededByBranchSelection,
+        },
+    )
+    .unwrap()
+    .expect("the earlier park tombstoned the re-adopted commit's row");
+
+    let live = |epoch: u64| superseded_system_row_shapes::system_row(&app, &group_id_hex, epoch);
+    assert_eq!(
+        live(2),
+        Some(None),
+        "control: the parked commit's row is live"
+    );
+    assert_eq!(
+        live(3),
+        Some(Some("SupersededByBranchSelection".to_owned())),
+        "control: the re-adopted commit's row is tombstoned"
+    );
+
+    // The crash. Both convergence apply transactions committed their
+    // dispositions; neither announcement ever reached this app.
+    {
+        let storage = app.account_storage("alice").unwrap();
+        for (commit, state) in [
+            (
+                &parked,
+                cgka_traits::message::MessageState::ConvergenceDeferred,
+            ),
+            (&readopted, cgka_traits::message::MessageState::Processed),
+        ] {
+            storage
+                .put_message(&cgka_traits::message::MessageRecord {
+                    id: commit.clone(),
+                    group_id: group_id.clone(),
+                    epoch: cgka_traits::EpochId(1),
+                    state,
+                    payload: cgka_traits::message::StoredMessagePayload::openmls_wire(
+                        cgka_traits::transport::TransportMessage {
+                            id: commit.clone(),
+                            payload: vec![0u8; 4],
+                            timestamp: cgka_traits::transport::Timestamp(0),
+                            causal_deps: Vec::new(),
+                            source: cgka_traits::transport::TransportSource("crash".into()),
+                            envelope: cgka_traits::transport::TransportEnvelope::GroupMessage {
+                                transport_group_id: group_id.as_slice().to_vec(),
+                            },
+                        },
+                    )
+                    .encode()
+                    .unwrap(),
+                    deferred_peel: None,
+                })
+                .unwrap();
+        }
+    }
+    drop(client);
+
+    // Restart. Account open reconciles both directions off stored state alone.
+    let reopened = client_on_app_relay_plane(&app, "alice").await;
+    assert_eq!(
+        live(2),
+        Some(Some("SupersededByBranchSelection".to_owned())),
+        "the withdrawal the crash lost is re-derived from the parked disposition"
+    );
+    assert_eq!(
+        live(3),
+        Some(None),
+        "and the revalidation the crash lost is re-derived from the re-adoption"
+    );
+    drop(reopened);
+
+    // Exactly once, and stable: a second open finds no divergence and writes
+    // nothing, so the repair cannot flap a converged account.
+    let storage = app.account_storage("alice").unwrap();
+    assert!(
+        storage
+            .diverged_branch_selection_withdrawals()
+            .unwrap()
+            .is_empty(),
+        "the repair must be a fixed point"
+    );
+    let reopened = client_on_app_relay_plane(&app, "alice").await;
+    assert_eq!(
+        live(2),
+        Some(Some("SupersededByBranchSelection".to_owned()))
+    );
+    assert_eq!(live(3), Some(None));
+    drop(reopened);
+}
+
+/// Shape 3 — a batch whose verdict on one commit FLIPS. A withdrawal and a
+/// revalidation of the same commit are opposite answers to one question, and a
+/// multi-pass batch can carry both: pass A re-adopts a parked commit (emitting
+/// its `GroupStateChanged` and `GroupStateRevalidated`), pass B parks it again.
+/// Only the last verdict is the batch's answer, so the tail must resolve them in
+/// event order rather than by membership.
+///
+/// Both directions are pinned. Withdrawn-last must leave no live row (a
+/// membership test exempts the commit and the tail's INSERT resurrects the
+/// #1593 shape, because with no pre-existing row the dispatch loop has nothing
+/// to tombstone). Revalidated-last must leave one, or the re-adoption has no
+/// row to be entitled to.
+#[tokio::test]
+async fn a_batch_that_flips_its_verdict_projects_the_last_one() {
+    use superseded_system_row_shapes::{
+        SUPERSEDED, batch, renamed, revalidated, superseded, system_row,
+    };
+
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://flipped-verdict-rows.example")
+        .with_test_relay_client(relay);
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client
+        .create_group("flipped verdict rows", &[])
+        .await
+        .unwrap();
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let actor = MemberId::new(hex::decode(&account.account_id_hex).unwrap());
+
+    // Withdrawn last, with no pre-existing row: net verdict is withdrawn.
+    let reparked = MessageId::new(vec![0xBE; 32]);
+    client
+        .observe_drained_session_events(&batch(vec![
+            renamed(&group_id, &actor, 2, "re-adopted rename", Some(&reparked)),
+            revalidated(&group_id, 2, &reparked),
+            superseded(&group_id, 2, &reparked),
+        ]))
+        .await
+        .unwrap();
+    assert_eq!(
+        system_row(&app, &group_id_hex, 2),
+        None,
+        "a commit the batch ends by withdrawing must not get a live row, \
+         however many times the batch changed its mind"
+    );
+
+    // Revalidated last: net verdict is canonical, so the row must exist and be
+    // live. This is the direction the exemption was reaching for.
+    let readopted = MessageId::new(vec![0xA1; 32]);
+    client
+        .observe_drained_session_events(&batch(vec![
+            superseded(&group_id, 3, &readopted),
+            renamed(&group_id, &actor, 3, "settled rename", Some(&readopted)),
+            revalidated(&group_id, 3, &readopted),
+        ]))
+        .await
+        .unwrap();
+    assert_eq!(
+        system_row(&app, &group_id_hex, 3),
+        Some(None),
+        "a commit the batch ends by re-adopting keeps a live row"
+    );
+
+    // Control: withdrawal-only is unchanged by the ordering rewrite.
+    let parked = MessageId::new(vec![0xC2; 32]);
+    client
+        .observe_drained_session_events(&batch(vec![
+            renamed(&group_id, &actor, 4, "parked rename", Some(&parked)),
+            superseded(&group_id, 4, &parked),
+        ]))
+        .await
+        .unwrap();
+    assert_eq!(system_row(&app, &group_id_hex, 4), None);
+
+    // And a batch that only revalidates a commit whose row an EARLIER batch
+    // tombstoned still revives it, since the dispatch loop owns that write.
+    let earlier = MessageId::new(vec![0xD3; 32]);
+    client
+        .observe_drained_session_events(&batch(vec![renamed(
+            &group_id,
+            &actor,
+            5,
+            "earlier rename",
+            Some(&earlier),
+        )]))
+        .await
+        .unwrap();
+    client
+        .observe_drained_session_events(&batch(vec![superseded(&group_id, 5, &earlier)]))
+        .await
+        .unwrap();
+    assert_eq!(
+        system_row(&app, &group_id_hex, 5),
+        Some(Some(SUPERSEDED.to_owned()))
+    );
+    client
+        .observe_drained_session_events(&batch(vec![revalidated(&group_id, 5, &earlier)]))
+        .await
+        .unwrap();
+    assert_eq!(
+        system_row(&app, &group_id_hex, 5),
+        Some(None),
+        "a later batch's revalidation revives the earlier batch's tombstone"
     );
 }
 

--- a/crates/marmot-c/include/marmot.h
+++ b/crates/marmot-c/include/marmot.h
@@ -3104,6 +3104,12 @@ typedef enum MarmotGroupEventKind_Tag {
    * matches: branch selection superseded that commit.
    */
   MARMOT_GROUP_EVENT_KIND_GROUP_STATE_INVALIDATED,
+  /**
+   * Takes a `GroupStateInvalidated` withdrawal back: a later convergence
+   * pass re-adopted the commit, so every notification it produced describes
+   * canonical history again.
+   */
+  MARMOT_GROUP_EVENT_KIND_GROUP_STATE_REVALIDATED,
   MARMOT_GROUP_EVENT_KIND_GROUP_UNRECOVERABLE,
   MARMOT_GROUP_EVENT_KIND_PENDING_COMMIT_RECOVERED,
   MARMOT_GROUP_EVENT_KIND_GROUP_HYDRATION_RECOVERED,
@@ -3169,6 +3175,11 @@ typedef struct MarmotGroupEventKind_GroupStateInvalidated_Body {
   char *reason;
 } MarmotGroupEventKind_GroupStateInvalidated_Body;
 
+typedef struct MarmotGroupEventKind_GroupStateRevalidated_Body {
+  uint64_t epoch;
+  char *revalidated_commit_id_hex;
+} MarmotGroupEventKind_GroupStateRevalidated_Body;
+
 typedef struct MarmotGroupEventKind_PendingCommitRecovered_Body {
   uint64_t recovered_epoch;
 } MarmotGroupEventKind_PendingCommitRecovered_Body;
@@ -3189,6 +3200,7 @@ typedef struct MarmotGroupEventKind {
     MarmotGroupEventKind_EpochChanged_Body EPOCH_CHANGED;
     MarmotGroupEventKind_CommitRolledBack_Body COMMIT_ROLLED_BACK;
     MarmotGroupEventKind_GroupStateInvalidated_Body GROUP_STATE_INVALIDATED;
+    MarmotGroupEventKind_GroupStateRevalidated_Body GROUP_STATE_REVALIDATED;
     MarmotGroupEventKind_PendingCommitRecovered_Body PENDING_COMMIT_RECOVERED;
     MarmotGroupEventKind_GroupHydrationRecovered_Body GROUP_HYDRATION_RECOVERED;
   };

--- a/crates/marmot-c/src/types/event.rs
+++ b/crates/marmot-c/src/types/event.rs
@@ -60,6 +60,13 @@ pub enum MarmotGroupEventKind {
         invalidated_commit_id_hex: *mut c_char,
         reason: *mut c_char,
     },
+    /// Takes a `GroupStateInvalidated` withdrawal back: a later convergence
+    /// pass re-adopted the commit, so every notification it produced describes
+    /// canonical history again.
+    GroupStateRevalidated {
+        epoch: u64,
+        revalidated_commit_id_hex: *mut c_char,
+    },
     GroupUnrecoverable,
     PendingCommitRecovered {
         recovered_epoch: u64,
@@ -135,6 +142,13 @@ impl From<GroupEventKindFfi> for MarmotGroupEventKind {
                 invalidated_commit_id_hex: owned_c_string(invalidated_commit_id_hex),
                 reason: owned_c_string(reason),
             },
+            F::GroupStateRevalidated {
+                epoch,
+                revalidated_commit_id_hex,
+            } => Self::GroupStateRevalidated {
+                epoch,
+                revalidated_commit_id_hex: owned_c_string(revalidated_commit_id_hex),
+            },
             F::GroupUnrecoverable => Self::GroupUnrecoverable,
             F::PendingCommitRecovered { recovered_epoch } => {
                 Self::PendingCommitRecovered { recovered_epoch }
@@ -202,6 +216,10 @@ impl CFree for MarmotGroupEventKind {
                     free_c_string(*invalidated_commit_id_hex);
                     free_c_string(*reason);
                 }
+                Self::GroupStateRevalidated {
+                    revalidated_commit_id_hex,
+                    ..
+                } => free_c_string(*revalidated_commit_id_hex),
             }
         }
     }

--- a/crates/marmot-uniffi/src/conversions/event.rs
+++ b/crates/marmot-uniffi/src/conversions/event.rs
@@ -24,6 +24,7 @@ fn group_id_from_event(event: &GroupEvent) -> &GroupId {
         | GroupEvent::EpochChanged { group_id, .. }
         | GroupEvent::CommitRolledBack { group_id, .. }
         | GroupEvent::GroupStateInvalidated { group_id, .. }
+        | GroupEvent::GroupStateRevalidated { group_id, .. }
         | GroupEvent::GroupUnrecoverable { group_id, .. }
         | GroupEvent::PendingCommitRecovered { group_id, .. }
         | GroupEvent::GroupHydrationQuarantined { group_id, .. }
@@ -154,6 +155,14 @@ pub enum GroupEventKindFfi {
         epoch: u64,
         invalidated_commit_id_hex: String,
         reason: String,
+    },
+    /// The inverse of `GroupStateInvalidated`: a later convergence pass
+    /// re-adopted `revalidated_commit_id_hex`, so every notification that
+    /// commit's withdrawal retracted describes canonical history again. Only a
+    /// `superseded_by_branch_selection` withdrawal is ever taken back.
+    GroupStateRevalidated {
+        epoch: u64,
+        revalidated_commit_id_hex: String,
     },
     GroupUnrecoverable,
     PendingCommitRecovered {
@@ -286,6 +295,14 @@ impl From<GroupEvent> for GroupEventKindFfi {
                 epoch: epoch.0,
                 invalidated_commit_id_hex: hex::encode(invalidated_commit_id.as_slice()),
                 reason: group_state_invalidation_reason_tag(&reason).to_string(),
+            },
+            GroupEvent::GroupStateRevalidated {
+                epoch,
+                revalidated_commit_id,
+                ..
+            } => Self::GroupStateRevalidated {
+                epoch: epoch.0,
+                revalidated_commit_id_hex: hex::encode(revalidated_commit_id.as_slice()),
             },
             GroupEvent::GroupUnrecoverable { .. } => Self::GroupUnrecoverable,
             GroupEvent::PendingCommitRecovered {

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -60,6 +60,7 @@ pub use storage::messages::MessageFormatPromotionProgress;
 #[cfg(feature = "storage-format-benchmarks")]
 pub use storage::messages::StorageFormatBenchSizes;
 pub use timeline::{
+    BRANCH_SELECTION_WITHDRAWAL_REASON, BranchSelectionWithdrawalDivergence,
     LOCAL_PUBLISH_FAILED_REASON, MAX_TIMELINE_LIMIT, SecurePruneAppEventsResult, StoredAppEvent,
     TimelineMessageChange, TimelineMessageQuery, TimelineMessageRecord, TimelineMessageTarget,
     TimelinePage, TimelinePagination, TimelineProjectionUpdate, TimelineReactionSummary,

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -16,6 +16,7 @@ use cgka_traits::app_event::{
     MARMOT_APP_EVENT_KIND_GROUP_SYSTEM, MARMOT_APP_EVENT_KIND_REACTION, QUOTE_REF_TAG,
     STREAM_CHUNKS_TAG, STREAM_HASH_TAG, STREAM_START_TAG, STREAM_TAG,
 };
+use cgka_traits::message::MessageState;
 use cgka_traits::storage::{StorageError, StorageResult};
 use rusqlite::{Connection, OptionalExtension, params, params_from_iter};
 use serde::{Deserialize, Serialize};
@@ -65,10 +66,44 @@ pub const LOCAL_PUBLISH_FAILED_REASON: &str = "local_publish_failed";
 /// The invalidation reason a kind-1210 system row carries when branch selection
 /// withdrew the commit that synthesized it. Storage owns the literal because it
 /// is the one reason [`SqliteAccountStorage::clear_branch_selection_withdrawal_by_origin_commit`]
-/// may clear; the app writes it by formatting
-/// `cgka_traits::engine::GroupStateInvalidationReason::SupersededByBranchSelection`,
-/// and `timeline::tests` pins the two to the same string.
+/// may clear.
+///
+/// **Frozen.** This exact string is already persisted in shipped account
+/// databases, so it is stored data, not a view of the engine enum. The app
+/// happens to produce it today by formatting
+/// `cgka_traits::engine::GroupStateInvalidationReason::SupersededByBranchSelection`
+/// with `Debug`, and `timeline::tests` pins the two together — but that pin is
+/// a *tripwire*, not a coupling to follow. Renaming the traits variant must be
+/// answered with a data migration that rewrites `app_events.invalidation_reason`
+/// (and re-points every reader), never by editing this constant: an edit here
+/// silently orphans every row an earlier release already wrote.
+///
+/// Note also that the FFI surface encodes the same variant differently — the
+/// uniffi/C boundary emits the snake_case tag `superseded_by_branch_selection`
+/// via `group_state_invalidation_reason_tag`. The two encodings are deliberate
+/// and independent: one is a durable column value, the other is a wire tag. Do
+/// not "unify" them without migrating the stored column.
 pub const BRANCH_SELECTION_WITHDRAWAL_REASON: &str = "SupersededByBranchSelection";
+
+/// Commits whose stored engine disposition disagrees with the branch-selection
+/// tombstones on the rows they synthesized. See
+/// [`SqliteAccountStorage::diverged_branch_selection_withdrawals`].
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct BranchSelectionWithdrawalDivergence {
+    /// Hex commit ids parked `ConvergenceDeferred` that still have live rows.
+    pub to_withdraw: Vec<String>,
+    /// Hex commit ids back on the selected branch whose rows are still
+    /// tombstoned under [`BRANCH_SELECTION_WITHDRAWAL_REASON`].
+    pub to_revive: Vec<String>,
+}
+
+impl BranchSelectionWithdrawalDivergence {
+    /// Whether the account's tombstones already agree with engine state, in
+    /// which case reconciliation has no work and performs no writes.
+    pub fn is_empty(&self) -> bool {
+        self.to_withdraw.is_empty() && self.to_revive.is_empty()
+    }
+}
 
 /// The one row shape [`SqliteAccountStorage::clear_local_publish_failure`] may
 /// revive, bound to `?1` group id, `?2` message id, `?3` reason. Its early-exit
@@ -940,12 +975,29 @@ impl SqliteAccountStorage {
     /// Returns `None` when no row matched, so a caller can tell a real revival
     /// from a no-op without a second read.
     ///
-    /// Scoping on `origin_commit_id` inherits that column's re-record rule: the
-    /// upsert repoints it to the newest non-NULL attribution, so a row a
-    /// *different* commit later re-recorded under the same deterministic id
-    /// answers to that commit and not to the one being revalidated. It stays
-    /// tombstoned, exactly as `invalidate_app_events_by_origin_commit` would
-    /// already have missed it.
+    /// Scoping on `origin_commit_id` inherits that column's re-record rule.
+    /// [`Self::record_app_event`] repoints the column to the newest non-NULL
+    /// attribution (`origin_commit_id = COALESCE(excluded.origin_commit_id,
+    /// app_events.origin_commit_id)`), which cuts both ways:
+    ///
+    /// - **Missed revival.** A row a *different* commit later re-recorded
+    ///   answers to that commit, so revalidating the original misses it and it
+    ///   stays tombstoned — exactly as `invalidate_app_events_by_origin_commit`
+    ///   would already have missed it.
+    /// - **Revival by the "wrong" commit.** Symmetrically, revalidating the
+    ///   commit the row was re-pointed to clears a tombstone some *other*
+    ///   commit's withdrawal wrote.
+    ///
+    /// The second direction is benign, and the reason is row identity. A
+    /// synthesized system row is keyed by `group_system_event_material(group_id,
+    /// epoch, actor, change)` — content, not commit. Two commits can only
+    /// collide on that id by being the same actor making the same change at the
+    /// same epoch, i.e. by producing an *identical* row. So whichever of them is
+    /// canonical, the surviving row says the same thing, and reviving it under
+    /// the canonical commit is the correct verdict rather than a leak of some
+    /// unrelated change. (The common case is not even two commits: it is one
+    /// logical commit seen under both its wrap-time transport id and its content
+    /// dedup id.)
     pub fn clear_branch_selection_withdrawal_by_origin_commit(
         &self,
         origin_commit_id: &str,
@@ -1024,6 +1076,93 @@ impl SqliteAccountStorage {
                 messages,
                 changes,
             }))
+        })
+    }
+
+    /// Commits whose stored engine disposition disagrees with the
+    /// branch-selection tombstones their synthesized rows currently carry.
+    ///
+    /// The engine announces a branch-selection withdrawal exactly once, on the
+    /// transition into `ConvergenceDeferred`, and takes it back exactly once, on
+    /// re-adoption. Those announcements travel in `events_buf`, which is
+    /// in-memory: a process death between the convergence apply transaction and
+    /// the app projection loses them, and because the engine will not repeat an
+    /// announcement it already made, nothing re-derives them. Before
+    /// announce-once, every later pass re-announced and the app's
+    /// already-invalidated filter turned the repeat into a no-op — accidental
+    /// self-healing that the once-only rule removed.
+    ///
+    /// This query is the deliberate replacement, and it is a total function
+    /// rather than a queue because the two sides live in the *same* account
+    /// database. A commit's branch-selection tombstone state is not independent
+    /// information the app has to be told and must not lose: it is derivable at
+    /// any moment from `cgka_messages.state`.
+    ///
+    /// - `ConvergenceDeferred` is precisely "a pass parked this commit off the
+    ///   selected branch", so every live row it synthesized owes a
+    ///   [`BRANCH_SELECTION_WITHDRAWAL_REASON`] tombstone.
+    /// - `Processed` is precisely "this commit is on the selected branch", so no
+    ///   row it synthesized may carry one.
+    ///
+    /// Every other stored state is left entirely alone. `EpochInvalidated` in
+    /// particular is the terminal retirement a parked commit ages into, and its
+    /// rows stay withdrawn under whatever reason retired them.
+    ///
+    /// Scoping to commits needs no message-kind decode: `origin_commit_id` is
+    /// only ever stamped with a commit id, so the join itself excludes proposals
+    /// and application messages.
+    ///
+    /// Returns hex commit ids, deterministically ordered, for the caller to feed
+    /// back through [`Self::invalidate_app_events_by_origin_commit`] and
+    /// [`Self::clear_branch_selection_withdrawal_by_origin_commit`]. Both are
+    /// already no-ops when the row set is in the state they would write, so a
+    /// reconciliation pass over a converged account performs no writes at all.
+    pub fn diverged_branch_selection_withdrawals(
+        &self,
+    ) -> StorageResult<BranchSelectionWithdrawalDivergence> {
+        let conn = self.lock()?;
+        // `state` is the integer encoding from `codec::message_state_to_i64`:
+        // 2 = Processed, 7 = ConvergenceDeferred. Bind them as parameters so the
+        // magic numbers stay at one call site with the mapping named beside it.
+        let processed = crate::codec::message_state_to_i64(MessageState::Processed);
+        let deferred = crate::codec::message_state_to_i64(MessageState::ConvergenceDeferred);
+        let collect =
+            |sql: &str, binds: Vec<rusqlite::types::Value>| -> StorageResult<Vec<String>> {
+                let mut stmt = conn.prepare(sql).storage()?;
+                let rows = stmt
+                    .query_map(params_from_iter(binds), |row| row.get(0))
+                    .storage()?
+                    .collect::<Result<Vec<String>, _>>()
+                    .storage()?;
+                Ok(rows)
+            };
+        let to_withdraw = collect(
+            "SELECT DISTINCT app_events.origin_commit_id
+             FROM app_events
+             JOIN cgka_messages
+               ON lower(hex(cgka_messages.id)) = app_events.origin_commit_id
+             WHERE cgka_messages.state = ?1
+               AND app_events.invalidated = 0
+             ORDER BY app_events.origin_commit_id",
+            vec![deferred.into()],
+        )?;
+        let to_revive = collect(
+            "SELECT DISTINCT app_events.origin_commit_id
+             FROM app_events
+             JOIN cgka_messages
+               ON lower(hex(cgka_messages.id)) = app_events.origin_commit_id
+             WHERE cgka_messages.state = ?1
+               AND app_events.invalidated = 1
+               AND app_events.invalidation_reason = ?2
+             ORDER BY app_events.origin_commit_id",
+            vec![
+                processed.into(),
+                BRANCH_SELECTION_WITHDRAWAL_REASON.to_owned().into(),
+            ],
+        )?;
+        Ok(BranchSelectionWithdrawalDivergence {
+            to_withdraw,
+            to_revive,
         })
     }
 

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -62,6 +62,14 @@ pub const MAX_TIMELINE_LIMIT: usize = 200;
 /// [`SqliteAccountStorage::clear_local_publish_failure`] may clear.
 pub const LOCAL_PUBLISH_FAILED_REASON: &str = "local_publish_failed";
 
+/// The invalidation reason a kind-1210 system row carries when branch selection
+/// withdrew the commit that synthesized it. Storage owns the literal because it
+/// is the one reason [`SqliteAccountStorage::clear_branch_selection_withdrawal_by_origin_commit`]
+/// may clear; the app writes it by formatting
+/// `cgka_traits::engine::GroupStateInvalidationReason::SupersededByBranchSelection`,
+/// and `timeline::tests` pins the two to the same string.
+pub const BRANCH_SELECTION_WITHDRAWAL_REASON: &str = "SupersededByBranchSelection";
+
 /// The one row shape [`SqliteAccountStorage::clear_local_publish_failure`] may
 /// revive, bound to `?1` group id, `?2` message id, `?3` reason. Its early-exit
 /// probe and its UPDATE interpolate this same fragment: the probe decides
@@ -889,6 +897,117 @@ impl SqliteAccountStorage {
                 timeline_records_by_ids_tx(&conn, &group_id_hex, affected_message_ids.clone())?;
             // One change set covers all invalidated rows. Each invalidated row's own
             // message id anchors its change; pass each in turn and merge.
+            let mut changes = Vec::new();
+            for (_, message_id_hex, kind, tags) in &rows {
+                changes.extend(timeline_changes_for_invalidation(
+                    message_id_hex,
+                    *kind,
+                    tags,
+                    &before,
+                    &messages,
+                ));
+            }
+            dedup_timeline_changes(&mut changes);
+            Ok(Some(TimelineProjectionUpdate {
+                group_id_hex,
+                messages,
+                changes,
+            }))
+        })
+    }
+
+    /// Exact inverse of [`Self::invalidate_app_events_by_origin_commit`] for
+    /// the one withdrawal reason convergence can reverse.
+    ///
+    /// A branch-selection withdrawal is provisional: the engine parks the
+    /// losing commit reconsiderable, and a later convergence pass holding
+    /// deeper evidence can re-adopt it. When that happens the engine emits
+    /// `GroupEvent::GroupStateRevalidated` naming the commit, and the rows it
+    /// synthesized describe canonical history again.
+    ///
+    /// The re-adoption is evidence [`Self::record_app_event`] does not have —
+    /// re-recording a row is not proof the withdrawal was reversed, which is
+    /// why that upsert never revives — so this is a primitive the revalidation
+    /// dispatch calls explicitly, exactly as the send path calls
+    /// [`Self::clear_local_publish_failure`].
+    ///
+    /// The predicate is reason-scoped by design. `SupersededByBranchSelection`
+    /// is the only reason whose underlying decision a later pass can reverse;
+    /// every other withdrawal (`LosingBranch`, `BeyondAnchor`, the terminal
+    /// sweep's `local_publish_failed`) stays terminal, and a commit-scoped
+    /// predicate alone would reach rows those reasons own.
+    ///
+    /// Returns `None` when no row matched, so a caller can tell a real revival
+    /// from a no-op without a second read.
+    ///
+    /// Scoping on `origin_commit_id` inherits that column's re-record rule: the
+    /// upsert repoints it to the newest non-NULL attribution, so a row a
+    /// *different* commit later re-recorded under the same deterministic id
+    /// answers to that commit and not to the one being revalidated. It stays
+    /// tombstoned, exactly as `invalidate_app_events_by_origin_commit` would
+    /// already have missed it.
+    pub fn clear_branch_selection_withdrawal_by_origin_commit(
+        &self,
+        origin_commit_id: &str,
+    ) -> StorageResult<Option<TimelineProjectionUpdate>> {
+        self.connection.with_transaction(|| {
+            let conn = self.lock()?;
+            let rows: Vec<(String, String, u64, Vec<Vec<String>>)> = {
+                let mut stmt = conn
+                    .prepare(
+                        "SELECT group_id_hex, message_id_hex, kind, tags_json
+                         FROM app_events
+                         WHERE origin_commit_id = ?1
+                           AND invalidated = 1
+                           AND invalidation_reason = ?2",
+                    )
+                    .storage()?;
+                stmt.query_map(
+                    params![origin_commit_id, BRANCH_SELECTION_WITHDRAWAL_REASON],
+                    |row| {
+                        let kind = row.get::<_, i64>(2)?.try_into().unwrap_or_default();
+                        let tags = tags_from_json(row.get::<_, String>(3)?).map_err(|err| {
+                            rusqlite::Error::FromSqlConversionFailure(
+                                3,
+                                rusqlite::types::Type::Text,
+                                Box::new(err),
+                            )
+                        })?;
+                        Ok((row.get(0)?, row.get(1)?, kind, tags))
+                    },
+                )
+                .storage()?
+                .collect::<Result<Vec<_>, _>>()
+                .storage()?
+            };
+            let Some(group_id_hex) = rows.first().map(|(group_id_hex, ..)| group_id_hex.clone())
+            else {
+                return Ok(None);
+            };
+            let mut affected_message_ids = BTreeSet::new();
+            for (row_group_id_hex, message_id_hex, kind, tags) in &rows {
+                affected_message_ids.extend(affected_timeline_message_ids_for_parts_tx(
+                    &conn,
+                    row_group_id_hex,
+                    message_id_hex,
+                    *kind,
+                    tags,
+                )?);
+            }
+            let before =
+                timeline_records_by_ids_tx(&conn, &group_id_hex, affected_message_ids.clone())?;
+            conn.execute(
+                "UPDATE app_events
+                 SET invalidated = 0, invalidation_reason = NULL
+                 WHERE origin_commit_id = ?1
+                   AND invalidated = 1
+                   AND invalidation_reason = ?2",
+                params![origin_commit_id, BRANCH_SELECTION_WITHDRAWAL_REASON],
+            )
+            .storage()?;
+            rebuild_message_timeline_for_group_tx(&conn, &group_id_hex)?;
+            let messages =
+                timeline_records_by_ids_tx(&conn, &group_id_hex, affected_message_ids.clone())?;
             let mut changes = Vec::new();
             for (_, message_id_hex, kind, tags) in &rows {
                 changes.extend(timeline_changes_for_invalidation(

--- a/crates/storage-sqlite/src/timeline/tests.rs
+++ b/crates/storage-sqlite/src/timeline/tests.rs
@@ -622,6 +622,137 @@ fn rerecording_an_origin_commit_invalidated_row_keeps_its_tombstone() {
 }
 
 #[test]
+fn revalidating_an_origin_commit_revives_only_branch_selection_withdrawals() {
+    // A convergence pass parks a losing commit and the app tombstones every
+    // kind-1210 row it synthesized. A later pass holding deeper evidence
+    // re-adopts that commit, so those rows describe canonical history again and
+    // the revalidation must bring all of them back — while leaving rows another
+    // commit owns, and rows withdrawn for a reason convergence cannot reverse,
+    // exactly where they are.
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    for (id, system_type, at, commit) in [
+        ("parked-added", "member_added", 10, "commit-parked"),
+        ("parked-admin", "admin_added", 11, "commit-parked"),
+        ("other-added", "member_added", 12, "commit-other"),
+    ] {
+        store
+            .record_app_event(&group_system_from_commit(id, system_type, at, commit))
+            .unwrap();
+    }
+    store
+        .invalidate_app_events_by_origin_commit("commit-parked", BRANCH_SELECTION_WITHDRAWAL_REASON)
+        .unwrap()
+        .expect("the park must tombstone both rows");
+    store
+        .invalidate_app_events_by_origin_commit("commit-other", "LosingBranch")
+        .unwrap()
+        .expect("the other commit's row is withdrawn terminally");
+
+    let update = store
+        .clear_branch_selection_withdrawal_by_origin_commit("commit-parked")
+        .unwrap()
+        .expect("re-adoption must project an update");
+
+    let changed_ids: Vec<&str> = update
+        .changes
+        .iter()
+        .map(|change| match change {
+            TimelineMessageChange::Upsert { message, .. } => message.message_id_hex.as_str(),
+            TimelineMessageChange::Remove { message_id_hex, .. } => message_id_hex.as_str(),
+        })
+        .collect();
+    assert!(changed_ids.contains(&"parked-added"));
+    assert!(changed_ids.contains(&"parked-admin"));
+    assert!(!changed_ids.contains(&"other-added"));
+
+    let rows = list(&store);
+    let status = |id: &str| {
+        rows.iter()
+            .find(|row| row.message_id_hex == id)
+            .map(|row| row.invalidation_status.clone())
+    };
+    assert_eq!(status("parked-added"), Some(None));
+    assert_eq!(status("parked-admin"), Some(None));
+    assert_eq!(
+        status("other-added"),
+        Some(Some("LosingBranch".to_owned())),
+        "a withdrawal convergence cannot reverse must stay terminal"
+    );
+}
+
+#[test]
+fn revalidating_leaves_other_withdrawal_reasons_and_live_rows_alone() {
+    // The predicate is reason-scoped AND state-scoped: a row withdrawn under a
+    // reason this primitive does not own is untouched even when the named
+    // commit matches, and a live row is never rewritten. Both cases return
+    // `None` so the caller can tell a real revival from a no-op.
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    store
+        .record_app_event(&group_system_from_commit(
+            "terminal",
+            "member_added",
+            10,
+            "commit-terminal",
+        ))
+        .unwrap();
+    store
+        .record_app_event(&group_system_from_commit(
+            "live",
+            "member_added",
+            11,
+            "commit-live",
+        ))
+        .unwrap();
+    store
+        .invalidate_app_events_by_origin_commit("commit-terminal", "LosingBranch")
+        .unwrap()
+        .expect("withdrawal");
+
+    assert!(
+        store
+            .clear_branch_selection_withdrawal_by_origin_commit("commit-terminal")
+            .unwrap()
+            .is_none(),
+        "only a branch-selection withdrawal may be taken back"
+    );
+    assert!(
+        store
+            .clear_branch_selection_withdrawal_by_origin_commit("commit-live")
+            .unwrap()
+            .is_none(),
+        "a live row is left untouched rather than rewritten"
+    );
+    assert!(
+        store
+            .clear_branch_selection_withdrawal_by_origin_commit("commit-unknown")
+            .unwrap()
+            .is_none()
+    );
+    let rows = list(&store);
+    let status = |id: &str| {
+        rows.iter()
+            .find(|row| row.message_id_hex == id)
+            .map(|row| row.invalidation_status.clone())
+    };
+    assert_eq!(status("terminal"), Some(Some("LosingBranch".to_owned())));
+    assert_eq!(status("live"), Some(None));
+}
+
+#[test]
+fn branch_selection_withdrawal_reason_matches_the_engine_variant() {
+    // The app writes this literal by formatting the engine's reason; storage
+    // reads it back as a predicate. Nothing else couples the two, so a rename
+    // on either side has to fail here rather than silently stop reviving.
+    assert_eq!(
+        format!(
+            "{:?}",
+            cgka_traits::engine::GroupStateInvalidationReason::SupersededByBranchSelection
+        ),
+        BRANCH_SELECTION_WITHDRAWAL_REASON
+    );
+}
+
+#[test]
 fn rerecording_a_source_invalidated_message_keeps_its_tombstone() {
     // A delivered app message the engine withdrew as a fork loser is
     // redelivered by a relay and re-recorded under the same inner id in a later

--- a/crates/storage-sqlite/src/timeline/tests.rs
+++ b/crates/storage-sqlite/src/timeline/tests.rs
@@ -648,6 +648,27 @@ fn revalidating_an_origin_commit_revives_only_branch_selection_withdrawals() {
         .unwrap()
         .expect("the other commit's row is withdrawn terminally");
 
+    // A SECOND branch-selection tombstone, under a DIFFERENT origin commit.
+    // Only the reason predicate separates this row from the parked commit's
+    // rows, so without the `origin_commit_id` conjunct the revalidation below
+    // would revive it too — which is the whole account's withdrawal history
+    // being cleared by one unrelated re-adoption.
+    store
+        .record_app_event(&group_system_from_commit(
+            "sibling-added",
+            "member_added",
+            13,
+            "commit-sibling",
+        ))
+        .unwrap();
+    store
+        .invalidate_app_events_by_origin_commit(
+            "commit-sibling",
+            BRANCH_SELECTION_WITHDRAWAL_REASON,
+        )
+        .unwrap()
+        .expect("a second commit is parked under the same reason");
+
     let update = store
         .clear_branch_selection_withdrawal_by_origin_commit("commit-parked")
         .unwrap()
@@ -664,6 +685,7 @@ fn revalidating_an_origin_commit_revives_only_branch_selection_withdrawals() {
     assert!(changed_ids.contains(&"parked-added"));
     assert!(changed_ids.contains(&"parked-admin"));
     assert!(!changed_ids.contains(&"other-added"));
+    assert!(!changed_ids.contains(&"sibling-added"));
 
     let rows = list(&store);
     let status = |id: &str| {
@@ -677,6 +699,11 @@ fn revalidating_an_origin_commit_revives_only_branch_selection_withdrawals() {
         status("other-added"),
         Some(Some("LosingBranch".to_owned())),
         "a withdrawal convergence cannot reverse must stay terminal"
+    );
+    assert_eq!(
+        status("sibling-added"),
+        Some(Some(BRANCH_SELECTION_WITHDRAWAL_REASON.to_owned())),
+        "another commit's branch-selection withdrawal is not this commit's to take back"
     );
 }
 
@@ -740,15 +767,158 @@ fn revalidating_leaves_other_withdrawal_reasons_and_live_rows_alone() {
 
 #[test]
 fn branch_selection_withdrawal_reason_matches_the_engine_variant() {
-    // The app writes this literal by formatting the engine's reason; storage
-    // reads it back as a predicate. Nothing else couples the two, so a rename
-    // on either side has to fail here rather than silently stop reviving.
+    // TRIPWIRE, not a coupling. `BRANCH_SELECTION_WITHDRAWAL_REASON` is frozen
+    // stored data: shipped databases already hold this exact string in
+    // `app_events.invalidation_reason`. The app happens to produce it today by
+    // `Debug`-formatting the traits variant, so a rename there would silently
+    // stop matching every stored row, and this assertion is what turns that
+    // silence into a build failure.
+    //
+    // When it fires, the fix is a DATA MIGRATION that rewrites the stored
+    // column (and re-points every reader), never an edit to the constant.
+    // Editing the constant to match a renamed variant makes the code
+    // self-consistent while orphaning every row an earlier release wrote.
+    //
+    // The FFI encodes the same variant as `superseded_by_branch_selection`
+    // (`group_state_invalidation_reason_tag`). That divergence is deliberate:
+    // one is a durable column value, the other a wire tag.
     assert_eq!(
         format!(
             "{:?}",
             cgka_traits::engine::GroupStateInvalidationReason::SupersededByBranchSelection
         ),
         BRANCH_SELECTION_WITHDRAWAL_REASON
+    );
+}
+
+/// Seed a group plus one commit row in `cgka_messages` under `commit_hex`, in
+/// the stored disposition a convergence pass would have left behind.
+fn seed_commit(store: &SqliteAccountStorage, group: u8, commit_hex: &str, state: MessageState) {
+    use cgka_traits::storage::{GroupStorage, MessageStorage};
+    let group_id = crate::storage::test_support::gid(group);
+    let _ = store.put_group(&crate::storage::test_support::sample_group(
+        group_id.clone(),
+        1,
+        1,
+    ));
+    let id = cgka_traits::types::MessageId::new(hex::decode(commit_hex).unwrap());
+    let mut record = crate::storage::test_support::sample_message(id, group_id, 1);
+    record.state = state;
+    store.put_message(&record).unwrap();
+}
+
+#[test]
+fn divergence_query_reports_only_tombstones_that_disagree_with_engine_state() {
+    // The crash-repair contract. `events_buf` is in-memory, so a process death
+    // between the convergence apply transaction and the app projection loses a
+    // withdrawal or a revalidation outright, and announce-once means no later
+    // pass re-derives it. Both sides live in this one database, so the
+    // divergence is always recomputable from `cgka_messages.state`.
+    //
+    // parked:  engine parked it, but its row is still live (withdrawal lost).
+    // adopted: engine re-adopted it, row still tombstoned (revalidation lost).
+    // settled: canonical commit with a live row -- agreement, no work.
+    // retired: aged out to EpochInvalidated; its rows stay withdrawn forever.
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    for (row_id, commit, state) in [
+        ("parked-row", "aa11", MessageState::ConvergenceDeferred),
+        ("adopted-row", "bb22", MessageState::Processed),
+        ("settled-row", "cc33", MessageState::Processed),
+        ("retired-row", "dd44", MessageState::EpochInvalidated),
+    ] {
+        seed_commit(&store, 1, commit, state);
+        store
+            .record_app_event(&group_system_from_commit(
+                row_id,
+                "member_added",
+                10,
+                commit,
+            ))
+            .unwrap();
+    }
+    for commit in ["bb22", "dd44"] {
+        store
+            .invalidate_app_events_by_origin_commit(commit, BRANCH_SELECTION_WITHDRAWAL_REASON)
+            .unwrap()
+            .expect("seed withdrawal");
+    }
+
+    let divergence = store.diverged_branch_selection_withdrawals().unwrap();
+    assert_eq!(
+        divergence.to_withdraw,
+        vec!["aa11".to_owned()],
+        "a parked commit with a live row owes the withdrawal the crash lost"
+    );
+    assert_eq!(
+        divergence.to_revive,
+        vec!["bb22".to_owned()],
+        "a re-adopted commit still tombstoned owes the revalidation the crash lost,          while a retired commit stays withdrawn"
+    );
+
+    // Applying the divergence converges the account, and a second pass finds
+    // nothing: the fixed-point property that lets this run on every open.
+    for commit in &divergence.to_withdraw {
+        store
+            .invalidate_app_events_by_origin_commit(commit, BRANCH_SELECTION_WITHDRAWAL_REASON)
+            .unwrap();
+    }
+    for commit in &divergence.to_revive {
+        store
+            .clear_branch_selection_withdrawal_by_origin_commit(commit)
+            .unwrap();
+    }
+    assert!(
+        store
+            .diverged_branch_selection_withdrawals()
+            .unwrap()
+            .is_empty(),
+        "reconciliation must be a fixed point"
+    );
+
+    let rows = list(&store);
+    let status = |id: &str| {
+        rows.iter()
+            .find(|row| row.message_id_hex == id)
+            .map(|row| row.invalidation_status.clone())
+    };
+    assert_eq!(
+        status("parked-row"),
+        Some(Some(BRANCH_SELECTION_WITHDRAWAL_REASON.to_owned()))
+    );
+    assert_eq!(status("adopted-row"), Some(None));
+    assert_eq!(status("settled-row"), Some(None), "agreement is untouched");
+    assert_eq!(
+        status("retired-row"),
+        Some(Some(BRANCH_SELECTION_WITHDRAWAL_REASON.to_owned())),
+        "a retired commit is terminal: reconciliation must never revive it"
+    );
+}
+
+#[test]
+fn divergence_query_ignores_rows_withdrawn_for_other_reasons() {
+    // Reconciliation owns exactly one reason. A row withdrawn under a reason
+    // convergence cannot reverse must never be revived just because its origin
+    // commit is canonical.
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    seed_commit(&store, 2, "ee55", MessageState::Processed);
+    store
+        .record_app_event(&group_system_from_commit(
+            "terminal-row",
+            "member_added",
+            10,
+            "ee55",
+        ))
+        .unwrap();
+    store
+        .invalidate_app_events_by_origin_commit("ee55", "LosingBranch")
+        .unwrap()
+        .expect("seed withdrawal");
+
+    assert!(
+        store
+            .diverged_branch_selection_withdrawals()
+            .unwrap()
+            .is_empty()
     );
 }
 

--- a/crates/traits/src/engine.rs
+++ b/crates/traits/src/engine.rs
@@ -551,6 +551,32 @@ pub enum GroupEvent {
         invalidated_commit_id: MessageId,
         reason: GroupStateInvalidationReason,
     },
+    /// The exact inverse of [`GroupEvent::GroupStateInvalidated`]: a commit
+    /// whose state notifications were withdrawn by
+    /// [`GroupStateInvalidationReason::SupersededByBranchSelection`] is back on
+    /// the selected branch, so those notifications describe canonical history
+    /// again and the application MUST restore them.
+    ///
+    /// A branch-selection withdrawal is not terminal, because the state it
+    /// reports on is not: convergence parks a losing commit *reconsiderable*
+    /// (`MessageState::ConvergenceDeferred`), and a later pass holding deeper
+    /// evidence can re-adopt it. Without this event the application's
+    /// withdrawal is permanent while the engine's is not, and the re-adopted
+    /// commit's system rows stay tombstoned under a branch decision that has
+    /// since been reversed.
+    ///
+    /// Scope: this revives only what `SupersededByBranchSelection` withdrew.
+    /// Every other withdrawal reason stays terminal.
+    GroupStateRevalidated {
+        group_id: GroupId,
+        /// Epoch the re-adopted commit branched from — the same value its
+        /// withdrawal carried.
+        epoch: EpochId,
+        /// Transport-layer `MessageId` of the re-adopted commit, in the same
+        /// identifier space as `invalidated_commit_id` and the
+        /// `origin_commit_id` stamped on [`GroupEvent::GroupStateChanged`].
+        revalidated_commit_id: MessageId,
+    },
     /// The group entered the `Unrecoverable` state: convergence reported a
     /// `MissingRetainedAnchor` inside the rollback horizon, so the client
     /// stopped applying group-state changes and now needs a verified repair

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -750,6 +750,14 @@ fn snapshot_group_events() {
         }
     );
     insta::assert_json_snapshot!(
+        "event_group_state_revalidated",
+        GroupEvent::GroupStateRevalidated {
+            group_id: gid(),
+            epoch: EpochId(1),
+            revalidated_commit_id: mid(),
+        }
+    );
+    insta::assert_json_snapshot!(
         "event_pending_commit_recovered",
         GroupEvent::PendingCommitRecovered {
             group_id: gid(),

--- a/crates/traits/tests/snapshots/snapshots__event_group_state_revalidated.snap
+++ b/crates/traits/tests/snapshots/snapshots__event_group_state_revalidated.snap
@@ -1,0 +1,21 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: "GroupEvent::GroupStateRevalidated\n{ group_id: gid(), epoch: EpochId(1), revalidated_commit_id: mid(), }"
+---
+{
+  "GroupStateRevalidated": {
+    "group_id": [
+      170,
+      170,
+      170,
+      170
+    ],
+    "epoch": 1,
+    "revalidated_commit_id": [
+      187,
+      187,
+      187,
+      187
+    ]
+  }
+}


### PR DESCRIPTION
Convergence rollback withdrawals are now announce-once, reversible, and crash-safe. Closes the (a) and (e) follow-ups from #1602's review and the re-adoption tombstone found in #1608's review.

Engine: emit_rolled_back_commits announced the same GroupStateInvalidated withdrawal on every convergence pass for parked losers, and never took a withdrawal back when a deferred commit was later re-adopted (reachable via the rewind path; with storage terminal since #1608 the re-adopted commit's timeline rows stayed dead forever). Now: a withdrawal is announced only on the transition into a parked state (derived from a pre-apply state snapshot, no new persisted state, no migration), and a new GroupStateRevalidated event fires when a previously-parked commit is accepted. Revalidation is deliberately over-broad; the storage side is scoped (origin commit + invalidated + SupersededByBranchSelection reason only), so a spurious event is a no-op. Wired through uniffi and C bindings.

Crash safety: engine events are in-memory, and announce-once removed the accidental repair that re-announcing provided. Instead of a durable event queue, both consumers now re-derive from stored state, which is strictly stronger (repairs divergences that predate this change too): the app reconciles branch-selection tombstones and revivals from cgka_messages state at account open, and marmot-account re-derives evolution supersession at the top of run_due_maintenance. That second one closes a real PCS hole with a network-wide loss window: a stranded evolution could let a self-update rotation obligation close from a leaf that never rotated, or keep republishing a commit convergence had withdrawn. That path had zero test coverage before; it is red-first tested now.

Batch projection: resolving withdraw-vs-revalidate for one commit within a single drained batch is now done in event order (last verdict wins), matching how storage applies them. The initial set-membership exemption reopened the #1593 same-batch live-row shape; the review reproduced it and the fix ships with the reproduction as a test.

Behavior change worth review (Jeff): announce-once means an unresolved contested fork no longer re-announces its withdrawal every pass, so it no longer resets the epoch-stall detector's arm run each pass. A stalled contested group can now escalate to backfill where it previously never did. Docs and tests updated to pin the new behavior; the direction seemed right but it was previously undocumented coupling, so calling it out explicitly.

Scope note: an intermediate version of this branch widened the withdrawal reason filter to cover previously-applied commits deferred as MissingCandidateParent; review instrumentation showed that arm only fires on passes that select no branch at all, where a withdrawal would tombstone applied history a pass decided nothing about. It was reverted as unsafe; the open-time reconciliation covers any genuinely superseded commit whatever reason parked it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reporting when previously withdrawn group state is revalidated after convergence.
  * Added durable message-state lookup for session integrations.
  * Added automatic reconciliation when accounts open, restoring eligible timeline entries and withdrawing outdated ones.

* **Bug Fixes**
  * Prevented duplicate withdrawal announcements for the same commit.
  * Improved recovery after interruptions, missed events, and stalled convergence.
  * Ensured later revalidation restores only affected system rows.
  * Prevented failed maintenance obligations from being retried after member removal.
  * Improved warnings when reconciliation remains incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->