### PR TITLE
Bound SQLCipher mlock diagnostics on Android

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3232,8 +3232,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 [[package]]
 name = "libsqlite3-sys"
 version = "0.38.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
+source = "git+https://github.com/rusqlite/rusqlite.git?rev=5ae7fdf83085c595fd54f977b3a56ccacabaf16b#5ae7fdf83085c595fd54f977b3a56ccacabaf16b"
 dependencies = [
  "cc",
  "openssl-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,3 +147,7 @@ marmot-terminal-harness = { path = "integrations/terminal-harness" }
 # release contains it, then remove this patch and update the libcrux path.
 [patch.crates-io]
 hax-lib-macros = { git = "https://github.com/cryspen/hax.git", rev = "8f9cb576e58f6cc7e9ed249a7d4439b0f7ed0da7" }
+# libsqlite3-sys 0.38.2 still bundles SQLCipher 4.14.0, whose enhanced
+# memory-security allocator emits one WARN for every mlock failure. Pin the
+# merged 4.17.0 amalgamation until a crates.io release contains that lineage.
+libsqlite3-sys = { git = "https://github.com/rusqlite/rusqlite.git", rev = "5ae7fdf83085c595fd54f977b3a56ccacabaf16b" }

--- a/crates/storage-sqlite/README.md
+++ b/crates/storage-sqlite/README.md
@@ -55,7 +55,9 @@ The default connection settings are privacy/durability oriented:
 - `secure_delete=ON`
 - `temp_store=MEMORY`
 - `trusted_schema=OFF`
-- `cipher_memory_security=ON` when supported by the linked SQLCipher build
+- `cipher_memory_security=ON` process-wide; Android reports a once-per-process
+  `platform_limited` diagnostic because its finite `mlock` budget makes memory
+  residency best effort while SQLCipher still sanitizes allocations on free
 
 Use `open_encrypted_with_options` or `in_memory_with_options` to override these runtime settings. The crate does not
 expose first-class key rotation for v1; rotate by creating a new encrypted database, migrating data, and replacing the

--- a/crates/storage-sqlite/src/connection.rs
+++ b/crates/storage-sqlite/src/connection.rs
@@ -7,6 +7,8 @@ use cgka_traits::types::Backend;
 use std::fmt;
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
+#[cfg(any(target_os = "android", test))]
+use std::sync::Once;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 use std::thread::ThreadId;
@@ -31,6 +33,26 @@ const BUSY_BACKOFF_BASE: Duration = Duration::from_millis(20);
 
 /// Upper bound on a single busy-retry backoff sleep.
 const BUSY_BACKOFF_CAP: Duration = Duration::from_millis(250);
+
+/// Android imposes a finite process-wide `mlock` budget (64 KiB on API 34+),
+/// so SQLCipher's enhanced whole-library memory locking is necessarily best
+/// effort there. SQLCipher 4.17 keeps allocation failures below its default
+/// log level; retain one bounded MDK-owned diagnostic instead.
+#[cfg(target_os = "android")]
+static SQLCIPHER_PLATFORM_LIMIT_REPORTED: Once = Once::new();
+
+#[cfg(any(target_os = "android", test))]
+fn report_sqlcipher_platform_limit_once(report_once: &Once) {
+    report_once.call_once(|| {
+        tracing::warn!(
+            target: "storage_sqlite::connection",
+            method = "configure_cipher_memory_security",
+            configured = true,
+            lock_posture = "platform_limited",
+            "SQLCipher memory locking is best effort on Android"
+        );
+    });
+}
 
 /// An error that may represent transient SQLite lock contention worth retrying.
 /// Implemented for the two storage error types so [`retry_on_busy`] can drive a
@@ -663,6 +685,10 @@ pub struct SqliteStorageOptions {
     pub secure_delete: bool,
     pub temp_store_memory: bool,
     pub trusted_schema: bool,
+    /// Enable SQLCipher's process-global enhanced memory allocator. Once any
+    /// connection enables it, it remains enabled for every SQLite connection
+    /// in the process. Android receives a once-per-process diagnostic because
+    /// its finite `mlock` budget makes page locking best effort.
     pub cipher_memory_security: bool,
     pub cipher_compatibility: u8,
 }
@@ -852,6 +878,8 @@ fn apply_cipher_pragmas(
         connection
             .execute_batch("PRAGMA cipher_memory_security = ON;")
             .storage()?;
+        #[cfg(target_os = "android")]
+        report_sqlcipher_platform_limit_once(&SQLCIPHER_PLATFORM_LIMIT_REPORTED);
     }
     Ok(())
 }
@@ -1019,9 +1047,42 @@ mod tests {
         atomic::{AtomicU32, Ordering},
         mpsc,
     };
