### PR TITLE
Store OpenMLS values as MessagePack instead of JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5024,6 +5024,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5684,6 +5703,7 @@ dependencies = [
  "hex",
  "openmls",
  "openmls_traits",
+ "rmp-serde",
  "rusqlite",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,15 +82,12 @@ unicode-properties = { version = "0.1", default-features = false, features = ["g
 # one emoji). Already in the tree via ratatui; declared here so wn-cli can depend
 # on it directly at the workspace-consistent version.
 unicode-segmentation = "1"
-unicode-normalization = "0.1"
 rand = "0.8"
 sha2 = "0.10"
 url = "2"
 psl = "2"
-bech32 = "0.11"
 chacha20poly1305 = "0.10"
 bytes = "1"
-scrypt = "0.11"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
 zeroize = "1"
 keyring-core = "1"
@@ -125,21 +122,17 @@ cgka-engine = { path = "crates/cgka-engine" }
 cgka-session = { path = "crates/cgka-session" }
 storage-sqlite = { path = "crates/storage-sqlite" }
 cgka-conformance-simulator = { path = "crates/cgka-conformance-simulator" }
-convergence-campaign-runner = { path = "crates/convergence-campaign-runner" }
 transport-nostr-peeler = { path = "crates/transport-nostr-peeler" }
 transport-nostr-adapter = { path = "crates/transport-nostr-adapter" }
 transport-quic-stream = { path = "crates/transport-quic-stream" }
 transport-quic-broker = { path = "crates/transport-quic-broker" }
 agent-stream-compose = { path = "crates/agent-stream-compose" }
 agent-control = { path = "crates/agent-control" }
-agent-connector = { path = "crates/agent-connector" }
 marmot-forensics = { path = "crates/marmot-forensics" }
 marmot-markdown = { path = "crates/marmot-markdown" }
 marmot-account = { path = "crates/marmot-account" }
 marmot-app = { path = "crates/marmot-app" }
-marmot-c = { path = "crates/marmot-c" }
 marmot-uniffi = { path = "crates/marmot-uniffi" }
-wn-cli = { path = "crates/cli" }
 marmot-terminal-harness = { path = "integrations/terminal-harness" }
 
 # hax-lib-macros 0.3.7 still declares the unmaintained proc-macro-error2

--- a/crates/storage-sqlite/Cargo.toml
+++ b/crates/storage-sqlite/Cargo.toml
@@ -12,6 +12,7 @@ fs-private.workspace = true
 hex.workspace = true
 openmls.workspace = true
 openmls_traits.workspace = true
+rmp-serde = "1.3.1"
 rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/storage-sqlite/src/codec.rs
+++ b/crates/storage-sqlite/src/codec.rs
@@ -72,6 +72,19 @@ impl SensitiveBytes {
     }
 }
 
+impl Write for SensitiveBytes {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        for byte in bytes {
+            self.push(*byte);
+        }
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
 impl AsRef<[u8]> for SensitiveBytes {
     fn as_ref(&self) -> &[u8] {
         self.as_slice()

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -110,6 +110,8 @@ mod migration_0054_transport_reconciliation_items;
 mod migration_0055_epoch_stall_evidence;
 #[path = "migrations/0056_chat_list_accepted_activity_high_water.rs"]
 mod migration_0056_chat_list_accepted_activity_high_water;
+#[path = "migrations/0057_openmls_values_cbor_encoding.rs"]
+mod migration_0057_openmls_values_cbor_encoding;
 #[cfg(test)]
 #[path = "migrations/test_support.rs"]
 mod test_support;
@@ -404,6 +406,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 56,
         name: "0056_chat_list_accepted_activity_high_water",
         apply: migration_0056_chat_list_accepted_activity_high_water::apply,
+    },
+    Migration {
+        version: 57,
+        name: "0057_openmls_values_cbor_encoding",
+        apply: migration_0057_openmls_values_cbor_encoding::apply,
     },
 ];
 
@@ -932,7 +939,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 56,
+                found: 57,
                 latest_supported: 46,
             }
         ));
@@ -988,7 +995,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 56,
+                found: 57,
                 latest_supported: 46,
             }
         ));
@@ -1292,7 +1299,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 56,
+                found: 57,
                 latest_supported: 46,
             }
         ));

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -110,8 +110,8 @@ mod migration_0054_transport_reconciliation_items;
 mod migration_0055_epoch_stall_evidence;
 #[path = "migrations/0056_chat_list_accepted_activity_high_water.rs"]
 mod migration_0056_chat_list_accepted_activity_high_water;
