### PR TITLE
chore(release): prepare 0.9.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-connector"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "agent-control",
  "agent-stream-compose",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "agent-control"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "serde",
  "serde_json",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "agent-stream-compose"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -864,7 +864,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgka-conformance-simulator"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-engine"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-session"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-traits"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "async-trait",
  "criterion",
@@ -1192,7 +1192,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convergence-campaign-runner"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "async-trait",
  "cgka-conformance-simulator",
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "fs-private"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "libc",
  "tempfile",
@@ -2725,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "incident-replay"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "cgka-conformance-simulator",
  "fs-private",
@@ -3322,7 +3322,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-account"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-app"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-c"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "libc",
  "marmot-uniffi",
@@ -3410,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-forensics"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "fs-private",
  "serde",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-markdown"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "serde",
  "serde_json",
@@ -3428,7 +3428,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-terminal-harness"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "agent-control",
  "async-trait",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-uniffi"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "cgka-engine",
  "cgka-traits",
@@ -5668,7 +5668,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-sqlite"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "cgka-traits",
  "fs-private",
@@ -6285,7 +6285,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-adapter"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6305,7 +6305,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-peeler"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6322,7 +6322,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-broker"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "cgka-traits",
  "clap",
@@ -6341,7 +6341,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-stream"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
@@ -7408,7 +7408,7 @@ dependencies = [
 
 [[package]]
 name = "wn-cli"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "agent-stream-compose",
  "cgka-session",
@@ -7442,7 +7442,7 @@ dependencies = [
 
 [[package]]
 name = "wn-codex"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "async-trait",
  "clap",
@@ -7456,7 +7456,7 @@ dependencies = [
 
 [[package]]
 name = "wn-opencode"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "async-trait",
  "clap",
@@ -7471,7 +7471,7 @@ dependencies = [
 
 [[package]]
 name = "wn-pi"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.9.16"
+version = "0.9.17"
 license = "MIT"
 publish = false
 

--- a/crates/cgka-conformance-simulator/vectors/admin-handover.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-handover.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-handover/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "admin-handover/v1",

--- a/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-policy-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "admin-policy-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "concurrent-invite-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "concurrent-invite-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-committer-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "convergence-committer-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-witness-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "convergence-witness-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/conversation.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/conversation.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "conversation/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "conversation/v1",

--- a/crates/cgka-conformance-simulator/vectors/cross-route-own-commit-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/cross-route-own-commit-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "cross-route-own-commit-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "cross-route-own-commit-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "current-profile-required-set/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "application_profile": {
     "name": "current",

--- a/crates/cgka-conformance-simulator/vectors/deferred-tick-catchup.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/deferred-tick-catchup.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "deferred-tick-catchup/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "deferred-tick-catchup/v1",

--- a/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "delayed-past-epoch-app-message/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "delayed-past-epoch-app-message/v1",

--- a/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "drop-queued/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "drop-queued/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "group-data-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "group-data-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-profile-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-profile-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-profile-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "group-profile-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "convergence-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "membership-fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "membership-fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incremental-growth.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incremental-growth.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "incremental-growth/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "incremental-growth/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-member/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "invite-member/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "invite-publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/late-welcome-backfill.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/late-welcome-backfill.v1.json
@@ -1,7 +1,7 @@
 {
  "scenario_name": "late-welcome-backfill/v1",
  "vector_version": "1",
- "conformance_version": "0.9.16",
+ "conformance_version": "0.9.17",
  "seed": null,
  "scenario": {
   "name": "late-welcome-backfill/v1",

--- a/crates/cgka-conformance-simulator/vectors/latecomer-forward-secrecy.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/latecomer-forward-secrecy.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "latecomer-forward-secrecy/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "latecomer-forward-secrecy/v1",

--- a/crates/cgka-conformance-simulator/vectors/leaver-removal-secrecy.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/leaver-removal-secrecy.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "leaver-removal-secrecy/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "leaver-removal-secrecy/v1",

--- a/crates/cgka-conformance-simulator/vectors/multigroup-isolation.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/multigroup-isolation.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "multigroup-isolation/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "multigroup-isolation/v1",

--- a/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "partition-clear-leave/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "partition-clear-leave/v1",

--- a/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "queue-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "queue-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/readd-after-eviction.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/readd-after-eviction.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "readd-after-eviction/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "readd-after-eviction/v1",

--- a/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "restart-delivery-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "restart-delivery-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/route-equivalence.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/route-equivalence.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "route-equivalence/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "route-equivalence/v1",

--- a/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "three-client-message-exchange/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.16",
+  "conformance_version": "0.9.17",
   "seed": null,
   "scenario": {
     "name": "three-client-message-exchange/v1",

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,20 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+## [0.9.17] - 2026-09-02
+
+### Changed
+
+- Group projection and deferred convergence recovery perform less repeated
+  MLS and storage work. Component projections now share one batched group
+  read, contested-state checks avoid materializing the full candidate graph,
+  pass admission reuses one member walk, and idle deferred-peel sweeps avoid
+  repeatedly recomputing unchanged fingerprints.
+  ([#1617](https://github.com/marmot-protocol/mdk/pull/1617),
+  [#1620](https://github.com/marmot-protocol/mdk/pull/1620),
+  [#1621](https://github.com/marmot-protocol/mdk/pull/1621),
+  [#1622](https://github.com/marmot-protocol/mdk/pull/1622))
+
 ## [0.9.16] - 2026-09-01
 
 ### Added
@@ -1973,7 +1987,8 @@ Initial release of the `dm` command-line app, the `dmd` background daemon, and t
 - Local installation docs for `cargo install --path crates/cli --locked --bins`.
 - Homebrew release checklist and namespaced tap packaging path for `marmot-protocol/tap/darkmatter`.
 
-[Unreleased]: https://github.com/marmot-protocol/mdk/compare/v0.9.16...HEAD
+[Unreleased]: https://github.com/marmot-protocol/mdk/compare/v0.9.17...HEAD
+[0.9.17]: https://github.com/marmot-protocol/mdk/compare/v0.9.16...v0.9.17
 [0.9.16]: https://github.com/marmot-protocol/mdk/compare/v0.9.15...v0.9.16
 [0.9.15]: https://github.com/marmot-protocol/mdk/compare/v0.9.14...v0.9.15
 [0.9.14]: https://github.com/marmot-protocol/mdk/compare/v0.9.13...v0.9.14

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -23,7 +23,7 @@ Choose the runtime you already use:
 | Pi | Terminal harness | Repository and coding tasks through Pi |
 
 The guided installers prompt on the terminal for the White Noise account that
-may invite and message the agent. They install release `wn-agent-v0.9.16`, create
+may invite and message the agent. They install release `wn-agent-v0.9.17`, create
 an isolated White Noise identity for the selected connector, and start same-user
 services where supported. Download each installer with its adjacent checksum,
 verify it, and only then execute the local file:
@@ -50,7 +50,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.17"
 ```
 
 ### Hermes
@@ -110,7 +110,7 @@ install_verified "$base_url/install-pi-marmot.sh" \
 
 ### Finish In White Noise
 
-Release 0.9.16 records the new agent's `npub` and `nprofile` in the
+Release 0.9.17 records the new agent's `npub` and `nprofile` in the
 `bootstrap.json` path printed at completion. Display them with:
 
 ```sh

--- a/integrations/codex/marmot/README.md
+++ b/integrations/codex/marmot/README.md
@@ -54,7 +54,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.17"
 install_verified "$base_url/install-codex-marmot.sh" \
   "$base_url/install-codex-marmot.sh.sha256" \
   --yes --allow-welcomer npub1...

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -75,7 +75,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.17"
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256"
 ```
@@ -92,7 +92,7 @@ repeated or given a comma-separated list to authorize multiple senders:
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.17"
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256" \
   --yes \
@@ -108,7 +108,7 @@ with `--generate-identity`). To preserve an existing Nostr identity, place its
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.17"
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256" \
   --yes \
@@ -138,7 +138,7 @@ To accept Marmot messages from any sender (explicit opt-in):
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.17"
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256" \
   --yes --allow-all-users

--- a/integrations/openclaw/marmot/README.md
+++ b/integrations/openclaw/marmot/README.md
@@ -82,7 +82,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.17"
 install_verified "$base_url/install-openclaw-marmot.sh" \
   "$base_url/install-openclaw-marmot.sh.sha256"
 ```
@@ -102,7 +102,7 @@ an `npub` or raw hex public key:
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.17"
 install_verified "$base_url/install-openclaw-marmot.sh" \
   "$base_url/install-openclaw-marmot.sh.sha256" \
   --yes --allow-welcomer npub1...
@@ -116,7 +116,7 @@ with `--generate-identity`). To preserve an existing Nostr identity, place its
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.17"
 install_verified "$base_url/install-openclaw-marmot.sh" \
   "$base_url/install-openclaw-marmot.sh.sha256" \
   --yes \

--- a/integrations/opencode/marmot/README.md
+++ b/integrations/opencode/marmot/README.md
@@ -56,7 +56,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.17"
 install_verified "$base_url/install-opencode-marmot.sh" \
   "$base_url/install-opencode-marmot.sh.sha256"
 ```
@@ -67,7 +67,7 @@ as either an `npub` or raw hex public key:
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.17"
 install_verified "$base_url/install-opencode-marmot.sh" \
   "$base_url/install-opencode-marmot.sh.sha256" \
   --yes --allow-welcomer npub1...

--- a/integrations/pi/marmot/README.md
+++ b/integrations/pi/marmot/README.md
@@ -48,7 +48,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.17"
 install_verified "$base_url/install-pi-marmot.sh" \
   "$base_url/install-pi-marmot.sh.sha256"
 ```
@@ -58,7 +58,7 @@ For noninteractive setup, provide the allowed inviter and prompt sender:
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.17"
 install_verified "$base_url/install-pi-marmot.sh" \
   "$base_url/install-pi-marmot.sh.sha256" \
   --yes --allow-welcomer npub1...

--- a/release.md
+++ b/release.md
@@ -354,7 +354,7 @@ workspace release looks like:
 ```sh
 (
 set -eu
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.17"
 
 install_verified() (
   set -eu

--- a/scripts/install-hermes-marmot.sh
+++ b/scripts/install-hermes-marmot.sh
@@ -118,7 +118,7 @@ Hermes accepts after gateway restart via $HERMES_HOME/.env.
 
 Verified download (then choose one invocation below):
   set -eu
-  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16
+  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.17
   tmpdir="$(mktemp -d)"
   trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
   installer_script=install-hermes-marmot.sh

--- a/scripts/install-openclaw-marmot.sh
+++ b/scripts/install-openclaw-marmot.sh
@@ -110,7 +110,7 @@ Environment:
 
 Verified download (then choose one invocation below):
   set -eu
-  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.16
+  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.17
   tmpdir="$(mktemp -d)"
   trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
   installer_script=install-openclaw-marmot.sh


### PR DESCRIPTION
## Summary

- bump the MDK compatibility cohort to 0.9.17
- record the projection and deferred-convergence performance changes since 0.9.16
- advance canonical conformance vectors and current release installer references

## Validation

- `just fast-ci`
- `cargo test -p marmot-uniffi` (163 tests)
- `git diff --check`

This is release preparation for a new MarmotKit bindings release from current master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the product version to **0.9.17**.

- **Performance**
  - Improved group projection performance.
  - Improved recovery during deferred convergence.

- **Documentation**
  - Updated installation instructions and examples to reference the 0.9.17 release.
  - Added the 0.9.17 changelog entry and refreshed release comparison links.

- **Conformance**
  - Updated conformance scenarios to version 0.9.17 without changing their expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->