### PR TITLE
Read the group record once per outbound gate pass

### DIFF
--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -2219,66 +2219,6 @@ impl<S: StorageProvider> Engine<S> {
         Ok(())
     }
 
-    /// The durable group record, or `None` for an unknown group — callers
-    /// fail those with their own unknown-group handling.
-    ///
-    /// The outbound gates read this once and answer the removed,
-    /// unrecoverable, and legacy-profile checks from the same record instead
-    /// of paying one O(members) deserialize per check. `removed` marks a
-    /// realized self-eviction (member-departure.md "Realizing removal"),
-    /// terminal for outbound work; it clears through an authenticated re-join
-    /// (`do_join_welcome` rebuilds the record) or when branch selection
-    /// supersedes the removal that set it — the convergence reorg path
-    /// re-derives membership from the selected canonical branch
-    /// (`emit_convergence_events`).
-    pub(crate) fn stored_group_record(
-        &self,
-        group_id: &GroupId,
-    ) -> Result<Option<Group>, EngineError> {
-        match self.storage.get_group(group_id) {
-            Ok(group) => Ok(Some(group)),
-            Err(StorageError::NotFound) => Ok(None),
-            Err(err) => Err(EngineError::Storage(err)),
-        }
-    }
-
-    /// Ensure a durable `Unrecoverable` halt is reflected in the in-memory
-    /// epoch map (mdk#971). Returns `true` when the group is halted. Used as
-    /// defense-in-depth on paths that may run before or without session-open
-    /// hydration so a persisted marker cannot be skipped by a bare
-    /// `set_stable` overwrite.
-    pub(crate) fn sync_unrecoverable_halt_from_storage(
-        &mut self,
-        group_id: &GroupId,
-    ) -> Result<bool, EngineError> {
-        if self.epoch_manager.is_unrecoverable(group_id) {
-            return Ok(true);
-        }
-        let group = self.stored_group_record(group_id)?;
-        Ok(self.sync_unrecoverable_halt_from_record(group_id, group.as_ref()))
-    }
-
-    /// [`Self::sync_unrecoverable_halt_from_storage`] for a caller that has
-    /// already read the group record (`None` for an unknown group).
-    pub(crate) fn sync_unrecoverable_halt_from_record(
-        &mut self,
-        group_id: &GroupId,
-        group: Option<&Group>,
-    ) -> bool {
-        if self.epoch_manager.is_unrecoverable(group_id) {
-            return true;
-        }
-        let Some(group) = group else {
-            return false;
-        };
-        if !group.unrecoverable {
-            return false;
-        }
-        self.epoch_manager
-            .restore_unrecoverable(group_id.clone(), group.epoch);
-        true
-    }
-
     /// Clear ONLY the live OpenMLS group state for `group_id`, leaving every
     /// retained artifact in place.
     ///

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -2219,19 +2219,25 @@ impl<S: StorageProvider> Engine<S> {
         Ok(())
     }
 
-    /// Whether the local copy of `group_id` is marked removed (realized
-    /// self-eviction; member-departure.md "Realizing removal"). A removed copy
-    /// is terminal for outbound work: nothing may be prepared or published for
-    /// it. Unknown groups report `false` — callers fail them with their own
-    /// unknown-group handling. The marker clears through an authenticated
-    /// re-join (`do_join_welcome` rebuilds the record) or when branch
-    /// selection supersedes the removal that set it — the convergence reorg
-    /// path re-derives membership from the selected canonical branch
+    /// The durable group record, or `None` for an unknown group — callers
+    /// fail those with their own unknown-group handling.
+    ///
+    /// The outbound gates read this once and answer the removed,
+    /// unrecoverable, and legacy-profile checks from the same record instead
+    /// of paying one O(members) deserialize per check. `removed` marks a
+    /// realized self-eviction (member-departure.md "Realizing removal"),
+    /// terminal for outbound work; it clears through an authenticated re-join
+    /// (`do_join_welcome` rebuilds the record) or when branch selection
+    /// supersedes the removal that set it — the convergence reorg path
+    /// re-derives membership from the selected canonical branch
     /// (`emit_convergence_events`).
