### PR TITLE
Guard cached relay lists against stale events

### DIFF
--- a/crates/cli/src/commands/account.rs
+++ b/crates/cli/src/commands/account.rs
@@ -239,12 +239,14 @@ fn missing_relay_list_status(missing: Vec<MissingRelayListKind>) -> AccountRelay
         bootstrap_relays: Vec::new(),
         nip65: marmot_app::AccountRelayListState {
             kind: 10002,
+            created_at: 0,
             relays: Vec::new(),
             read_relays: Vec::new(),
             write_relays: Vec::new(),
         },
         inbox: marmot_app::AccountRelayListState {
             kind: 10050,
+            created_at: 0,
             relays: Vec::new(),
             read_relays: Vec::new(),
             write_relays: Vec::new(),

--- a/crates/cli/src/commands/relays.rs
+++ b/crates/cli/src/commands/relays.rs
@@ -201,6 +201,7 @@ mod tests {
     fn nip65_update_preserves_unmodified_directional_relays() {
         let state = AccountRelayListState {
             kind: 10_002,
+            created_at: 0,
             relays: vec!["wss://both.example".into(), "wss://write.example".into()],
             read_relays: vec!["wss://both.example".into(), "wss://read.example".into()],
             write_relays: vec!["wss://both.example".into(), "wss://write.example".into()],

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -1167,12 +1167,14 @@ impl MarmotApp {
         // publication, matching the profile ingest rule (mdk#920).
         match record.event.kind {
             KIND_NIP65_RELAY_LIST
-                if entry.relay_lists.nip65.created_at >= record.event.created_at =>
+                if entry.relay_lists.nip65.created_at != 0
+                    && entry.relay_lists.nip65.created_at >= record.event.created_at =>
             {
                 return Ok(());
             }
             KIND_MARMOT_INBOX_RELAY_LIST
-                if entry.relay_lists.inbox.created_at >= record.event.created_at =>
+                if entry.relay_lists.inbox.created_at != 0
+                    && entry.relay_lists.inbox.created_at >= record.event.created_at =>
             {
                 return Ok(());
             }

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -1162,7 +1162,20 @@ impl MarmotApp {
         let mut entry = self
             .directory_entry_for_account_id(account_id_hex)?
             .unwrap_or_else(|| self.empty_directory_record(account_id_hex));
+        // Replaceable-event timestamps have second resolution. Keep the cache
+        // on equality so a lagging relay cannot revert an accepted same-second
+        // publication, matching the profile ingest rule (mdk#920).
         match record.event.kind {
+            KIND_NIP65_RELAY_LIST
+                if entry.relay_lists.nip65.created_at >= record.event.created_at =>
+            {
+                return Ok(());
+            }
+            KIND_MARMOT_INBOX_RELAY_LIST
+                if entry.relay_lists.inbox.created_at >= record.event.created_at =>
+            {
+                return Ok(());
+            }
             KIND_NIP65_RELAY_LIST => entry.relay_lists.nip65 = state,
             KIND_MARMOT_INBOX_RELAY_LIST => entry.relay_lists.inbox = state,
             _ => return Ok(()),

--- a/crates/marmot-app/src/directory/records.rs
+++ b/crates/marmot-app/src/directory/records.rs
@@ -262,6 +262,10 @@ fn directory_record_recency(entry: &UserDirectoryRecord) -> u64 {
                 .as_ref()
                 .map(|key_package| key_package.created_at),
         )
+        .chain([
+            entry.relay_lists.nip65.created_at,
+            entry.relay_lists.inbox.created_at,
+        ])
         .max()
         .unwrap_or_default()
 }

--- a/crates/marmot-app/src/directory/records.rs
+++ b/crates/marmot-app/src/directory/records.rs
@@ -250,43 +250,56 @@ pub(crate) fn user_directory_record_from_public(
     })
 }
 
-fn directory_record_recency(entry: &UserDirectoryRecord) -> u64 {
-    entry
-        .profile
-        .as_ref()
-        .map(|profile| profile.created_at)
-        .into_iter()
-        .chain(
-            entry
-                .key_package
-                .as_ref()
-                .map(|key_package| key_package.created_at),
-        )
-        .chain([
-            entry.relay_lists.nip65.created_at,
-            entry.relay_lists.inbox.created_at,
-        ])
-        .max()
-        .unwrap_or_default()
+/// Merge independently replaceable Nostr components without allowing a fresh
+/// sibling field to drag an older component across cache boundaries.
+///
+/// The first record wins equal timestamps. Nostr timestamps have one-second
+/// resolution, so this preserves a just-published local value against a stale
+/// same-second relay copy. Fields without event recency remain from the first
+/// record; public/shared records do not carry local-account or source hints.
+fn merge_directory_entries(
+    mut preferred: UserDirectoryRecord,
+    alternate: UserDirectoryRecord,
+) -> UserDirectoryRecord {
+    if alternate.profile.as_ref().is_some_and(|candidate| {
+        preferred
+            .profile
+            .as_ref()
+            .is_none_or(|current| candidate.created_at > current.created_at)
+    }) {
+        preferred.profile = alternate.profile;
+    }
+    if alternate.key_package.as_ref().is_some_and(|candidate| {
+        preferred
+            .key_package
+            .as_ref()
+            .is_none_or(|current| candidate.created_at > current.created_at)
+    }) {
+        preferred.key_package = alternate.key_package;
+    }
+    if alternate.relay_lists.nip65.created_at > preferred.relay_lists.nip65.created_at {
+        preferred.relay_lists.nip65 = alternate.relay_lists.nip65;
+    }
+    if alternate.relay_lists.inbox.created_at > preferred.relay_lists.inbox.created_at {
+        preferred.relay_lists.inbox = alternate.relay_lists.inbox;
+    }
+    preferred.relay_lists.refresh();
+    preferred
 }
 
+/// Reconcile account-cache and shared-cache directory records component-wise.
 pub(crate) fn select_newer_directory_entry(
     cached: Option<UserDirectoryRecord>,
     shared: Option<UserDirectoryRecord>,
 ) -> Option<UserDirectoryRecord> {
     match (cached, shared) {
-        (Some(cached), Some(shared)) => {
-            if directory_record_recency(&shared) > directory_record_recency(&cached) {
-                Some(shared)
-            } else {
-                Some(cached)
-            }
-        }
+        (Some(cached), Some(shared)) => Some(merge_directory_entries(cached, shared)),
         (Some(entry), None) | (None, Some(entry)) => Some(entry),
         (None, None) => None,
     }
 }
 
+/// Insert a directory record or merge each timestamped component independently.
 pub(crate) fn upsert_newer_directory_entry(
     entries_by_id: &mut BTreeMap<String, UserDirectoryRecord>,
     entry: UserDirectoryRecord,
@@ -296,9 +309,8 @@ pub(crate) fn upsert_newer_directory_entry(
             slot.insert(entry);
         }
         std::collections::btree_map::Entry::Occupied(mut slot) => {
-            if directory_record_recency(&entry) > directory_record_recency(slot.get()) {
-                *slot.get_mut() = entry;
-            }
+            let current = slot.get().clone();
+            *slot.get_mut() = merge_directory_entries(current, entry);
         }
     }
 }

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -716,6 +716,11 @@ impl MissingRelayListKind {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AccountRelayListState {
     pub kind: u64,
+    /// Timestamp of the replaceable event that produced this cached state.
+    ///
+    /// Zero denotes a legacy or caller-constructed state with unknown recency.
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub created_at: u64,
     /// Direction-appropriate relay targets for this list.
     ///
     /// For NIP-65 kind 10002 this is specifically the write-capable set:
@@ -734,6 +739,10 @@ pub struct AccountRelayListState {
     /// `relays` field. Empty for non-NIP-65 lists and for legacy cache records.
     #[serde(default)]
     pub write_relays: Vec<String>,
+}
+
+fn is_zero_u64(value: &u64) -> bool {
+    *value == 0
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -768,12 +777,14 @@ impl AccountRelayListStatus {
             bootstrap_relays: Vec::new(),
             nip65: AccountRelayListState {
                 kind: KIND_NIP65_RELAY_LIST,
+                created_at: 0,
                 relays: Vec::new(),
                 read_relays: Vec::new(),
                 write_relays: Vec::new(),
             },
             inbox: AccountRelayListState {
                 kind: KIND_MARMOT_INBOX_RELAY_LIST,
+                created_at: 0,
                 relays: Vec::new(),
                 read_relays: Vec::new(),
                 write_relays: Vec::new(),
@@ -1957,12 +1968,14 @@ impl MarmotApp {
                 .collect(),
             nip65: AccountRelayListState {
                 kind: KIND_NIP65_RELAY_LIST,
+                created_at: requests[0].event.created_at,
                 relays: relays.clone(),
                 read_relays: relays.clone(),
                 write_relays: relays.clone(),
             },
             inbox: AccountRelayListState {
                 kind: KIND_MARMOT_INBOX_RELAY_LIST,
+                created_at: requests[1].event.created_at,
                 relays,
                 read_relays: Vec::new(),
                 write_relays: Vec::new(),
@@ -2254,7 +2267,7 @@ impl MarmotApp {
         // again adds no confirmation strength and used to turn a post-success
         // read outage into account-setup rollback (mdk#1436).
         let mut status = self.account_relay_list_status_for_account_id(&account_id_hex)?;
-        for list_kind in list_kinds {
+        for (list_kind, request) in list_kinds.iter().zip(&requests) {
             match list_kind {
                 NostrAccountRelayListKind::Nip65 => {
                     let (read_relays, write_relays) = nip65_relay_set
@@ -2282,6 +2295,7 @@ impl MarmotApp {
                         });
                     status.nip65 = AccountRelayListState {
                         kind: KIND_NIP65_RELAY_LIST,
+                        created_at: request.event.created_at,
                         relays: write_relays.clone(),
                         read_relays,
                         write_relays,
@@ -2290,6 +2304,7 @@ impl MarmotApp {
                 NostrAccountRelayListKind::Inbox => {
                     status.inbox = AccountRelayListState {
                         kind: KIND_MARMOT_INBOX_RELAY_LIST,
+                        created_at: request.event.created_at,
                         relays: bootstrap
                             .default_relays
                             .iter()
@@ -6262,6 +6277,7 @@ fn relay_list_state_from_event(event: &NostrTransportEvent) -> Option<AccountRel
                 .collect::<Vec<_>>();
             Some(AccountRelayListState {
                 kind: KIND_NIP65_RELAY_LIST,
+                created_at: event.created_at,
                 relays: write_relays.clone(),
                 read_relays,
                 write_relays,
@@ -6278,6 +6294,7 @@ fn relay_list_state_from_event(event: &NostrTransportEvent) -> Option<AccountRel
             }
             Some(AccountRelayListState {
                 kind: KIND_MARMOT_INBOX_RELAY_LIST,
+                created_at: event.created_at,
                 relays,
                 read_relays: Vec::new(),
                 write_relays: Vec::new(),

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -23,6 +23,7 @@ fn profile_relay_status(
             .collect(),
         nip65: crate::AccountRelayListState {
             kind: crate::KIND_NIP65_RELAY_LIST,
+            created_at: 0,
             relays: publish_relays
                 .iter()
                 .map(|relay| (*relay).to_owned())
@@ -35,6 +36,7 @@ fn profile_relay_status(
         },
         inbox: crate::AccountRelayListState {
             kind: crate::KIND_MARMOT_INBOX_RELAY_LIST,
+            created_at: 0,
             relays: Vec::new(),
             read_relays: Vec::new(),
             write_relays: Vec::new(),

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -7943,26 +7943,33 @@ fn ingesting_all_read_nip65_list_replaces_cached_write_targets() {
         .unwrap();
     let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
     let account_id = "22".repeat(32);
-    let record = |tags| crate::relay_plane::DirectoryRelayEventRecord {
-        endpoints: vec![TransportEndpoint("wss://source.example".into())],
-        event: NostrTransportEvent::new_unsigned(
+    let record = |created_at, tags| {
+        let mut event = NostrTransportEvent::new_unsigned(
             account_id.clone(),
             KIND_NIP65_RELAY_LIST,
             tags,
             String::new(),
-        ),
+        );
+        event.created_at = created_at;
+        crate::relay_plane::DirectoryRelayEventRecord {
+            endpoints: vec![TransportEndpoint("wss://source.example".into())],
+            event,
+        }
     };
 
-    app.ingest_directory_relay_event(record(vec![vec![
-        "r".into(),
-        "wss://stale-write.example".into(),
-    ]]))
+    app.ingest_directory_relay_event(record(
+        1,
+        vec![vec!["r".into(), "wss://stale-write.example".into()]],
+    ))
     .unwrap();
-    app.ingest_directory_relay_event(record(vec![vec![
-        "r".into(),
-        "wss://read-only.example".into(),
-        "read".into(),
-    ]]))
+    app.ingest_directory_relay_event(record(
+        2,
+        vec![vec![
+            "r".into(),
+            "wss://read-only.example".into(),
+            "read".into(),
+        ]],
+    ))
     .unwrap();
 
     let cached = app
@@ -7978,9 +7985,57 @@ fn ingesting_all_read_nip65_list_replaces_cached_write_targets() {
 }
 
 #[test]
+fn stale_live_relay_list_events_do_not_replace_newer_cached_lists() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    let account_id = "23".repeat(32);
+
+    for (kind, tag_name) in [
+        (KIND_NIP65_RELAY_LIST, "r"),
+        (KIND_MARMOT_INBOX_RELAY_LIST, "relay"),
+    ] {
+        let record = |created_at, relay: &str| {
+            let mut event = NostrTransportEvent::new_unsigned(
+                account_id.clone(),
+                kind,
+                vec![vec![tag_name.into(), relay.into()]],
+                String::new(),
+            );
+            event.created_at = created_at;
+            crate::relay_plane::DirectoryRelayEventRecord {
+                endpoints: vec![TransportEndpoint("wss://source.example".into())],
+                event,
+            }
+        };
+
+        app.ingest_directory_relay_event(record(20, "wss://new.example"))
+            .unwrap();
+        app.ingest_directory_relay_event(record(10, "wss://old.example"))
+            .unwrap();
+        app.ingest_directory_relay_event(record(20, "wss://equal.example"))
+            .unwrap();
+
+        let cached = app
+            .directory_entry_for_account_id(&account_id)
+            .unwrap()
+            .expect("cached relay list");
+        let state = if kind == KIND_NIP65_RELAY_LIST {
+            cached.relay_lists.nip65
+        } else {
+            cached.relay_lists.inbox
+        };
+        assert_eq!(state.relays, vec!["wss://new.example"]);
+    }
+}
+
+#[test]
 fn nip65_setter_round_trip_preserves_existing_roles() {
     let current = AccountRelayListState {
         kind: KIND_NIP65_RELAY_LIST,
+        created_at: 0,
         relays: vec!["wss://both.example".into(), "wss://write.example".into()],
         read_relays: vec!["wss://both.example".into(), "wss://read.example".into()],
         write_relays: vec!["wss://both.example".into(), "wss://write.example".into()],

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -7863,7 +7863,6 @@ fn nip65_relay_list_targets_only_include_write_capable_entries() {
         ],
         String::new(),
     );
-
     assert_eq!(
         relays_from_relay_list_event(&event),
         vec![
@@ -8029,6 +8028,35 @@ fn stale_live_relay_list_events_do_not_replace_newer_cached_lists() {
         };
         assert_eq!(state.relays, vec!["wss://new.example"]);
     }
+}
+
+#[test]
+fn zero_timestamp_relay_list_event_populates_legacy_empty_state() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    let account_id = "24".repeat(32);
+    let mut event = NostrTransportEvent::new_unsigned(
+        account_id.clone(),
+        KIND_MARMOT_INBOX_RELAY_LIST,
+        vec![vec!["relay".into(), "wss://inbox.example".into()]],
+        String::new(),
+    );
+    event.created_at = 0;
+
+    app.ingest_directory_relay_event(crate::relay_plane::DirectoryRelayEventRecord {
+        endpoints: vec![TransportEndpoint("wss://source.example".into())],
+        event,
+    })
+    .unwrap();
+
+    let cached = app
+        .directory_entry_for_account_id(&account_id)
+        .unwrap()
+        .expect("zero-timestamp relay list is cached");
+    assert_eq!(cached.relay_lists.inbox.relays, vec!["wss://inbox.example"]);
 }
 
 #[test]
@@ -8583,6 +8611,102 @@ fn directory_entry_prefers_newer_shared_record_over_stale_cache() {
     assert_eq!(
         app.display_name_for_account_id(&contact).unwrap(),
         Some("new-shared".to_owned())
+    );
+}
+
+#[test]
+fn directory_entry_reconciles_nostr_components_independently() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    let account = home.create_account("alice").unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    let cache = app.directory_cache_for_account(&account).unwrap();
+    let contact = format!("{:064x}", 920);
+
+    let mut cached = test_directory_record(&contact, "new-profile", 100);
+    cached.relay_lists.nip65.created_at = 10;
+    cached.relay_lists.nip65.relays = vec!["wss://old.example".into()];
+    cached.relay_lists.nip65.write_relays = cached.relay_lists.nip65.relays.clone();
+    cached.relay_lists.inbox.created_at = 30;
+    cached.relay_lists.inbox.relays = vec!["wss://cached-inbox.example".into()];
+    cached.key_package = Some(DirectoryKeyPackage {
+        key_package_id: "old-package".into(),
+        key_package_ref_hex: String::new(),
+        key_package_event_id: String::new(),
+        key_package_hex: "00".into(),
+        created_at: 30,
+        source_relays: Vec::new(),
+    });
+    cached.relay_lists.refresh();
+    cache.put(&cached).unwrap();
+
+    let mut shared = test_directory_record(&contact, "old-profile", 1);
+    shared.relay_lists.nip65.created_at = 20;
+    shared.relay_lists.nip65.relays = vec!["wss://new.example".into()];
+    shared.relay_lists.nip65.write_relays = shared.relay_lists.nip65.relays.clone();
+    shared.relay_lists.inbox.created_at = 20;
+    shared.relay_lists.inbox.relays = vec!["wss://shared-inbox.example".into()];
+    shared.key_package = Some(DirectoryKeyPackage {
+        key_package_id: "new-package".into(),
+        key_package_ref_hex: String::new(),
+        key_package_event_id: String::new(),
+        key_package_hex: "00".into(),
+        created_at: 40,
+        source_relays: Vec::new(),
+    });
+    shared.relay_lists.refresh();
+    app.shared_storage()
+        .unwrap()
+        .put_public_directory_user(&public_directory_user_record(&shared).unwrap())
+        .unwrap();
+
+    let reconciled = app
+        .directory_entry_for_account_id(&contact)
+        .unwrap()
+        .expect("reconciled directory entry");
+    assert_eq!(
+        reconciled.profile.and_then(|profile| profile.name),
+        Some("new-profile".into())
+    );
+    assert_eq!(reconciled.relay_lists.nip65.created_at, 20);
+    assert_eq!(
+        reconciled.relay_lists.nip65.relays,
+        vec!["wss://new.example"]
+    );
+    assert_eq!(reconciled.relay_lists.inbox.created_at, 30);
+    assert_eq!(
+        reconciled.relay_lists.inbox.relays,
+        vec!["wss://cached-inbox.example"]
+    );
+    assert_eq!(
+        reconciled
+            .key_package
+            .as_ref()
+            .map(|key_package| key_package.key_package_id.as_str()),
+        Some("new-package")
+    );
+
+    let mut stale_event = NostrTransportEvent::new_unsigned(
+        contact.clone(),
+        KIND_NIP65_RELAY_LIST,
+        vec![vec!["r".into(), "wss://stale.example".into()]],
+        String::new(),
+    );
+    stale_event.created_at = 15;
+    app.ingest_directory_relay_event(crate::relay_plane::DirectoryRelayEventRecord {
+        event: stale_event,
+        endpoints: vec![TransportEndpoint("wss://source.example".into())],
+    })
+    .unwrap();
+
+    let after_stale_replay = app
+        .directory_entry_for_account_id(&contact)
+        .unwrap()
+        .expect("directory entry after stale replay");
+    assert_eq!(after_stale_replay.relay_lists.nip65.created_at, 20);
+    assert_eq!(
+        after_stale_replay.relay_lists.nip65.relays,
+        vec!["wss://new.example"]
     );
 }
 


### PR DESCRIPTION
## Summary
- persist the originating replaceable-event timestamp with each cached NIP-65 and Marmot inbox relay-list state
- reject older and equal-timestamp live replays while allowing a zero-timestamp event to populate legacy empty state
- reconcile profile, KeyPackage, NIP-65, and inbox independently across account and shared caches so a fresh sibling field cannot drag stale state with it
- stamp locally published relay lists from the authoritative signed events while retaining backward compatibility for timestamp-less cache JSON

Fixes #920

## Test plan
- [x] New live-ingest regression failed before the fix and passes after
- [x] Divergent account/shared-cache regression failed before component-wise reconciliation and passes after
- [x] Zero-timestamp legacy-empty regression
- [x] Adjacent newer-list replacement and profile recency regressions
- [x] `just fast-ci`
- [ ] `cargo test -p marmot-app -- --test-threads=1` (868 passed; the same 6 unrelated epoch-backfill tests reported on the original head still fail)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed relay-list updates being incorrectly rejected when no prior timestamp existed.
  * Improved directory synchronization by merging profile, key-package, and relay-list data independently according to each component’s timestamp.
  * Prevented stale relay-list events from replacing newer cached data while preserving preferred data when timestamps match.
  * Preserved relay-list event timestamps across initialization, publication, parsing, caching, and restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->