### PR TITLE
Answer the contested probe from the commit-edge memo

### DIFF
--- a/crates/cgka-engine/src/convergence_input.rs
+++ b/crates/cgka-engine/src/convergence_input.rs
@@ -45,10 +45,7 @@ impl ClassifiedConvergenceInput {
     }
 
     fn can_start_pass(self) -> bool {
-        matches!(
-            self.state,
-            MessageState::Sent | MessageState::Created | MessageState::Retryable
-        )
+        PASS_OPENING_STATES.contains(&self.state)
     }
 
     fn can_gate_outbound(self) -> bool {
@@ -63,6 +60,17 @@ impl ClassifiedConvergenceInput {
 /// same constant keeps the fast path and the classifier in lockstep.
 pub(crate) const OUTBOUND_GATING_STATES: [MessageState; 2] =
     [MessageState::Created, MessageState::Retryable];
+
+/// The states in which a retained input can open a convergence pass
+/// ([`ConvergenceInputContext::opens_pass`]). Pass seeding probes storage for
+/// these before projecting the retained window; the same constant backs
+/// [`ClassifiedConvergenceInput::can_start_pass`] so probe and classifier
+/// stay in lockstep.
+pub(crate) const PASS_OPENING_STATES: [MessageState; 3] = [
+    MessageState::Sent,
+    MessageState::Created,
+    MessageState::Retryable,
+];
 
 #[derive(Default)]
 pub(crate) struct ConvergenceInputContext {

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -787,21 +787,38 @@ impl<S: StorageProvider> Engine<S> {
                 ),
             );
         }
-        let projected = self
+        // The caller discards the members unless a trigger opens a pass, and a
+        // trigger needs either a row in a pass-opening state or a disband
+        // candidate. Answer the common "nothing to open" case with two indexed
+        // reads before projecting the window.
+        let candidate_ids: HashSet<MessageId> = self
             .storage
-            .list_messages(group_id, EpochId(floor))
+            .list_disband_candidates(group_id)
             .map_err(storage_projection_error)?
             .into_iter()
-            .filter(|record| {
-                matches!(
-                    record.state,
-                    MessageState::Sent
-                        | MessageState::Created
-                        | MessageState::Retryable
-                        | MessageState::ConvergenceDeferred
-                        | MessageState::Processed
+            .flat_map(|candidate| [candidate.commit_id, candidate.content_commit_id])
+            .collect();
+        if candidate_ids.is_empty()
+            && !self
+                .storage
+                .has_messages_in_states(
+                    group_id,
+                    &crate::convergence_input::PASS_OPENING_STATES,
+                    EpochId(floor),
                 )
-            })
+                .map_err(storage_projection_error)?
+        {
+            return Ok((Vec::new(), false));
+        }
+        let projected = self
+            .storage
+            .list_messages_in_states(
+                group_id,
+                &crate::openmls_projection::OPENMLS_GRAPH_INPUT_STATES,
+                EpochId(floor),
+            )
+            .map_err(storage_projection_error)?
+            .into_iter()
             .filter_map(|record| {
                 let payload = match StoredMessagePayload::decode(&record.payload) {
                     Ok(payload) => payload,
@@ -837,20 +854,9 @@ impl<S: StorageProvider> Engine<S> {
             .collect::<Result<Vec<_>, _>>()?;
         let context =
             ConvergenceInputContext::from_inputs(projected.iter().map(|(_, input)| *input));
-        let has_terminal_trigger = if projected.is_empty() {
-            false
-        } else {
-            let candidate_ids: HashSet<MessageId> = self
-                .storage
-                .list_disband_candidates(group_id)
-                .map_err(storage_projection_error)?
-                .into_iter()
-                .flat_map(|candidate| [candidate.commit_id, candidate.content_commit_id])
-                .collect();
-            projected
-                .iter()
-                .any(|(member, _)| candidate_ids.contains(&member.message_id))
-        };
+        let has_terminal_trigger = projected
+            .iter()
+            .any(|(member, _)| candidate_ids.contains(&member.message_id));
         let has_trigger = has_terminal_trigger
             || projected
                 .iter()

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -36,9 +36,7 @@ use marmot_forensics::{
     AuditEngineContext, AuditEventContext, AuditEventKind, AuditGroupContext, AuditRecord,
     ForensicRecorder, NoopRecorder,
 };
-use openmls::prelude::{
-    MlsMessageBodyIn, MlsMessageIn, ProcessedMessageContent, Proposal, ProtocolMessage,
-};
+use openmls::prelude::{ProcessedMessageContent, Proposal};
 use openmls_rust_crypto::RustCrypto;
 pub use openmls_traits::types::Ciphersuite;
 use rand::RngCore;
@@ -46,7 +44,7 @@ use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tls_codec::{Deserialize as _, Serialize as _};
+use tls_codec::Serialize as _;
 
 /// Default ciphersuite. MLS-1.0 mandatory-to-implement; TLS-ish naming.
 pub const DEFAULT_CIPHERSUITE: Ciphersuite =
@@ -2327,22 +2325,14 @@ impl<S: StorageProvider> Engine<S> {
             let Some(message) = stored_payload.as_openmls_wire() else {
                 continue;
             };
-            let Ok(projection) = crate::openmls_projection::project_mls_message(&message.payload)
+            let Ok((projection, Some(protocol))) =
+                crate::openmls_projection::project_protocol_message(&message.payload)
             else {
                 continue;
             };
             if projection.kind != crate::openmls_projection::OpenMlsContentKind::Proposal {
                 continue;
             }
-
-            let Ok(msg_in) = MlsMessageIn::tls_deserialize_exact(message.payload.as_slice()) else {
-                continue;
-            };
-            let protocol: ProtocolMessage = match msg_in.extract() {
-                MlsMessageBodyIn::PrivateMessage(private) => private.into(),
-                MlsMessageBodyIn::PublicMessage(public) => public.into(),
-                _ => continue,
-            };
             let mut hasher = Sha256::new();
             hasher.update(b"cgka-engine-hydrate-selfremove-probe/v1");
             hasher.update(group_id.as_slice());

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -174,17 +174,20 @@ pub(crate) struct DeferredPeelGroupState {
     /// logged, or copied into durable generation state, and process restart
     /// drops it naturally.
     candidate_cache: Option<DeferredPeelCandidateCacheEntry>,
-    /// Per-row verdicts backing `stored_convergence_commit_digests`: the
-    /// stored payload's hash, plus the commit digest or `None` for a row that
-    /// is not an MLS-wire commit. A row id CAN map to different payload bytes
+    /// Per-row verdicts backing `stored_convergence_commit_edges`: the
+    /// stored payload's hash, plus the commit's `(source_epoch, digest)` or
+    /// `None` for a row that is not an MLS-wire commit. A row id CAN map to different payload bytes
     /// over its lifetime — `persist_stored_message_payload` overwrites a
     /// same-id row stored under a different payload variant (e.g. RawTransport
     /// re-persisted as OpenMlsWire, #369) — so each reuse revalidates the
     /// cheap payload hash and only then skips the decode + TLS parse. Rebuilt
     /// to the currently listed rows on every use, so it cannot outgrow the
     /// group's stored history.
-    commit_digest_memo: HashMap<MessageId, ([u8; 32], Option<[u8; 32]>)>,
+    commit_digest_memo: HashMap<MessageId, ([u8; 32], Option<CommitEdge>)>,
 }
+
+/// `(source_epoch, digest)` of one stored commit in the convergence graph.
+type CommitEdge = (u64, [u8; 32]);
 
 struct DeferredPeelCandidateCacheEntry {
     context_fingerprint: [u8; 32],
@@ -2026,15 +2029,15 @@ impl<S: StorageProvider> Engine<S> {
         let policy = self
             .convergence_policy_for_group_ungated(group_id)
             .map_err(|error| EngineError::Backend(format!("load convergence policy: {error}")))?;
-        let contested = crate::openmls_projection::stored_graph_is_contested(
-            &self.storage,
-            group_id,
-            group
-                .epoch
-                .0
-                .saturating_sub(policy.convergence.max_rewind_commits),
-        )
-        .map_err(|error| EngineError::Backend(format!("stored graph contested probe: {error}")))?;
+        let floor = group
+            .epoch
+            .0
+            .saturating_sub(policy.convergence.max_rewind_commits);
+        let contested = crate::openmls_projection::commit_edges_are_contested(
+            self.stored_convergence_commit_edges(group_id)?
+                .into_iter()
+                .filter(|(source_epoch, _)| *source_epoch >= floor),
+        );
         Ok(if contested {
             DeferralLineage::ContestedFork
         } else {
@@ -2259,7 +2262,12 @@ impl<S: StorageProvider> Engine<S> {
         // anchor set are both unchanged. Without this term the gate would stay
         // armed exactly where it must not — on a device holding its own branch
         // while a rival branch's traffic sits unreadable.
-        for digest in self.stored_convergence_commit_digests(group_id)? {
+        let digests: BTreeSet<[u8; 32]> = self
+            .stored_convergence_commit_edges(group_id)?
+            .into_iter()
+            .map(|(_source_epoch, digest)| digest)
+            .collect();
+        for digest in digests {
             hasher.update(digest);
         }
         let mut out = [0u8; 32];
@@ -2267,20 +2275,25 @@ impl<S: StorageProvider> Engine<S> {
         Ok(out)
     }
 
-    /// Content digests of the stored commits that can contribute to this
-    /// group's convergence graph, in a stable order.
+    /// `(source_epoch, digest)` of the stored commits that can contribute to
+    /// this group's convergence graph, in listing order.
     ///
-    /// The fingerprint gate computes this set at least twice per sweep, so a
-    /// row's decode + TLS parse + digest is remembered in
+    /// The fingerprint gate computes this set at least twice per sweep and
+    /// the deferral-lineage probe once per deferred message, so a row's
+    /// decode + TLS parse + digest is remembered in
     /// `DeferredPeelGroupState::commit_digest_memo` and paid once per stored
     /// payload version instead of once per computation. State membership is
     /// re-read from the fresh listing every call, and each reuse revalidates
     /// the payload hash; only the payload verdict is memoized.
-    fn stored_convergence_commit_digests(
+    fn stored_convergence_commit_edges(
         &mut self,
         group_id: &GroupId,
-    ) -> Result<BTreeSet<[u8; 32]>, EngineError> {
-        let records = self.storage.list_messages(group_id, EpochId(0))?;
+    ) -> Result<Vec<CommitEdge>, EngineError> {
+        let records = self.storage.list_messages_in_states(
+            group_id,
+            &crate::openmls_projection::OPENMLS_GRAPH_INPUT_STATES,
+            EpochId(0),
+        )?;
         let mut memo = std::mem::take(
             &mut self
                 .deferred_peel
@@ -2289,17 +2302,8 @@ impl<S: StorageProvider> Engine<S> {
                 .commit_digest_memo,
         );
         let mut next_memo = HashMap::with_capacity(records.len());
-        let mut digests = BTreeSet::new();
+        let mut edges = Vec::new();
         for record in records {
-            // Share the graph's own membership predicate rather than restating
-            // it: this set must describe exactly the commits a pass would build
-            // candidate branches from, and a private copy of that match drifts
-            // without any test noticing.
-            if !crate::openmls_projection::record_state_can_contribute_to_openmls_graph(
-                record.state,
-            ) {
-                continue;
-            }
             // The memo entry is valid only for the payload bytes it was
             // computed from: a same-id row can be overwritten under a
             // different payload variant (RawTransport re-persisted as
@@ -2311,10 +2315,12 @@ impl<S: StorageProvider> Engine<S> {
                     .filter(|(_message, projection)| {
                         projection.kind == crate::openmls_projection::OpenMlsContentKind::Commit
                     })
-                    .map(|(_message, projection)| projection.message_digest),
+                    .and_then(|(_message, projection)| {
+                        Some((projection.source_epoch?, projection.message_digest))
+                    }),
             };
-            if let Some(digest) = verdict {
-                digests.insert(digest);
+            if let Some(edge) = verdict {
+                edges.push(edge);
             }
             next_memo.insert(record.id, (payload_hash, verdict));
         }
@@ -2322,7 +2328,7 @@ impl<S: StorageProvider> Engine<S> {
             .entry(group_id.clone())
             .or_default()
             .commit_digest_memo = next_memo;
-        Ok(digests)
+        Ok(edges)
     }
 
     /// Check capacity for one new `PeelDeferred` row, lazily counting the

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -647,22 +647,35 @@ pub(crate) fn stamp_processed_own_commit_record<S: StorageProvider>(
 pub fn project_mls_message(
     bytes: &[u8],
 ) -> Result<OpenMlsMessageProjection, OpenMlsProjectionError> {
+    Ok(project_protocol_message(bytes)?.0)
+}
+
+/// [`project_mls_message`] that also hands back the parsed
+/// [`ProtocolMessage`] (`None` for a Welcome), so a caller that goes on to
+/// process the message pays one TLS parse instead of two.
+pub(crate) fn project_protocol_message(
+    bytes: &[u8],
+) -> Result<(OpenMlsMessageProjection, Option<ProtocolMessage>), OpenMlsProjectionError> {
     let digest = message_digest(bytes);
     let msg = MlsMessageIn::tls_deserialize_exact(bytes)
         .map_err(|e| OpenMlsProjectionError::Decode(format!("{e:?}")))?;
     let body = msg.extract();
     let Some(protocol) = protocol_message_from_body(body)? else {
-        return Ok(OpenMlsMessageProjection {
-            kind: OpenMlsContentKind::Welcome,
-            source_epoch: None,
-            message_digest: digest,
-        });
+        return Ok((
+            OpenMlsMessageProjection {
+                kind: OpenMlsContentKind::Welcome,
+                source_epoch: None,
+                message_digest: digest,
+            },
+            None,
+        ));
     };
-    Ok(OpenMlsMessageProjection {
+    let projection = OpenMlsMessageProjection {
         kind: kind_from_content_type(protocol.content_type()),
         source_epoch: Some(protocol.epoch().as_u64()),
         message_digest: digest,
-    })
+    };
+    Ok((projection, Some(protocol)))
 }
 
 /// Retire unresolved commits that a verified replacement Welcome superseded.
@@ -741,13 +754,14 @@ pub(crate) fn retire_stale_convergence_deferred_commits<S: StorageProvider>(
     retained_anchor_epoch: u64,
 ) -> Result<Vec<(MessageId, EpochId)>, OpenMlsProjectionError> {
     storage.with_transaction(|storage| {
-        let records = storage.list_messages(group_id, EpochId(0))?;
+        let records = storage.list_messages_in_states(
+            group_id,
+            &[MessageState::ConvergenceDeferred],
+            EpochId(0),
+        )?;
         let mut retired = Vec::new();
 
         for record in records {
-            if record.state != MessageState::ConvergenceDeferred {
-                continue;
-            }
             let Ok(payload) = StoredMessagePayload::decode(&record.payload) else {
                 continue;
             };
@@ -1780,60 +1794,24 @@ pub(crate) fn candidate_branch_peel<S: StorageProvider>(
     contexts.map(CandidateBranchPeel::contested_over)
 }
 
-/// Whether this group's stored commit graph is contested: two retained commits
-/// at or above the retained anchor fork from the same source epoch.
-///
-/// The replay-free half of [`candidate_branch_peel`]. Deliberately the same
-/// record-contribution rules as the commit arm of
-/// [`seed_stored_openmls_graph_inputs`] and the same fork predicate
-/// ([`SourceEpochForkDetector`], shared with [`commits_share_a_source_epoch`])
-/// — a privately restated notion of "forked" would drift from the one branch
-/// enumeration acts on without any test noticing; the deferral-lineage pair in
-/// `tests/distributed_convergence.rs` pins the parity. Unlike the full seed it
-/// touches commits only — no payload clones, no proposal/app/own-commit
-/// materialization — and returns at the first fork. No snapshot, no rewind,
-/// no OpenMLS replay.
-pub(crate) fn stored_graph_is_contested<S: StorageProvider>(
-    storage: &S,
-    group_id: &GroupId,
-    retained_anchor_epoch: u64,
-) -> Result<bool, OpenMlsProjectionError> {
-    let records = storage
-        .list_messages(group_id, EpochId(0))
-        .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
+/// Whether the stored commit graph is contested: two distinct commits fork
+/// from one source epoch. `edges` are `(source_epoch, digest)` pairs of the
+/// retained commits at or above the anchor; the deferral-lineage caller reads
+/// them from the sweep's commit-digest memo, so a backlog of undecryptable
+/// input does not re-decode the group's history per message. Folds through
+/// the same detector as branch enumeration so the two cannot drift; the
+/// deferral-lineage pair in `tests/distributed_convergence.rs` pins the
+/// parity.
+pub(crate) fn commit_edges_are_contested(edges: impl IntoIterator<Item = (u64, [u8; 32])>) -> bool {
     let mut detector = SourceEpochForkDetector::default();
-    for record in records {
-        if !record_state_can_contribute_to_openmls_graph(record.state) {
-            continue;
-        }
-        let payload = StoredMessagePayload::decode(&record.payload)
-            .map_err(|e| OpenMlsProjectionError::Serialize(format!("{e:?}")))?;
-        let Some(message) = payload.as_openmls_wire() else {
-            continue;
-        };
-        if matches!(message.envelope, TransportEnvelope::Welcome { .. }) {
-            continue;
-        }
-        let projection = project_mls_message(&message.payload)?;
-        if projection.kind != OpenMlsContentKind::Commit {
-            continue;
-        }
-        let Some(source_epoch) = projection.source_epoch else {
-            continue;
-        };
-        if source_epoch < retained_anchor_epoch {
-            continue;
-        }
-        if detector.observe(source_epoch, projection.message_digest) {
-            return Ok(true);
-        }
-    }
-    Ok(false)
+    edges
+        .into_iter()
+        .any(|(source_epoch, digest)| detector.observe(source_epoch, digest))
 }
 
 /// Incremental form of the fork predicate: `observe` reports true the moment
 /// two distinct commit digests share a source epoch. Both contested-ness
-/// answers ([`stored_graph_is_contested`] and [`commits_share_a_source_epoch`])
+/// answers ([`commit_edges_are_contested`] and [`commits_share_a_source_epoch`])
 /// fold through this one detector so they cannot drift.
 #[derive(Default)]
 struct SourceEpochForkDetector {
@@ -1851,10 +1829,11 @@ impl SourceEpochForkDetector {
 /// Whether two distinct stored commits fork from the same source epoch — the
 /// structural precondition for more than one candidate branch.
 fn commits_share_a_source_epoch(commits: &[StoredCommitMessage]) -> bool {
-    let mut detector = SourceEpochForkDetector::default();
-    commits
-        .iter()
-        .any(|commit| detector.observe(commit.source_epoch, commit.digest))
+    commit_edges_are_contested(
+        commits
+            .iter()
+            .map(|commit| (commit.source_epoch, commit.digest)),
+    )
 }
 
 /// Enumerate and capture branch tips from the state currently restored.
@@ -3073,8 +3052,20 @@ fn record_state_is_canonicalization_input(state: MessageState) -> bool {
 /// this rather than restating the match. A restatement drifts silently: the
 /// graph and its describer disagree, and nothing fails.
 pub(crate) fn record_state_can_contribute_to_openmls_graph(state: MessageState) -> bool {
-    record_state_is_canonicalization_input(state) || state == MessageState::Processed
+    OPENMLS_GRAPH_INPUT_STATES.contains(&state)
 }
+
+/// The states [`record_state_can_contribute_to_openmls_graph`] accepts, as a
+/// slice for indexed `list_messages_in_states` calls. Pass seeding lists on
+/// this so a bounded window is materialized instead of the group's whole
+/// retained history.
+pub(crate) const OPENMLS_GRAPH_INPUT_STATES: [MessageState; 5] = [
+    MessageState::Sent,
+    MessageState::Created,
+    MessageState::Retryable,
+    MessageState::ConvergenceDeferred,
+    MessageState::Processed,
+];
 
 fn unresolved_commit_state(state: MessageState) -> bool {
     matches!(
@@ -3485,9 +3476,9 @@ fn process_openmls_messages_inner<S: StorageProvider>(
     // not be the state the commit actually produces there.
     let mut prefix_canonical = true;
     for message in messages {
-        let projection = project_mls_message(&message.payload)?;
+        let (projection, protocol) = project_protocol_message(&message.payload)?;
         let message_id = hex::encode(message.id.as_slice());
-        let Some(protocol) = protocol_message_from_bytes(&message.payload)? else {
+        let Some(protocol) = protocol else {
             observations.push(OpenMlsReplayObservation::Ignored {
                 message_id,
                 kind: projection.kind,


### PR DESCRIPTION
### Summary

The deferral-lineage contested probe, pass seeding, and two replay sites stop re-decoding the group's stored history.

### Context

Every inbound message that could not be peeled asked whether the stored commit graph is contested. That probe listed the whole retained history and decoded, TLS-parsed, and hashed each row. During a backlog it fires once per deferred message, so a drain cost O(history) per message. #1620 removed graph seeding from this path but left the scan.

Pass seeding had the same shape. It scanned the full history to retire stale deferred commits, then projected the retained window, and the caller discarded both whenever no trigger opened a pass.

The replay loop and the hydrate self-remove probe parsed each message twice: once to project its kind, once to process it.

### What changed

The deferred-peel sweep already keeps a per-row memo of which rows are commits and their digests, validated by payload hash. The memo now also records each commit's source epoch, and `commit_edges_are_contested` folds the fork detector over those edges. `stored_graph_is_contested` is gone; `commits_share_a_source_epoch` uses the same fold.

Pass seeding lists retire candidates by state through the index, and probes for a pass-opening row or a disband candidate before projecting the window. `OPENMLS_GRAPH_INPUT_STATES` and `PASS_OPENING_STATES` back the predicates and the storage filters so they cannot drift.

`project_protocol_message` returns the parsed message alongside the projection; the replay loop and hydrate probe use it.

### Impact

A deferred message pays one indexed listing and one payload hash per row instead of a decode and parse. Seeding on a quiet group returns after two indexed reads. Replay and hydrate do one TLS parse per message instead of two.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved convergence handling when no eligible messages or disband candidates are available.
  * Improved detection of contested message branches and deferred commits during replay and recovery.
  * Improved handling of Welcome messages that do not contain protocol values.
  * Reduced redundant message parsing and storage scanning during convergence processing.

* **Reliability**
  * Improved consistency when identifying messages that can open a convergence pass, including retryable states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->