-    pub(crate) fn group_record_is_removed(&self, group_id: &GroupId) -> Result<bool, EngineError> {
+    pub(crate) fn stored_group_record(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<Option<Group>, EngineError> {
         match self.storage.get_group(group_id) {
-            Ok(group) => Ok(group.removed),
-            Err(StorageError::NotFound) => Ok(false),
+            Ok(group) => Ok(Some(group)),
+            Err(StorageError::NotFound) => Ok(None),
             Err(err) => Err(EngineError::Storage(err)),
         }
     }
@@ -2248,17 +2254,29 @@ impl<S: StorageProvider> Engine<S> {
         if self.epoch_manager.is_unrecoverable(group_id) {
             return Ok(true);
         }
-        let group = match self.storage.get_group(group_id) {
-            Ok(group) => group,
-            Err(StorageError::NotFound) => return Ok(false),
-            Err(err) => return Err(EngineError::Storage(err)),
+        let group = self.stored_group_record(group_id)?;
+        Ok(self.sync_unrecoverable_halt_from_record(group_id, group.as_ref()))
+    }
+
+    /// [`Self::sync_unrecoverable_halt_from_storage`] for a caller that has
+    /// already read the group record (`None` for an unknown group).
+    pub(crate) fn sync_unrecoverable_halt_from_record(
+        &mut self,
+        group_id: &GroupId,
+        group: Option<&Group>,
+    ) -> bool {
+        if self.epoch_manager.is_unrecoverable(group_id) {
+            return true;
+        }
+        let Some(group) = group else {
+            return false;
         };
         if !group.unrecoverable {
-            return Ok(false);
+            return false;
         }
         self.epoch_manager
             .restore_unrecoverable(group_id.clone(), group.epoch);
-        Ok(true)
+        true
     }
 
     /// Clear ONLY the live OpenMLS group state for `group_id`, leaving every

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -1615,6 +1615,70 @@ pub(crate) fn mirror_app_components_into_record(
     }
 }
 
+/// Durable group-record gates shared by the outbound send, queued-drain, and
+/// convergence paths.
+impl<S: StorageProvider> Engine<S> {
+    /// The durable group record, or `None` for an unknown group — callers
+    /// fail those with their own unknown-group handling.
+    ///
+    /// The outbound gates read this once and answer the removed,
+    /// unrecoverable, and legacy-profile checks from the same record instead
+    /// of paying one O(members) deserialize per check. `removed` marks a
+    /// realized self-eviction (member-departure.md "Realizing removal"),
+    /// terminal for outbound work; it clears through an authenticated re-join
+    /// (`do_join_welcome` rebuilds the record) or when branch selection
+    /// supersedes the removal that set it — the convergence reorg path
+    /// re-derives membership from the selected canonical branch
+    /// (`emit_convergence_events`).
+    pub(crate) fn stored_group_record(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<Option<Group>, EngineError> {
+        match self.storage.get_group(group_id) {
+            Ok(group) => Ok(Some(group)),
+            Err(StorageError::NotFound) => Ok(None),
+            Err(err) => Err(EngineError::Storage(err)),
+        }
+    }
+
+    /// Ensure a durable `Unrecoverable` halt is reflected in the in-memory
+    /// epoch map (mdk#971). Returns `true` when the group is halted. Used as
+    /// defense-in-depth on paths that may run before or without session-open
+    /// hydration so a persisted marker cannot be skipped by a bare
+    /// `set_stable` overwrite.
+    pub(crate) fn sync_unrecoverable_halt_from_storage(
+        &mut self,
+        group_id: &GroupId,
+    ) -> Result<bool, EngineError> {
+        if self.epoch_manager.is_unrecoverable(group_id) {
+            return Ok(true);
+        }
+        let group = self.stored_group_record(group_id)?;
+        Ok(self.sync_unrecoverable_halt_from_record(group_id, group.as_ref()))
+    }
+
+    /// [`Self::sync_unrecoverable_halt_from_storage`] for a caller that has
+    /// already read the group record (`None` for an unknown group).
+    pub(crate) fn sync_unrecoverable_halt_from_record(
+        &mut self,
+        group_id: &GroupId,
+        group: Option<&Group>,
+    ) -> bool {
+        if self.epoch_manager.is_unrecoverable(group_id) {
+            return true;
+        }
+        let Some(group) = group else {
+            return false;
+        };
+        if !group.unrecoverable {
+            return false;
+        }
+        self.epoch_manager
+            .restore_unrecoverable(group_id.clone(), group.epoch);
+        true
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -615,17 +615,21 @@ impl<S: StorageProvider> Engine<S> {
         let group = self.stored_group_record(&group_id)?;
         if self.new_protocol_profile == cgka_traits::group::ProtocolProfile::Current
             && matches!(intent, SendIntent::Invite { .. })
-            && group.as_ref().is_some_and(|group| {
-                group.protocol_profile == cgka_traits::group::ProtocolProfile::Legacy
-            })
         {
-            return Err(EngineError::InvalidTransition(
-                cgka_traits::engine_state::InvalidTransition {
-                    from: "LegacyProfile",
-                    to: "Invite",
-                    reason: "strict cutover forbids adding members to legacy groups",
-                },
-            ));
+            // An Invite needs the record to read its profile; an unknown group
+            // fails here with the storage error the direct read used to raise.
+            let Some(group) = group.as_ref() else {
+                return Err(EngineError::Storage(StorageError::NotFound));
+            };
+            if group.protocol_profile == cgka_traits::group::ProtocolProfile::Legacy {
+                return Err(EngineError::InvalidTransition(
+                    cgka_traits::engine_state::InvalidTransition {
+                        from: "LegacyProfile",
+                        to: "Invite",
+                        reason: "strict cutover forbids adding members to legacy groups",
+                    },
+                ));
+            }
         }
         // Terminal gate before queueing: a local copy marked removed (realized
         // self-eviction) must never accept or queue outbound work. Checked

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -611,10 +611,13 @@ impl<S: StorageProvider> Engine<S> {
         // Strict cutover freezes membership growth in legacy groups. Existing
         // members may continue messaging and applying other group changes, but
         // no add (including a re-add) may be staged or queued.
+        // One record read serves this gate and the two terminal gates below.
+        let group = self.stored_group_record(&group_id)?;
         if self.new_protocol_profile == cgka_traits::group::ProtocolProfile::Current
             && matches!(intent, SendIntent::Invite { .. })
-            && self.storage.get_group(&group_id)?.protocol_profile
-                == cgka_traits::group::ProtocolProfile::Legacy
+            && group.as_ref().is_some_and(|group| {
+                group.protocol_profile == cgka_traits::group::ProtocolProfile::Legacy
+            })
         {
             return Err(EngineError::InvalidTransition(
                 cgka_traits::engine_state::InvalidTransition {
@@ -628,7 +631,7 @@ impl<S: StorageProvider> Engine<S> {
         // self-eviction) must never accept or queue outbound work. Checked
         // again in `do_send_ready` so queued-intent drains for a copy removed
         // after queueing hit the same deterministic error.
-        if self.group_record_is_removed(&group_id)? {
+        if group.as_ref().is_some_and(|group| group.removed) {
             return Err(EngineError::InvalidTransition(
                 cgka_traits::engine_state::InvalidTransition {
                     from: "Removed",
@@ -639,7 +642,7 @@ impl<S: StorageProvider> Engine<S> {
         }
         // mdk#971: durable Unrecoverable halt — sync into memory and refuse
         // outbound work until a verified repair path clears the marker.
-        if self.sync_unrecoverable_halt_from_storage(&group_id)? {
+        if self.sync_unrecoverable_halt_from_record(&group_id, group.as_ref()) {
             // mdk#1177: typed, not `InvalidTransition`. A halted group is a
             // durable condition whose only exit is another member's repair
             // Welcome, so the host has something to tell the user and act on —
@@ -810,7 +813,8 @@ impl<S: StorageProvider> Engine<S> {
         // An advance can be invoked directly without session-open hydration.
         // Synchronize the durable halt before convergence or queued work can
         // run so restart never bypasses `Unrecoverable`.
-        if self.sync_unrecoverable_halt_from_storage(group_id)? {
+        let group = self.stored_group_record(group_id)?;
+        if self.sync_unrecoverable_halt_from_record(group_id, group.as_ref()) {
             return Ok(false);
         }
         // Terminal: a removed copy must never publish, and the removed-copy
@@ -819,7 +823,7 @@ impl<S: StorageProvider> Engine<S> {
         // queue and report nothing to drain. This is the defense-in-depth
         // side; the marker sites (realization, commit-apply seam, convergence
         // reorg) also purge at the moment the copy becomes removed.
-        if self.group_record_is_removed(group_id)? {
+        if group.is_some_and(|group| group.removed) {
             self.discard_queued_outbound_intents_for_removed_group(group_id)?;
             return Ok(false);
         }

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -45,7 +45,8 @@ impl<S: StorageProvider> Engine<S> {
         // here (not just `do_send`) so queued-intent drains hit the same
         // deterministic terminal error. Every intent kind is blocked,
         // including `Leave` — there is nothing left to leave.
-        if self.group_record_is_removed(&group_id)? {
+        let group = self.stored_group_record(&group_id)?;
+        if group.as_ref().is_some_and(|group| group.removed) {
             return Err(EngineError::InvalidTransition(
                 cgka_traits::engine_state::InvalidTransition {
                     from: "Removed",
@@ -57,7 +58,7 @@ impl<S: StorageProvider> Engine<S> {
         // Queued drains call this method directly, bypassing `do_send`.
         // Recheck the durable lifecycle marker here so no outbound work can
         // escape an `Unrecoverable` halt after restart.
-        if self.sync_unrecoverable_halt_from_storage(&group_id)? {
+        if self.sync_unrecoverable_halt_from_record(&group_id, group.as_ref()) {
             // Same condition and same typed error as the `validate_send_acceptance`
             // gate (mdk#1177): a drain reaching a halted group must not report it
             // differently just because it bypassed `do_send`.

--- a/crates/cgka-engine/tests/group_creation.rs
+++ b/crates/cgka-engine/tests/group_creation.rs
@@ -24,7 +24,7 @@ use cgka_traits::app_components::{
 };
 use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MarmotAppEvent};
 use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
-use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, SendResult};
+use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, SendIntent, SendResult};
 use cgka_traits::error::PeelerError;
 use cgka_traits::group::ProtocolProfile;
 use cgka_traits::group_context::GroupContextSnapshot;
@@ -37,7 +37,7 @@ use cgka_traits::storage::{
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
 };
-use cgka_traits::types::{MemberId, MessageId};
+use cgka_traits::types::{GroupId, MemberId, MessageId};
 use openmls::component::ComponentType;
 use openmls::extensions::{
     AppDataDictionary, AppDataDictionaryExtension, Extension, LastResortExtension,
@@ -3031,4 +3031,38 @@ async fn audit_log_records_welcome_recipient_expectation() {
     ));
     assert_eq!(app_message.expected_count, Some(1));
     assert_eq!(app_message.expected_member_refs.len(), 1);
+}
+
+/// The strict-cutover Invite gate reads the durable group record to check its
+/// profile. With no record (`get_group` -> `NotFound`) the gate must fail
+/// with that storage error rather than fall through to later stages.
+#[tokio::test]
+async fn current_invite_to_unknown_group_fails_on_missing_record() {
+    let storage = SqliteAccountStorage::in_memory().unwrap();
+    let mut current = build_profile_client_on_storage(
+        b"missing-record-invite",
+        storage.clone(),
+        ProtocolProfile::Current,
+    );
+    let unknown = GroupId::new(vec![0xAB; 16]);
+    assert!(matches!(
+        storage.get_group(&unknown),
+        Err(cgka_traits::storage::StorageError::NotFound)
+    ));
+
+    let error = current
+        .send(SendIntent::Invite {
+            group_id: unknown,
+            key_packages: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .expect_err("invite to an unknown group must fail");
+    assert!(
+        matches!(
+            error,
+            EngineError::Storage(cgka_traits::storage::StorageError::NotFound)
+        ),
+        "expected missing-record error, got {error:?}"
+    );
 }


### PR DESCRIPTION
### Summary

Each outbound gate pass loads the group record once and answers the removed, unrecoverable, and legacy-profile checks from it.

### Context

Send acceptance, the queued-drain preflight, and the ready-to-prepare recheck each asked storage for the same group record up to three times. Every read deserializes the full member list. A direct send runs two of those passes, so a small app message paid five record reads for three yes/no answers.

The recheck in `do_send_ready` is not redundant and stays. The convergence advance that runs between acceptance and preparation can realize a removal, a durable halt, or a disband, so the second pass is live.

### What changed

`stored_group_record` reads the record once and returns `None` for an unknown group. `sync_unrecoverable_halt_from_record` takes that record instead of re-reading it; the storage-reading variant now wraps it. The three gate sites use the pair. `group_record_is_removed` had no callers left and is gone.

### Impact

Three record reads per app send instead of five, and one fewer per drained queued intent. No behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of group lifecycle states during message sending and synchronization.
  * Fixed validation inconsistencies for invitations, convergence, and removed groups.
  * Unknown groups now return a clear “not found” storage error during invitation validation.
  * Ensured persisted removal and unrecoverable-halt states are applied consistently across message-processing flows.
  * Improved restoration of halted processing when persisted group state requires it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->