+    use tracing::{Event, Subscriber, field::Visit};
+    use tracing_subscriber::{Layer, layer::Context, prelude::*};
 
     static TRACE_TEST_LOCK: Mutex<()> = Mutex::new(());
     static TRACED_SQLCIPHER_SETUP: Mutex<Vec<&'static str>> = Mutex::new(Vec::new());
+
+    #[derive(Clone)]
+    struct PlatformLimitLayer {
+        events: Arc<Mutex<Vec<Vec<String>>>>,
+    }
+
+    #[derive(Default)]
+    struct PlatformLimitVisitor {
+        fields: Vec<String>,
+    }
+
+    impl Visit for PlatformLimitVisitor {
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn fmt::Debug) {
+            self.fields.push(format!("{}={value:?}", field.name()));
+        }
+    }
+
+    impl<S> Layer<S> for PlatformLimitLayer
+    where
+        S: Subscriber,
+    {
+        fn on_event(&self, event: &Event<'_>, _context: Context<'_, S>) {
+            if event.metadata().target() == "storage_sqlite::connection"
+                && event.metadata().level() == &tracing::Level::WARN
+            {
+                let mut visitor = PlatformLimitVisitor::default();
+                event.record(&mut visitor);
+                self.events.lock().unwrap().push(visitor.fields);
+            }
+        }
+    }
 
     fn delete_journal_options() -> SqliteStorageOptions {
         SqliteStorageOptions {
@@ -1081,7 +1142,35 @@ mod tests {
     }
 
     #[test]
-    fn bundled_sqlcipher_contains_the_wal_reset_corruption_fix() {
+    fn android_memory_lock_platform_limit_is_reported_once() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry().with(PlatformLimitLayer {
+            events: Arc::clone(&events),
+        });
+        let report_once = Once::new();
+
+        tracing::subscriber::with_default(subscriber, || {
+            report_sqlcipher_platform_limit_once(&report_once);
+            report_sqlcipher_platform_limit_once(&report_once);
+        });
+
+        let events = events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(
+            events[0]
+                .iter()
+                .any(|field| field == "method=\"configure_cipher_memory_security\"")
+        );
+        assert!(events[0].iter().any(|field| field == "configured=true"));
+        assert!(
+            events[0]
+                .iter()
+                .any(|field| field == "lock_posture=\"platform_limited\"")
+        );
+    }
+
+    #[test]
+    fn bundled_sqlcipher_contains_android_mlock_warning_fix() {
         fn version_tuple(value: &str) -> (u64, u64, u64) {
             let numeric = value.split_ascii_whitespace().next().unwrap_or(value);
             let mut components = numeric.split('.').map(|part| {
@@ -1108,8 +1197,8 @@ mod tests {
             "SQLite {sqlite_version} predates the WAL-reset corruption fix"
         );
         assert!(
-            version_tuple(&sqlcipher_version) >= (4, 14, 0),
-            "SQLCipher {sqlcipher_version} does not contain fixed SQLite 3.51.3"
+            version_tuple(&sqlcipher_version) >= (4, 17, 0),
+            "SQLCipher {sqlcipher_version} predates the Android mlock warning fix"
         );
     }
 


### PR DESCRIPTION
## Summary

- Pin libsqlite3-sys to the merged SQLCipher 4.17 amalgamation, eliminating the per-allocation mlock WARN storm while preserving encryption, allocation wiping, and best-effort memory locking.
- Emit one privacy-safe MDK warning per Android process when enhanced memory security is enabled, with fixed configured and platform_limited fields.
- Guard the bundled SQLCipher lineage and the bounded diagnostic with regression tests, and document the Android posture.

## Root cause

Android 14 and later cap mlock usage at 64 KiB per process. SQLCipher 4.14 treats exhausted best-effort memory locks as non-fatal but emits a WARN for every failed allocation. SQLCipher 4.17 lowers that internal message below the default log level, so this patch retains one actionable MDK-owned diagnostic without flooding logs. Database reads, writes, encryption, and memory sanitization continue normally; only residency protection above the platform budget is lost.

## Test plan

- [x] Confirmed the SQLCipher version regression test fails against the previous 4.14 amalgamation.
- [x] cargo test -p storage-sqlite (446 passed, 4 ignored)
- [x] just fast-ci on Rust 1.97.1
- [x] cargo check -p storage-sqlite --target aarch64-linux-android against NDK API 26
- [ ] Reproduce the original workload on GrapheneOS and confirm one MDK platform_limited warning with no SQLCipher WARN storm.

Fixes #1522

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Updated the bundled SQLCipher protection to version 4.17.0.
  - Improved memory-security handling for encrypted storage.

- **Bug Fixes**
  - Android now provides a clear, limited warning when platform restrictions prevent full memory locking. Memory sanitization remains active.

- **Documentation**
  - Clarified that memory-security settings apply across the application process and that Android memory locking is best effort.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->