### PR TITLE
fix(app,forensics): upload audit segments once instead of re-posting whole files

### DIFF
--- a/crates/incident-replay/src/classify.rs
+++ b/crates/incident-replay/src/classify.rs
@@ -344,9 +344,13 @@ impl HaltLifecycle<'_> {
     /// Both rows also come from a single engine — one clock, one recorder file —
     /// so none of rule 6's cross-device [`CATCH_UP_GRACE_MS`] skew allowance
     /// applies and a strict comparison is sound. (`seq` must never be substituted
-    /// for the clock: it restarts at 0 on every recorder open *within the same
-    /// file*, so it does not order rows across a restart — the exact boundary a
-    /// durable halt survives. See `docs/marmot-architecture/audit-logging.md`.)
+    /// for the clock. It restarts at 0 on every recorder open, so it does not
+    /// order rows across a restart — the exact boundary a durable halt
+    /// survives — and since mdk#1181 it does not identify a file either: a
+    /// segment roll carries `seq` across into an `audit-*-seg<NNNNNN>.jsonl`
+    /// sibling, so one session's rows span several source files and a file can
+    /// start at a nonzero `seq`. Neither direction is orderable by `seq`. See
+    /// `docs/marmot-architecture/audit-logging.md`.)
     ///
     /// Absence fails closed in both directions: an unrepaired halt keeps its
     /// quarantine, and so does a halt whose evidence cannot be ordered — arming

--- a/crates/marmot-app/AGENTS.md
+++ b/crates/marmot-app/AGENTS.md
@@ -52,6 +52,14 @@ App runtime bridge for the first real Marmot app surfaces.
   Do not add a trigger path that bypasses the size-1 coalescing queue in `runtime/audit_tracker.rs`, and do not let one
   oversized or failing file block the files behind it. Retention/deletion of sealed segments is mdk#1014, not this
   contract.
+- Keep the upload checkpoint's cost proportional to the account's *live* audit files, not to its history. `retain_present`
+  prunes entries for files that are gone, so the sidecar is O(live `audit-*.jsonl` files) — but nothing deletes sealed
+  segments (mdk#1014), so that bound grows with cumulative audit volume, and each tracker run stats every file and
+  rewrites the whole sidecar. Do not add a per-upload or per-line entry, and do not treat the sidecar as durable state:
+  losing it costs one repeat transfer per file and nothing else.
+- A file above `AUDIT_LOG_UPLOAD_MAX_BYTES` has no app-level transfer path. `post_audit_log_file` enforces the same
+  ceiling, so the tracker's skip is the whole story: the file stays on disk for manual handling. Do not document an
+  escape hatch that does not exist, and do not widen the ceiling to invent one.
 - Keep SQLCipher key derivation, per-database salt persistence, legacy-key migration/recovery, and the in-process
   v2-open probe-verdict cache (mdk#1439) in `src/sqlcipher.rs`. The verdict cache is advisory only: a durable
   migration marker or a missing verdict always re-runs the recovery probe, so the mdk#568 crash windows keep their

--- a/crates/marmot-app/AGENTS.md
+++ b/crates/marmot-app/AGENTS.md
@@ -44,8 +44,14 @@ App runtime bridge for the first real Marmot app surfaces.
   messages, app events, push registrations, telemetry/audit settings) in `src/conversions.rs`. They hold no `MarmotApp`
   state.
 - Keep the forensic audit-log feature in `src/audit_log.rs`: the `AuditLog*` DTOs, salted-hash identity derivation,
-  the upload client, and the `MarmotApp` methods for audit settings, recorder open/build, file enumeration, path
-  validation/resolution/removal, and HTTP upload. Audit-log unit tests live in its own `#[cfg(test)] mod tests`.
+  the upload client, the per-account upload checkpoint (`audit-upload-checkpoint.json`), and the `MarmotApp` methods for
+  audit settings, recorder open/build, file enumeration, path validation/resolution/removal, and HTTP upload. Audit-log
+  unit tests live in its own `#[cfg(test)] mod tests`.
+- Keep audit uploads incremental (mdk#1181). An audit file whose size and mtime still match its checkpoint entry is
+  never re-read or re-posted; only the growing active file re-transfers, bounded by the recorder's segment threshold.
+  Do not add a trigger path that bypasses the size-1 coalescing queue in `runtime/audit_tracker.rs`, and do not let one
+  oversized or failing file block the files behind it. Retention/deletion of sealed segments is mdk#1014, not this
+  contract.
 - Keep SQLCipher key derivation, per-database salt persistence, legacy-key migration/recovery, and the in-process
   v2-open probe-verdict cache (mdk#1439) in `src/sqlcipher.rs`. The verdict cache is advisory only: a durable
   migration marker or a missing verdict always re-runs the recovery probe, so the mdk#568 crash windows keep their

--- a/crates/marmot-app/Cargo.toml
+++ b/crates/marmot-app/Cargo.toml
@@ -57,6 +57,7 @@ zeroize.workspace = true
 
 [dev-dependencies]
 keyring-core.workspace = true
+marmot-forensics.workspace = true
 nostr-relay-builder.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/marmot-app/src/audit_log.rs
+++ b/crates/marmot-app/src/audit_log.rs
@@ -129,9 +129,17 @@ impl AuditUploadCheckpoint {
     }
 
     /// Record `outcome` for `file`. `acknowledged_bytes` is the length actually
-    /// handed to the endpoint, which can trail the enumerated size when the
-    /// recorder appended mid-run; recording the smaller number keeps a later
-    /// match from claiming unsent bytes were acknowledged.
+    /// handed to the endpoint, re-stat'd inside the upload and therefore taken
+    /// *after* `file` was enumerated — so for an append-only audit file it is
+    /// greater than or equal to `file.size_bytes`, never less.
+    ///
+    /// Pairing it with the enumerated `modified_at_ms` is what makes that safe.
+    /// Size only grows and mtime only moves forward, so if the recorder
+    /// appended between enumeration and upload, the stored pair describes no
+    /// state the file will ever be in again and every later run re-uploads.
+    /// The identity can therefore cost a redundant transfer, which the
+    /// endpoint's `file_sha256` short-circuit absorbs, but it cannot claim
+    /// unsent bytes were acknowledged.
     pub(crate) fn acknowledge(
         &mut self,
         file: &AuditLogFile,

--- a/crates/marmot-app/src/audit_log.rs
+++ b/crates/marmot-app/src/audit_log.rs
@@ -32,8 +32,14 @@ const AUDIT_DEVICE_ID_FILE: &str = "audit-device-id";
 /// The name matches the `audit-*.jsonl` glob so it is enumerable via
 /// [`MarmotApp::audit_log_files`].
 const KEY_REVEAL_AUDIT_FILE: &str = "audit-key-reveal.jsonl";
+/// Per-account record of which audit files the tracker has already handed to
+/// the upload endpoint (mdk#1181).
+///
+/// Deliberately *not* an `audit-*.jsonl` name: it must never be enumerated by
+/// [`MarmotApp::audit_log_files`] and uploaded as if it were forensic data.
+const AUDIT_UPLOAD_CHECKPOINT_FILE: &str = "audit-upload-checkpoint.json";
 pub(crate) const AUDIT_ID_BYTES: usize = 16;
-const AUDIT_LOG_UPLOAD_MAX_BYTES: u64 = 64 * 1024 * 1024;
+pub(crate) const AUDIT_LOG_UPLOAD_MAX_BYTES: u64 = 64 * 1024 * 1024;
 const AUDIT_LOG_UPLOAD_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const AUDIT_LOG_UPLOAD_TIMEOUT: Duration = Duration::from_secs(60);
 static AUDIT_LOG_UPLOAD_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
@@ -65,6 +71,95 @@ pub struct AuditLogTrackerUpdateResult {
     pub enabled: bool,
     pub uploaded: Vec<AuditLogUploadResult>,
     pub skipped_reason: Option<String>,
+}
+
+/// What the tracker already did with one audit file.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AuditUploadOutcome {
+    /// The endpoint accepted the file's whole content.
+    Uploaded,
+    /// The file is larger than the endpoint's per-request ceiling, so no
+    /// automatic upload can ever accept it. Recorded so the tracker reports it
+    /// once instead of re-attempting on every trigger.
+    TooLargeToUpload,
+}
+
+/// One acknowledged audit file, identified by the size and mtime it had when
+/// the tracker was done with it.
+///
+/// Identity is metadata, not a content hash, precisely because the point of the
+/// checkpoint is to *avoid reading* the file again. Audit files only ever grow
+/// (segments never change at all), so a later enumeration reporting the exact
+/// same pair means the acknowledged content is still the whole file. Every
+/// mismatch — including the racy ones, where the file grew between enumeration
+/// and upload — falls back to re-uploading, which the endpoint's `file_sha256`
+/// short-circuit absorbs without parsing.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct AuditUploadCheckpointEntry {
+    size_bytes: u64,
+    #[serde(default)]
+    modified_at_ms: Option<u64>,
+    outcome: AuditUploadOutcome,
+}
+
+/// Per-account upload checkpoint (mdk#1181).
+///
+/// Losing or corrupting this file is safe by design: the worst case is that
+/// each still-present file transfers once more, and the upload endpoint
+/// short-circuits a byte-identical re-upload on `file_sha256` without parsing
+/// a line. That is why it is a plain sidecar rather than a migration in the
+/// account database.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub(crate) struct AuditUploadCheckpoint {
+    #[serde(default)]
+    files: std::collections::BTreeMap<String, AuditUploadCheckpointEntry>,
+}
+
+impl AuditUploadCheckpoint {
+    /// What the tracker already did with `file`, if its content is unchanged
+    /// since then.
+    pub(crate) fn acknowledged(&self, file: &AuditLogFile) -> Option<AuditUploadOutcome> {
+        self.files
+            .get(&file.file_name)
+            .filter(|entry| {
+                entry.size_bytes == file.size_bytes && entry.modified_at_ms == file.modified_at_ms
+            })
+            .map(|entry| entry.outcome)
+    }
+
+    /// Record `outcome` for `file`. `acknowledged_bytes` is the length actually
+    /// handed to the endpoint, which can trail the enumerated size when the
+    /// recorder appended mid-run; recording the smaller number keeps a later
+    /// match from claiming unsent bytes were acknowledged.
+    pub(crate) fn acknowledge(
+        &mut self,
+        file: &AuditLogFile,
+        acknowledged_bytes: u64,
+        outcome: AuditUploadOutcome,
+    ) {
+        self.files.insert(
+            file.file_name.clone(),
+            AuditUploadCheckpointEntry {
+                size_bytes: acknowledged_bytes,
+                modified_at_ms: file.modified_at_ms,
+                outcome,
+            },
+        );
+    }
+
+    /// Drop entries for files that are no longer on disk, so the sidecar stays
+    /// bounded by the account's live audit files. Returns whether anything
+    /// changed.
+    pub(crate) fn retain_present<'a>(
+        &mut self,
+        present: impl IntoIterator<Item = &'a str>,
+    ) -> bool {
+        let present: std::collections::BTreeSet<&str> = present.into_iter().collect();
+        let before = self.files.len();
+        self.files.retain(|name, _| present.contains(name.as_str()));
+        before != self.files.len()
+    }
 }
 
 /// Outcome of deleting a single audit log file.
@@ -308,6 +403,46 @@ impl MarmotApp {
                 .then_with(|| left.file_name.cmp(&right.file_name))
         });
         Ok(files)