-#[path = "migrations/0057_openmls_values_cbor_encoding.rs"]
-mod migration_0057_openmls_values_cbor_encoding;
+#[path = "migrations/0057_openmls_values_msgpack.rs"]
+mod migration_0057_openmls_values_msgpack;
 #[cfg(test)]
 #[path = "migrations/test_support.rs"]
 mod test_support;
@@ -409,8 +409,8 @@ const MIGRATIONS: &[Migration] = &[
     },
     Migration {
         version: 57,
-        name: "0057_openmls_values_cbor_encoding",
-        apply: migration_0057_openmls_values_cbor_encoding::apply,
+        name: "0057_openmls_values_msgpack",
+        apply: migration_0057_openmls_values_msgpack::apply,
     },
 ];
 

--- a/crates/storage-sqlite/src/migrations/0057_openmls_values_cbor_encoding.rs
+++ b/crates/storage-sqlite/src/migrations/0057_openmls_values_cbor_encoding.rs
@@ -1,0 +1,15 @@
+//! Version marker for the CBOR encoding of `openmls_values`.
+//!
+//! Rows written from this version on start with a NUL-prefixed format tag and
+//! carry CBOR instead of a serde_json document. The table shape is
+//! unchanged and older rows stay readable, so this migration alters nothing;
+//! it exists so a build without the decoder refuses to open the database
+//! through `reject_unknown_future_migrations` instead of failing on the first
+//! group load.
+
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(crate) fn apply(_tx: &Transaction<'_>) -> StorageResult<()> {
+    Ok(())
+}

--- a/crates/storage-sqlite/src/migrations/0057_openmls_values_msgpack.rs
+++ b/crates/storage-sqlite/src/migrations/0057_openmls_values_msgpack.rs
@@ -1,7 +1,7 @@
-//! Version marker for the CBOR encoding of `openmls_values`.
+//! Version marker for the MessagePack encoding of `openmls_values`.
 //!
 //! Rows written from this version on start with a NUL-prefixed format tag and
-//! carry CBOR instead of a serde_json document. The table shape is
+//! carry MessagePack instead of a serde_json document. The table shape is
 //! unchanged and older rows stay readable, so this migration alters nothing;
 //! it exists so a build without the decoder refuses to open the database
 //! through `reject_unknown_future_migrations` instead of failing on the first

