### PR TITLE
Reuse vetted Blossom clients and bound locator startup

### DIFF
--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -39,10 +39,10 @@ use crate::groups::{
 };
 use crate::ids::{admin_pubkey_from_account_id_hex, admin_pubkey_from_member_id};
 use crate::media::{
-    DEFAULT_BLOSSOM_SERVER_URLS, EncryptedMediaVersion, MediaOperationPolicy,
-    download_encrypted_media, fetch_group_image, is_loopback_http_endpoint,
-    prepare_group_image_upload, upload_encrypted_media, upload_group_image,
-    upload_prepared_group_image,
+    BlossomHttpTransport, DEFAULT_BLOSSOM_SERVER_URLS, EncryptedMediaVersion, MediaOperationPolicy,
+    download_encrypted_media_with_transport, fetch_group_image_with_transport,
+    is_loopback_http_endpoint, prepare_group_image_upload, upload_encrypted_media,
+    upload_group_image, upload_prepared_group_image,
 };
 use crate::messages::{AppMessageIntent, build_inner_event, encode_inner_event};
 use crate::notifications;
@@ -165,17 +165,17 @@ pub(crate) struct EncryptedMediaDownloadHttp {
     media_secret: SecretBytes,
     default_blob_endpoints: Vec<AppBlobEndpoint>,
     allowed_locator_kinds: Vec<String>,
-    allow_loopback: bool,
+    transport: BlossomHttpTransport,
 }
 
 impl EncryptedMediaDownloadHttp {
     pub(crate) async fn run(self) -> Result<MediaDownloadResult, AppError> {
-        download_encrypted_media(
+        download_encrypted_media_with_transport(
             self.reference,
             self.media_secret.as_ref(),
             &self.default_blob_endpoints,
             &self.allowed_locator_kinds,
-            self.allow_loopback,
+            &self.transport,
         )
         .await
     }
@@ -186,6 +186,7 @@ pub(crate) struct GroupImageDownloadHttp {
     image_key_hex: String,
     image_nonce_hex: String,
     media_type: String,
+    transport: BlossomHttpTransport,
 }
 
 pub(crate) struct PreparedGroupImageUploadHttp {
@@ -224,12 +225,13 @@ pub(crate) enum InitialGroupImageSource {
 
 impl GroupImageDownloadHttp {
     pub(crate) async fn run(self) -> Result<Vec<u8>, AppError> {
-        fetch_group_image(
+        fetch_group_image_with_transport(
             &self.image_hash_hex,
             &self.image_key_hex,
             &self.image_nonce_hex,
             &self.media_type,
             None,
+            &self.transport,
         )
         .await
     }
@@ -294,6 +296,7 @@ pub struct AppClient {
     pub(crate) routing: AppTransportRouting,
     pub(crate) relay_plane: MarmotRelayPlane,
     pub(crate) transport_signer: Arc<dyn nostr::NostrSigner>,
+    pub(crate) blossom_http_transport: BlossomHttpTransport,
     pub(crate) state: AccountState,
     /// O(1) membership index over `state.seen_events`, kept in lockstep by
     /// `remember_seen_event` (which removes pruned ring entries from it).
@@ -3615,7 +3618,7 @@ impl AppClient {
             media_secret,
             default_blob_endpoints: policy.default_blob_endpoints,
             allowed_locator_kinds: policy.allowed_locator_kinds,
-            allow_loopback: self.app.allow_loopback_blob_endpoints(),
+            transport: self.blossom_http_transport.clone(),
         })
     }
 
@@ -3695,6 +3698,7 @@ impl AppClient {
             image_key_hex: input.image_key_hex,
             image_nonce_hex: input.image_nonce_hex,
             media_type: input.media_type.unwrap_or_default(),
+            transport: self.blossom_http_transport.clone(),
         })
     }
 

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1702,6 +1702,9 @@ impl MarmotApp {
             routing: open.routing,
             relay_plane: relay_plane.clone(),
             transport_signer: open.signer,
+            blossom_http_transport: crate::media::BlossomHttpTransport::new(
+                self.allow_loopback_blob_endpoints(),
+            ),
             state: open.state,
             seen_events_index,
             pending_seen_event_count: 0,

--- a/crates/marmot-app/src/media/blossom.rs
+++ b/crates/marmot-app/src/media/blossom.rs
@@ -30,7 +30,8 @@ const MEDIA_HTTP_TOTAL_TIMEOUT: Duration = Duration::from_secs(60);
 const MEDIA_BLOB_TRANSFER_TIMEOUT: Duration = Duration::from_secs(15 * 60);
 /// A candidate that cannot resolve, connect, return headers, and yield its first
 /// body bytes within this bound gives the next ordered locator a chance. The
-/// longer transfer deadline and read-idle timeout still govern an active body.
+/// longer transfer deadline and read-idle timeout still govern an active body,
+/// so a peer that continuously trickles bytes can occupy the transfer deadline.
 const BLOSSOM_CANDIDATE_STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
 /// Reusing a pinned client inside this lease amortizes DNS and TLS setup without
 /// turning one resolution result into a process-lifetime routing decision.
@@ -90,7 +91,8 @@ struct BlossomHttpTransportInner {
 ///
 /// Every cached client is bound to one exact origin and one vetted address set.
 /// Expiry creates a fresh client generation, forcing DNS resolution, vetting,
-/// and pinning again before any later request can use the origin.
+/// and pinning again before any later request can use the origin. A rehomed
+/// origin can therefore retain a failing stale pin only until the lease ends.
 #[derive(Clone)]
 pub(crate) struct BlossomHttpTransport {
     inner: Arc<BlossomHttpTransportInner>,
@@ -204,6 +206,8 @@ impl BlossomHttpTransport {
     }
 
     pub(super) fn with_loopback_disabled(&self) -> Self {
+        // The stricter view may share the pool because client_for_url validates
+        // its own loopback policy before consulting a cached generation.
         Self {
             inner: self.inner.clone(),
             allow_loopback_http: false,

--- a/crates/marmot-app/src/media/blossom.rs
+++ b/crates/marmot-app/src/media/blossom.rs
@@ -1,7 +1,10 @@
+use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
-use std::time::Duration;
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::{Duration, Instant};
 
 use bytes::Bytes;
+use futures::future::BoxFuture;
 use nostr::base64::Engine as _;
 use nostr::base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64_URL_SAFE_NO_PAD;
 use nostr::{EventBuilder, JsonUtil, Kind, NostrSigner, Tag, Timestamp as NostrTimestamp};
@@ -25,6 +28,14 @@ const MEDIA_HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const MEDIA_HTTP_READ_TIMEOUT: Duration = Duration::from_secs(15);
 const MEDIA_HTTP_TOTAL_TIMEOUT: Duration = Duration::from_secs(60);
 const MEDIA_BLOB_TRANSFER_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+/// A candidate that cannot resolve, connect, return headers, and yield its first
+/// body bytes within this bound gives the next ordered locator a chance. The
+/// longer transfer deadline and read-idle timeout still govern an active body.
+const BLOSSOM_CANDIDATE_STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
+/// Reusing a pinned client inside this lease amortizes DNS and TLS setup without
+/// turning one resolution result into a process-lifetime routing decision.
+const BLOSSOM_ADDRESS_LEASE: Duration = Duration::from_secs(60);
+const BLOSSOM_ORIGIN_CACHE_LIMIT: usize = 32;
 const BLOSSOM_REDIRECT_LIMIT: usize = 5;
 /// Largest encrypted media blob this implementation will upload or download.
 ///
@@ -32,6 +43,186 @@ const BLOSSOM_REDIRECT_LIMIT: usize = 5;
 /// implementation bound finite for resource safety while allowing release APKs
 /// and other substantial application artifacts.
 pub const MAX_ENCRYPTED_MEDIA_BLOB_BYTES: u64 = 512 * 1024 * 1024;
+
+pub(super) type DnsResolver =
+    Arc<dyn Fn(String, u16) -> BoxFuture<'static, Result<Vec<SocketAddr>, AppError>> + Send + Sync>;
+
+#[derive(Clone, Hash, PartialEq, Eq)]
+struct MediaOrigin {
+    scheme: String,
+    host: String,
+    port: u16,
+}
+
+impl MediaOrigin {
+    fn from_url(url: &Url) -> Result<Self, AppError> {
+        let host = url
+            .host_str()
+            .ok_or_else(|| AppError::BlobStore("Blossom URL is missing a host".into()))?
+            .to_ascii_lowercase();
+        let port = url
+            .port_or_known_default()
+            .ok_or_else(|| AppError::BlobStore("Blossom URL is missing a fetch port".into()))?;
+        Ok(Self {
+            scheme: url.scheme().to_owned(),
+            host,
+            port,
+        })
+    }
+}
+
+struct CachedMediaClient {
+    client: reqwest::Client,
+    expires_at: Instant,
+}
+
+struct MediaOriginSlot {
+    generation: Arc<tokio::sync::Mutex<Option<CachedMediaClient>>>,
+    last_used: Instant,
+}
+
+struct BlossomHttpTransportInner {
+    origins: StdMutex<HashMap<MediaOrigin, MediaOriginSlot>>,
+    resolver: DnsResolver,
+}
+
+/// Per-account HTTP setup shared by compatible Blossom downloads.
+///
+/// Every cached client is bound to one exact origin and one vetted address set.
+/// Expiry creates a fresh client generation, forcing DNS resolution, vetting,
+/// and pinning again before any later request can use the origin.
+#[derive(Clone)]
+pub(crate) struct BlossomHttpTransport {
+    inner: Arc<BlossomHttpTransportInner>,
+    pub(super) allow_loopback_http: bool,
+    address_lease: Duration,
+    candidate_startup_timeout: Duration,
+}
+
+impl BlossomHttpTransport {
+    pub(crate) fn new(allow_loopback_http: bool) -> Self {
+        Self::with_policy(
+            allow_loopback_http,
+            BLOSSOM_ADDRESS_LEASE,
+            BLOSSOM_CANDIDATE_STARTUP_TIMEOUT,
+            system_dns_resolver(),
+        )
+    }
+
+    fn with_policy(
+        allow_loopback_http: bool,
+        address_lease: Duration,
+        candidate_startup_timeout: Duration,
+        resolver: DnsResolver,
+    ) -> Self {
+        Self {
+            inner: Arc::new(BlossomHttpTransportInner {
+                origins: StdMutex::new(HashMap::new()),
+                resolver,
+            }),
+            allow_loopback_http,
+            address_lease,
+            candidate_startup_timeout,
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn for_test(
+        allow_loopback_http: bool,
+        address_lease: Duration,
+        candidate_startup_timeout: Duration,
+    ) -> Self {
+        Self::with_policy(
+            allow_loopback_http,
+            address_lease,
+            candidate_startup_timeout,
+            system_dns_resolver(),
+        )
+    }
+
+    #[cfg(test)]
+    pub(super) fn for_test_with_resolver(
+        allow_loopback_http: bool,
+        address_lease: Duration,
+        candidate_startup_timeout: Duration,
+        resolver: DnsResolver,
+    ) -> Self {
+        Self::with_policy(
+            allow_loopback_http,
+            address_lease,
+            candidate_startup_timeout,
+            resolver,
+        )
+    }
+
+    pub(super) async fn client_for_url(&self, url: &Url) -> Result<reqwest::Client, AppError> {
+        validate_blossom_fetch_url(url, self.allow_loopback_http)
+            .map_err(|err| AppError::BlobStore(format!("unsafe Blossom URL: {err}")))?;
+        let origin = MediaOrigin::from_url(url)?;
+        let generation = {
+            let now = Instant::now();
+            let mut origins = self
+                .inner
+                .origins
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if !origins.contains_key(&origin)
+                && origins.len() >= BLOSSOM_ORIGIN_CACHE_LIMIT
+                && let Some(oldest) = origins
+                    .iter()
+                    .min_by_key(|(_, slot)| slot.last_used)
+                    .map(|(origin, _)| origin.clone())
+            {
+                origins.remove(&oldest);
+            }
+            let slot = origins.entry(origin).or_insert_with(|| MediaOriginSlot {
+                generation: Arc::new(tokio::sync::Mutex::new(None)),
+                last_used: now,
+            });
+            slot.last_used = now;
+            slot.generation.clone()
+        };
+
+        let mut generation = generation.lock().await;
+        let now = Instant::now();
+        if let Some(cached) = generation.as_ref()
+            && cached.expires_at > now
+        {
+            return Ok(cached.client.clone());
+        }
+
+        let allow_loopback = url.scheme() == "http"
+            && self.allow_loopback_http
+            && url.host().map(is_loopback_host).unwrap_or(false);
+        let pin = resolve_media_host_with(url, allow_loopback, &self.inner.resolver).await?;
+        let client = build_pinned_media_http_client(pin)?;
+        *generation = Some(CachedMediaClient {
+            client: client.clone(),
+            expires_at: now + self.address_lease,
+        });
+        Ok(client)
+    }
+
+    pub(super) fn with_loopback_disabled(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            allow_loopback_http: false,
+            address_lease: self.address_lease,
+            candidate_startup_timeout: self.candidate_startup_timeout,
+        }
+    }
+}
+
+fn system_dns_resolver() -> DnsResolver {
+    Arc::new(|domain, port| {
+        Box::pin(async move {
+            tokio::net::lookup_host((domain.as_str(), port))
+                .await
+                .map_err(|_| AppError::BlobStore("media host DNS lookup failed".into()))
+                .map(|addrs| addrs.collect())
+        })
+    })
+}
 
 #[derive(Debug, Deserialize)]
 struct BlossomBlobDescriptor {
@@ -178,27 +369,37 @@ fn privacy_safe_server_reason(reason: &str) -> Option<String> {
     Some(reason)
 }
 
+#[cfg(test)]
 pub(crate) async fn fetch_blossom_blob(
     url: &str,
     allow_loopback_http: bool,
 ) -> Result<Vec<u8>, AppError> {
+    let transport = BlossomHttpTransport::new(allow_loopback_http);
+    fetch_blossom_blob_with_transport(url, &transport).await
+}
+
+pub(crate) async fn fetch_blossom_blob_with_transport(
+    url: &str,
+    transport: &BlossomHttpTransport,
+) -> Result<Vec<u8>, AppError> {
     let current = Url::parse(url)
         .map_err(|_| AppError::InvalidEncryptedMedia("media URL is invalid".into()))?;
-    validate_blossom_fetch_url(&current, allow_loopback_http)
+    validate_blossom_fetch_url(&current, transport.allow_loopback_http)
         .map_err(|err| AppError::BlobStore(format!("unsafe Blossom URL: {err}")))?;
     fetch_http_with_bounded_redirects(
         current,
         MAX_ENCRYPTED_MEDIA_BLOB_BYTES,
         MEDIA_BLOB_TRANSFER_TIMEOUT,
+        Some(transport.candidate_startup_timeout),
         move |url| {
-            let allow_loopback_http = allow_loopback_http;
-            async move { media_http_client_for_url(&url, allow_loopback_http).await }
+            let transport = transport.clone();
+            async move { transport.client_for_url(&url).await }
         },
         move |current, location| {
             let next = current.join(location).map_err(|_| {
                 AppError::BlobStore("redirect Location header is not a valid URL".into())
             })?;
-            validate_blossom_redirect_target(current, &next, allow_loopback_http)?;
+            validate_blossom_redirect_target(current, &next, transport.allow_loopback_http)?;
             Ok(next)
         },
     )
@@ -228,6 +429,7 @@ pub(crate) async fn fetch_profile_image_with_loopback(
         current,
         max_bytes,
         MEDIA_HTTP_TOTAL_TIMEOUT,
+        None,
         move |url| async move { media_http_client_for_url(&url, true).await },
         move |current, location| {
             let raw_location = location.trim();
@@ -262,6 +464,7 @@ async fn fetch_profile_image_impl(url: &str, max_bytes: u64) -> Result<Vec<u8>, 
         current,
         max_bytes,
         MEDIA_HTTP_TOTAL_TIMEOUT,
+        None,
         move |url| async move { media_http_client_for_profile(&url).await },
         move |current, location| {
             parse_profile_image_redirect_url(current, location).map_err(AppError::UnsafeMediaFetch)
@@ -286,6 +489,7 @@ async fn fetch_http_with_bounded_redirects<C, CFut, R>(
     mut current: Url,
     max_body_bytes: u64,
     request_timeout: Duration,
+    startup_timeout: Option<Duration>,
     mut client_for_url: C,
     mut redirect_target: R,
 ) -> Result<Vec<u8>, AppError>
@@ -296,28 +500,45 @@ where
 {
     let mut redirects = 0_usize;
     let deadline = tokio::time::Instant::now() + request_timeout;
+    let startup_deadline = startup_timeout.map(|timeout| tokio::time::Instant::now() + timeout);
 
     loop {
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
         if remaining.is_zero() {
             return Err(AppError::BlobStore("request timed out".into()));
         }
-        let client = tokio::time::timeout(remaining, client_for_url(current.clone()))
+        let startup_remaining = startup_deadline
+            .map(|deadline| deadline.saturating_duration_since(tokio::time::Instant::now()))
+            .unwrap_or(remaining);
+        let operation_remaining = remaining.min(startup_remaining);
+        if operation_remaining.is_zero() {
+            return Err(AppError::BlobStore("request timed out".into()));
+        }
+        let client = tokio::time::timeout(operation_remaining, client_for_url(current.clone()))
             .await
             .map_err(|_| AppError::BlobStore("request timed out".into()))??;
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
         if remaining.is_zero() {
             return Err(AppError::BlobStore("request timed out".into()));
         }
-        let response = client
-            .get(current.clone())
-            .timeout(remaining)
-            .send()
-            .await
-            .map_err(reqwest_blob_error)?;
+        let startup_remaining = startup_deadline
+            .map(|deadline| deadline.saturating_duration_since(tokio::time::Instant::now()))
+            .unwrap_or(remaining);
+        let operation_remaining = remaining.min(startup_remaining);
+        if operation_remaining.is_zero() {
+            return Err(AppError::BlobStore("request timed out".into()));
+        }
+        let response = tokio::time::timeout(
+            operation_remaining,
+            client.get(current.clone()).timeout(remaining).send(),
+        )
+        .await
+        .map_err(|_| AppError::BlobStore("request timed out".into()))?
+        .map_err(reqwest_blob_error)?;
         let status = response.status();
         if status.is_success() {
-            return read_limited_blossom_body(response, max_body_bytes).await;
+            return read_limited_blossom_body_until(response, max_body_bytes, startup_deadline)
+                .await;
         }
         if !status.is_redirection() {
             return Err(AppError::BlobStore(format!(
@@ -508,6 +729,14 @@ async fn resolve_media_host(
     url: &Url,
     allow_loopback: bool,
 ) -> Result<Option<(String, Vec<SocketAddr>)>, AppError> {
+    resolve_media_host_with(url, allow_loopback, &system_dns_resolver()).await
+}
+
+async fn resolve_media_host_with(
+    url: &Url,
+    allow_loopback: bool,
+    resolver: &DnsResolver,
+) -> Result<Option<(String, Vec<SocketAddr>)>, AppError> {
     match url
         .host()
         .ok_or_else(|| AppError::BlobStore("Blossom URL is missing a host".into()))?
@@ -516,10 +745,7 @@ async fn resolve_media_host(
             let port = url
                 .port_or_known_default()
                 .ok_or_else(|| AppError::BlobStore("Blossom URL is missing a fetch port".into()))?;
-            let addrs = tokio::net::lookup_host((domain, port))
-                .await
-                .map_err(|_| AppError::BlobStore("media host DNS lookup failed".into()))?
-                .collect::<Vec<_>>();
+            let addrs = resolver(domain.to_owned(), port).await?;
             validated_media_domain_pin(domain, &addrs, allow_loopback).map(Some)
         }
         Host::Ipv4(addr) => {
@@ -539,6 +765,14 @@ pub(crate) async fn read_limited_blossom_body(
     response: reqwest::Response,
     max_bytes: u64,
 ) -> Result<Vec<u8>, AppError> {
+    read_limited_blossom_body_until(response, max_bytes, None).await
+}
+
+async fn read_limited_blossom_body_until(
+    response: reqwest::Response,
+    max_bytes: u64,
+    first_byte_deadline: Option<tokio::time::Instant>,
+) -> Result<Vec<u8>, AppError> {
     if let Some(content_length) = response.content_length()
         && content_length > max_bytes
     {
@@ -548,7 +782,24 @@ pub(crate) async fn read_limited_blossom_body(
     }
     let mut body = Vec::new();
     let mut response = response;
-    while let Some(chunk) = response.chunk().await.map_err(reqwest_blob_error)? {
+    loop {
+        let next = if body.is_empty()
+            && let Some(deadline) = first_byte_deadline
+        {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return Err(AppError::BlobStore("request timed out".into()));
+            }
+            tokio::time::timeout(remaining, response.chunk())
+                .await
+                .map_err(|_| AppError::BlobStore("request timed out".into()))?
+        } else {
+            response.chunk().await
+        }
+        .map_err(reqwest_blob_error)?;
+        let Some(chunk) = next else {
+            break;
+        };
         let next_len = body
             .len()
             .checked_add(chunk.len())

--- a/crates/marmot-app/src/media/group_image.rs
+++ b/crates/marmot-app/src/media/group_image.rs
@@ -12,7 +12,9 @@ use zeroize::Zeroizing;
 use cgka_traits::app_components::canonicalize_marmot_media_type;
 
 use super::DEFAULT_BLOSSOM_SERVER_URL;
-use super::blossom::{blossom_blob_url, fetch_blossom_blob, upload_blossom_blob};
+use super::blossom::{
+    BlossomHttpTransport, blossom_blob_url, fetch_blossom_blob_with_transport, upload_blossom_blob,
+};
 use crate::{AppError, AppGroupImageInput};
 
 const GROUP_IMAGE_VERSION: &str = "marmot-group-image-v1";
@@ -88,7 +90,7 @@ fn validate_group_image_input(plaintext: &[u8], media_type: &str) -> Result<Stri
 /// MLS-protected component bytes and the SQLCipher-protected projections, but
 /// must never be logged or `Debug`-rendered — do not add a `Debug` derive
 /// here, and keep the raw key buffers in `upload_group_image`/
-/// `fetch_group_image` wrapped in `Zeroizing`.
+/// `fetch_group_image_with_transport` wrapped in `Zeroizing`.
 pub(crate) struct GroupImageUpload {
     pub(crate) image_hash_hex: String,
     pub(crate) image_key_hex: String,
@@ -223,12 +225,13 @@ pub(crate) async fn upload_prepared_group_image(
 
 /// Fetch a group avatar's ciphertext from Blossom (addressed by `image_hash_hex`)
 /// and decrypt it with the in-band content key + nonce.
-pub(crate) async fn fetch_group_image(
+pub(crate) async fn fetch_group_image_with_transport(
     image_hash_hex: &str,
     image_key_hex: &str,
     image_nonce_hex: &str,
     media_type: &str,
     server: Option<&str>,
+    transport: &BlossomHttpTransport,
 ) -> Result<Vec<u8>, AppError> {
     let media_type = canonical_group_image_media_type(media_type)?;
     let content_key: Zeroizing<[u8; 32]> = Zeroizing::new(
@@ -247,7 +250,8 @@ pub(crate) async fn fetch_group_image(
     // Group images are content-addressed over the public default Blossom server
     // and are not part of the loopback-blob-endpoint dev/test path, so loopback
     // HTTP is never permitted here.
-    let encrypted = fetch_blossom_blob(&url, false).await?;
+    let encrypted =
+        fetch_blossom_blob_with_transport(&url, &transport.with_loopback_disabled()).await?;
     let actual_hash = hex::encode(Sha256::digest(&encrypted));
     if actual_hash != image_hash_hex.to_ascii_lowercase() {
         return Err(AppError::InvalidEncryptedMedia(

--- a/crates/marmot-app/src/media/mod.rs
+++ b/crates/marmot-app/src/media/mod.rs
@@ -728,11 +728,6 @@ pub(crate) async fn download_encrypted_media_with_transport(
         transport,
     )
     .await?;
-    if !encrypted_media_hash_matches(&encrypted, &reference.ciphertext_sha256) {
-        return Err(AppError::InvalidEncryptedMedia(
-            "encrypted blob hash does not match media reference".into(),
-        ));
-    }
     let plaintext_hash = media_hash_from_reference(&reference)?;
     let media_type = match version {
         EncryptedMediaVersion::V1 => canonical_media_type_v1(&reference.media_type)?,

--- a/crates/marmot-app/src/media/mod.rs
+++ b/crates/marmot-app/src/media/mod.rs
@@ -20,7 +20,8 @@ mod group_image;
 mod host_safety;
 
 use blossom::{
-    blossom_content_hash_from_url, upload_blossom_blob, upload_blossom_blob_with_content_type,
+    blossom_content_hash_from_url, fetch_blossom_blob_with_transport, upload_blossom_blob,
+    upload_blossom_blob_with_content_type,
 };
 use crypto::{
     canonical_media_type_v1, canonical_media_type_v2, derive_media_file_key, media_aad,
@@ -29,10 +30,13 @@ use crypto::{
 use host_safety::validate_locator;
 
 pub use blossom::MAX_ENCRYPTED_MEDIA_BLOB_BYTES;
-pub(crate) use blossom::{blossom_blob_url, fetch_blossom_blob};
+#[cfg(test)]
+pub(crate) use blossom::fetch_blossom_blob;
+pub(crate) use blossom::{BlossomHttpTransport, blossom_blob_url};
 pub use group_image::{MAX_GROUP_IMAGE_BYTES, MAX_GROUP_IMAGE_DIMENSION, MAX_GROUP_IMAGE_PIXELS};
 pub(crate) use group_image::{
-    fetch_group_image, prepare_group_image_upload, upload_group_image, upload_prepared_group_image,
+    fetch_group_image_with_transport, prepare_group_image_upload, upload_group_image,
+    upload_prepared_group_image,
 };
 pub(crate) use host_safety::is_loopback_http_endpoint;
 
@@ -686,6 +690,7 @@ fn upload_error_summary(err: &AppError) -> String {
     }
 }
 
+#[cfg(test)]
 pub(crate) async fn download_encrypted_media(
     reference: MediaAttachmentReference,
     media_secret: &[u8],
@@ -693,16 +698,34 @@ pub(crate) async fn download_encrypted_media(
     allowed_locator_kinds: &[String],
     allow_loopback_blob_endpoints: bool,
 ) -> Result<MediaDownloadResult, AppError> {
+    let transport = BlossomHttpTransport::new(allow_loopback_blob_endpoints);
+    download_encrypted_media_with_transport(
+        reference,
+        media_secret,
+        fallback_endpoints,
+        allowed_locator_kinds,
+        &transport,
+    )
+    .await
+}
+
+pub(crate) async fn download_encrypted_media_with_transport(
+    reference: MediaAttachmentReference,
+    media_secret: &[u8],
+    fallback_endpoints: &[crate::AppBlobEndpoint],
+    allowed_locator_kinds: &[String],
+    transport: &BlossomHttpTransport,
+) -> Result<MediaDownloadResult, AppError> {
     // Structural validation only: an out-of-policy or client-unsupported locator
     // is judged at fetch time below, where it degrades to an unfetchable outcome
     // rather than a hard "corrupt reference" error.
-    reference.validate(allow_loopback_blob_endpoints)?;
+    reference.validate(transport.allow_loopback_http)?;
     let version = EncryptedMediaVersion::parse(&reference.version)?;
-    let encrypted = fetch_encrypted_media_blob(
+    let encrypted = fetch_encrypted_media_blob_with_transport(
         &reference,
         fallback_endpoints,
         allowed_locator_kinds,
-        allow_loopback_blob_endpoints,
+        transport,
     )
     .await?;
     if !encrypted_media_hash_matches(&encrypted, &reference.ciphertext_sha256) {
@@ -748,11 +771,28 @@ fn encrypted_media_hash_matches(encrypted: &[u8], expected_hash: &str) -> bool {
     hex::encode(Sha256::digest(encrypted)).eq_ignore_ascii_case(expected_hash)
 }
 
+#[cfg(test)]
 async fn fetch_encrypted_media_blob(
     reference: &MediaAttachmentReference,
     fallback_endpoints: &[crate::AppBlobEndpoint],
     allowed_locator_kinds: &[String],
     allow_loopback_blob_endpoints: bool,
+) -> Result<Vec<u8>, AppError> {
+    let transport = BlossomHttpTransport::new(allow_loopback_blob_endpoints);
+    fetch_encrypted_media_blob_with_transport(
+        reference,
+        fallback_endpoints,
+        allowed_locator_kinds,
+        &transport,
+    )
+    .await
+}
+
+async fn fetch_encrypted_media_blob_with_transport(
+    reference: &MediaAttachmentReference,
+    fallback_endpoints: &[crate::AppBlobEndpoint],
+    allowed_locator_kinds: &[String],
+    transport: &BlossomHttpTransport,
 ) -> Result<Vec<u8>, AppError> {
     // Fetchability is judged against CURRENT policy + current client support.
     // This client only fetches `blossom-v1`, so if the group's current policy
@@ -765,7 +805,7 @@ async fn fetch_encrypted_media_blob(
         ));
     }
     let mut candidates = encrypted_media_fetch_candidates(reference, fallback_endpoints);
-    if !allow_loopback_blob_endpoints {
+    if !transport.allow_loopback_http {
         // A loopback-HTTP candidate is valid component state but unusable in a
         // production build: skip it rather than GETting the local host. The
         // candidate may come from a remote-admin policy endpoint or a
@@ -795,8 +835,13 @@ async fn fetch_encrypted_media_blob(
                 continue;
             }
         }
-        match fetch_blossom_blob(&candidate, allow_loopback_blob_endpoints).await {
-            Ok(bytes) => return Ok(bytes),
+        match fetch_blossom_blob_with_transport(&candidate, transport).await {
+            Ok(bytes) if encrypted_media_hash_matches(&bytes, &expected_hash) => return Ok(bytes),
+            Ok(_) => {
+                last_error = Some(AppError::InvalidEncryptedMedia(
+                    "encrypted blob hash does not match media reference".into(),
+                ));
+            }
             Err(err) => last_error = Some(err),
         }
     }

--- a/crates/marmot-app/src/media/tests.rs
+++ b/crates/marmot-app/src/media/tests.rs
@@ -1662,7 +1662,7 @@ async fn stalled_first_locator_reaches_healthy_fallback_within_startup_bound() {
     let healthy_url = spawn_http_response(http_ok_response(body));
     let reference = blob_reference_for_servers(body, &[stalled_url, healthy_url]);
     let transport =
-        BlossomHttpTransport::for_test(true, Duration::from_secs(60), Duration::from_millis(100));
+        BlossomHttpTransport::for_test(true, Duration::from_secs(60), Duration::from_millis(500));
     let allowed = [BLOSSOM_LOCATOR_KIND_V1.to_owned()];
 
     let downloaded = tokio::time::timeout(

--- a/crates/marmot-app/src/media/tests.rs
+++ b/crates/marmot-app/src/media/tests.rs
@@ -1,15 +1,18 @@
 use super::*;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpListener;
-use std::sync::mpsc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, mpsc};
 use std::thread;
+use std::time::Duration;
 
 use chacha20poly1305::aead::{Aead, AeadInPlace, KeyInit, Payload};
 use chacha20poly1305::{ChaCha20Poly1305, Nonce};
 use url::Url;
 
 use super::blossom::{
-    MAX_BLOSSOM_DESCRIPTOR_BYTES, MAX_ENCRYPTED_MEDIA_BLOB_BYTES, read_limited_blossom_body,
+    BlossomHttpTransport, DnsResolver, MAX_BLOSSOM_DESCRIPTOR_BYTES,
+    MAX_ENCRYPTED_MEDIA_BLOB_BYTES, fetch_blossom_blob_with_transport, read_limited_blossom_body,
 };
 use super::host_safety::validate_blossom_fetch_url;
 
@@ -342,6 +345,77 @@ pub(super) fn spawn_http_responses(responses: Vec<Vec<u8>>) -> String {
 
 pub(super) fn spawn_http_response(response: Vec<u8>) -> String {
     spawn_http_responses(vec![response])
+}
+
+async fn spawn_keep_alive_http_server(
+    body: &'static [u8],
+    requests_expected: usize,
+) -> (String, Arc<AtomicUsize>, tokio::task::JoinHandle<()>) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    let accepted = Arc::new(AtomicUsize::new(0));
+    let server_accepted = accepted.clone();
+    let server = tokio::spawn(async move {
+        let (request_tx, mut request_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut requests = 0_usize;
+        while requests < requests_expected {
+            tokio::select! {
+                accepted = listener.accept() => {
+                    let (mut stream, _) = accepted.unwrap();
+                    server_accepted.fetch_add(1, Ordering::SeqCst);
+                    let request_tx = request_tx.clone();
+                    tokio::spawn(async move {
+                        loop {
+                            let mut request = Vec::new();
+                            let mut buffer = [0_u8; 1024];
+                            loop {
+                                let read = stream.read(&mut buffer).await.unwrap();
+                                if read == 0 {
+                                    break;
+                                }
+                                request.extend_from_slice(&buffer[..read]);
+                                if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                                    break;
+                                }
+                            }
+                            if request.is_empty() {
+                                break;
+                            }
+                            let response = format!(
+                                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n",
+                                body.len()
+                            );
+                            stream.write_all(response.as_bytes()).await.unwrap();
+                            stream.write_all(body).await.unwrap();
+                            let _ = request_tx.send(());
+                        }
+                    });
+                }
+                request = request_rx.recv() => {
+                    if request.is_some() {
+                        requests += 1;
+                    }
+                }
+            }
+        }
+    });
+    (url, accepted, server)
+}
+
+async fn spawn_stalled_http_server() -> (String, tokio::task::JoinHandle<()>) {
+    use tokio::io::AsyncReadExt;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut buffer = [0_u8; 1024];
+        let _ = stream.read(&mut buffer).await;
+        std::future::pending::<()>().await;
+    });
+    (url, server)
 }
 
 fn spawn_roundtrip_blob_server() -> (String, mpsc::Receiver<(u64, String)>) {
@@ -1452,6 +1526,173 @@ fn blossom_redirect_validation_rejects_cross_scheme_private_ip_and_cross_domain(
             "expected {expected:?}, got {err}"
         );
     }
+}
+
+fn blob_reference_for_servers(body: &[u8], servers: &[String]) -> MediaAttachmentReference {
+    let hash = hex::encode(Sha256::digest(body));
+    let mut reference = blossom_reference();
+    reference.ciphertext_sha256 = hash.clone();
+    reference.locators = servers
+        .iter()
+        .map(|server| MediaLocator {
+            kind: BLOSSOM_LOCATOR_KIND_V1.to_owned(),
+            value: format!("{server}/{hash}.bin"),
+        })
+        .collect();
+    reference
+}
+
+#[tokio::test]
+async fn repeated_same_origin_downloads_reuse_one_vetted_connection() {
+    let (server_url, accepted, server) = spawn_keep_alive_http_server(b"hello", 2).await;
+    let transport =
+        BlossomHttpTransport::for_test(true, Duration::from_secs(60), Duration::from_secs(1));
+    let url = format!("{server_url}/{}.bin", valid_hash());
+
+    assert_eq!(
+        fetch_blossom_blob_with_transport(&url, &transport)
+            .await
+            .unwrap(),
+        b"hello"
+    );
+    assert_eq!(
+        fetch_blossom_blob_with_transport(&url, &transport)
+            .await
+            .unwrap(),
+        b"hello"
+    );
+    server.await.unwrap();
+
+    assert_eq!(
+        accepted.load(Ordering::SeqCst),
+        1,
+        "compatible same-origin downloads should reuse the vetted connection"
+    );
+}
+
+#[tokio::test]
+async fn concurrent_same_origin_client_setup_resolves_and_vets_once() {
+    let resolutions = Arc::new(AtomicUsize::new(0));
+    let resolver_resolutions = resolutions.clone();
+    let resolver: DnsResolver = Arc::new(move |_domain, port| {
+        resolver_resolutions.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async move {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+            Ok(vec![format!("1.1.1.1:{port}").parse().unwrap()])
+        })
+    });
+    let transport = BlossomHttpTransport::for_test_with_resolver(
+        false,
+        Duration::from_secs(60),
+        Duration::from_secs(1),
+        resolver,
+    );
+    let url = Url::parse(&format!("https://media.example/{}.bin", valid_hash())).unwrap();
+
+    let clients = futures::future::join_all((0..4).map(|_| transport.client_for_url(&url))).await;
+
+    assert!(clients.into_iter().all(|client| client.is_ok()));
+    assert_eq!(
+        resolutions.load(Ordering::SeqCst),
+        1,
+        "concurrent setup for one origin should share resolution and vetting"
+    );
+}
+
+#[tokio::test]
+async fn separate_download_transports_do_not_share_connections() {
+    let (server_url, accepted, server) = spawn_keep_alive_http_server(b"hello", 2).await;
+    let first =
+        BlossomHttpTransport::for_test(true, Duration::from_secs(60), Duration::from_secs(1));
+    let second =
+        BlossomHttpTransport::for_test(true, Duration::from_secs(60), Duration::from_secs(1));
+    let url = format!("{server_url}/{}.bin", valid_hash());
+
+    fetch_blossom_blob_with_transport(&url, &first)
+        .await
+        .unwrap();
+    fetch_blossom_blob_with_transport(&url, &second)
+        .await
+        .unwrap();
+    server.await.unwrap();
+
+    assert_eq!(
+        accepted.load(Ordering::SeqCst),
+        2,
+        "account-scoped transports must not share connection pools"
+    );
+}
+
+#[tokio::test]
+async fn expired_origin_lease_is_resolved_and_vetted_again() {
+    let resolutions = Arc::new(AtomicUsize::new(0));
+    let resolver_resolutions = resolutions.clone();
+    let resolver: DnsResolver = Arc::new(move |_domain, port| {
+        let attempt = resolver_resolutions.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async move {
+            let ip = if attempt == 0 { "1.1.1.1" } else { "127.0.0.1" };
+            Ok(vec![format!("{ip}:{port}").parse().unwrap()])
+        })
+    });
+    let transport = BlossomHttpTransport::for_test_with_resolver(
+        false,
+        Duration::ZERO,
+        Duration::from_secs(1),
+        resolver,
+    );
+    let url = Url::parse(&format!("https://media.example/{}.bin", valid_hash())).unwrap();
+
+    transport
+        .client_for_url(&url)
+        .await
+        .expect("first public address set should be accepted");
+    let error = transport
+        .client_for_url(&url)
+        .await
+        .expect_err("expired lease must reject the newly resolved loopback address");
+
+    assert_eq!(resolutions.load(Ordering::SeqCst), 2);
+    assert!(error.to_string().contains("public unicast"));
+}
+
+#[tokio::test]
+async fn stalled_first_locator_reaches_healthy_fallback_within_startup_bound() {
+    let body = b"healthy ciphertext";
+    let (stalled_url, stalled_server) = spawn_stalled_http_server().await;
+    let healthy_url = spawn_http_response(http_ok_response(body));
+    let reference = blob_reference_for_servers(body, &[stalled_url, healthy_url]);
+    let transport =
+        BlossomHttpTransport::for_test(true, Duration::from_secs(60), Duration::from_millis(100));
+    let allowed = [BLOSSOM_LOCATOR_KIND_V1.to_owned()];
+
+    let downloaded = tokio::time::timeout(
+        Duration::from_secs(2),
+        fetch_encrypted_media_blob_with_transport(&reference, &[], &allowed, &transport),
+    )
+    .await
+    .expect("healthy fallback must be reached promptly")
+    .expect("healthy fallback must succeed");
+    stalled_server.abort();
+
+    assert_eq!(downloaded, body);
+}
+
+#[tokio::test]
+async fn corrupt_first_locator_does_not_prevent_integrity_valid_fallback() {
+    let body = b"integrity-valid ciphertext";
+    let corrupt_url = spawn_http_response(http_ok_response(b"corrupt"));
+    let healthy_url = spawn_http_response(http_ok_response(body));
+    let reference = blob_reference_for_servers(body, &[corrupt_url, healthy_url]);
+    let transport =
+        BlossomHttpTransport::for_test(true, Duration::from_secs(60), Duration::from_secs(1));
+    let allowed = [BLOSSOM_LOCATOR_KIND_V1.to_owned()];
+
+    let downloaded =
+        fetch_encrypted_media_blob_with_transport(&reference, &[], &allowed, &transport)
+            .await
+            .expect("corrupt first candidate must fall through to the healthy locator");
+
+    assert_eq!(downloaded, body);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- add a per-account, exact-origin Blossom download transport that single-flights DNS resolution and client creation across a backlog
- reuse pinned reqwest clients for 60 seconds, then resolve, vet, and pin a fresh address set; keep the cache bounded to 32 origins
- bound each ordered locator startup to 10 seconds so DNS, connection, headers, or first-byte stalls reach the next candidate promptly
- require ciphertext hash validity before a candidate wins, allowing corrupt first locators to fall through
- preserve redirect revalidation, proxy isolation, loopback policy, sequential candidate order, and the existing four-operation account cap

## Tests

- cargo test -p marmot-app media::tests::
- cargo test -p marmot-app media_http
- cargo clippy -p marmot-app --all-targets -- -D warnings
- just fast-ci

The full marmot-app test run passed 874 tests but reported six unrelated epoch-backfill timing failures. One representative failure, deferred_primary_epoch_backfill_rotates_behind_queued_older_operation, reproduces in isolation on an unchanged origin/master worktree.

## Scope

This draft implements the surgical reuse and bounded-failover correction discussed for #1529. The issue broader privacy-safe phase telemetry, repository benchmark, and before/after p95 evidence remain outside this patch, so this PR intentionally does not auto-close the issue.

Addresses #1529

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for media and group-image downloads, including better handling of stalled or slow connections.
  - Added fallback handling when downloaded encrypted media is corrupted or fails integrity verification.
  - Improved connection reuse for repeated media downloads from the same source.
  - Strengthened network address validation during media downloads to improve safety and resilience.
  - Improved handling of concurrent requests and expired connection information during media retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->