### PR TITLE
Group each message's OpenMLS writes into one commit

### DIFF
--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -1004,21 +1004,28 @@ impl<S: StorageProvider> Engine<S> {
             );
         }
 
-        self.persist_openmls_wire_message(
-            &openmls_msg,
-            &group_id,
-            current_epoch,
-            MessageState::Created,
-        )?;
-
+        // The retained row and the secret-tree ratchet `process_message`
+        // writes share one durable unit: under `synchronous = FULL` every
+        // COMMIT is an fsync, and these were three per inbound message. The
+        // processing result leaves the closure as a value so a decrypt
+        // failure still commits the row the error branches below transition.
+        //
         // Process via MLS. Commits may contain AppDataUpdate proposals,
         // which require the application to compute the resulting
         // AppDataDictionary before OpenMLS stages the commit.
-        let processed = match if msg_content_type == ContentType::Commit {
-            process_commit_with_app_data_updates(&mut mls_group, &provider, proto)
-        } else {
-            mls_group.process_message(&provider, proto)
-        } {
+        let processed = match self.storage.with_transaction(|_storage| {
+            self.persist_openmls_wire_message(
+                &openmls_msg,
+                &group_id,
+                current_epoch,
+                MessageState::Created,
+            )?;
+            Ok::<_, EngineError>(if msg_content_type == ContentType::Commit {
+                process_commit_with_app_data_updates(&mut mls_group, &provider, proto)
+            } else {
+                mls_group.process_message(&provider, proto)
+            })
+        })? {
             Ok(p) => p,
             Err(e) if process_message_error_is_too_distant_in_the_past(&e) => {
                 // Refine the historical classification (mdk#339):

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -888,12 +888,16 @@ impl<S: StorageProvider> Engine<S> {
         let wrap_metadata =
             GroupMessageMetadata::application(app_event.created_at, source_retention_seconds);
 
-        let out: MlsMessageOut = mls_group
-            .create_message(&provider, &self.identity.signer, &payload)
-            .map_err(|e| EngineError::Backend(format!("create_message: {e:?}")))?;
-        let out_bytes = out
-            .tls_serialize_detached()
-            .map_err(|e| EngineError::Serialize(format!("{e:?}")))?;
+        // `create_message` ratchets the sender secret tree and writes it back;
+        // one transaction turns that write's two autocommits into one COMMIT
+        // (one fsync under `synchronous = FULL`).
+        let out_bytes = self.storage.with_transaction(|_storage| {
+            let out: MlsMessageOut = mls_group
+                .create_message(&provider, &self.identity.signer, &payload)
+                .map_err(|e| EngineError::Backend(format!("create_message: {e:?}")))?;
+            out.tls_serialize_detached()
+                .map_err(|e| EngineError::Serialize(format!("{e:?}")))
+        })?;
 
         let ctx = group_lifecycle::build_group_context_snapshot(&mls_group, &provider)?;
         let wrapped = self


### PR DESCRIPTION
### Summary

Each message's OpenMLS secret-tree write shares a commit with the work around it: inbound, with the retained message row; outbound, with the legacy-key delete that follows it.

### Context

create_message and process_message each ratchet the sender secret tree and write it back through the OpenMLS provider. Those writes ran outside any caller transaction, so each was its own autocommit unit, and under synchronous = FULL every commit is an fsync. An inbound message paid three commits before its application event was applied.

### What changed

The inbound path runs the retained-row persist and the MLS processing inside one with_transaction. The processing result leaves the closure as a value, so a decrypt failure still commits the row the error branches transition, as before.

The outbound path runs create_message inside one transaction so its secret write and legacy-key delete share a commit. The retained outgoing row still commits on its own afterwards. Transport wrapping sits between the two and is async, and the storage transaction API is synchronous, so this change does not make the outgoing row atomic with the ratchet advance. That gap predates this change and is unchanged by it.

### Impact

File-backed SQLCipher on btrfs, warm app-message send, together with the statement cache beneath: 0 members 5043 to 2728 µs, 64 members 14574 to 4766 µs. Disk numbers vary run to run by a wide margin, so treat these as the direction, not a precise split.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability Improvements**
  * Improved consistency when receiving and processing messages by grouping related storage updates into a single transaction.
  * Improved consistency when creating and sending application messages by ensuring message data and associated state are saved together.
  * Existing message handling and error behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->