+    }
+
+    /// Load the tracker's upload checkpoint for `account_ref`.
+    ///
+    /// Never fails: a missing, unreadable, or malformed sidecar reads as empty,
+    /// which costs one re-upload per still-present file and nothing else.
+    pub(crate) fn audit_upload_checkpoint(&self, account_ref: &str) -> AuditUploadCheckpoint {
+        let path = self
+            .account_dir(account_ref)
+            .join(AUDIT_UPLOAD_CHECKPOINT_FILE);
+        fs::read(path)
+            .ok()
+            .and_then(|bytes| serde_json::from_slice(&bytes).ok())
+            .unwrap_or_default()
+    }
+
+    /// Persist the tracker's upload checkpoint for `account_ref`.
+    ///
+    /// Written to an owner-only staging sibling and renamed into place, so a
+    /// crash mid-write leaves the previous checkpoint intact rather than a torn
+    /// one that would strand every entry.
+    pub(crate) fn store_audit_upload_checkpoint(
+        &self,
+        account_ref: &str,
+        checkpoint: &AuditUploadCheckpoint,
+    ) -> Result<(), AppError> {
+        let path = self
+            .account_dir(account_ref)
+            .join(AUDIT_UPLOAD_CHECKPOINT_FILE);
+        let mut staged = path.clone().into_os_string();
+        staged.push(".tmp");
+        let staged = PathBuf::from(staged);
+        fs_private::write_private(&staged, &serde_json::to_vec(checkpoint)?)?;
+        // `rename` preserves the staged 0600 mode, so the checkpoint is never
+        // reachable at umask-default permissions.
+        if let Err(err) = fs::rename(&staged, &path) {
+            let _ = fs::remove_file(&staged);
+            return Err(err.into());
+        }
+        Ok(())
     }
 
     pub async fn post_audit_log_file(
@@ -844,6 +979,78 @@ mod tests {
                 .as_str()
                 .is_some_and(|value| !value.is_empty())
         );
+    }
+
+    #[test]
+    fn audit_upload_checkpoint_round_trips_and_is_never_enumerated_as_forensic_data() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = AccountHome::open(dir.path());
+        home.create_account("alice").unwrap();
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+        std::fs::write(
+            home.account_dir("alice").join("audit-engine-v3.jsonl"),
+            b"{\"seq\":1}\n",
+        )
+        .unwrap();
+        let file = app.audit_log_files().unwrap().remove(0);
+
+        assert!(
+            app.audit_upload_checkpoint("alice")
+                .acknowledged(&file)
+                .is_none()
+        );
+        let mut checkpoint = AuditUploadCheckpoint::default();
+        checkpoint.acknowledge(&file, file.size_bytes, AuditUploadOutcome::Uploaded);
+        app.store_audit_upload_checkpoint("alice", &checkpoint)
+            .unwrap();
+
+        assert_eq!(
+            app.audit_upload_checkpoint("alice").acknowledged(&file),
+            Some(AuditUploadOutcome::Uploaded)
+        );
+        // The sidecar must never be uploaded as if it were forensic data.
+        let enumerated = app.audit_log_files().unwrap();
+        assert_eq!(enumerated.len(), 1);
+        assert_eq!(enumerated[0].file_name, "audit-engine-v3.jsonl");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let path = home.account_dir("alice").join(AUDIT_UPLOAD_CHECKPOINT_FILE);
+            assert_eq!(
+                fs::metadata(path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+    }
+
+    #[test]
+    fn audit_upload_checkpoint_acknowledgement_is_scoped_to_unchanged_content() {
+        let file = AuditLogFile {
+            account_ref: "alice".to_owned(),
+            path: "/tmp/audit-engine-v3.jsonl".to_owned(),
+            file_name: "audit-engine-v3.jsonl".to_owned(),
+            size_bytes: 10,
+            modified_at_ms: Some(1_000),
+        };
+        let mut checkpoint = AuditUploadCheckpoint::default();
+        checkpoint.acknowledge(&file, file.size_bytes, AuditUploadOutcome::Uploaded);
+
+        let grown = AuditLogFile {
+            size_bytes: 20,
+            modified_at_ms: Some(1_100),
+            ..file.clone()
+        };
+        assert!(checkpoint.acknowledged(&grown).is_none());
+        // Same length, rewritten content: the mtime change still forces a
+        // re-upload rather than silently skipping unsent forensic data.
+        let replaced = AuditLogFile {
+            modified_at_ms: Some(2_000),
+            ..file.clone()
+        };
+        assert!(checkpoint.acknowledged(&replaced).is_none());
+
+        assert!(checkpoint.retain_present(["audit-other.jsonl"]));
+        assert!(checkpoint.acknowledged(&file).is_none());
     }
 
     #[test]

--- a/crates/marmot-app/src/runtime/audit_tracker.rs
+++ b/crates/marmot-app/src/runtime/audit_tracker.rs
@@ -6,8 +6,16 @@ use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
 
 use super::{RuntimeLifecycle, runtime_shutdown_requested, wait_for_runtime_shutdown};
-use crate::{AppError, AuditLogTrackerConfig, AuditLogTrackerUpdateResult, MarmotApp};
+use crate::audit_log::{AUDIT_LOG_UPLOAD_MAX_BYTES, AuditUploadOutcome};
+use crate::{
+    AppError, AuditLogFile, AuditLogTrackerConfig, AuditLogTrackerUpdateResult, MarmotApp,
+};
 
+/// Trigger queue depth. One slot is the coalescing contract (mdk#1181): a
+/// burst of send/receive/convergence triggers arriving while an update is
+/// scheduled or running collapses into exactly one follow-up run — `schedule`
+/// drops triggers that find the slot full, and the worker never starts a second
+/// update concurrently because it drains the slot only between runs.
 const APP_RUNTIME_AUDIT_TRACKER_QUEUE: usize = 1;
 
 #[derive(Clone)]
@@ -213,30 +221,101 @@ pub(crate) async fn post_audit_log_tracker_update_for_app(
 
     let mut uploaded = Vec::new();
     let mut failed = 0_usize;
-    for (file_index, file) in files.into_iter().enumerate() {
-        match app
-            .post_audit_log_file_with_tracker_config(&file.path, &config)
-            .await
-        {
-            Ok(result) => uploaded.push(result),
-            Err(_err) => {
-                failed += 1;
+    let mut acknowledged = 0_usize;
+    let mut too_large = 0_usize;
+    // `audit_log_files` sorts by account first, so each account's files arrive
+    // as one contiguous run and its checkpoint is loaded and stored once.
+    for account_files in group_by_account(files) {
+        let account_ref = account_files[0].account_ref.clone();
+        let mut checkpoint = app.audit_upload_checkpoint(&account_ref);
+        let mut checkpoint_changed =
+            checkpoint.retain_present(account_files.iter().map(|file| file.file_name.as_str()));
+        for (file_index, file) in account_files.iter().enumerate() {
+            // An acknowledged file is never re-read or re-posted. Sealed
+            // segments are immutable, so a single 200 is a durable
+            // acknowledgment of their whole content; the active file changes on
+            // every append and therefore re-transfers in full each trigger.
+            // That residual is accepted by design and is bounded by the
+            // recorder's segment threshold — a byte-offset acknowledgment
+            // protocol was considered and rejected as overkill (mdk#1181).
+            if checkpoint.acknowledged(file).is_some() {
+                acknowledged += 1;
+                continue;
+            }
+            if file.size_bytes > AUDIT_LOG_UPLOAD_MAX_BYTES {
+                // Upgrade path: a file grown past the per-request ceiling by a
+                // build without segment rotation. Rotation keeps new files well
+                // under the ceiling, so this can only be a legacy artifact.
+                // Splitting it is out of scope; record the verdict so it
+                // surfaces once instead of failing silently on every trigger,
+                // and keep going so it never wedges the other files. A host can
+                // still transfer it deliberately via `post_audit_log_file`, and
+                // deleting it belongs to mdk#1014.
+                too_large += 1;
+                checkpoint.acknowledge(file, file.size_bytes, AuditUploadOutcome::TooLargeToUpload);
+                checkpoint_changed = true;
                 tracing::warn!(
                     target: "marmot_app::audit_log",
                     method = "post_audit_log_tracker_update",
                     file_index,
-                    "failed to post forensic audit log file to tracker"
+                    size_bytes = file.size_bytes,
+                    limit_bytes = AUDIT_LOG_UPLOAD_MAX_BYTES,
+                    "skipped forensic audit log file larger than the tracker request limit"
                 );
+                continue;
+            }
+            match app
+                .post_audit_log_file_with_tracker_config(&file.path, &config)
+                .await
+            {
+                Ok(result) => {
+                    checkpoint.acknowledge(file, result.bytes_sent, AuditUploadOutcome::Uploaded);
+                    checkpoint_changed = true;
+                    uploaded.push(result);
+                }
+                Err(_err) => {
+                    // Unacknowledged: left out of the checkpoint so the next
+                    // trigger retries it.
+                    failed += 1;
+                    tracing::warn!(
+                        target: "marmot_app::audit_log",
+                        method = "post_audit_log_tracker_update",
+                        file_index,
+                        "failed to post forensic audit log file to tracker"
+                    );
+                }
             }
         }
+        // Recorded after the effects it mirrors, so a crash before this point
+        // costs one repeat transfer rather than dropping forensic data.
+        if checkpoint_changed
+            && let Err(err) = app.store_audit_upload_checkpoint(&account_ref, &checkpoint)
+        {
+            tracing::warn!(
+                target: "marmot_app::audit_log",
+                method = "post_audit_log_tracker_update",
+                error_kind = err.privacy_safe_kind(),
+                "failed to persist forensic audit log upload checkpoint"
+            );
+        }
     }
-    if failed > 0 {
+    if failed > 0 || too_large > 0 {
         tracing::warn!(
             target: "marmot_app::audit_log",
             method = "post_audit_log_tracker_update",
             uploaded = uploaded.len(),
+            acknowledged,
+            too_large,
             failed,
             "completed forensic audit log tracker update with file upload failures"
+        );
+    } else {
+        tracing::debug!(
+            target: "marmot_app::audit_log",
+            method = "post_audit_log_tracker_update",
+            uploaded = uploaded.len(),
+            acknowledged,
+            "completed forensic audit log tracker update"
         );
     }
     Ok(AuditLogTrackerUpdateResult {
@@ -244,4 +323,16 @@ pub(crate) async fn post_audit_log_tracker_update_for_app(
         uploaded,
         skipped_reason: None,
     })
+}
+
+/// Split the account-sorted enumeration into one non-empty run per account.
+fn group_by_account(files: Vec<AuditLogFile>) -> Vec<Vec<AuditLogFile>> {
+    let mut grouped: Vec<Vec<AuditLogFile>> = Vec::new();
+    for file in files {
+        match grouped.last_mut() {
+            Some(run) if run[0].account_ref == file.account_ref => run.push(file),
+            _ => grouped.push(vec![file]),
+        }
+    }
+    grouped
 }

--- a/crates/marmot-app/src/runtime/audit_tracker.rs
+++ b/crates/marmot-app/src/runtime/audit_tracker.rs
@@ -222,7 +222,8 @@ pub(crate) async fn post_audit_log_tracker_update_for_app(
     let mut uploaded = Vec::new();
     let mut failed = 0_usize;
     let mut acknowledged = 0_usize;
-    let mut too_large = 0_usize;
+    let mut too_large_recorded = 0_usize;
+    let mut too_large_known = 0_usize;
     // `audit_log_files` sorts by account first, so each account's files arrive
     // as one contiguous run and its checkpoint is loaded and stored once.
     for account_files in group_by_account(files) {
@@ -238,9 +239,21 @@ pub(crate) async fn post_audit_log_tracker_update_for_app(
             // That residual is accepted by design and is bounded by the
             // recorder's segment threshold — a byte-offset acknowledgment
             // protocol was considered and rejected as overkill (mdk#1181).
-            if checkpoint.acknowledged(file).is_some() {
-                acknowledged += 1;
-                continue;
+            // Both outcomes skip the file, but they are not the same fact: one
+            // means the endpoint has the content, the other means it never
+            // will. Keep them apart in the aggregates so an operator reading
+            // the counts is not told a permanently untransferable file was
+            // delivered.
+            match checkpoint.acknowledged(file) {
+                Some(AuditUploadOutcome::Uploaded) => {
+                    acknowledged += 1;
+                    continue;
+                }
+                Some(AuditUploadOutcome::TooLargeToUpload) => {
+                    too_large_known += 1;
+                    continue;
+                }
+                None => {}
             }
             if file.size_bytes > AUDIT_LOG_UPLOAD_MAX_BYTES {
                 // Upgrade path: a file grown past the per-request ceiling by a
@@ -248,10 +261,16 @@ pub(crate) async fn post_audit_log_tracker_update_for_app(
                 // under the ceiling, so this can only be a legacy artifact.
                 // Splitting it is out of scope; record the verdict so it
                 // surfaces once instead of failing silently on every trigger,
-                // and keep going so it never wedges the other files. A host can
-                // still transfer it deliberately via `post_audit_log_file`, and
-                // deleting it belongs to mdk#1014.
-                too_large += 1;
+                // and keep going so it never wedges the other files.
+                //
+                // There is no app-level escape hatch: `post_audit_log_file`
+                // enforces the same ceiling before it opens a body
+                // (`audit_log.rs`, pinned by
+                // `post_audit_log_file_rejects_oversized_files_before_upload`),
+                // so a file this size is not transferable through any app API.
+                // It stays on disk for manual handling, and deleting it belongs
+                // to mdk#1014.
+                too_large_recorded += 1;
                 checkpoint.acknowledge(file, file.size_bytes, AuditUploadOutcome::TooLargeToUpload);
                 checkpoint_changed = true;
                 tracing::warn!(
@@ -299,13 +318,17 @@ pub(crate) async fn post_audit_log_tracker_update_for_app(
             );
         }
     }
-    if failed > 0 || too_large > 0 {
+    // Only a newly recorded over-ceiling file warrants a warning: one already
+    // in the checkpoint has been reported, and re-warning every trigger is the
+    // noise this contract removes. Counts only — no file names or paths.
+    if failed > 0 || too_large_recorded > 0 {
         tracing::warn!(
             target: "marmot_app::audit_log",
             method = "post_audit_log_tracker_update",
             uploaded = uploaded.len(),
             acknowledged,
-            too_large,
+            too_large_recorded,
+            too_large_known,
             failed,
             "completed forensic audit log tracker update with file upload failures"
         );
@@ -315,6 +338,7 @@ pub(crate) async fn post_audit_log_tracker_update_for_app(
             method = "post_audit_log_tracker_update",
             uploaded = uploaded.len(),
             acknowledged,
+            too_large_known,
             "completed forensic audit log tracker update"
         );
     }

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -2260,6 +2260,14 @@ impl MarmotAppRuntime {
         post_audit_log_tracker_update_for_app(&self.accounts.app, config).await
     }
 
+    /// Test seam: fire one tracker trigger through the same scheduling path
+    /// ordinary send/receive/convergence activity uses, so a burst can be
+    /// observed coalescing instead of queueing N runs (mdk#1181).
+    #[cfg(any(test, feature = "test-policy-overrides"))]
+    pub fn schedule_audit_log_tracker_update_for_test(&self, trigger: &'static str) {
+        self.shared.schedule_audit_log_tracker_update(trigger);
+    }
+
     /// Delete one local JSONL audit log file. When a session for the file's
     /// account is live and audit logging is on, the recorder rotates to a fresh
     /// file and keeps recording; otherwise the file is simply removed.

--- a/crates/marmot-app/tests/audit_logs.rs
+++ b/crates/marmot-app/tests/audit_logs.rs
@@ -593,3 +593,402 @@ async fn local_message_send_tags_engine_rows_with_human_action() {
         "local_user"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Incremental upload contract (mdk#1181)
+// ---------------------------------------------------------------------------
+
+/// Capture sink that stays up across many tracker runs, so a test can assert on
+/// what was *not* re-transferred as well as what was.
+// The pacing/concurrency knobs exist for the coalescing regression, which needs
+// the `test-policy-overrides` trigger seam; without that feature they are unused.
+#[cfg_attr(not(feature = "test-policy-overrides"), allow(dead_code))]
+struct CaptureSink {
+    addr: std::net::SocketAddr,
+    requests: std::sync::Arc<std::sync::Mutex<Vec<CapturedRequest>>>,
+    statuses: std::sync::Arc<std::sync::Mutex<std::collections::VecDeque<u16>>>,
+    /// Milliseconds a handler holds a request open before answering, so a test
+    /// can schedule more triggers while an upload is genuinely in flight.
+    hold_ms: std::sync::Arc<std::sync::atomic::AtomicU64>,
+    default_status: std::sync::Arc<std::sync::atomic::AtomicU16>,
+    in_flight: std::sync::Arc<std::sync::Mutex<(usize, usize)>>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+#[cfg_attr(not(feature = "test-policy-overrides"), allow(dead_code))]
+impl CaptureSink {
+    async fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let requests = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let statuses = std::sync::Arc::new(std::sync::Mutex::new(
+            std::collections::VecDeque::<u16>::new(),
+        ));
+        let hold_ms = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let default_status = std::sync::Arc::new(std::sync::atomic::AtomicU16::new(204));
+        let in_flight = std::sync::Arc::new(std::sync::Mutex::new((0_usize, 0_usize)));
+        let handle = tokio::spawn({
+            use std::sync::atomic::Ordering;
+            let requests = requests.clone();
+            let statuses = statuses.clone();
+            let hold_ms = hold_ms.clone();
+            let default_status = default_status.clone();
+            let in_flight = in_flight.clone();
+            async move {
+                loop {
+                    let Ok((mut stream, _)) = listener.accept().await else {
+                        return;
+                    };
+                    let requests = requests.clone();
+                    let statuses = statuses.clone();
+                    let hold_ms = hold_ms.clone();
+                    let default_status = default_status.clone();
+                    let in_flight = in_flight.clone();
+                    // One task per connection so overlapping uploads are
+                    // observable instead of serialized behind `accept`.
+                    tokio::spawn(async move {
+                        let Some(request) = read_captured_request(&mut stream).await else {
+                            return;
+                        };
+                        {
+                            let mut counts = in_flight.lock().unwrap();
+                            counts.0 += 1;
+                            counts.1 = counts.1.max(counts.0);
+                        }
+                        let hold = hold_ms.load(Ordering::Relaxed);
+                        if hold > 0 {
+                            tokio::time::sleep(std::time::Duration::from_millis(hold)).await;
+                        }
+                        let status = statuses
+                            .lock()
+                            .unwrap()
+                            .pop_front()
+                            .unwrap_or_else(|| default_status.load(Ordering::Relaxed));
+                        write_http_response(&mut stream, status).await;
+                        let _ = stream.shutdown().await;
+                        in_flight.lock().unwrap().0 -= 1;
+                        requests.lock().unwrap().push(request);
+                    });
+                }
+            }
+        });
+        Self {
+            addr,
+            requests,
+            statuses,
+            hold_ms,
+            default_status,
+            in_flight,
+            handle,
+        }
+    }
+
+    fn endpoint(&self) -> String {
+        format!("http://{}/api/v1/audit-logs/", self.addr)
+    }
+
+    fn script(&self, statuses: &[u16]) {
+        *self.statuses.lock().unwrap() = statuses.iter().copied().collect();
+    }
+
+    fn hold_each_request_for(&self, millis: u64) {
+        self.hold_ms
+            .store(millis, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn always_answer(&self, status: u16) {
+        self.default_status
+            .store(status, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn max_concurrent_requests(&self) -> usize {
+        self.in_flight.lock().unwrap().1
+    }
+
+    fn take_bodies(&self) -> Vec<Vec<u8>> {
+        std::mem::take(&mut *self.requests.lock().unwrap())
+            .into_iter()
+            .map(|request| request.body)
+            .collect()
+    }
+}
+
+impl Drop for CaptureSink {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+fn tracker_runtime(root: &std::path::Path, endpoint: &str) -> MarmotAppRuntime {
+    let app = MarmotApp::with_relay(root, "wss://relay.example");
+    app.set_audit_log_settings(AuditLogSettings { enabled: true })
+        .unwrap();
+    let runtime = MarmotAppRuntime::new(app);
+    runtime
+        .set_audit_log_tracker_config(AuditLogTrackerConfig {
+            endpoint: Some(endpoint.to_owned()),
+            authorization_bearer_token: Some("goggles_dev_secret".to_owned()),
+            source: AuditLogUploadSource::default(),
+        })
+        .unwrap();
+    runtime
+}
+
+fn checkpoint_path(home: &AccountHome, label: &str) -> std::path::PathBuf {
+    home.account_dir(label).join("audit-upload-checkpoint.json")
+}
+
+#[tokio::test]
+async fn acknowledged_audit_files_are_not_re_posted_without_new_rows() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(tmp.path());
+    let account = home.create_account("alice").unwrap();
+    let sealed = b"{\"seq\":1}\n{\"seq\":2}\n{\"seq\":3}\n";
+    std::fs::write(
+        home.account_dir(&account.label)
+            .join("audit-engine-v3-seg000001.jsonl"),
+        sealed,
+    )
+    .unwrap();
+
+    let sink = CaptureSink::start().await;
+    let runtime = tracker_runtime(tmp.path(), &sink.endpoint());
+
+    let first = runtime.post_audit_log_tracker_update().await.unwrap();
+    assert_eq!(first.uploaded.len(), 1);
+    assert_eq!(sink.take_bodies(), vec![sealed.to_vec()]);
+
+    for _ in 0..5 {
+        let repeat = runtime.post_audit_log_tracker_update().await.unwrap();
+        assert!(repeat.uploaded.is_empty(), "{repeat:?}");
+    }
+    assert!(
+        sink.take_bodies().is_empty(),
+        "an acknowledged segment must never be re-read or re-posted"
+    );
+}
+
+#[tokio::test]
+async fn appending_a_suffix_transfers_only_the_changed_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(tmp.path());
+    let account = home.create_account("alice").unwrap();
+    let dir = home.account_dir(&account.label);
+    let sealed = b"{\"seq\":1}\n";
+    std::fs::write(dir.join("audit-engine-v3-seg000001.jsonl"), sealed).unwrap();
+    std::fs::write(dir.join("audit-engine-v3.jsonl"), b"{\"seq\":2}\n").unwrap();
+
+    let sink = CaptureSink::start().await;
+    let runtime = tracker_runtime(tmp.path(), &sink.endpoint());
+
+    runtime.post_audit_log_tracker_update().await.unwrap();
+    assert_eq!(sink.take_bodies().len(), 2);
+
+    // A new immutable segment plus growth of the active file.
+    std::fs::write(
+        dir.join("audit-engine-v3-seg000002.jsonl"),
+        b"{\"seq\":3}\n",
+    )
+    .unwrap();
+    let active = b"{\"seq\":2}\n{\"seq\":4}\n";
+    std::fs::write(dir.join("audit-engine-v3.jsonl"), active).unwrap();
+
+    runtime.post_audit_log_tracker_update().await.unwrap();
+
+    let bodies = sink.take_bodies();
+    assert_eq!(
+        bodies,
+        vec![b"{\"seq\":3}\n".to_vec(), active.to_vec()],
+        "only the new segment and the grown active file should transfer"
+    );
+}
+
+#[tokio::test]
+async fn acknowledgement_survives_restart_and_a_lost_checkpoint_costs_one_repeat() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(tmp.path());
+    let account = home.create_account("alice").unwrap();
+    let sealed = b"{\"seq\":1}\n";
+    std::fs::write(
+        home.account_dir(&account.label)
+            .join("audit-engine-v3-seg000001.jsonl"),
+        sealed,
+    )
+    .unwrap();
+
+    let sink = CaptureSink::start().await;
+    {
+        let runtime = tracker_runtime(tmp.path(), &sink.endpoint());
+        runtime.post_audit_log_tracker_update().await.unwrap();
+    }
+    assert_eq!(sink.take_bodies().len(), 1);
+
+    // Restart after acknowledgement: nothing re-transfers.
+    {
+        let runtime = tracker_runtime(tmp.path(), &sink.endpoint());
+        runtime.post_audit_log_tracker_update().await.unwrap();
+    }
+    assert!(sink.take_bodies().is_empty());
+
+    // Checkpoint loss is bounded: exactly one repeat transfer, which the
+    // endpoint's whole-file dedupe absorbs, and then quiet again.
+    std::fs::remove_file(checkpoint_path(&home, &account.label)).unwrap();
+    {
+        let runtime = tracker_runtime(tmp.path(), &sink.endpoint());
+        runtime.post_audit_log_tracker_update().await.unwrap();
+        assert_eq!(sink.take_bodies(), vec![sealed.to_vec()]);
+        runtime.post_audit_log_tracker_update().await.unwrap();
+    }
+    assert!(sink.take_bodies().is_empty());
+}
+
+#[tokio::test]
+async fn failed_uploads_retry_while_acknowledged_files_do_not() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(tmp.path());
+    let account = home.create_account("alice").unwrap();
+    let dir = home.account_dir(&account.label);
+    let failing = b"{\"seq\":1}\n";
+    let succeeding = b"{\"seq\":2}\n";
+    std::fs::write(dir.join("audit-engine-v3-seg000001.jsonl"), failing).unwrap();
+    std::fs::write(dir.join("audit-engine-v3-seg000002.jsonl"), succeeding).unwrap();
+
+    let sink = CaptureSink::start().await;
+    sink.script(&[500, 204]);
+    let runtime = tracker_runtime(tmp.path(), &sink.endpoint());
+
+    let first = runtime.post_audit_log_tracker_update().await.unwrap();
+    assert_eq!(first.uploaded.len(), 1);
+    assert_eq!(
+        sink.take_bodies(),
+        vec![failing.to_vec(), succeeding.to_vec()]
+    );
+
+    let second = runtime.post_audit_log_tracker_update().await.unwrap();
+    assert_eq!(second.uploaded.len(), 1);
+    assert_eq!(
+        sink.take_bodies(),
+        vec![failing.to_vec()],
+        "only the unacknowledged file retries"
+    );
+}
+
+#[tokio::test]
+async fn oversized_legacy_file_is_reported_once_and_never_wedges_other_uploads() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(tmp.path());
+    let account = home.create_account("alice").unwrap();
+    let dir = home.account_dir(&account.label);
+    // Upgrade path: an active file grown past the request ceiling by a build
+    // without segment rotation. It sorts first, so it also proves the oversized
+    // file does not block the files behind it.
+    let huge = std::fs::File::create(dir.join("audit-engine-v3-seg000001.jsonl")).unwrap();
+    huge.set_len(64 * 1024 * 1024 + 1).unwrap();
+    let normal = b"{\"seq\":1}\n";
+    std::fs::write(dir.join("audit-engine-v3.jsonl"), normal).unwrap();
+
+    let sink = CaptureSink::start().await;
+    let runtime = tracker_runtime(tmp.path(), &sink.endpoint());
+
+    let first = runtime.post_audit_log_tracker_update().await.unwrap();
+    assert_eq!(first.uploaded.len(), 1);
+    assert_eq!(sink.take_bodies(), vec![normal.to_vec()]);
+    // Never deleted or truncated: retention is mdk#1014's contract.
+    assert_eq!(
+        std::fs::metadata(dir.join("audit-engine-v3-seg000001.jsonl"))
+            .unwrap()
+            .len(),
+        64 * 1024 * 1024 + 1
+    );
+
+    // A second run neither retries the oversized file nor re-posts the small
+    // one it already acknowledged.
+    runtime.post_audit_log_tracker_update().await.unwrap();
+    assert!(sink.take_bodies().is_empty());
+}
+
+#[tokio::test]
+async fn recorder_segments_upload_once_each_and_stay_under_the_request_ceiling() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(tmp.path());
+    let account = home.create_account("alice").unwrap();
+    let path = home
+        .account_dir(&account.label)
+        .join("audit-00112233445566778899aabbccddeeff-v3.jsonl");
+    let recorder = marmot_forensics::JsonlRecorder::open(&path, "0011".repeat(8)).unwrap();
+    {
+        use marmot_forensics::ForensicRecorder as _;
+        // Enough rows to seal several segments at the recorder's threshold.
+        while std::fs::read_dir(home.account_dir(&account.label))
+            .unwrap()
+            .flatten()
+            .filter(|entry| entry.file_name().to_string_lossy().contains("-seg"))
+            .count()
+            < 2
+        {
+            recorder.record(marmot_forensics::AuditRecord::new(
+                None,
+                marmot_forensics::AuditEventKind::SendEntry {
+                    intent_kind: "app_message".into(),
+                },
+            ));
+        }
+    }
+
+    let sink = CaptureSink::start().await;
+    let runtime = tracker_runtime(tmp.path(), &sink.endpoint());
+    runtime.post_audit_log_tracker_update().await.unwrap();
+
+    let bodies = sink.take_bodies();
+    assert_eq!(bodies.len(), 3, "two sealed segments plus the active file");
+    for body in &bodies {
+        assert!(
+            (body.len() as u64) < 64 * 1024 * 1024,
+            "every transfer must stay under the per-request ceiling"
+        );
+        assert!((body.len() as u64) < 2 * marmot_forensics::AUDIT_LOG_SEGMENT_MAX_BYTES);
+    }
+
+    // No new rows: nothing at all is re-read or re-posted.
+    runtime.post_audit_log_tracker_update().await.unwrap();
+    assert!(sink.take_bodies().is_empty());
+}
+
+#[cfg(feature = "test-policy-overrides")]
+#[tokio::test]
+async fn trigger_bursts_coalesce_into_one_follow_up_run() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(tmp.path());
+    let account = home.create_account("alice").unwrap();
+    let dir = home.account_dir(&account.label);
+    std::fs::write(dir.join("audit-engine-v3.jsonl"), b"{\"seq\":1}\n").unwrap();
+
+    let sink = CaptureSink::start().await;
+    // Hold each upload open so the burst lands while a run is in flight, which
+    // is the case the coalescing contract is about, and refuse every upload so
+    // nothing is ever acknowledged — then each run posts, and the request count
+    // measures runs rather than changed content.
+    sink.hold_each_request_for(400);
+    sink.always_answer(500);
+    let runtime = tracker_runtime(tmp.path(), &sink.endpoint());
+
+    runtime.schedule_audit_log_tracker_update_for_test("burst");
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+    for _ in 0..50 {
+        runtime.schedule_audit_log_tracker_update_for_test("burst");
+    }
+    tokio::time::sleep(std::time::Duration::from_millis(1_500)).await;
+
+    // 50 triggers arriving during a run collapse into exactly one follow-up,
+    // and no two uploads are ever in flight at once.
+    assert_eq!(
+        sink.take_bodies().len(),
+        2,
+        "a burst during an in-flight run must produce one follow-up, not one run per trigger"
+    );
+    assert_eq!(
+        sink.max_concurrent_requests(),
+        1,
+        "tracker updates must never upload concurrently"
+    );
+}

--- a/crates/marmot-app/tests/audit_logs.rs
+++ b/crates/marmot-app/tests/audit_logs.rs
@@ -901,6 +901,22 @@ async fn oversized_legacy_file_is_reported_once_and_never_wedges_other_uploads()
         64 * 1024 * 1024 + 1
     );
 
+    // The verdict is recorded, which is what makes the skip a one-time report
+    // rather than a silent re-evaluation on every trigger. Asserted through the
+    // sidecar because the skip never reaches the network, so the capture sink
+    // cannot tell "recorded once" from "retried forever" on its own.
+    let checkpoint = std::fs::read_to_string(checkpoint_path(&home, &account.label))
+        .expect("checkpoint written");
+    let checkpoint: serde_json::Value = serde_json::from_str(&checkpoint).unwrap();
+    assert_eq!(
+        checkpoint["files"]["audit-engine-v3-seg000001.jsonl"]["outcome"],
+        serde_json::json!("too_large_to_upload")
+    );
+    assert_eq!(
+        checkpoint["files"]["audit-engine-v3.jsonl"]["outcome"],
+        serde_json::json!("uploaded")
+    );
+
     // A second run neither retries the oversized file nor re-posts the small
     // one it already acknowledged.
     runtime.post_audit_log_tracker_update().await.unwrap();

--- a/crates/marmot-app/tests/audit_logs.rs
+++ b/crates/marmot-app/tests/audit_logs.rs
@@ -664,10 +664,16 @@ impl CaptureSink {
                             .unwrap()
                             .pop_front()
                             .unwrap_or_else(|| default_status.load(Ordering::Relaxed));
+                        // Record the body before answering, after the hold: once the
+                        // response is written the client may fire its next request,
+                        // and the order-asserting tests need bodies pushed in serve
+                        // order. Pushing before the hold would instead expose a body
+                        // while its request is still deliberately in flight, which
+                        // the coalescing test's contract cannot tolerate.
+                        requests.lock().unwrap().push(request);
                         write_http_response(&mut stream, status).await;
                         let _ = stream.shutdown().await;
                         in_flight.lock().unwrap().0 -= 1;
-                        requests.lock().unwrap().push(request);
                     });
                 }
             }

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -9708,15 +9708,26 @@ async fn runtime_sync_emits_subscription_rebuild_and_sync_drain_audit_rows() {
     // Force a completed sync so the rebuild + drain rows are flushed to disk.
     runtime.catch_up_accounts().await.unwrap();
 
-    let files = app.audit_log_files().unwrap();
-    let alice_file = files
+    // Read every file for the account, not the first: the recorder seals the
+    // active file into `-seg<NNNNNN>` siblings (mdk#1181), and those sort ahead
+    // of it, so picking one file silently reads a prefix once audit volume
+    // crosses the segment threshold. Path order is session order.
+    let mut files = app.audit_log_files().unwrap();
+    files.sort_by(|left, right| left.path.cmp(&right.path));
+    let alice_files = files
         .iter()
-        .find(|file| file.account_ref == alice.account.label)
-        .expect("alice has a live audit file");
-    let events = std::fs::read_to_string(&alice_file.path)
-        .unwrap()
-        .lines()
-        .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+        .filter(|file| file.account_ref == alice.account.label)
+        .collect::<Vec<_>>();
+    assert!(!alice_files.is_empty(), "alice has a live audit file");
+    let events = alice_files
+        .iter()
+        .flat_map(|file| {
+            std::fs::read_to_string(&file.path)
+                .unwrap()
+                .lines()
+                .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+                .collect::<Vec<_>>()
+        })
         .collect::<Vec<_>>();
 
     // subscription_rebuild: exact wire tag, the lookback recorded, and the mock

--- a/crates/marmot-forensics/AGENTS.md
+++ b/crates/marmot-forensics/AGENTS.md
@@ -8,6 +8,12 @@ Shared JSONL forensic audit schema for Marmot incident capture.
   implementations) used by engine/runtime incident capture.
 - Keep this crate independent of engine, app, storage, transport SDK, and simulator crates.
 - Keep static snapshot dump analysis out of this repo; external tools should consume JSONL audit files.
+- Keep `JsonlRecorder` segment rotation transparent (mdk#1181). Sealing the active file at
+  `AUDIT_LOG_SEGMENT_MAX_BYTES` is a rename into an `audit-*-seg<NNNNNN>.jsonl` sibling that deletes and truncates
+  nothing; `seq`, the recorder session id, and health counters carry across the boundary and no `recorder_started` row
+  is written, so a session's segments plus its active file concatenate back to one continuous log. Retention and disk
+  bounding of sealed segments belong to mdk#1014. Destructive `rotate()` — which discards the current file — stays a
+  separate, explicit operation.
 - Keep audit logging opt-in and explicit. The sole supported event model is privacy-safe: hashed/truncated identifiers,
   digests, lengths, counts, and typed outcomes only. Never add decrypted content, cleartext group values, full account
   or member identities, bearer/upload tokens, auth headers, private keys, ciphertext, or raw MLS bytes.

--- a/crates/marmot-forensics/AGENTS.md
+++ b/crates/marmot-forensics/AGENTS.md
@@ -14,6 +14,12 @@ Shared JSONL forensic audit schema for Marmot incident capture.
   is written, so a session's segments plus its active file concatenate back to one continuous log. Retention and disk
   bounding of sealed segments belong to mdk#1014. Destructive `rotate()` — which discards the current file — stays a
   separate, explicit operation.
+- Keep `segment_roll_failed` scoped to the directory-unwritable episode, not to the recorder. It exists only to stop a
+  persistently unwritable directory from re-attempting (and re-scanning) on every `record`, so every site that proves
+  the directory writable again — a fresh open, and `swap_to_fresh_file` — must clear it alongside the other per-episode
+  fields (`active_bytes`, `seq`, the session id, the health counters). Latching it for the recorder's lifetime lets one
+  transient `ENOSPC`/`EMFILE` stop rotation for the whole session and grow the active file back past the app's upload
+  ceiling. When adding a per-episode field, enumerate reset-sites x fields.
 - Keep audit logging opt-in and explicit. The sole supported event model is privacy-safe: hashed/truncated identifiers,
   digests, lengths, counts, and typed outcomes only. Never add decrypted content, cleartext group values, full account
   or member identities, bearer/upload tokens, auth headers, private keys, ciphertext, or raw MLS bytes.

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -1259,6 +1259,14 @@ pub struct JsonlRecorder {
     /// reopens the same path, so this is held outside the mutex.
     path: PathBuf,
     inner: Mutex<JsonlInner>,
+    /// Test seam: forces [`Self::reopen_active`] to fail, so the compensating
+    /// rename-back in [`Self::roll_into_segment`] — the only step that must
+    /// undo an applied rename — has a deterministic red. One-shot. There is no
+    /// way to fail the reopen and not the rename from outside the process:
+    /// both need the same directory permission, and the rename removes the
+    /// very path the reopen would recreate.
+    #[cfg(test)]
+    fail_segment_reopen: std::sync::atomic::AtomicBool,
 }
 
 struct JsonlInner {
@@ -1270,11 +1278,27 @@ struct JsonlInner {
     health: AuditRecorderHealthSnapshot,
     /// Bytes in the file the writer currently owns, driving segment rolls.
     active_bytes: u64,
-    /// Latched for the lifetime of this recorder when a segment roll fails, so
-    /// a persistently unwritable directory cannot make every subsequent
-    /// `record` re-attempt (and re-scan the directory). A fresh recorder — the
-    /// next session open — clears it.
+    /// Set when a segment roll fails, so a persistently unwritable directory
+    /// cannot make every subsequent `record` re-attempt (and re-scan the
+    /// directory).
+    ///
+    /// Its lifetime is the *directory-unwritable episode*, not the recorder's:
+    /// it is cleared by anything that proves the directory writable again — a
+    /// fresh recorder open, and [`JsonlRecorder::swap_to_fresh_file`], which
+    /// cannot succeed unless it created and renamed a sibling in that same
+    /// directory. Latching it for the whole recorder lifetime instead would
+    /// mean one transient `ENOSPC`/`EMFILE` stops rotation for the rest of the
+    /// session and lets the active file grow back past the app's upload
+    /// ceiling — the permanent-failure cliff mdk#1181 exists to close.
     segment_roll_failed: bool,
+    /// Lower-bound hint for the next unclaimed segment index, so a roll does
+    /// not `read_dir` the account directory on the engine hot path once per
+    /// segment. Scanned once when absent and advanced after each sealed
+    /// segment; the `exists()` probe in [`JsonlRecorder::next_segment_path`]
+    /// stays the authority that no roll ever overwrites a segment, so a stale
+    /// or absent hint costs a gap in the numbering at worst. Unbounded segment
+    /// counts are mdk#1014's to bound.
+    next_segment_index: Option<u32>,
 }
 
 fn validate_account_ref_hex(account_ref: &str) -> std::io::Result<()> {
@@ -1320,7 +1344,10 @@ impl JsonlRecorder {
                 health: AuditRecorderHealthSnapshot::default(),
                 active_bytes,
                 segment_roll_failed: false,
+                next_segment_index: None,
             }),
+            #[cfg(test)]
+            fail_segment_reopen: std::sync::atomic::AtomicBool::new(false),
         };
         // Upgrade path: a file left over-threshold by a build without segment
         // rotation — including one already past the app's upload ceiling, which
@@ -1518,6 +1545,14 @@ impl JsonlRecorder {
         inner.recorder_session_id = generate_recorder_session_id();
         inner.health = AuditRecorderHealthSnapshot::default();
         inner.active_bytes = 0;
+        // The latch's lifetime is the directory-unwritable episode, not the
+        // recorder's: reaching here means a sibling was created and renamed
+        // over the live path, which proves the directory writable again. Left
+        // set, one transient roll failure would stop rotation for the rest of
+        // the session and let the active file grow back past the upload
+        // ceiling (mdk#1181). Counter-lifetime hazard: every per-episode field
+        // reset here must be enumerated against every site that sets one.
+        inner.segment_roll_failed = false;
         Ok(())
     }
 
@@ -1548,12 +1583,13 @@ impl JsonlRecorder {
         // Best-effort flush so the sealed segment holds everything recorded so
         // far; the fd survives the rename either way.
         let _ = inner.writer.flush();
-        let segment = next_segment_path(&self.path)?;
+        let (segment, index) = self.next_segment_path(inner)?;
         std::fs::rename(&self.path, &segment)?;
-        match fs_private::open_private_append(&self.path) {
+        match self.reopen_active() {
             Ok(file) => {
                 inner.writer = BufWriter::new(file);
                 inner.active_bytes = 0;
+                inner.next_segment_index = Some(index.saturating_add(1));
                 Ok(())
             }
             Err(err) => {
@@ -1563,6 +1599,56 @@ impl JsonlRecorder {
                 let _ = std::fs::rename(&segment, &self.path);
                 Err(err)
             }
+        }
+    }
+
+    /// Reopen the active path after a seal.
+    fn reopen_active(&self) -> std::io::Result<std::fs::File> {
+        #[cfg(test)]
+        if self
+            .fail_segment_reopen
+            .swap(false, std::sync::atomic::Ordering::Relaxed)
+        {
+            return Err(std::io::Error::other("forced segment reopen failure"));
+        }
+        fs_private::open_private_append(&self.path)
+    }
+
+    /// Make the *next* segment reopen fail, so a test can drive the
+    /// compensating rename-back and the `segment_roll_failed` latch it sets.
+    /// One-shot, so a test can also observe recovery afterwards.
+    #[cfg(test)]
+    fn fail_next_segment_reopen(&self) {
+        self.fail_segment_reopen
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Next unclaimed segment name for the active path, and its index.
+    ///
+    /// Segments keep the audit path's stem so the app's `audit-*.jsonl`
+    /// enumeration still finds them, and sort ahead of the active file (`-`
+    /// precedes `.`), so the uploader drains sealed segments before the growing
+    /// one.
+    ///
+    /// The starting index comes from `inner.next_segment_index` so the common
+    /// case costs no directory read at all; only the first roll of a recorder
+    /// (or one following a failed roll) scans. The `exists()` probe below is
+    /// what actually guarantees a roll never renames over an existing segment,
+    /// which would destroy already-recorded data — the hint only decides where
+    /// the probe starts.
+    fn next_segment_path(&self, inner: &mut JsonlInner) -> std::io::Result<(PathBuf, u32)> {
+        let mut next = match inner.next_segment_index {
+            Some(next) => next,
+            None => scan_next_segment_index(&self.path),
+        };
+        loop {
+            let candidate = segment_path(&self.path, next);
+            if !candidate.exists() {
+                return Ok((candidate, next));
+            }
+            next = next
+                .checked_add(1)
+                .ok_or_else(|| std::io::Error::other("audit log segment indexes exhausted"))?;
         }
     }
 }
@@ -1587,14 +1673,10 @@ fn segment_path(path: &Path, index: u32) -> PathBuf {
     }
 }
 
-/// Next unclaimed segment name for `path`.
-///
-/// Segments keep the audit path's stem so the app's `audit-*.jsonl` enumeration
-/// still finds them, and sort ahead of the active file (`-` precedes `.`), so
-/// the uploader drains sealed segments before the growing one. The scan-then-
-/// probe walk guarantees a roll never renames over an existing segment, which
-/// would destroy already-recorded data.
-fn next_segment_path(path: &Path) -> std::io::Result<PathBuf> {
+/// One directory scan for the highest segment index already sitting next to
+/// `path`, plus one. Used to seed the cached hint on a recorder's first roll —
+/// after a crash mid-roll, or an earlier session, left segments behind.
+fn scan_next_segment_index(path: &Path) -> u32 {
     let prefix = format!("{}-seg", segment_base_name(path));
     let mut next = 1u32;
     if let Some(parent) = path
@@ -1615,15 +1697,7 @@ fn next_segment_path(path: &Path) -> std::io::Result<PathBuf> {
             next = next.max(index.saturating_add(1));
         }
     }
-    loop {
-        let candidate = segment_path(path, next);
-        if !candidate.exists() {
-            return Ok(candidate);
-        }
-        next = next
-            .checked_add(1)
-            .ok_or_else(|| std::io::Error::other("audit log segment indexes exhausted"))?;
-    }
+    next
 }
 
 /// Staging sibling for [`JsonlRecorder::swap_to_fresh_file`]: the audit path

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -30,6 +30,29 @@ use serde::{Deserialize, Serialize};
 
 pub const AUDIT_LOG_SCHEMA_VERSION: &str = "marmot-forensics-audit/v3";
 
+/// Size at which [`JsonlRecorder`] seals the active file into an immutable
+/// segment and continues into a fresh one (mdk#1181).
+///
+/// The number is picked from measured rows, not from the upload ceiling:
+///
+/// - A recorded row measures ~597 bytes on average (p90 696, max 811 over a
+///   real create-group + 50-send session), so a 1 MiB segment holds ~1,750
+///   rows — roughly 250 sends of activity, still an analytically useful unit
+///   even for a 4x richer row mix in large groups.
+/// - The uploader re-posts the *active* file in full on every trigger, so the
+///   threshold is also the bound on that residual. Before rotation the active
+///   file grew without bound, which is what made cumulative transfer quadratic;
+///   1 MiB makes the per-trigger cost constant instead. Against the ~5.3 MiB
+///   mean upload measured in the field that is a 5-10x cut, and it does not
+///   decay as a device keeps running.
+/// - It leaves a 64x margin under the app's 64 MiB per-request upload ceiling,
+///   so no automatically produced file can reach the permanent-failure cliff.
+///
+/// Smaller segments would cut the residual further but multiply file count
+/// (segments are never deleted here — retention is mdk#1014); larger ones
+/// re-inflate the residual. 1 MiB is the balance point.
+pub const AUDIT_LOG_SEGMENT_MAX_BYTES: u64 = 1024 * 1024;
+
 /// Hex-encoded 16-byte account identity hash. Stable across devices for the
 /// same account when the caller supplies it.
 pub type AccountRefHex = String;
@@ -1245,6 +1268,13 @@ struct JsonlInner {
     engine_id: EngineIdHex,
     recorder_session_id: String,
     health: AuditRecorderHealthSnapshot,
+    /// Bytes in the file the writer currently owns, driving segment rolls.
+    active_bytes: u64,
+    /// Latched for the lifetime of this recorder when a segment roll fails, so
+    /// a persistently unwritable directory cannot make every subsequent
+    /// `record` re-attempt (and re-scan the directory). A fresh recorder — the
+    /// next session open — clears it.
+    segment_roll_failed: bool,
 }
 
 fn validate_account_ref_hex(account_ref: &str) -> std::io::Result<()> {
@@ -1277,6 +1307,7 @@ impl JsonlRecorder {
         // Audit files are private local operational artifacts. Create them
         // owner-only and tighten pre-existing permissive files.
         let file = fs_private::open_private_append(&path)?;
+        let active_bytes = file.metadata().map(|meta| meta.len()).unwrap_or(0);
         let recorder_session_id = generate_recorder_session_id();
         let recorder = Self {
             path,
@@ -1287,8 +1318,27 @@ impl JsonlRecorder {
                 engine_id,
                 recorder_session_id,
                 health: AuditRecorderHealthSnapshot::default(),
+                active_bytes,
+                segment_roll_failed: false,
             }),
         };
+        // Upgrade path: a file left over-threshold by a build without segment
+        // rotation — including one already past the app's upload ceiling, which
+        // no automatic upload can ever accept — is sealed aside here so this
+        // session starts on a fresh, uploadable active file. Splitting the
+        // oversized file is deliberately not attempted; it stays an immutable
+        // segment and the uploader surfaces it. Best-effort: a roll failure
+        // must not cost the caller its audit log entirely, so recording
+        // continues into the existing file.
+        if active_bytes >= AUDIT_LOG_SEGMENT_MAX_BYTES {
+            let mut inner = recorder
+                .inner
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if recorder.roll_into_segment(&mut inner).is_err() {
+                inner.segment_roll_failed = true;
+            }
+        }
         recorder.record(AuditRecord::new(None, recorder_started_kind()));
         Ok(recorder)
     }
@@ -1379,8 +1429,18 @@ impl ForensicRecorder for JsonlRecorder {
                 inner.health.write_failures = inner.health.write_failures.saturating_add(1);
                 return;
             }
+            inner.active_bytes = inner
+                .active_bytes
+                .saturating_add(line.len() as u64)
+                .saturating_add(1);
             if inner.writer.flush().is_err() {
                 inner.health.flush_failures = inner.health.flush_failures.saturating_add(1);
+            }
+            if !inner.segment_roll_failed
+                && inner.active_bytes >= AUDIT_LOG_SEGMENT_MAX_BYTES
+                && self.roll_into_segment(&mut inner).is_err()
+            {
+                inner.segment_roll_failed = true;
             }
         } else {
             inner.health.serialization_failures =
@@ -1457,7 +1517,112 @@ impl JsonlRecorder {
         inner.seq = 0;
         inner.recorder_session_id = generate_recorder_session_id();
         inner.health = AuditRecorderHealthSnapshot::default();
+        inner.active_bytes = 0;
         Ok(())
+    }
+
+    /// Seal the active file into an immutable segment sibling and continue
+    /// recording into a fresh file at the same path (mdk#1181). The caller must
+    /// hold the inner lock.
+    ///
+    /// Nothing is deleted or truncated: the rename hands the *same inode* — and
+    /// therefore every recorded byte — to the segment name, and the concatenation
+    /// of the segments and the active file is byte-identical to the single file
+    /// this recorder would otherwise have written. Retention and disk bounding
+    /// of the sealed segments are deliberately out of scope here; they belong to
+    /// mdk#1014.
+    ///
+    /// Rotation is transparent to consumers on purpose: `seq`, the recorder
+    /// session id, and the health counters carry across the boundary and no
+    /// `recorder_started` row is fabricated, so an analyzer sees one continuous
+    /// session and the upload endpoint's content-keyed line dedupe never
+    /// re-mints a line just because it moved to a new filename.
+    ///
+    /// Crash safety (`multi-step-state-changes.md`): the rename is atomic and is
+    /// the only step that moves data. A crash between the rename and the fresh
+    /// open leaves the complete segment on disk and no active file, which the
+    /// next open converges from by creating one. If the fresh open fails, the
+    /// segment is renamed back so the still-open writer fd and the active path
+    /// agree again.
+    fn roll_into_segment(&self, inner: &mut JsonlInner) -> std::io::Result<()> {
+        // Best-effort flush so the sealed segment holds everything recorded so
+        // far; the fd survives the rename either way.
+        let _ = inner.writer.flush();
+        let segment = next_segment_path(&self.path)?;
+        std::fs::rename(&self.path, &segment)?;
+        match fs_private::open_private_append(&self.path) {
+            Ok(file) => {
+                inner.writer = BufWriter::new(file);
+                inner.active_bytes = 0;
+                Ok(())
+            }
+            Err(err) => {
+                // Compensate the one applied step. If even this fails the data
+                // is still on disk under the segment name and the writer keeps
+                // appending to it, so no forensic line is lost.
+                let _ = std::fs::rename(&segment, &self.path);
+                Err(err)
+            }
+        }
+    }
+}
+
+/// Name stem shared by an audit path and its segments: the file name with a
+/// trailing `.jsonl` removed.
+fn segment_base_name(path: &Path) -> String {
+    let name = path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    name.strip_suffix(".jsonl")
+        .map(str::to_owned)
+        .unwrap_or(name)
+}
+
+fn segment_path(path: &Path, index: u32) -> PathBuf {
+    let name = format!("{}-seg{index:06}.jsonl", segment_base_name(path));
+    match path.parent() {
+        Some(parent) => parent.join(name),
+        None => PathBuf::from(name),
+    }
+}
+
+/// Next unclaimed segment name for `path`.
+///
+/// Segments keep the audit path's stem so the app's `audit-*.jsonl` enumeration
+/// still finds them, and sort ahead of the active file (`-` precedes `.`), so
+/// the uploader drains sealed segments before the growing one. The scan-then-
+/// probe walk guarantees a roll never renames over an existing segment, which
+/// would destroy already-recorded data.
+fn next_segment_path(path: &Path) -> std::io::Result<PathBuf> {
+    let prefix = format!("{}-seg", segment_base_name(path));
+    let mut next = 1u32;
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        && let Ok(entries) = std::fs::read_dir(parent)
+    {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            let Some(index) = name
+                .strip_prefix(&prefix)
+                .and_then(|rest| rest.strip_suffix(".jsonl"))
+                .and_then(|digits| digits.parse::<u32>().ok())
+            else {
+                continue;
+            };
+            next = next.max(index.saturating_add(1));
+        }
+    }
+    loop {
+        let candidate = segment_path(path, next);
+        if !candidate.exists() {
+            return Ok(candidate);
+        }
+        next = next
+            .checked_add(1)
+            .ok_or_else(|| std::io::Error::other("audit log segment indexes exhausted"))?;
     }
 }
 

--- a/crates/marmot-forensics/src/audit/tests.rs
+++ b/crates/marmot-forensics/src/audit/tests.rs
@@ -1404,3 +1404,195 @@ fn rolled_segment_is_owner_only() {
     assert_eq!(mode(&segment_paths(&path)[0]), 0o600);
     assert_eq!(mode(&path), 0o600);
 }
+
+/// Record `rows` `send_entry` rows whose payloads differ per row, so a
+/// boundary that dropped, duplicated, or truncated a line cannot pass by
+/// accident.
+fn record_numbered_rows(recorder: &JsonlRecorder, rows: usize) {
+    for row in 0..rows {
+        recorder.record(AuditRecord::new(
+            None,
+            AuditEventKind::SendEntry {
+                intent_kind: format!("app_message_{row}"),
+            },
+        ));
+    }
+}
+
+/// Record until the recorder has attempted a roll — i.e. the active file has
+/// crossed the threshold at least once — returning the number of rows written.
+fn record_until_roll_attempted(recorder: &JsonlRecorder, path: &Path) -> usize {
+    for rows in 1..500_000 {
+        recorder.record(AuditRecord::new(
+            None,
+            AuditEventKind::SendEntry {
+                intent_kind: "app_message".into(),
+            },
+        ));
+        if fs::metadata(path).map(|meta| meta.len()).unwrap_or(0) >= AUDIT_LOG_SEGMENT_MAX_BYTES {
+            return rows;
+        }
+    }
+    panic!("recorder never reached the segment threshold");
+}
+
+/// Blank the two values that legitimately differ between two recorder runs —
+/// the per-open session id and the wall clock — leaving everything a segment
+/// roll could have damaged to compare exactly.
+fn normalize_run(bytes: &[u8]) -> String {
+    let mut out = String::new();
+    for line in std::str::from_utf8(bytes).unwrap().lines() {
+        let mut value: serde_json::Value = serde_json::from_str(line).unwrap();
+        let object = value.as_object_mut().unwrap();
+        object.insert("wall_time_ms".to_owned(), serde_json::json!(0));
+        object.insert(
+            "recorder_session_id".to_owned(),
+            serde_json::json!("normalized"),
+        );
+        out.push_str(&serde_json::to_string(&value).unwrap());
+        out.push('\n');
+    }
+    out
+}
+
+/// mdk#1181: a transient roll failure must not stop rotation for the rest of
+/// the recorder's life.
+///
+/// This is the counter-lifetime hazard class. `segment_roll_failed` is a latch
+/// whose lifetime is the *directory-unwritable episode*, not the recorder's,
+/// so every site that resets the other per-episode fields (`active_bytes`,
+/// `seq`, the session id, the health counters) must reset it too. Leaving it
+/// set through `swap_to_fresh_file` meant a single `EACCES`/`ENOSPC`/`EMFILE`
+/// let the active file grow back past the app's 64 MiB upload ceiling — the
+/// permanent-failure cliff this issue exists to close. Adding another
+/// per-episode field means enumerating reset-sites x fields again.
+#[test]
+#[cfg(unix)]
+fn a_transient_roll_failure_does_not_disable_rotation_for_the_session() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = TempDir::new().unwrap();
+    let path = default_jsonl_path(dir.path(), "engine-abc");
+    fs::write(
+        &path,
+        "x".repeat(usize::try_from(AUDIT_LOG_SEGMENT_MAX_BYTES).unwrap() + 1),
+    )
+    .unwrap();
+
+    // The episode: the directory is momentarily unwritable, so the roll-on-open
+    // cannot rename and latches.
+    fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o500)).unwrap();
+    let recorder = JsonlRecorder::open(&path, "engine-abc".to_string()).unwrap();
+    assert!(
+        segment_paths(&path).is_empty(),
+        "the roll must have failed for this test to mean anything"
+    );
+
+    // The episode ends. `rotate` is the proof it ended: it cannot succeed
+    // unless it created a sibling in this directory and renamed it over the
+    // live path.
+    fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o700)).unwrap();
+    recorder.rotate().unwrap();
+
+    record_until_segment_rolls(&recorder, &path, 0);
+    assert_eq!(
+        segment_paths(&path).len(),
+        1,
+        "rotation must resume once the directory is writable again"
+    );
+    assert!(
+        fs::metadata(&path).unwrap().len() < AUDIT_LOG_SEGMENT_MAX_BYTES,
+        "the active file must be back under the threshold"
+    );
+}
+
+/// mdk#1181 / `multi-step-state-changes.md`: the rename is the one applied
+/// step of a roll, so a failed reopen must take it back.
+#[test]
+fn a_failed_segment_reopen_renames_the_segment_back_and_keeps_recording() {
+    let dir = TempDir::new().unwrap();
+    let path = default_jsonl_path(dir.path(), "engine-abc");
+    let recorder = JsonlRecorder::open(&path, "engine-abc".to_string()).unwrap();
+
+    recorder.fail_next_segment_reopen();
+    let rows = record_until_roll_attempted(&recorder, &path);
+    let before = fs::read(&path).expect("the active path must exist again after compensation");
+
+    assert!(
+        segment_paths(&path).is_empty(),
+        "the sealed segment must have been renamed back, leaving no orphan"
+    );
+    assert_eq!(
+        before.iter().filter(|byte| **byte == b'\n').count(),
+        rows + 1,
+        "nothing recorded before the failed roll may be lost"
+    );
+
+    // The writer fd and the active path agree again, so recording continues
+    // into the same file.
+    record_numbered_rows(&recorder, 3);
+    let after = fs::read(&path).unwrap();
+    assert!(
+        after.starts_with(&before),
+        "compensation must leave the pre-roll bytes untouched"
+    );
+    let events: Vec<AuditEvent> = std::str::from_utf8(&after)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(events.len(), rows + 4);
+    assert!(
+        events.windows(2).all(|pair| pair[1].seq == pair[0].seq + 1),
+        "seq must stay continuous across a compensated roll"
+    );
+}
+
+/// mdk#1181: the concatenation of a session's segments and its active file is
+/// byte-identical to the single file the recorder would otherwise have
+/// written.
+#[test]
+fn segments_plus_active_file_concatenate_to_the_unrotated_log() {
+    // Enough rows to seal more than one segment, so this covers two boundaries
+    // rather than one.
+    const ROWS: usize = 8_000;
+
+    let rotated_dir = TempDir::new().unwrap();
+    let rotated_path = default_jsonl_path(rotated_dir.path(), "engine-abc");
+    let rotated = JsonlRecorder::open(&rotated_path, "engine-abc".to_string()).unwrap();
+    record_numbered_rows(&rotated, ROWS);
+    let segments = segment_paths(&rotated_path);
+    assert!(
+        segments.len() >= 2,
+        "the rotated run must cross at least two boundaries, got {}",
+        segments.len()
+    );
+    let mut rotated_bytes = Vec::new();
+    for segment in &segments {
+        rotated_bytes.extend_from_slice(&fs::read(segment).unwrap());
+    }
+    rotated_bytes.extend_from_slice(&fs::read(&rotated_path).unwrap());
+
+    // The baseline: one recorder, the same rows, no rotation. Failing its first
+    // reopen latches `segment_roll_failed`, so after the compensating
+    // rename-back it writes one continuous file for the rest of the run.
+    let plain_dir = TempDir::new().unwrap();
+    let plain_path = default_jsonl_path(plain_dir.path(), "engine-abc");
+    let plain = JsonlRecorder::open(&plain_path, "engine-abc".to_string()).unwrap();
+    plain.fail_next_segment_reopen();
+    record_numbered_rows(&plain, ROWS);
+    assert!(
+        segment_paths(&plain_path).is_empty(),
+        "the baseline run must not have rotated"
+    );
+    let plain_bytes = fs::read(&plain_path).unwrap();
+
+    // Only the session id and the wall clock may differ, and both are
+    // fixed-width here, so even the raw lengths must match.
+    assert_eq!(
+        rotated_bytes.len(),
+        plain_bytes.len(),
+        "rotation must not add, drop, or pad a single byte"
+    );
+    assert_eq!(normalize_run(&rotated_bytes), normalize_run(&plain_bytes));
+}

--- a/crates/marmot-forensics/src/audit/tests.rs
+++ b/crates/marmot-forensics/src/audit/tests.rs
@@ -1472,7 +1472,11 @@ fn a_transient_roll_failure_does_not_disable_rotation_for_the_session() {
     use std::os::unix::fs::PermissionsExt;
 
     let dir = TempDir::new().unwrap();
-    let path = default_jsonl_path(dir.path(), "engine-abc");
+    // A dedicated subdir takes the chmod fault so a failing assertion can
+    // never leave the TempDir root unwritable and block its cleanup.
+    let logs = dir.path().join("logs");
+    fs::create_dir(&logs).unwrap();
+    let path = default_jsonl_path(&logs, "engine-abc");
     fs::write(
         &path,
         "x".repeat(usize::try_from(AUDIT_LOG_SEGMENT_MAX_BYTES).unwrap() + 1),
@@ -1481,17 +1485,26 @@ fn a_transient_roll_failure_does_not_disable_rotation_for_the_session() {
 
     // The episode: the directory is momentarily unwritable, so the roll-on-open
     // cannot rename and latches.
-    fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o500)).unwrap();
+    fs::set_permissions(&logs, fs::Permissions::from_mode(0o500)).unwrap();
+    if fs::write(logs.join("probe.tmp"), b"").is_ok() {
+        // Root ignores permission bits, so the roll cannot be made to fail
+        // and the episode this test needs cannot exist. Same guard as
+        // `rotate_failure_keeps_recording_to_original_file`.
+        fs::set_permissions(&logs, fs::Permissions::from_mode(0o700)).unwrap();
+        return;
+    }
     let recorder = JsonlRecorder::open(&path, "engine-abc".to_string()).unwrap();
+    let rolled_during_episode = segment_paths(&path);
+
+    // The episode ends. Restore the mode before asserting the premise so a
+    // failure here cannot strand an unwritable directory. `rotate` below is
+    // the proof the episode ended: it cannot succeed unless it created a
+    // sibling in this directory and renamed it over the live path.
+    fs::set_permissions(&logs, fs::Permissions::from_mode(0o700)).unwrap();
     assert!(
-        segment_paths(&path).is_empty(),
+        rolled_during_episode.is_empty(),
         "the roll must have failed for this test to mean anything"
     );
-
-    // The episode ends. `rotate` is the proof it ended: it cannot succeed
-    // unless it created a sibling in this directory and renamed it over the
-    // live path.
-    fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o700)).unwrap();
     recorder.rotate().unwrap();
 
     record_until_segment_rolls(&recorder, &path, 0);

--- a/crates/marmot-forensics/src/audit/tests.rs
+++ b/crates/marmot-forensics/src/audit/tests.rs
@@ -1240,3 +1240,167 @@ fn sample_events_serialize_within_schema_property_names() {
     let value = serde_json::to_value(&event).unwrap();
     assert_keys_within_schema(&value, &schema, &defs, "event");
 }
+
+fn segment_paths(path: &Path) -> Vec<PathBuf> {
+    let name = path.file_name().unwrap().to_string_lossy().into_owned();
+    let prefix = format!("{}-seg", name.strip_suffix(".jsonl").unwrap_or(&name));
+    let mut found: Vec<PathBuf> = fs::read_dir(path.parent().unwrap())
+        .unwrap()
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|candidate| {
+            candidate
+                .file_name()
+                .is_some_and(|name| name.to_string_lossy().starts_with(&prefix))
+        })
+        .collect();
+    found.sort();
+    found
+}
+
+/// Record rows until one more segment than `already_rolled` exists, returning
+/// the number of rows recorded.
+fn record_until_segment_rolls(
+    recorder: &JsonlRecorder,
+    path: &Path,
+    already_rolled: usize,
+) -> usize {
+    for rows in 1..500_000 {
+        recorder.record(AuditRecord::new(
+            None,
+            AuditEventKind::SendEntry {
+                intent_kind: "app_message".into(),
+            },
+        ));
+        if segment_paths(path).len() > already_rolled {
+            return rows;
+        }
+    }
+    panic!("recorder never rolled a segment");
+}
+
+#[test]
+fn active_audit_file_rolls_into_a_segment_at_the_size_threshold() {
+    let dir = TempDir::new().unwrap();
+    let path = default_jsonl_path(dir.path(), "engine-abc");
+    let recorder = JsonlRecorder::open(&path, "engine-abc".to_string()).unwrap();
+
+    let mut rows = record_until_segment_rolls(&recorder, &path, 0);
+    // The roll seals the file the instant the threshold is crossed, so the
+    // fresh active file is empty until the next row lands in it.
+    assert_eq!(fs::read_to_string(&path).unwrap(), "");
+    recorder.record(AuditRecord::new(
+        None,
+        AuditEventKind::SendEntry {
+            intent_kind: "app_message".into(),
+        },
+    ));
+    rows += 1;
+
+    let segments = segment_paths(&path);
+    assert_eq!(segments.len(), 1, "one segment should have been rolled");
+    let segment_bytes = fs::metadata(&segments[0]).unwrap().len();
+    assert!(
+        segment_bytes >= AUDIT_LOG_SEGMENT_MAX_BYTES,
+        "the segment should hold the threshold-crossing prefix, got {segment_bytes}"
+    );
+    // The cliff: a segment is sealed as soon as it crosses the threshold, so it
+    // never approaches the app's per-request upload ceiling.
+    assert!(segment_bytes < 2 * AUDIT_LOG_SEGMENT_MAX_BYTES);
+    assert!(fs::metadata(&path).unwrap().len() < AUDIT_LOG_SEGMENT_MAX_BYTES);
+
+    // Nothing is lost, and the segment plus the active file concatenate back
+    // into one continuous session: the recorder session id is unchanged and
+    // `seq` keeps counting across the boundary.
+    let events = |at: &Path| -> Vec<AuditEvent> {
+        fs::read_to_string(at)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect()
+    };
+    let segment_events = events(&segments[0]);
+    let active_events = events(&path);
+    assert!(!active_events.is_empty());
+    // `recorder_started` plus every recorded row.
+    assert_eq!(segment_events.len() + active_events.len(), rows + 1);
+    assert_eq!(
+        segment_events[0].recorder_session_id, active_events[0].recorder_session_id,
+        "a segment roll is not a new recorder session"
+    );
+    assert_eq!(
+        active_events[0].seq,
+        segment_events.last().unwrap().seq + 1,
+        "seq must stay continuous across the segment boundary"
+    );
+    assert!(
+        !active_events
+            .iter()
+            .any(|event| matches!(event.kind, AuditEventKind::RecorderStarted { .. })),
+        "a segment roll must not fabricate a new session boundary row"
+    );
+}
+
+#[test]
+fn oversized_pre_existing_audit_file_is_rolled_aside_on_open() {
+    let dir = TempDir::new().unwrap();
+    let path = default_jsonl_path(dir.path(), "engine-abc");
+    // Upgrade path: a file left behind by a build without segment rotation,
+    // already past the point where automatic upload can succeed.
+    let legacy = "x".repeat(usize::try_from(AUDIT_LOG_SEGMENT_MAX_BYTES).unwrap() + 1);
+    fs::write(&path, &legacy).unwrap();
+
+    let recorder = JsonlRecorder::open(&path, "engine-abc".to_string()).unwrap();
+    recorder.record(AuditRecord::new(
+        None,
+        AuditEventKind::SendEntry {
+            intent_kind: "app_message".into(),
+        },
+    ));
+
+    let segments = segment_paths(&path);
+    assert_eq!(segments.len(), 1);
+    assert_eq!(
+        fs::read_to_string(&segments[0]).unwrap(),
+        legacy,
+        "the oversized file is preserved verbatim, never truncated"
+    );
+    let active = fs::read_to_string(&path).unwrap();
+    assert_eq!(active.lines().count(), 2);
+    assert!(active.len() < 4096);
+}
+
+#[test]
+fn segment_rolls_never_overwrite_an_existing_segment() {
+    let dir = TempDir::new().unwrap();
+    let path = default_jsonl_path(dir.path(), "engine-abc");
+    let recorder = JsonlRecorder::open(&path, "engine-abc".to_string()).unwrap();
+    record_until_segment_rolls(&recorder, &path, 0);
+    let first = segment_paths(&path);
+    let first_bytes = fs::read(&first[0]).unwrap();
+
+    record_until_segment_rolls(&recorder, &path, 1);
+
+    let segments = segment_paths(&path);
+    assert_eq!(segments.len(), 2, "the second roll must claim a fresh name");
+    assert_eq!(
+        fs::read(&segments[0]).unwrap(),
+        first_bytes,
+        "an earlier segment is immutable"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn rolled_segment_is_owner_only() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = TempDir::new().unwrap();
+    let path = default_jsonl_path(dir.path(), "engine-abc");
+    let recorder = JsonlRecorder::open(&path, "engine-abc".to_string()).unwrap();
+    record_until_segment_rolls(&recorder, &path, 0);
+
+    let mode = |p: &Path| fs::metadata(p).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode(&segment_paths(&path)[0]), 0o600);
+    assert_eq!(mode(&path), 0o600);
+}

--- a/crates/marmot-forensics/src/lib.rs
+++ b/crates/marmot-forensics/src/lib.rs
@@ -1,11 +1,11 @@
 pub mod audit;
 
 pub use audit::{
-    AUDIT_LOG_SCHEMA_VERSION, AccountRefHex, AuditConvergenceContext, AuditEngineContext,
-    AuditEvent, AuditEventContext, AuditEventKind, AuditGroupContext, AuditHumanActionContext,
-    AuditRecord, AuditRecorderHealthSnapshot, AuditSourceContext, AuditTransportContext,
-    AuditTransportWire, ConvergenceAppWitness, ConvergenceCandidate, ConvergencePhase,
-    ConvergenceScore, DigestHex, EngineIdHex, EpochBackfillActivationOutcome,
+    AUDIT_LOG_SCHEMA_VERSION, AUDIT_LOG_SEGMENT_MAX_BYTES, AccountRefHex, AuditConvergenceContext,
+    AuditEngineContext, AuditEvent, AuditEventContext, AuditEventKind, AuditGroupContext,
+    AuditHumanActionContext, AuditRecord, AuditRecorderHealthSnapshot, AuditSourceContext,
+    AuditTransportContext, AuditTransportWire, ConvergenceAppWitness, ConvergenceCandidate,
+    ConvergencePhase, ConvergenceScore, DigestHex, EngineIdHex, EpochBackfillActivationOutcome,
     EpochBackfillCompletionKind, EpochBackfillDeferredReason, EpochBackfillExecutionSeam,
     EpochBackfillReplayScope, EpochStallBackfillTrigger, ForensicRecorder, ForkWinner, GroupRefHex,
     GroupStateValue, JsonlRecorder, MemberRefHex, MembershipChangeSource, MessageArtifactKind,

--- a/docs/marmot-architecture/audit-logging.md
+++ b/docs/marmot-architecture/audit-logging.md
@@ -1047,6 +1047,10 @@ still enumerated by `audit_log_files()` and sort ahead of the active file.
   re-mints a line just because it moved to a new file name.
 - A file already over the threshold at open — the upgrade path from builds without rotation, including one already past
   the 64 MiB request ceiling — is rolled aside on the first open, so a session always starts on an uploadable file.
+- A failed roll is compensated and retried later, not absorbed: the rename is the only step that moves data, so a failed
+  reopen renames the segment back to the active path and recording continues into the same file. The recorder then stops
+  attempting rolls until something proves the directory writable again — a fresh open, or a `rotate()` — so a transient
+  `ENOSPC`/`EMFILE` costs a delayed roll, not a session with rotation disabled.
 - Retention, deletion, and disk bounding of sealed segments are out of scope here; they belong to mdk#1014.
 
 ### Explicit upload
@@ -1154,8 +1158,16 @@ it, plus whether that was an accepted upload or a file above the request ceiling
   falls back to re-uploading, which the endpoint short-circuits on `file_sha256` without parsing a line.
 - Losing or corrupting the sidecar costs one repeat transfer per still-present file and nothing else.
 - A file above the 64 MiB ceiling is recorded as such, logged once with aggregate counts, and skipped on later runs
-  instead of failing on every trigger. It never blocks the files behind it, and `post_audit_log_file` remains the
-  deliberate escape hatch.
+  instead of failing on every trigger. It never blocks the files behind it.
+- There is no app-level escape hatch for a file above the ceiling. `post_audit_log_file` enforces the same limit before
+  it opens a request body, so an oversized legacy audit file is not transferable through any app API: it stays on disk
+  for manual handling (copy it off the device and hand it to the endpoint out of band, or split it). Deleting it is
+  mdk#1014's contract. Segment rotation is what keeps any newly produced file well under the ceiling, so this is an
+  upgrade-path condition only.
+- The sidecar is bounded by the account's *live* audit files, not by its upload history: entries for files that are gone
+  are pruned each run. Because sealed segments are never deleted (mdk#1014), that bound still grows with cumulative
+  audit volume — each tracker run stats every enumerated file and rewrites the whole sidecar. Both costs are linear in
+  file count and small next to the HTTP request each run already makes.
 
 The runtime has a coalescing uploader queue of size `1`: triggers arriving while an update is scheduled or running
 collapse into exactly one follow-up run, and two updates never upload concurrently. It schedules tracker updates after
@@ -1185,8 +1197,12 @@ these triggers:
 - `catch_up`
 - `receive`
 
-Tracker scheduling itself logs only the trigger, skip reason, uploaded/acknowledged/too-large/failed counts, file
-sizes, and file index for failed uploads. It does not log audit file names, paths, or contents.
+Tracker scheduling itself logs only the trigger, skip reason, file sizes, the file index for failed and skipped
+uploads, and aggregate counts: `uploaded`, `acknowledged` (already accepted by the endpoint), `too_large_recorded`
+(newly found above the ceiling this run, which is what warrants the warning), `too_large_known` (already recorded as
+above the ceiling, so skipped without a repeat warning), and `failed`. Acknowledged-and-uploaded is kept distinct from
+skipped-as-too-large so the counts never report a permanently untransferable file as delivered. It does not log audit
+file names, paths, or contents.
 
 ## Coverage audit
 

--- a/docs/marmot-architecture/audit-logging.md
+++ b/docs/marmot-architecture/audit-logging.md
@@ -1,7 +1,7 @@
 ---
 title: "Forensic Audit Logging Inventory"
 created: 2026-06-10
-updated: 2026-08-29
+updated: 2026-09-03
 tags: [marmot, architecture, audit, forensics, jsonl, privacy]
 status: current
 ---

--- a/docs/marmot-architecture/audit-logging.md
+++ b/docs/marmot-architecture/audit-logging.md
@@ -23,7 +23,7 @@ member identities, or arbitrary convergence-rule input/result JSON. There is no 
 | Local JSONL recording | Implemented by `marmot-forensics::JsonlRecorder`, installed into each `AccountDeviceSession` only when app-level `AuditLogSettings.enabled` is true before that account session opens. |
 | Default behavior | Off. Without an installed recorder, the engine uses `NoopRecorder` and emits no JSONL records. |
 | File shape | Append-only JSONL/NDJSON, one `AuditEvent` per line, schema version `marmot-forensics-audit/v3`; the line-level JSON Schema is [`audit-log-event.v3.schema.json`](../../crates/marmot-forensics/schema/audit-log-event.v3.schema.json). |
-| Local file location | `<account_dir>/audit-<engine_id>-v3.jsonl` for app-opened account sessions. Existing v1/v2 files are not rewritten or appended to. |
+| Local file location | `<account_dir>/audit-<engine_id>-v3.jsonl` for app-opened account sessions, sealed into `-seg<NNNNNN>` siblings at 1 MiB. Existing v1/v2 files are not rewritten or appended to. |
 | Upload/listing | App and UniFFI expose listing and explicit upload of all local `audit-*.jsonl` files. Runtime tracker uploads continue to include existing v1/v2 files. |
 | Static bundle analyzer | Not present in the current repo path. The current artifact model is raw append-only JSONL audit logs. |
 
@@ -1034,6 +1034,21 @@ The app can list and upload audit logs, but upload is separate from local record
 
 Files are sorted by app account label, then file name.
 
+### Segment rotation
+
+The recorder seals the active file into an immutable segment once it reaches `AUDIT_LOG_SEGMENT_MAX_BYTES` (1 MiB) and
+continues into a fresh file at the same path. Segments are named `audit-<engine_id>-v3-seg<NNNNNN>.jsonl`, so they are
+still enumerated by `audit_log_files()` and sort ahead of the active file.
+
+- Rotation is a rename, so nothing is deleted or truncated, and the concatenation of a session's segments plus its
+  active file is byte-identical to the single file the recorder would otherwise have written.
+- `seq`, the recorder session id, and the health counters carry across a segment boundary, and no `recorder_started`
+  row is written: a roll is not a new recorder session, and the upload endpoint's content-keyed line dedupe never
+  re-mints a line just because it moved to a new file name.
+- A file already over the threshold at open — the upgrade path from builds without rotation, including one already past
+  the 64 MiB request ceiling — is rolled aside on the first open, so a session always starts on an uploadable file.
+- Retention, deletion, and disk bounding of sealed segments are out of scope here; they belong to mdk#1014.
+
 ### Explicit upload
 
 `MarmotApp::post_audit_log_file(path, endpoint)` / `post_audit_log_file_with_tracker_config(...)` upload one selected
@@ -1124,7 +1139,27 @@ Structured skip reasons:
 | `uploaded` | Per-file upload results. |
 | `skipped_reason` | Optional reason the update did not upload. |
 
-The runtime has a coalescing uploader queue of size `1`. It schedules tracker updates after these triggers:
+### Upload checkpoint
+
+Each account directory holds `audit-upload-checkpoint.json` (owner-only, staged-and-renamed, deliberately not an
+`audit-*.jsonl` name). It records, per audit file, the size and mtime the file had when the tracker last finished with
+it, plus whether that was an accepted upload or a file above the request ceiling.
+
+- A file whose current size and mtime match its entry is never re-read or re-posted. Sealed segments never change, so
+  one `2xx` is a durable acknowledgment of their whole content.
+- The active file changes on every append and therefore re-transfers in full on each trigger. That residual is accepted
+  by design and is bounded by the segment threshold; a byte-offset acknowledgment protocol was considered and rejected.
+- Identity is metadata, not a content hash, because the point of the checkpoint is to avoid reading the file. Audit
+  files only grow, so every mismatch — including the racy ones where the file grew between enumeration and upload —
+  falls back to re-uploading, which the endpoint short-circuits on `file_sha256` without parsing a line.
+- Losing or corrupting the sidecar costs one repeat transfer per still-present file and nothing else.
+- A file above the 64 MiB ceiling is recorded as such, logged once with aggregate counts, and skipped on later runs
+  instead of failing on every trigger. It never blocks the files behind it, and `post_audit_log_file` remains the
+  deliberate escape hatch.
+
+The runtime has a coalescing uploader queue of size `1`: triggers arriving while an update is scheduled or running
+collapse into exactly one follow-up run, and two updates never upload concurrently. It schedules tracker updates after
+these triggers:
 
 - `create_group`
 - `invite_members`
@@ -1150,8 +1185,8 @@ The runtime has a coalescing uploader queue of size `1`. It schedules tracker up
 - `catch_up`
 - `receive`
 
-Tracker scheduling itself logs only the trigger, skip reason, uploaded count, failed count, and file index for failed
-uploads. It does not log audit file contents.
+Tracker scheduling itself logs only the trigger, skip reason, uploaded/acknowledged/too-large/failed counts, file
+sizes, and file index for failed uploads. It does not log audit file names, paths, or contents.
 
 ## Coverage audit
 


### PR DESCRIPTION
Fixes #1181: the audit tracker re-uploaded every growing JSONL file from byte zero on each send/sync trigger — field-measured at 99.8% duplicate lines and ~471x amplification — and once a file crossed the 64 MiB request ceiling, automatic upload failed permanently, silently dropping that device out of the forensic fleet.

Client-only fix, no Goggles changes. The server already provides the needed acknowledgment semantics: line dedupe is content-keyed (filename-agnostic) and byte-identical re-uploads short-circuit on file_sha256 without parsing, so for an immutable file one HTTP 200 is a durable ack.

1. Segment rotation (marmot-forensics): JsonlRecorder seals the active file at 1 MiB by renaming it into an immutable audit-<engine>-v3-segNNNNNN.jsonl sibling and reopening. Transparent: seq, session id, and health counters carry across, no fabricated recorder_started row, and segments plus active concatenate byte-identical to the unrotated log (pinned by a literal concat test). Crash mid-roll leaves a complete segment; a failed reopen renames the segment back (compensation, tested); a transient roll failure latches only for the directory-unwritable episode, not the recorder's lifetime (regression-tested). The threshold was chosen from measured row sizes: at 1 MiB the steady-state residual is ~45x vs 176x at 4 MiB, with 64x margin under the request ceiling.
2. Upload-once checkpoint (marmot-app): a per-account fs-private sidecar records each successfully uploaded file as (name, size, mtime). Matches are never re-read or re-posted; any mismatch re-uploads and the server dedupe absorbs it. The checkpoint is deliberately losable — a torn or missing sidecar costs one cheap re-upload per file. Files are append-only, so a recorded pair can never falsely match future state.
3. Trigger coalescing was already correct (size-1 queue); it is now a documented contract with a discriminating regression test.
4. Upgrade path for the cliff: an already-oversized active file is rolled aside at open so new uploads flow immediately; an oversized immutable file is warned once (aggregate counts only), recorded as too-large, and skipped without blocking other files. The doc now states honestly that no app API transfers such a file; retention is #1014's contract.

Deliberately out of scope, recorded as follow-ups: retention/deletion/disk bounding, fsync and tamper evidence (#1014); the remaining ~45x active-file residual (the 1.0x design — upload only sealed segments — trades tail freshness and needs a product call); the public post_audit_log_tracker_update host API bypassing the coalescing queue; a pre-existing Content-Length race on files appended mid-upload, now confined to the active segment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit logs now automatically rotate into immutable 1 MiB segments while continuing to record new events.
  * Incremental uploads use persistent checkpoints to avoid retransferring unchanged files and retry failed transfers.
  * Oversized files are reported without blocking other uploads.
  * Upload processing remains queued and coalesces bursts to prevent concurrent runs.

* **Bug Fixes**
  * Improved recovery after interrupted or failed segment rotation.
  * Preserved audit-log continuity across segment rolls and recorder reopenings.

* **Documentation**
  * Clarified segmentation, upload checkpointing, retries, and ordering limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->