### PR TITLE
Keep loaded MlsGroups across engine calls

### DIFF
--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -2410,7 +2410,7 @@ fn decode_convergence_policy(
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::sync::Arc;
 
     use async_trait::async_trait;
@@ -2524,7 +2524,7 @@ mod tests {
         }
     }
 
-    fn test_engine() -> crate::Engine<storage_sqlite::SqliteAccountStorage> {
+    pub(crate) fn test_engine() -> crate::Engine<storage_sqlite::SqliteAccountStorage> {
         let key = signing_key();
         let identity = key.verifying_key().to_bytes().to_vec();
         crate::EngineBuilder::new(storage_sqlite::SqliteAccountStorage::in_memory().unwrap())

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -144,6 +144,7 @@ pub struct Engine<S: StorageProvider> {
     /// Per-group state-machine owner. Every transition, pending-ref
     /// allocation, and fork-detection marker flows through this struct.
     pub(crate) epoch_manager: crate::epoch_manager::EpochManager,
+    pub(crate) mls_group_cache: crate::mls_group_cache::MlsGroupCache,
 
     /// Storage-layer identity of the origin commit behind each in-flight
     /// pending publish, so `do_confirm_published` can mark the sent commit
@@ -554,6 +555,7 @@ impl<S: StorageProvider> EngineBuilder<S> {
             wall_clock: self.wall_clock,
             maintenance_random: self.maintenance_random,
             epoch_manager: crate::epoch_manager::EpochManager::new(),
+            mls_group_cache: crate::mls_group_cache::MlsGroupCache::default(),
             pending_origin_commits: HashMap::new(),
             events_buf: pending_application_events.into(),
             auto_publish_buf: VecDeque::new(),
@@ -2921,28 +2923,23 @@ impl<S: StorageProvider> Engine<S> {
         self.update_stored_message_state(id, MessageState::Processed)
     }
 
-    /// One liveness-gated `MlsGroup::load` for read-only accessors. A missing
-    /// group maps to `UnknownGroup`.
-    fn live_mls_group(&self, group_id: &GroupId) -> Result<openmls::group::MlsGroup, EngineError> {
+    /// Liveness-gated read-only access to the group's `MlsGroup`, served from
+    /// the engine's group cache. A missing group maps to `UnknownGroup`.
+    fn with_live_mls_group<R>(
+        &self,
+        group_id: &GroupId,
+        f: impl FnOnce(&openmls::group::MlsGroup) -> Result<R, EngineError>,
+    ) -> Result<R, EngineError> {
         self.ensure_group_live(group_id)?;
-        let provider = crate::provider::EngineOpenMlsProvider::<S>::new(
-            &self.crypto,
-            self.storage.mls_storage(),
-        );
-        let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
-        openmls::group::MlsGroup::load(
-            <crate::provider::EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(&provider),
-            &mls_gid,
-        )
-        .map_err(|e| EngineError::Backend(format!("load: {e:?}")))?
-        .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))
+        self.with_mls_group(group_id, f)
     }
 
     /// Return the current Marmot admin policy keys mirrored from signed MLS
     /// group state.
     pub fn admin_pubkeys(&self, group_id: &GroupId) -> Result<Vec<[u8; 32]>, EngineError> {
-        let mls_group = self.live_mls_group(group_id)?;
-        let mut admins = crate::app_components::admins_of_group(&mls_group)?;
+        let mut admins = self.with_live_mls_group(group_id, |mls_group| {
+            crate::app_components::admins_of_group(mls_group)
+        })?;
         admins.sort();
         admins.dedup();
         Ok(admins)
@@ -3002,21 +2999,21 @@ impl<S: StorageProvider> Engine<S> {
         group_id: &GroupId,
         component_id: AppComponentId,
     ) -> Result<EpochId, EngineError> {
-        let mls_group = self.live_mls_group(group_id)?;
+        self.with_live_mls_group(group_id, |mls_group| {
+            let required_components =
+                crate::app_components::required_app_components_of_group(mls_group)?;
+            if !required_components.contains(component_id) {
+                return Err(EngineError::Other(format!(
+                    "group does not require app component {component_id:#06x}"
+                )));
+            }
 
-        let required_components =
-            crate::app_components::required_app_components_of_group(&mls_group)?;
-        if !required_components.contains(component_id) {
-            return Err(EngineError::Other(format!(
-                "group does not require app component {component_id:#06x}"
-            )));
-        }
-
-        if let Some(staged) = mls_group.pending_commit() {
-            Ok(EpochId(staged.group_context().epoch().as_u64()))
-        } else {
-            Ok(EpochId(mls_group.epoch().as_u64()))
-        }
+            if let Some(staged) = mls_group.pending_commit() {
+                Ok(EpochId(staged.group_context().epoch().as_u64()))
+            } else {
+                Ok(EpochId(mls_group.epoch().as_u64()))
+            }
+        })
     }
 }
 
@@ -3161,13 +3158,9 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
         // MemberValidationFailed) — never export its secrets.
         self.ensure_group_live(group_id)?;
         let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
-        let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
-        let mls_group = openmls::group::MlsGroup::load(
-            <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(&provider),
-            &mls_gid,
-        )
-        .map_err(|e| EngineError::Backend(format!("load: {e:?}")))?
-        .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
+        let mls_group = self
+            .take_mls_group(group_id)?
+            .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
         // When the group is in `PendingPublish`, the MLS group is at the
         // pre-stage epoch but the staged commit carries the projected
         // future state. Project so callers see the same epoch the rest of
@@ -3260,13 +3253,15 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
             crate::group_lifecycle::AGENT_TEXT_STREAM_EXPORTER_SNAPSHOT_KEY.to_string(),
             cgka_traits::SecretBytes::new(stream_secret),
         );
-        Ok(Box::new(crate::group_context_view::GroupContextView::new(
+        let view = crate::group_context_view::GroupContextView::new(
             EpochId(epoch),
             map,
             Some(crate::app_components::transport_group_id_of_group(
                 &mls_group,
             )?),
-        )))
+        );
+        self.return_mls_group(group_id, mls_group);
+        Ok(Box::new(view))
     }
 
     fn safe_export_secret(
@@ -3283,11 +3278,12 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
         group_id: &GroupId,
         component_id: AppComponentId,
     ) -> Result<Option<Vec<u8>>, EngineError> {
-        let mls_group = self.live_mls_group(group_id)?;
-        Ok(crate::app_components::app_component_data_of_group(
-            &mls_group,
-            component_id,
-        ))
+        self.with_live_mls_group(group_id, |mls_group| {
+            Ok(crate::app_components::app_component_data_of_group(
+                mls_group,
+                component_id,
+            ))
+        })
     }
 
     // One `MlsGroup::load` (13 storage reads + a ratchet-tree deserialize)
@@ -3297,13 +3293,14 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
         group_id: &GroupId,
         component_ids: &[AppComponentId],
     ) -> Result<Vec<Option<Vec<u8>>>, EngineError> {
-        let mls_group = self.live_mls_group(group_id)?;
-        Ok(component_ids
-            .iter()
-            .map(|component_id| {
-                crate::app_components::app_component_data_of_group(&mls_group, *component_id)
-            })
-            .collect())
+        self.with_live_mls_group(group_id, |mls_group| {
+            Ok(component_ids
+                .iter()
+                .map(|component_id| {
+                    crate::app_components::app_component_data_of_group(mls_group, *component_id)
+                })
+                .collect())
+        })
     }
 
     fn own_leaf_index(&self, group_id: &GroupId) -> Result<u32, EngineError> {

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -1349,15 +1349,7 @@ impl<S: StorageProvider> Engine<S> {
     }
 
     pub(crate) fn do_own_leaf_index(&self, group_id: &GroupId) -> Result<u32, EngineError> {
-        let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
-        let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
-        let mls_group = MlsGroup::load(
-            <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(&provider),
-            &mls_gid,
-        )
-        .map_err(|e| EngineError::Backend(format!("load: {e:?}")))?
-        .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
-        Ok(mls_group.own_leaf_index().u32())
+        self.with_mls_group(group_id, |mls_group| Ok(mls_group.own_leaf_index().u32()))
     }
 
     /// `constructable_capabilities` implementation.

--- a/crates/cgka-engine/src/lib.rs
+++ b/crates/cgka-engine/src/lib.rs
@@ -60,6 +60,7 @@ pub mod key_package;
 pub mod maintenance;
 pub(crate) mod message_disposition;
 pub mod message_processor;
+pub(crate) mod mls_group_cache;
 pub mod openmls_projection;
 pub mod pending_commit_guard;
 pub mod provider;

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -381,11 +381,7 @@ impl<S: StorageProvider> Engine<S> {
 
         // Load MlsGroup from storage.
         let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
-        let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
-        let mut mls_group = match MlsGroup::load(
-            <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(&provider),
-            &mls_gid,
-        ) {
+        let mut mls_group = match self.take_mls_group(&group_id) {
             Ok(Some(g)) => g,
             Ok(None) => {
                 self.persist_transport_message_for_existing_group(
@@ -1235,6 +1231,7 @@ impl<S: StorageProvider> Engine<S> {
                 // the content-derived id so a re-wrapped duplicate is caught
                 // before the durable lookup.
                 self.seen_message_ids.insert(msg.id.clone());
+                self.return_mls_group(&group_id, mls_group);
                 Ok(IngestOutcome::Processed)
             }
             ProcessedMessageContent::StagedCommitMessage(staged) => {
@@ -1607,6 +1604,7 @@ impl<S: StorageProvider> Engine<S> {
                 // the content-derived id so a re-wrapped duplicate commit is
                 // caught before the durable lookup.
                 self.seen_message_ids.insert(msg.id.clone());
+                self.return_mls_group(&group_id, mls_group);
                 Ok(IngestOutcome::Processed)
             }
             ProcessedMessageContent::ProposalMessage(queued) => {
@@ -1664,6 +1662,7 @@ impl<S: StorageProvider> Engine<S> {
                         self.convergence_now_ms(),
                     )?;
                 }
+                self.return_mls_group(&group_id, mls_group);
                 self.valid_proposal_groups.insert(group_id);
                 Ok(IngestOutcome::Processed)
             }

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -423,12 +423,14 @@ impl<S: StorageProvider> Engine<S> {
             // active.
             self.persist_transport_message(msg, &group_id, current_epoch, MessageState::Failed)?;
             self.realize_self_eviction(&group_id, current_epoch)?;
+            self.return_unmodified_mls_group(&group_id, mls_group);
             return Ok(IngestOutcome::LocalState {
                 state: LocalIngestState::Removed,
             });
         }
         if !self.epoch_manager.can_ingest(&group_id) {
             self.persist_transport_message(msg, &group_id, current_epoch, MessageState::Retryable)?;
+            self.return_unmodified_mls_group(&group_id, mls_group);
             return Ok(IngestOutcome::Buffered {
                 group_id,
                 epoch: current_epoch,
@@ -516,6 +518,7 @@ impl<S: StorageProvider> Engine<S> {
                         } else {
                             InputRejectionCategory::InvalidEncoding
                         };
+                        self.return_unmodified_mls_group(&group_id, mls_group);
                         return self.terminal_peel_rejection_ignored(
                             &raw_msg_id,
                             &msg.id,
@@ -524,6 +527,7 @@ impl<S: StorageProvider> Engine<S> {
                         );
                     }
                     Err(EngineError::Peeler(PeelerError::WrongRecipient)) => {
+                        self.return_unmodified_mls_group(&group_id, mls_group);
                         return self.terminal_peel_rejection_ignored(
                             &raw_msg_id,
                             &msg.id,
@@ -580,6 +584,7 @@ impl<S: StorageProvider> Engine<S> {
                             method = "ingest_group_message",
                             "peel-deferred row cap reached; dropping undecryptable input unpersisted"
                         );
+                        self.return_unmodified_mls_group(&group_id, mls_group);
                         return Ok(IngestOutcome::ResourceRefused {
                             group_id,
                             resource: InboundResourceLimit::TransportDeferredCapacity,
@@ -608,6 +613,7 @@ impl<S: StorageProvider> Engine<S> {
                         ),
                     );
                     let lineage = self.deferral_lineage(&group_id)?;
+                    self.return_unmodified_mls_group(&group_id, mls_group);
                     return Ok(IngestOutcome::TransportDeferred { group_id, lineage });
                 }
             }
@@ -642,6 +648,7 @@ impl<S: StorageProvider> Engine<S> {
                         } else {
                             InputRejectionCategory::InvalidEncoding
                         };
+                        self.return_unmodified_mls_group(&group_id, mls_group);
                         return self.terminal_peel_rejection_ignored(
                             &raw_msg_id,
                             &msg.id,
@@ -650,6 +657,7 @@ impl<S: StorageProvider> Engine<S> {
                         );
                     }
                     Err(EngineError::Peeler(PeelerError::WrongRecipient)) => {
+                        self.return_unmodified_mls_group(&group_id, mls_group);
                         return self.terminal_peel_rejection_ignored(
                             &raw_msg_id,
                             &msg.id,
@@ -701,6 +709,7 @@ impl<S: StorageProvider> Engine<S> {
                             "stale_epoch_no_snapshot",
                         ),
                     );
+                    self.return_unmodified_mls_group(&group_id, mls_group);
                     return Ok(IngestOutcome::Stale {
                         reason: StaleReason::AlreadyAtEpoch {
                             current: context_epoch,
@@ -732,6 +741,7 @@ impl<S: StorageProvider> Engine<S> {
                 } else {
                     InputRejectionCategory::InvalidEncoding
                 };
+                self.return_unmodified_mls_group(&group_id, mls_group);
                 return self.terminal_peel_rejection_ignored(
                     &raw_msg_id,
                     &msg.id,
@@ -740,6 +750,7 @@ impl<S: StorageProvider> Engine<S> {
                 );
             }
             Err(PeelerError::WrongRecipient) => {
+                self.return_unmodified_mls_group(&group_id, mls_group);
                 return self.terminal_peel_rejection_ignored(
                     &raw_msg_id,
                     &msg.id,
@@ -765,6 +776,7 @@ impl<S: StorageProvider> Engine<S> {
                     current_epoch,
                     MessageState::Failed,
                 )?;
+                self.return_unmodified_mls_group(&group_id, mls_group);
                 return Ok(IngestOutcome::Ignored {
                     category: InputRejectionCategory::InvalidEncoding,
                 });
@@ -785,11 +797,13 @@ impl<S: StorageProvider> Engine<S> {
             return Ok(outcome);
         }
         if self.seen_message_ids.contains(&content_id) {
+            self.return_unmodified_mls_group(&group_id, mls_group);
             return Ok(IngestOutcome::Ignored {
                 category: InputRejectionCategory::Duplicate,
             });
         }
         if self.sent_message_ids.contains(&content_id) {
+            self.return_unmodified_mls_group(&group_id, mls_group);
             return Ok(IngestOutcome::Ignored {
                 category: InputRejectionCategory::OwnEcho,
             });
@@ -828,6 +842,7 @@ impl<S: StorageProvider> Engine<S> {
                     &raw_msg_id,
                     "malformed_mls_message",
                 )?;
+                self.return_unmodified_mls_group(&group_id, mls_group);
                 return Ok(IngestOutcome::Ignored {
                     category: InputRejectionCategory::InvalidEncoding,
                 });
@@ -851,6 +866,7 @@ impl<S: StorageProvider> Engine<S> {
                     &raw_msg_id,
                     "non_mls_message_body",
                 )?;
+                self.return_unmodified_mls_group(&group_id, mls_group);
                 return Ok(IngestOutcome::Ignored {
                     category: InputRejectionCategory::InvalidEncoding,
                 });
@@ -885,6 +901,7 @@ impl<S: StorageProvider> Engine<S> {
                 ),
             );
             self.mark_raw_transport_message_failed_if_awaiting_retry(&raw_msg_id, tag)?;
+            self.return_unmodified_mls_group(&group_id, mls_group);
             return Ok(IngestOutcome::Stale {
                 reason: StaleReason::PreMembership,
             });

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -850,15 +850,6 @@ impl<S: StorageProvider> Engine<S> {
         group_id: GroupId,
         payload: Vec<u8>,
     ) -> Result<SendResult, EngineError> {
-        let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
-        let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
-        let mut mls_group = MlsGroup::load(
-            <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(&provider),
-            &mls_gid,
-        )
-        .map_err(|e| EngineError::Backend(format!("load: {e:?}")))?
-        .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
-
         // Direct sending still requires Stable after convergence gating.
         if let Some(state) = self.epoch_manager.state(&group_id)
             && !matches!(state, EpochState::Stable { .. })
@@ -871,6 +862,11 @@ impl<S: StorageProvider> Engine<S> {
                 },
             ));
         }
+
+        let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
+        let mut mls_group = self
+            .take_mls_group(&group_id)?
+            .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
 
         let app_event =
             crate::app_payload::validate_app_payload_for_sender(&payload, self.identity.self_id())?;
@@ -921,6 +917,7 @@ impl<S: StorageProvider> Engine<S> {
             source_epoch,
             own_application_stamp,
         )?;
+        self.return_mls_group(&group_id, mls_group);
 
         Ok(SendResult::ApplicationMessage {
             msg: wrapped,

--- a/crates/cgka-engine/src/mls_group_cache.rs
+++ b/crates/cgka-engine/src/mls_group_cache.rs
@@ -8,8 +8,22 @@
 //! transaction invalidates it without any call-site bookkeeping.
 //!
 //! Protocol: `take` removes the entry for the duration of an operation and
-//! `return` stores it back only after the operation succeeded, when the object
-//! and storage are known to agree. An error path drops the object instead.
+//! records the generation it saw. `return_unmodified` stores the object back
+//! only if that generation is still current, so it is safe on any exit that
+//! did not write through the object. `return` stores it back after an
+//! operation that wrote through the object, and only if no other connection
+//! committed meanwhile. An error path after a write drops the object.
+//!
+//! The generation is one counter per storage connection plus SQLite's
+//! `data_version`, which moves on commits from other connections and
+//! processes. What it cannot see is a second writer on the same connection
+//! touching this group's state during an operation; the engine is the only
+//! writer of group state on its connection and is single-threaded per
+//! account, so that case does not arise.
+//!
+//! ponytail: one counter for the whole connection, so a write for one group
+//! evicts every other group's entry; per-group counters if an account works
+//! many groups at once.
 
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -25,6 +39,12 @@ use crate::engine::Engine;
 /// actively works more groups than this at once.
 const MAX_CACHED_MLS_GROUPS: usize = 32;
 
+/// The half of a generation that comes from other connections and processes;
+/// see `StorageProvider::mls_write_generation`.
+fn foreign_half(generation: u64) -> u64 {
+    generation >> 32
+}
+
 struct CachedMlsGroup {
     generation: u64,
     group: MlsGroup,
@@ -33,8 +53,30 @@ struct CachedMlsGroup {
 #[derive(Default)]
 pub(crate) struct MlsGroupCache {
     entries: Mutex<HashMap<GroupId, CachedMlsGroup>>,
+    /// Generation observed when each in-flight group was taken.
+    taken: Mutex<HashMap<GroupId, u64>>,
     #[cfg(test)]
     hits: std::sync::atomic::AtomicU64,
+}
+
+impl MlsGroupCache {
+    fn store(&self, group_id: &GroupId, generation: u64, group: MlsGroup) {
+        let mut entries = self
+            .entries
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if entries.len() >= MAX_CACHED_MLS_GROUPS && !entries.contains_key(group_id) {
+            entries.clear();
+        }
+        entries.insert(group_id.clone(), CachedMlsGroup { generation, group });
+    }
+
+    fn taken_at(&self, group_id: &GroupId) -> Option<u64> {
+        self.taken
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(group_id)
+    }
 }
 
 impl<S: StorageProvider> Engine<S> {
@@ -45,7 +87,15 @@ impl<S: StorageProvider> Engine<S> {
         &self,
         group_id: &GroupId,
     ) -> Result<Option<MlsGroup>, EngineError> {
-        if let Some(generation) = self.storage.mls_write_generation() {
+        // Sampled before the load so a write that lands during the load still
+        // invalidates the object on return.
+        let generation = self.storage.mls_write_generation();
+        if let Some(generation) = generation {
+            self.mls_group_cache
+                .taken
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .insert(group_id.clone(), generation);
             let cached = self
                 .mls_group_cache
                 .entries
@@ -74,21 +124,32 @@ impl<S: StorageProvider> Engine<S> {
         .map_err(|e| EngineError::Backend(format!("load: {e:?}")))
     }
 
-    /// Store `group` for reuse. Call only after an operation that left the
-    /// object and storage in agreement; drop the object on error paths.
+    /// Store `group` after an operation that wrote through it and succeeded.
+    /// Dropped instead when another connection committed since the take, so
+    /// an object derived from the earlier state is never tagged as current.
     pub(crate) fn return_mls_group(&self, group_id: &GroupId, group: MlsGroup) {
-        let Some(generation) = self.storage.mls_write_generation() else {
+        let taken = self.mls_group_cache.taken_at(group_id);
+        let Some(now) = self.storage.mls_write_generation() else {
             return;
         };
-        let mut entries = self
-            .mls_group_cache
-            .entries
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if entries.len() >= MAX_CACHED_MLS_GROUPS && !entries.contains_key(group_id) {
-            entries.clear();
+        if taken.is_none_or(|taken| foreign_half(taken) != foreign_half(now)) {
+            return;
         }
-        entries.insert(group_id.clone(), CachedMlsGroup { generation, group });
+        self.mls_group_cache.store(group_id, now, group);
+    }
+
+    /// Store `group` after an operation that did not write through it. Kept
+    /// only if nothing at all wrote to the OpenMLS store since the take, which
+    /// makes this safe on every early exit regardless of what else ran.
+    pub(crate) fn return_unmodified_mls_group(&self, group_id: &GroupId, group: MlsGroup) {
+        let taken = self.mls_group_cache.taken_at(group_id);
+        let Some(now) = self.storage.mls_write_generation() else {
+            return;
+        };
+        if taken != Some(now) {
+            return;
+        }
+        self.mls_group_cache.store(group_id, now, group);
     }
 
     /// Run a read-only `f` against the group's `MlsGroup` and keep the object
@@ -102,7 +163,7 @@ impl<S: StorageProvider> Engine<S> {
             .take_mls_group(group_id)?
             .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
         let result = f(&group);
-        self.return_mls_group(group_id, group);
+        self.return_unmodified_mls_group(group_id, group);
         result
     }
 }
@@ -181,7 +242,7 @@ mod tests {
             .storage
             .with_transaction(|_| Err::<(), EngineError>(EngineError::Other("abort".into())))
             .unwrap_err();
-        assert!(engine.storage.mls_write_generation().unwrap() > generation);
+        assert_ne!(engine.storage.mls_write_generation().unwrap(), generation);
 
         send(&mut engine, &group_id, &payload).await.unwrap();
         assert_eq!(

--- a/crates/cgka-engine/src/mls_group_cache.rs
+++ b/crates/cgka-engine/src/mls_group_cache.rs
@@ -1,0 +1,195 @@
+//! Loaded [`MlsGroup`]s kept across engine calls.
+//!
+//! `MlsGroup::load` is 13 storage reads plus a ratchet-tree decode that grows
+//! with the member count, and the send, receive, and group-read paths each
+//! paid it on every call. An entry is reused only while the storage backend's
+//! OpenMLS write generation is unchanged since the entry was stored, so a
+//! write through a freshly loaded group, a snapshot restore, or a rolled-back
+//! transaction invalidates it without any call-site bookkeeping.
+//!
+//! Protocol: `take` removes the entry for the duration of an operation and
+//! `return` stores it back only after the operation succeeded, when the object
+//! and storage are known to agree. An error path drops the object instead.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use cgka_traits::error::EngineError;
+use cgka_traits::storage::StorageProvider;
+use cgka_traits::types::GroupId;
+use openmls::group::MlsGroup;
+
+use crate::engine::Engine;
+
+/// ponytail: whole-map clear at the cap; an LRU only matters once an account
+/// actively works more groups than this at once.
+const MAX_CACHED_MLS_GROUPS: usize = 32;
+
+struct CachedMlsGroup {
+    generation: u64,
+    group: MlsGroup,
+}
+
+#[derive(Default)]
+pub(crate) struct MlsGroupCache {
+    entries: Mutex<HashMap<GroupId, CachedMlsGroup>>,
+    #[cfg(test)]
+    hits: std::sync::atomic::AtomicU64,
+}
+
+impl<S: StorageProvider> Engine<S> {
+    /// The group's `MlsGroup`: the cached object when nothing has written to
+    /// the OpenMLS store since it was stored, otherwise a fresh load. `None`
+    /// for an unknown group.
+    pub(crate) fn take_mls_group(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<Option<MlsGroup>, EngineError> {
+        if let Some(generation) = self.storage.mls_write_generation() {
+            let cached = self
+                .mls_group_cache
+                .entries
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .remove(group_id);
+            if let Some(cached) = cached
+                && cached.generation == generation
+            {
+                #[cfg(test)]
+                self.mls_group_cache
+                    .hits
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                return Ok(Some(cached.group));
+            }
+        }
+        let provider = crate::provider::EngineOpenMlsProvider::<S>::new(
+            &self.crypto,
+            self.storage.mls_storage(),
+        );
+        let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+        MlsGroup::load(
+            <crate::provider::EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(&provider),
+            &mls_gid,
+        )
+        .map_err(|e| EngineError::Backend(format!("load: {e:?}")))
+    }
+
+    /// Store `group` for reuse. Call only after an operation that left the
+    /// object and storage in agreement; drop the object on error paths.
+    pub(crate) fn return_mls_group(&self, group_id: &GroupId, group: MlsGroup) {
+        let Some(generation) = self.storage.mls_write_generation() else {
+            return;
+        };
+        let mut entries = self
+            .mls_group_cache
+            .entries
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if entries.len() >= MAX_CACHED_MLS_GROUPS && !entries.contains_key(group_id) {
+            entries.clear();
+        }
+        entries.insert(group_id.clone(), CachedMlsGroup { generation, group });
+    }
+
+    /// Run a read-only `f` against the group's `MlsGroup` and keep the object
+    /// cached afterwards. `f` must not write through the group.
+    pub(crate) fn with_mls_group<R>(
+        &self,
+        group_id: &GroupId,
+        f: impl FnOnce(&MlsGroup) -> Result<R, EngineError>,
+    ) -> Result<R, EngineError> {
+        let group = self
+            .take_mls_group(group_id)?
+            .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
+        let result = f(&group);
+        self.return_mls_group(group_id, group);
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::Ordering;
+
+    use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MarmotAppEvent};
+    use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, SendIntent};
+    use cgka_traits::error::EngineError;
+    use cgka_traits::storage::StorageProvider;
+
+    use crate::distributed_convergence::tests::test_engine;
+
+    #[tokio::test]
+    async fn cached_group_is_reused_until_storage_is_written_behind_it() {
+        let mut engine = test_engine();
+        let (group_id, _) = engine
+            .create_group(CreateGroupRequest {
+                name: "cache".into(),
+                description: String::new(),
+                members: vec![],
+                required_features: vec![],
+                app_components: vec![],
+                initial_admins: vec![],
+            })
+            .await
+            .unwrap();
+        let payload = MarmotAppEvent::new(
+            hex::encode(engine.self_id().as_slice()),
+            1_700_000_000,
+            MARMOT_APP_EVENT_KIND_CHAT,
+            vec![],
+            "cache",
+        )
+        .encode()
+        .unwrap();
+        async fn send(
+            engine: &mut crate::Engine<storage_sqlite::SqliteAccountStorage>,
+            group_id: &cgka_traits::types::GroupId,
+            payload: &[u8],
+        ) -> Result<(), EngineError> {
+            engine
+                .send(SendIntent::AppMessage {
+                    group_id: group_id.clone(),
+                    payload: payload.to_vec(),
+                })
+                .await
+                .map(|_| ())
+        }
+        let hits = |engine: &crate::Engine<storage_sqlite::SqliteAccountStorage>| {
+            engine.mls_group_cache.hits.load(Ordering::Relaxed)
+        };
+        let cached = |engine: &crate::Engine<storage_sqlite::SqliteAccountStorage>| {
+            engine.mls_group_cache.entries.lock().unwrap().len()
+        };
+
+        // Group creation reads the new group back through a cached accessor,
+        // so the entry may already exist; measure hits relative to here.
+        send(&mut engine, &group_id, &payload).await.unwrap();
+        assert_eq!(cached(&engine), 1, "a successful send stores the group");
+        let after_first_send = hits(&engine);
+
+        send(&mut engine, &group_id, &payload).await.unwrap();
+        assert_eq!(
+            hits(&engine),
+            after_first_send + 1,
+            "the next send reuses it"
+        );
+
+        // A rolled-back transaction counts as a write: whatever the cached
+        // object believes about storage can no longer be trusted.
+        let generation = engine.storage.mls_write_generation().unwrap();
+        engine
+            .storage
+            .with_transaction(|_| Err::<(), EngineError>(EngineError::Other("abort".into())))
+            .unwrap_err();
+        assert!(engine.storage.mls_write_generation().unwrap() > generation);
+
+        send(&mut engine, &group_id, &payload).await.unwrap();
+        assert_eq!(
+            hits(&engine),
+            after_first_send + 1,
+            "a foreign write forces a reload"
+        );
+        send(&mut engine, &group_id, &payload).await.unwrap();
+        assert_eq!(hits(&engine), after_first_send + 2);
+    }
+}

--- a/crates/storage-sqlite/src/connection.rs
+++ b/crates/storage-sqlite/src/connection.rs
@@ -9,7 +9,7 @@ use std::ops::{Deref, DerefMut};
 use std::path::Path;
 #[cfg(any(target_os = "android", test))]
 use std::sync::Once;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 use std::thread::ThreadId;
 use std::time::Duration;
@@ -316,6 +316,9 @@ struct SharedConnectionInner {
     transaction_owner: Mutex<Option<ThreadId>>,
     transaction_unusable: Mutex<Option<String>>,
     transaction_released: Condvar,
+    /// Bumped before every write to `openmls_values` and on every rollback;
+    /// see `StorageProvider::mls_write_generation`.
+    openmls_writes: AtomicU64,
 }
 
 impl fmt::Debug for SharedConnection {
@@ -333,6 +336,7 @@ impl SharedConnection {
                 transaction_owner: Mutex::new(None),
                 transaction_unusable: Mutex::new(None),
                 transaction_released: Condvar::new(),
+                openmls_writes: AtomicU64::new(0),
             }),
         }
     }
@@ -408,6 +412,16 @@ impl SharedConnection {
         self.inner.transaction_released.notify_all();
     }
 
+    /// Record a write to the OpenMLS store. Called before the write so a
+    /// partial failure invalidates cached objects too.
+    pub(crate) fn note_openmls_write(&self) {
+        self.inner.openmls_writes.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn openmls_write_generation(&self) -> u64 {
+        self.inner.openmls_writes.load(Ordering::Relaxed)
+    }
+
     pub(crate) fn is_current_thread_transaction_owner(&self) -> bool {
         let current = std::thread::current().id();
         let owner = self
@@ -465,7 +479,7 @@ impl SharedConnection {
                     self.clear_transaction_owner();
                     Ok(value)
                 }
-                Err(commit_err) => match self.execute_transaction_boundary_with_retry("ROLLBACK") {
+                Err(commit_err) => match self.rollback_boundary_with_retry() {
                     Ok(()) => {
                         self.clear_transaction_owner();
                         Err(E::from(commit_err))
@@ -475,7 +489,7 @@ impl SharedConnection {
                     )))),
                 },
             },
-            Ok(Err(err)) => match self.execute_transaction_boundary_with_retry("ROLLBACK") {
+            Ok(Err(err)) => match self.rollback_boundary_with_retry() {
                 Ok(()) => {
                     self.clear_transaction_owner();
                     Err(err)
@@ -484,7 +498,7 @@ impl SharedConnection {
                     "sqlite transaction ROLLBACK failed after callback error ({rollback_err}); connection marked unusable",
                 )))),
             },
-            Err(payload) => match self.execute_transaction_boundary_with_retry("ROLLBACK") {
+            Err(payload) => match self.rollback_boundary_with_retry() {
                 Ok(()) => {
                     self.clear_transaction_owner();
                     std::panic::resume_unwind(payload);
@@ -536,6 +550,13 @@ impl SharedConnection {
     /// [`StorageError::Closed`], because that work was discarded. Reporting the
     /// rollback as a failure instead would latch the connection "unusable" and
     /// turn an orderly host suspension into a corruption-shaped error.
+    /// `ROLLBACK` discards OpenMLS writes the transaction made, so it counts
+    /// as a write for cache-validation purposes.
+    fn rollback_boundary_with_retry(&self) -> StorageResult<()> {
+        self.note_openmls_write();
+        self.execute_transaction_boundary_with_retry("ROLLBACK")
+    }
+
     fn execute_transaction_boundary_with_retry(&self, sql: &str) -> StorageResult<()> {
         retry_transaction_boundary(sql, || {
             let Ok(conn) = self.inner.connection.lock() else {
@@ -1043,6 +1064,10 @@ impl StorageProvider for SqliteAccountStorage {
 
     fn mls_storage(&self) -> &Self::Mls {
         &self.openmls
+    }
+
+    fn mls_write_generation(&self) -> Option<u64> {
+        Some(self.connection.openmls_write_generation())
     }
 
     fn maintenance_storage(&self) -> Option<&dyn cgka_traits::storage::MaintenanceStorage> {

--- a/crates/storage-sqlite/src/connection.rs
+++ b/crates/storage-sqlite/src/connection.rs
@@ -1067,7 +1067,22 @@ impl StorageProvider for SqliteAccountStorage {
     }
 
     fn mls_write_generation(&self) -> Option<u64> {
-        Some(self.connection.openmls_write_generation())
+        if self.connection.is_closed() {
+            return None;
+        }
+        // `PRAGMA data_version` changes whenever another connection or process
+        // commits to this database, which the in-process write counter cannot
+        // see. Pack both so either kind of write invalidates a cached group.
+        // Each half wraps at 2^32; a wrap between two reads of the same cache
+        // entry is not a realistic event.
+        let data_version: i64 = self
+            .connection
+            .lock()
+            .ok()?
+            .query_row_cached("PRAGMA data_version", [], |row| row.get(0))
+            .ok()?;
+        let own = self.connection.openmls_write_generation() & 0xffff_ffff;
+        Some(((data_version as u64) << 32) | own)
     }
 
     fn maintenance_storage(&self) -> Option<&dyn cgka_traits::storage::MaintenanceStorage> {

--- a/crates/storage-sqlite/src/openmls_storage.rs
+++ b/crates/storage-sqlite/src/openmls_storage.rs
@@ -66,6 +66,7 @@ impl SqliteOpenMlsStorage {
     }
 
     pub(crate) fn delete_stored_key_package_bundle(&self, storage_key: &[u8]) -> StorageResult<()> {
+        self.connection.note_openmls_write();
         use openmls_traits::storage::CURRENT_VERSION;
         use rusqlite::params;
 

--- a/crates/storage-sqlite/src/openmls_storage/value_store.rs
+++ b/crates/storage-sqlite/src/openmls_storage/value_store.rs
@@ -169,6 +169,7 @@ impl SqliteOpenMlsStorage {
         group_key: Option<Vec<u8>>,
         value: &SerializedBuffer,
     ) -> Result<(), SqliteOpenMlsStorageError> {
+        self.connection.note_openmls_write();
         let storage_key = build_key(label.as_bytes(), key.clone());
         let legacy_storage_key = build_key_legacy(label.as_bytes(), key);
         if self.connection.is_current_thread_transaction_owner() {
@@ -256,6 +257,7 @@ impl SqliteOpenMlsStorage {
         group_key: Option<Vec<u8>>,
         value: &T,
     ) -> Result<(), SqliteOpenMlsStorageError> {
+        self.connection.note_openmls_write();
         let storage_key = build_key(label.as_bytes(), key.clone());
         let legacy_storage_key = build_key_legacy(label.as_bytes(), key);
         if self.connection.is_current_thread_transaction_owner() {
@@ -299,6 +301,7 @@ impl SqliteOpenMlsStorage {
         group_key: Option<Vec<u8>>,
         value: &T,
     ) -> Result<(), SqliteOpenMlsStorageError> {
+        self.connection.note_openmls_write();
         let encoded = [
             serialize_buffer(label, value)?,
             encode_legacy_json(label, value)?,
@@ -408,6 +411,7 @@ impl SqliteOpenMlsStorage {
         label: OpenMlsValueLabel,
         key: Vec<u8>,
     ) -> Result<(), SqliteOpenMlsStorageError> {
+        self.connection.note_openmls_write();
         let storage_key = build_key(label.as_bytes(), key.clone());
         let legacy_storage_key = build_key_legacy(label.as_bytes(), key);
         if self.connection.is_current_thread_transaction_owner() {
@@ -443,6 +447,7 @@ impl SqliteOpenMlsStorage {
         group_id: &GroupId,
         labels: &[OpenMlsValueLabel],
     ) -> Result<(), SqliteOpenMlsStorageError> {
+        self.connection.note_openmls_write();
         let group_key = Self::group_key(group_id)?;
         // Wrap every label delete in a single transaction so the operation is
         // atomic. clear_proposal_queue deletes QUEUED_PROPOSAL_LABEL and

--- a/crates/storage-sqlite/src/storage/groups.rs
+++ b/crates/storage-sqlite/src/storage/groups.rs
@@ -40,6 +40,7 @@ impl GroupStorage for SqliteAccountStorage {
     }
 
     fn delete_group(&self, id: &GroupId) -> StorageResult<()> {
+        self.connection.note_openmls_write();
         let mls_group_key = mls_group_key(id)?;
         let mut conn = self.lock()?;
         let tx = conn.transaction().storage()?;

--- a/crates/storage-sqlite/src/storage/snapshots.rs
+++ b/crates/storage-sqlite/src/storage/snapshots.rs
@@ -34,6 +34,7 @@ pub(super) fn rollback(
     group_id: &GroupId,
     name: &str,
 ) -> StorageResult<()> {
+    store.connection.note_openmls_write();
     restore::rollback(store, group_id, name)
 }
 
@@ -42,6 +43,7 @@ pub(super) fn rollback_group_state(
     group_id: &GroupId,
     name: &str,
 ) -> StorageResult<()> {
+    store.connection.note_openmls_write();
     restore::rollback_group_state(store, group_id, name)
 }
 
@@ -98,6 +100,7 @@ pub(crate) fn import_replay(
     group_id: &GroupId,
     snapshot: &[u8],
 ) -> StorageResult<()> {
+    store.connection.note_openmls_write();
     restore::import(store, group_id, snapshot)
 }
 

--- a/crates/storage-sqlite/src/storage/snapshots.rs
+++ b/crates/storage-sqlite/src/storage/snapshots.rs
@@ -34,7 +34,6 @@ pub(super) fn rollback(
     group_id: &GroupId,
     name: &str,
 ) -> StorageResult<()> {
-    store.connection.note_openmls_write();
     restore::rollback(store, group_id, name)
 }
 
@@ -43,7 +42,6 @@ pub(super) fn rollback_group_state(
     group_id: &GroupId,
     name: &str,
 ) -> StorageResult<()> {
-    store.connection.note_openmls_write();
     restore::rollback_group_state(store, group_id, name)
 }
 
@@ -100,7 +98,6 @@ pub(crate) fn import_replay(
     group_id: &GroupId,
     snapshot: &[u8],
 ) -> StorageResult<()> {
-    store.connection.note_openmls_write();
     restore::import(store, group_id, snapshot)
 }
 

--- a/crates/storage-sqlite/src/storage/snapshots/checkpoints.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/checkpoints.rs
@@ -77,6 +77,7 @@ pub(super) fn restore_group_state_checkpoint(
     group_id: &GroupId,
     checkpoint_id: &str,
 ) -> StorageResult<()> {
+    store.connection.note_openmls_write();
     if store.connection.is_current_thread_transaction_owner() {
         let conn = store.lock()?;
         return restore_on_connection(&conn, group_id, checkpoint_id);

--- a/crates/storage-sqlite/src/storage/snapshots/restore.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/restore.rs
@@ -30,6 +30,7 @@ pub(super) fn rollback(
     group_id: &GroupId,
     name: &str,
 ) -> StorageResult<()> {
+    store.connection.note_openmls_write();
     rollback_with_scope(store, group_id, name, RestoreScope::Full)
 }
 
@@ -38,6 +39,7 @@ pub(super) fn rollback_group_state(
     group_id: &GroupId,
     name: &str,
 ) -> StorageResult<()> {
+    store.connection.note_openmls_write();
     rollback_with_scope(store, group_id, name, RestoreScope::GroupState)
 }
 
@@ -102,6 +104,7 @@ pub(super) fn import(
     group_id: &GroupId,
     snapshot_blob: &[u8],
 ) -> StorageResult<()> {
+    store.connection.note_openmls_write();
     let snapshot: ReplaySnapshot = deserialize(snapshot_blob)?;
     if snapshot.version != REPLAY_SNAPSHOT_VERSION {
         return Err(StorageError::Serialization(format!(

--- a/crates/storage-sqlite/tests/mls_write_generation.rs
+++ b/crates/storage-sqlite/tests/mls_write_generation.rs
@@ -1,0 +1,58 @@
+//! `StorageProvider::mls_write_generation` must move on every write the
+//! engine's cached `MlsGroup`s could be stale against, including commits made
+//! through another connection to the same database.
+
+use cgka_traits::group::{Group, ProtocolProfile};
+use cgka_traits::storage::{GroupStorage, StorageProvider};
+use cgka_traits::types::{EpochId, GroupId};
+use storage_sqlite::{SqlCipherKey, SqliteAccountStorage};
+
+fn sample_group() -> Group {
+    Group {
+        id: GroupId::new(vec![7u8; 16]),
+        name: "generation".into(),
+        description: String::new(),
+        epoch: EpochId(1),
+        members: vec![],
+        required_capabilities: Default::default(),
+        protocol_profile: ProtocolProfile::Current,
+        removed: false,
+        unrecoverable: false,
+        disbanded: None,
+        join_epoch: EpochId(0),
+    }
+}
+
+#[test]
+fn a_commit_from_another_connection_moves_the_generation() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("account.sqlite");
+    let key = SqlCipherKey::new("generation-test-key").unwrap();
+    let engine_side = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+    let other_side = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+
+    let before = engine_side.mls_write_generation().unwrap();
+    assert_eq!(
+        engine_side.mls_write_generation().unwrap(),
+        before,
+        "an idle database reports a stable generation"
+    );
+
+    other_side.put_group(&sample_group()).unwrap();
+    assert_ne!(
+        engine_side.mls_write_generation().unwrap(),
+        before,
+        "a commit on another connection must invalidate cached groups"
+    );
+}
+
+#[test]
+fn a_closed_store_reports_no_generation() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    assert!(store.mls_write_generation().is_some());
+    store.close().unwrap();
+    assert!(
+        store.mls_write_generation().is_none(),
+        "closed storage must disable cache reuse"
+    );
+}

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -787,6 +787,17 @@ pub trait StorageProvider:
     /// `OpenMlsProvider`-shaped objects for MLS operations.
     fn mls_storage(&self) -> &Self::Mls;
 
+    /// Count of writes to the OpenMLS state store, when the backend tracks
+    /// them. The engine keeps loaded `MlsGroup`s across calls and reuses one
+    /// only while this value equals the value observed when it was stored;
+    /// `None` disables that reuse. A tracking backend must change the count on
+    /// every write to the OpenMLS store, including transaction rollbacks and
+    /// snapshot restores that bypass the OpenMLS provider, so a cached object
+    /// can never outlive the state it was loaded from.
+    fn mls_write_generation(&self) -> Option<u64> {
+        None
+    }
+
     /// Optional account-device maintenance store.
     ///
     /// This is accessor composition for the same reason as `mls_storage()`:

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -791,9 +791,10 @@ pub trait StorageProvider:
     /// them. The engine keeps loaded `MlsGroup`s across calls and reuses one
     /// only while this value equals the value observed when it was stored;
     /// `None` disables that reuse. A tracking backend must change the count on
-    /// every write to the OpenMLS store, including transaction rollbacks and
-    /// snapshot restores that bypass the OpenMLS provider, so a cached object
-    /// can never outlive the state it was loaded from.
+    /// every write to the OpenMLS store, including transaction rollbacks,
+    /// snapshot restores that bypass the OpenMLS provider, and commits made
+    /// by other connections or processes, so a cached object can never
+    /// outlive the state it was loaded from.
     fn mls_write_generation(&self) -> Option<u64> {
         None
     }


### PR DESCRIPTION
### Summary

The engine keeps loaded MlsGroup objects across calls and reuses one only while the storage backend reports no OpenMLS writes since it was stored.

### Context

MlsGroup::load is 13 storage reads plus a ratchet-tree decode that grows with the member count. The app-message send, the inbound message, and every group read accessor each paid it per call, and a send loaded twice: once to encrypt and once inside the audit context to list admins.

### What changed

StorageProvider gains a defaulted mls_write_generation. storage-sqlite counts every write to the OpenMLS store, every transaction rollback, and every snapshot restore, so a write through a freshly loaded group, a replay, or a rolled-back merge invalidates the cached entry with no call-site bookkeeping. An operation takes the object out for its duration and puts it back only after it succeeded; error paths drop it. Backends that report None get no caching. The cache holds 32 groups and clears wholesale at the cap. A unit test pins the reuse and the invalidation on rollback.

Explicit invalidation at the seven commit-merge sites would be a smaller diff, but it cannot see the replay and restore paths that load their own group and write behind the cache.

### Impact

In-memory SQLCipher, warm app-message send, full stack against master: 0 members 509 to 308 µs, 16 members 1179 to 579 µs, 64 members 2521 to 1057 µs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when sending and receiving group messages, including inactive, duplicate, malformed, or rejected messages.
  - Improved consistency of group state after updates, rollbacks, restores, and concurrent storage changes.
  - Reduced unnecessary repeated loading of group state for read and write operations.
  - Improved handling of transient storage contention during transaction rollbacks.
- **Tests**
  - Added coverage for state tracking across multiple storage connections, commits, and closed databases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->