--- a/crates/storage-sqlite/src/openmls_storage.rs
+++ b/crates/storage-sqlite/src/openmls_storage.rs
@@ -99,6 +99,10 @@ pub enum SqliteOpenMlsStorageError {
     Sqlite(#[from] rusqlite::Error),
     #[error("serialization failure: {0}")]
     Serialization(#[from] serde_json::Error),
+    #[error("encoding failure: {0}")]
+    Encode(#[from] rmp_serde::encode::Error),
+    #[error("decoding failure: {0}")]
+    Decode(#[from] rmp_serde::decode::Error),
     #[error("queued proposal reference was present without a queued proposal")]
     MissingQueuedProposal,
 }

--- a/crates/storage-sqlite/src/openmls_storage/labels.rs
+++ b/crates/storage-sqlite/src/openmls_storage/labels.rs
@@ -40,6 +40,10 @@ impl OpenMlsValueLabel {
         self.sensitivity
     }
 
+    pub(in crate::openmls_storage) const fn is_key_package(self) -> bool {
+        matches!(self.bytes, b"KeyPackage")
+    }
+
     #[cfg(test)]
     pub(in crate::openmls_storage) const fn test_public(bytes: &'static [u8]) -> Self {
         Self::public(bytes)

--- a/crates/storage-sqlite/src/openmls_storage/value_store.rs
+++ b/crates/storage-sqlite/src/openmls_storage/value_store.rs
@@ -8,6 +8,70 @@ use rusqlite::{OptionalExtension, TransactionBehavior, params};
 use serde::de::DeserializeOwned;
 use serde::{Serialize, Serializer};
 
+/// Leading bytes of a MessagePack-encoded value. Rows written before this
+/// encoding are serde_json documents, which never begin with NUL, so a read
+/// tells the two apart by this prefix and older rows keep decoding until
+/// their next write replaces them.
+///
+/// serde_json spelled every `Vec<u8>` as an array of decimal integers: four
+/// times the bytes on disk and a text integer parse per byte on every read.
+/// A 64-member ratchet tree was 111 KB of JSON, parsed twice per app-message
+/// send. MessagePack is self-describing, which OpenMLS's hand-written
+/// `Deserialize` impls require, so a positional format such as postcard
+/// cannot serve here.
+const VALUE_ENCODING_V2_PREFIX: [u8; 2] = [0x00, 0x02];
+
+/// Labels whose raw row bytes leave this crate and are parsed by the engine
+/// as serde_json (`cgka_engine::key_package` reads stored bundles through
+/// `StoredKeyPackageBundle::value`). Those stay JSON until that seam carries
+/// decoded values.
+const fn label_stays_json(label: OpenMlsValueLabel) -> bool {
+    label.is_key_package()
+}
+
+fn encode_public<T: Serialize + ?Sized>(
+    label: OpenMlsValueLabel,
+    value: &T,
+) -> Result<Vec<u8>, SqliteOpenMlsStorageError> {
+    if label_stays_json(label) {
+        return Ok(serde_json::to_vec(value)?);
+    }
+    let mut out = VALUE_ENCODING_V2_PREFIX.to_vec();
+    rmp_serde::encode::write(&mut out, value)?;
+    Ok(out)
+}
+
+fn encode_secret<T: Serialize + ?Sized>(
+    label: OpenMlsValueLabel,
+    value: &T,
+) -> Result<SensitiveBytes, SqliteOpenMlsStorageError> {
+    if label_stays_json(label) {
+        return Ok(serialize_sensitive_json(value)?);
+    }
+    let mut out = SensitiveBytes::with_capacity(256);
+    std::io::Write::write_all(&mut out, &VALUE_ENCODING_V2_PREFIX)
+        .expect("in-memory sensitive buffer write cannot fail");
+    rmp_serde::encode::write(&mut out, value)?;
+    Ok(out)
+}
+
+fn decode<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, SqliteOpenMlsStorageError> {
+    match bytes.strip_prefix(&VALUE_ENCODING_V2_PREFIX) {
+        Some(body) => Ok(rmp_serde::from_slice(body)?),
+        None => Ok(serde_json::from_slice(bytes)?),
+    }
+}
+
+/// The serde_json form of `value`, for matching list elements written before
+/// [`VALUE_ENCODING_V2_PREFIX`].
+fn encode_legacy_json<T: Serialize + ?Sized>(
+    label: OpenMlsValueLabel,
+    value: &T,
+) -> Result<SerializedBuffer, SqliteOpenMlsStorageError> {
+    let bytes = serde_json::to_vec(value)?;
+    Ok(SerializedBuffer::from_database(label, bytes))
+}
+
 enum SerializedBuffer {
     Public(Vec<u8>),
     Secret(SensitiveBytes),
@@ -34,8 +98,8 @@ fn serialize_buffer<T: Serialize + ?Sized>(
     value: &T,
 ) -> Result<SerializedBuffer, SqliteOpenMlsStorageError> {
     match label.sensitivity() {
-        ValueSensitivity::Public => Ok(SerializedBuffer::Public(serde_json::to_vec(value)?)),
-        ValueSensitivity::Secret => Ok(SerializedBuffer::Secret(serialize_sensitive_json(value)?)),
+        ValueSensitivity::Public => Ok(SerializedBuffer::Public(encode_public(label, value)?)),
+        ValueSensitivity::Secret => Ok(SerializedBuffer::Secret(encode_secret(label, value)?)),
     }
 }
 
@@ -50,29 +114,40 @@ impl SerializedList {
         bytes: &[u8],
     ) -> Result<Self, SqliteOpenMlsStorageError> {
         match label.sensitivity() {
-            ValueSensitivity::Public => Ok(Self::Public(serde_json::from_slice(bytes)?)),
-            ValueSensitivity::Secret => Ok(Self::Secret(serde_json::from_slice(bytes)?)),
+            ValueSensitivity::Public => Ok(Self::Public(decode(bytes)?)),
+            ValueSensitivity::Secret => Ok(Self::Secret(decode(bytes)?)),
         }
     }
 
-    fn push<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), SqliteOpenMlsStorageError> {
+    fn push<T: Serialize + ?Sized>(
+        &mut self,
+        label: OpenMlsValueLabel,
+        value: &T,
+    ) -> Result<(), SqliteOpenMlsStorageError> {
         match self {
-            Self::Public(values) => values.push(serde_json::to_vec(value)?),
-            Self::Secret(values) => values.push(serialize_sensitive_json(value)?),
+            Self::Public(values) => values.push(encode_public(label, value)?),
+            Self::Secret(values) => values.push(encode_secret(label, value)?),
         }
         Ok(())
     }
 
-    fn remove_matching(&mut self, encoded: &SerializedBuffer) {
-        fn remove<T: AsRef<[u8]>>(values: &mut Vec<T>, encoded: &[u8]) {
-            if let Some(pos) = values.iter().position(|stored| stored.as_ref() == encoded) {
+    /// Remove the first element equal to any of `encodings`. A list written
+    /// before the current encoding holds serde_json elements, so callers pass
+    /// both the current and the legacy form of the value.
+    fn remove_matching(&mut self, encodings: &[SerializedBuffer]) {
+        fn remove<T: AsRef<[u8]>>(values: &mut Vec<T>, encodings: &[SerializedBuffer]) {
+            if let Some(pos) = values.iter().position(|stored| {
+                encodings
+                    .iter()
+                    .any(|encoded| stored.as_ref() == encoded.as_slice())
+            }) {
                 values.remove(pos);
             }
         }
 
         match self {
-            Self::Public(values) => remove(values, encoded.as_slice()),
-            Self::Secret(values) => remove(values, encoded.as_slice()),
+            Self::Public(values) => remove(values, encodings),
+            Self::Secret(values) => remove(values, encodings),
         }
     }
 }
@@ -224,7 +299,10 @@ impl SqliteOpenMlsStorage {
         group_key: Option<Vec<u8>>,
         value: &T,
     ) -> Result<(), SqliteOpenMlsStorageError> {
-        let encoded = serialize_buffer(label, value)?;
+        let encoded = [
+            serialize_buffer(label, value)?,
+            encode_legacy_json(label, value)?,
+        ];
         let storage_key = build_key(label.as_bytes(), key.clone());
         let legacy_storage_key = build_key_legacy(label.as_bytes(), key);
         if self.connection.is_current_thread_transaction_owner() {
@@ -294,9 +372,7 @@ impl SqliteOpenMlsStorage {
             Some(value) => Some(value),
             None => read_value_on_connection(&conn, &legacy_storage_key, label)?,
         };
-        value
-            .map(|value| serde_json::from_slice(value.as_slice()).map_err(Into::into))
-            .transpose()
+        value.map(|value| decode(value.as_slice())).transpose()
     }
 
     pub(in crate::openmls_storage) fn read_group_entity<
@@ -316,13 +392,12 @@ impl SqliteOpenMlsStorage {
         key: Vec<u8>,
     ) -> Result<Vec<T>, SqliteOpenMlsStorageError> {
         match self.read_raw_list(label, &key)? {
-            Some(SerializedList::Public(values)) => values
-                .into_iter()
-                .map(|value| serde_json::from_slice(&value).map_err(Into::into))
-                .collect(),
+            Some(SerializedList::Public(values)) => {
+                values.into_iter().map(|value| decode(&value)).collect()
+            }
             Some(SerializedList::Secret(values)) => values
                 .into_iter()
-                .map(|value| serde_json::from_slice(value.as_slice()).map_err(Into::into))
+                .map(|value| decode(value.as_slice()))
                 .collect(),
             None => Ok(Vec::new()),
         }
@@ -499,7 +574,7 @@ fn append_entity_on_connection<T: Entity<CURRENT_VERSION>>(
         legacy_storage_key.as_slice(),
         label,
     )?;
-    list.push(value)?;
+    list.push(label, value)?;
     write_list_on_connection(conn, label, storage_key.as_slice(), group_key, &list)?;
     delete_value_on_connection(conn, legacy_storage_key.as_slice())
 }
@@ -510,7 +585,7 @@ fn remove_entity_on_connection(
     storage_key: Vec<u8>,
     legacy_storage_key: Vec<u8>,
     group_key: Option<&[u8]>,
-    encoded: &SerializedBuffer,
+    encoded: &[SerializedBuffer],
 ) -> Result<(), SqliteOpenMlsStorageError> {
     let mut list = list_values_with_legacy_fallback_on_connection(
         conn,
@@ -575,8 +650,12 @@ mod tests {
             SerializedBuffer::Secret(_)
         ));
 
+        // A list written by the serde_json era: elements are JSON documents.
         let mut list = SerializedList::deserialize(label, b"[[55],[56]]").unwrap();
-        let encoded = serialize_buffer(label, &TestEntity(7)).unwrap();
+        let encoded = [
+            serialize_buffer(label, &TestEntity(7)).unwrap(),
+            encode_legacy_json(label, &TestEntity(7)).unwrap(),
+        ];
         list.remove_matching(&encoded);
         match list {
             SerializedList::Secret(values) => {
@@ -592,15 +671,80 @@ mod tests {
     #[test]
     fn list_push_derives_buffer_ownership_from_the_existing_list() {
         let mut public = SerializedList::Public(Vec::new());
-        public.push(&TestEntity(7)).unwrap();
-        assert!(matches!(public, SerializedList::Public(values) if values == [b"7"]));
+        public
+            .push(OpenMlsValueLabel::test_public(b"P"), &TestEntity(7))
+            .unwrap();
+        assert!(matches!(public, SerializedList::Public(values) if values == [[0, 2, 7]]));
 
         let mut secret = SerializedList::Secret(Vec::new());
-        secret.push(&TestEntity(8)).unwrap();
+        secret
+            .push(OpenMlsValueLabel::test_secret(b"S"), &TestEntity(8))
+            .unwrap();
         assert!(matches!(
             secret,
-            SerializedList::Secret(values) if values.len() == 1 && values[0].as_slice() == b"8"
+            SerializedList::Secret(values) if values.len() == 1 && values[0].as_slice() == [0, 2, 8]
         ));
+    }
+
+    #[test]
+    fn values_decode_from_either_encoding_and_write_the_current_one() {
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Blob {
+            bytes: Vec<u8>,
+            epoch: u64,
+        }
+        let blob = Blob {
+            bytes: (0..=255).collect(),
+            epoch: 7,
+        };
+
+        let json = serde_json::to_vec(&blob).unwrap();
+        assert_eq!(decode::<Blob>(&json).unwrap(), blob);
+
+        let label = OpenMlsValueLabel::test_public(b"Blob");
+        let current = encode_public(label, &blob).unwrap();
+        assert!(current.starts_with(&VALUE_ENCODING_V2_PREFIX));
+        assert_eq!(decode::<Blob>(&current).unwrap(), blob);
+        assert!(current.len() < json.len());
+
+        let secret = encode_secret(OpenMlsValueLabel::test_secret(b"Blob"), &blob).unwrap();
+        assert_eq!(secret.as_slice(), current.as_slice());
+        assert!(decode::<Blob>(b"\x00\x02\xff").is_err());
+        assert!(decode::<Blob>(b"[[55],").is_err());
+    }
+
+    #[test]
+    fn stored_json_row_reads_back_and_is_rewritten_in_the_current_encoding() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let mls = &store.openmls;
+        let label = OpenMlsValueLabel::test_public(b"Legacy");
+
+        mls.write_value(
+            label,
+            b"k".to_vec(),
+            None,
+            serde_json::to_vec(&TestEntity(9)).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            mls.read_entity::<TestEntity>(label, b"k".to_vec()).unwrap(),
+            Some(TestEntity(9))
+        );
+
+        mls.write_entity(label, b"k".to_vec(), None, &TestEntity(10))
+            .unwrap();
+        let raw = read_value_on_connection(
+            &store.lock().unwrap(),
+            &build_key(label.as_bytes(), b"k".to_vec()),
+            label,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(raw.as_slice().starts_with(&VALUE_ENCODING_V2_PREFIX));
+        assert_eq!(
+            mls.read_entity::<TestEntity>(label, b"k".to_vec()).unwrap(),
+            Some(TestEntity(10))
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Summary

New openmls_values rows are MessagePack behind a NUL-led format prefix. Existing JSON rows still read and move over on their next write.

### Context

OpenMLS entities are mostly byte vectors, and serde_json writes those as arrays of decimal integers: about four times the bytes on disk and a text integer parse per byte on every read. A 64-member ratchet tree was 111 KB of JSON, parsed by MlsGroup::load on every send and receive. In a profile of the send loop that parsing was the largest slice.

### What changed

Writes go through rmp-serde with a two-byte prefix a JSON document can never start with; reads sniff the prefix and fall back to serde_json. List removal matches both encodings so an element appended before the change can still be removed. Key package bundle rows stay JSON because the engine parses their raw bytes itself. A no-op migration marks the version so an older build refuses the database up front rather than failing on the first group load.

MessagePack rather than postcard because OpenMLS has hand-written Deserialize impls that need a self-describing format. ciborium was tried first and decoded slower than serde_json for this shape.

### Impact

In-memory SQLCipher, warm app-message send, against the statement cache beneath: 16 members 923 to 769 µs, 64 members 2286 to 1540 µs. MlsGroup::load at 64 members 485 to 234 µs. Adds rmp-serde as a storage-sqlite dependency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a versioned, compact format for storing application values, improving storage efficiency and consistency.
  - Added compatibility handling for identifying key-package data during storage operations.

- **Bug Fixes**
  - Existing data stored in the legacy format remains readable and can be transparently rewritten in the current format.
  - Improved handling of storage encoding and decoding failures.
  - Updated database migration tracking to reflect the new storage format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->