### PR TITLE
Read one group without loading the whole projection

### DIFF
--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -4916,11 +4916,15 @@ impl MarmotApp {
     }
 
     fn ensure_chat_list_projection(&self, account: &AccountSummary) -> Result<(), AppError> {
+        // Snapshot the obligation; it is cleared only after the refresh
+        // succeeded, so an error leaves every unrefreshed id dirty for the
+        // next read, and ids marked while the refresh ran stay dirty too.
         let stale = self
             .chat_list_projection_stale
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .remove(&account.label);
+            .get(&account.label)
+            .cloned();
         let warmed = self
             .chat_list_projection_warmed
             .lock()
@@ -4928,18 +4932,30 @@ impl MarmotApp {
             .contains(&account.label);
         let storage = self.account_storage(&account.label)?;
         let classifier = Self::chat_list_mention_classifier(&account.account_id_hex);
-        match stale {
+        match &stale {
             None if warmed => return Ok(()),
             Some(group_ids) if warmed => {
                 for group_id_hex in group_ids {
                     storage.refresh_chat_list_row(
                         &account.account_id_hex,
-                        &group_id_hex,
+                        group_id_hex,
                         &classifier,
                     )?;
                 }
             }
             _ => storage.ensure_chat_list_rows(&account.account_id_hex, &classifier)?,
+        }
+        if let Some(refreshed) = stale {
+            let mut dirty = self
+                .chat_list_projection_stale
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if let Some(remaining) = dirty.get_mut(&account.label) {
+                remaining.retain(|group_id_hex| !refreshed.contains(group_id_hex));
+                if remaining.is_empty() {
+                    dirty.remove(&account.label);
+                }
+            }
         }
         self.chat_list_projection_warmed
             .lock()

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -607,9 +607,12 @@ pub struct MarmotApp {
     account_state_ready: Arc<Mutex<HashSet<String>>>,
     chat_list_projection_warmed: Arc<Mutex<HashSet<String>>>,
     /// Per account label, the group ids whose chat-list row must be refreshed
-    /// before the next `chat_list()` answers. A single received message used
-    /// to mark the whole projection stale and rebuild every row.
-    chat_list_projection_stale: Arc<Mutex<HashMap<String, HashSet<String>>>>,
+    /// before the next `chat_list()` answers, each with a generation that
+    /// bumps on every mark. A refresh snapshots the map, refreshes the rows,
+    /// and drops only ids whose generation is unchanged, so a mark that raced
+    /// the refresh stays dirty. A single received message used to mark the
+    /// whole projection stale and rebuild every row.
+    chat_list_projection_stale: Arc<Mutex<HashMap<String, HashMap<String, u64>>>>,
     audit_log_tracker_config: Arc<Mutex<AuditLogTrackerConfig>>,
     external_signers: Arc<Mutex<HashMap<String, RegisteredExternalSigner>>>,
     /// One signer-bound publisher per account. Setup publishes and the managed
@@ -3192,6 +3195,9 @@ impl MarmotApp {
         self.ensure_account_state(&account.label)?;
         self.account_storage(&account.label)?
             .set_group_self_membership(group_id_hex, membership)?;
+        // This write bypasses the projection save, so the row's dirty mark
+        // must come from here or a warm chat list keeps the old membership.
+        self.mark_chat_list_stale(&account.label, HashSet::from([group_id_hex.to_owned()]));
         Ok(())
     }
 
@@ -4770,12 +4776,34 @@ impl MarmotApp {
     }
 
     fn mark_chat_list_stale(&self, label: &str, group_ids_hex: HashSet<String>) {
-        self.chat_list_projection_stale
+        if group_ids_hex.is_empty() {
+            return;
+        }
+        let mut stale = self
+            .chat_list_projection_stale
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .entry(label.to_owned())
-            .or_default()
-            .extend(group_ids_hex);
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let dirty = stale.entry(label.to_owned()).or_default();
+        for group_id_hex in group_ids_hex {
+            *dirty.entry(group_id_hex).or_insert(0) += 1;
+        }
+    }
+
+    /// Forget the dirty marks a refresh satisfied. An id whose generation
+    /// moved since the snapshot was re-marked during the refresh and stays.
+    fn clear_refreshed_chat_list_groups(&self, label: &str, refreshed: &HashMap<String, u64>) {
+        let mut stale = self
+            .chat_list_projection_stale
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let Some(remaining) = stale.get_mut(label) else {
+            return;
+        };
+        remaining
+            .retain(|group_id_hex, generation| refreshed.get(group_id_hex) != Some(generation));
+        if remaining.is_empty() {
+            stale.remove(label);
+        }
     }
 
     fn save_state_delta_clearing_local_group_deletion_frontiers_and_acking_application_events(
@@ -4918,7 +4946,8 @@ impl MarmotApp {
     fn ensure_chat_list_projection(&self, account: &AccountSummary) -> Result<(), AppError> {
         // Snapshot the obligation; it is cleared only after the refresh
         // succeeded, so an error leaves every unrefreshed id dirty for the
-        // next read, and ids marked while the refresh ran stay dirty too.
+        // next read, and ids marked while the refresh ran stay dirty too
+        // (their generation no longer matches the snapshot).
         let stale = self
             .chat_list_projection_stale
             .lock()
@@ -4935,7 +4964,7 @@ impl MarmotApp {
         match &stale {
             None if warmed => return Ok(()),
             Some(group_ids) if warmed => {
-                for group_id_hex in group_ids {
+                for group_id_hex in group_ids.keys() {
                     storage.refresh_chat_list_row(
                         &account.account_id_hex,
                         group_id_hex,
@@ -4946,16 +4975,7 @@ impl MarmotApp {
             _ => storage.ensure_chat_list_rows(&account.account_id_hex, &classifier)?,
         }
         if let Some(refreshed) = stale {
-            let mut dirty = self
-                .chat_list_projection_stale
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            if let Some(remaining) = dirty.get_mut(&account.label) {
-                remaining.retain(|group_id_hex| !refreshed.contains(group_id_hex));
-                if remaining.is_empty() {
-                    dirty.remove(&account.label);
-                }
-            }
+            self.clear_refreshed_chat_list_groups(&account.label, &refreshed);
         }
         self.chat_list_projection_warmed
             .lock()

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -606,7 +606,10 @@ pub struct MarmotApp {
     shared_storage: Arc<Mutex<Option<SqliteSharedStorage>>>,
     account_state_ready: Arc<Mutex<HashSet<String>>>,
     chat_list_projection_warmed: Arc<Mutex<HashSet<String>>>,
-    chat_list_projection_stale: Arc<Mutex<HashSet<String>>>,
+    /// Per account label, the group ids whose chat-list row must be refreshed
+    /// before the next `chat_list()` answers. A single received message used
+    /// to mark the whole projection stale and rebuild every row.
+    chat_list_projection_stale: Arc<Mutex<HashMap<String, HashSet<String>>>>,
     audit_log_tracker_config: Arc<Mutex<AuditLogTrackerConfig>>,
     external_signers: Arc<Mutex<HashMap<String, RegisteredExternalSigner>>>,
     /// One signer-bound publisher per account. Setup publishes and the managed
@@ -1454,7 +1457,7 @@ impl MarmotApp {
             shared_storage: Arc::new(Mutex::new(None)),
             account_state_ready: Arc::new(Mutex::new(HashSet::new())),
             chat_list_projection_warmed: Arc::new(Mutex::new(HashSet::new())),
-            chat_list_projection_stale: Arc::new(Mutex::new(HashSet::new())),
+            chat_list_projection_stale: Arc::new(Mutex::new(HashMap::new())),
             audit_log_tracker_config: Arc::new(Mutex::new(AuditLogTrackerConfig::default())),
             external_signers: Arc::new(Mutex::new(HashMap::new())),
             account_publish_clients: Arc::new(Mutex::new(HashMap::new())),
@@ -1528,7 +1531,7 @@ impl MarmotApp {
             shared_storage: Arc::new(Mutex::new(None)),
             account_state_ready: Arc::new(Mutex::new(HashSet::new())),
             chat_list_projection_warmed: Arc::new(Mutex::new(HashSet::new())),
-            chat_list_projection_stale: Arc::new(Mutex::new(HashSet::new())),
+            chat_list_projection_stale: Arc::new(Mutex::new(HashMap::new())),
             audit_log_tracker_config: Arc::new(Mutex::new(AuditLogTrackerConfig::default())),
             external_signers: Arc::new(Mutex::new(HashMap::new())),
             account_publish_clients: Arc::new(Mutex::new(HashMap::new())),
@@ -3369,13 +3372,24 @@ impl MarmotApp {
     pub fn groups(&self, label: &str) -> Result<Vec<AppGroupRecord>, AppError> {
         self.ensure_account_state(label)?;
         let mut groups = self.load_state(label)?.groups;
-        // `leave_requested_at_ms` is not part of the stored projection, so stamp
-        // it from the engine-owned leave-request table here. This is the single
-        // population point for the group record: `visible_groups`, `group`, and
-        // `subscribe_chats` all read through this method.
+        self.stamp_group_lifecycle(label, &mut groups)?;
+        Ok(groups)
+    }
+
+    /// Fill the engine-owned lifecycle fields the stored projection does not
+    /// carry. `leave_requested_at_ms` comes from the leave-request table
+    /// because the engine clears those rows from paths that never notify the
+    /// app layer; the disband fields likewise read the engine's tables. This
+    /// is the single population point for the group record: `visible_groups`,
+    /// `group`, and `subscribe_chats` all read through it.
+    fn stamp_group_lifecycle(
+        &self,
+        label: &str,
+        groups: &mut [AppGroupRecord],
+    ) -> Result<(), AppError> {
         let pending = self.pending_leave_requests(label)?;
         if !pending.is_empty() {
-            for group in &mut groups {
+            for group in groups.iter_mut() {
                 group.leave_requested_at_ms = pending.get(&group.group_id_hex).copied();
             }
         }
@@ -3387,12 +3401,12 @@ impl MarmotApp {
             .into_iter()
             .map(|(group_id, _)| hex::encode(group_id.as_slice()))
             .collect::<HashSet<_>>();
-        for group in &mut groups {
+        for group in groups.iter_mut() {
             group.disbanding = disbanding.contains(&group.group_id_hex);
             group.disband_request = requests.get(&group.group_id_hex).cloned().map(Into::into);
             group.disbanded = disbanded.contains(&group.group_id_hex);
         }
-        Ok(groups)
+        Ok(())
     }
 
     /// Outstanding durable leave requests for this account, keyed by group id hex
@@ -3471,15 +3485,25 @@ impl MarmotApp {
             .collect())
     }
 
+    /// One group by id. Reads that group's projection row alone rather than
+    /// the whole account projection (every group plus the seen-event window),
+    /// which is what opening a conversation used to cost.
     pub fn group(
         &self,
         label: &str,
         group_id_hex: &str,
     ) -> Result<Option<AppGroupRecord>, AppError> {
-        Ok(self
-            .groups(label)?
-            .into_iter()
-            .find(|group| group.group_id_hex == group_id_hex))
+        self.ensure_account_state(label)?;
+        let Some(stored) = self
+            .account_storage(label)?
+            .load_account_group(label, group_id_hex)?
+        else {
+            return Ok(None);
+        };
+        let mut group = [conversions::app_group_from_stored_group(stored)?];
+        self.stamp_group_lifecycle(label, &mut group)?;
+        let [group] = group;
+        Ok(Some(group))
     }
 
     pub fn set_group_archived(
@@ -4734,11 +4758,24 @@ impl MarmotApp {
                 MAX_SEEN_EVENT_IDS,
                 TRANSPORT_CURSOR_MAX_FUTURE_SKEW.as_secs(),
             )?;
+        self.mark_chat_list_stale(
+            &state.label,
+            state
+                .groups
+                .iter()
+                .map(|group| group.group_id_hex.clone())
+                .collect(),
+        );
+        Ok(())
+    }
+
+    fn mark_chat_list_stale(&self, label: &str, group_ids_hex: HashSet<String>) {
         self.chat_list_projection_stale
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .insert(state.label.clone());
-        Ok(())
+            .entry(label.to_owned())
+            .or_default()
+            .extend(group_ids_hex);
     }
 
     fn save_state_delta_clearing_local_group_deletion_frontiers_and_acking_application_events(
@@ -4755,10 +4792,14 @@ impl MarmotApp {
                 frontiers_to_clear,
                 application_event_ids_to_ack,
             )?;
-        self.chat_list_projection_stale
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .insert(delta.label.clone());
+        self.mark_chat_list_stale(
+            &delta.label,
+            delta
+                .groups
+                .iter()
+                .map(|group| group.group_id_hex.clone())
+                .collect(),
+        );
         Ok(())
     }
 
@@ -4771,10 +4812,12 @@ impl MarmotApp {
     ) -> Result<ChatListRow, AppError> {
         let account = self.account_home().account(&delta.label)?;
         let classifier = Self::chat_list_mention_classifier(&account.account_id_hex);
-        let has_other_dirty_groups = delta
+        let other_dirty_groups: HashSet<String> = delta
             .groups
             .iter()
-            .any(|group| group.group_id_hex != group_id_hex);
+            .filter(|group| group.group_id_hex != group_id_hex)
+            .map(|group| group.group_id_hex.clone())
+            .collect();
         let mut row = self
             .account_storage(&delta.label)?
             .save_account_projection_delta_and_refresh_chat_list_row(
@@ -4794,11 +4837,8 @@ impl MarmotApp {
         // pre-existing stale marker, and add one if this delta also persisted
         // another dirty group; a later full-list query performs that rebuild.
         // A single-row refresh does not prove the full projection is warmed.
-        if has_other_dirty_groups {
-            self.chat_list_projection_stale
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .insert(delta.label.clone());
+        if !other_dirty_groups.is_empty() {
+            self.mark_chat_list_stale(&delta.label, other_dirty_groups);
         }
         Ok(row)
     }
@@ -4819,10 +4859,7 @@ impl MarmotApp {
             return Err(AppError::GroupDisbanding(group_id_hex.to_owned()));
         }
         let deleted = storage.delete_local_group_data(group_id_hex)?.did_delete();
-        self.chat_list_projection_stale
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .insert(label.to_owned());
+        self.mark_chat_list_stale(label, HashSet::from([normalized_group_id_hex]));
         self.chat_list_projection_warmed
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -4883,30 +4920,31 @@ impl MarmotApp {
             .chat_list_projection_stale
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .contains(&account.label);
+            .remove(&account.label);
         let warmed = self
             .chat_list_projection_warmed
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .contains(&account.label);
-        if warmed && !stale {
-            return Ok(());
-        }
         let storage = self.account_storage(&account.label)?;
         let classifier = Self::chat_list_mention_classifier(&account.account_id_hex);
-        if stale {
-            storage.refresh_chat_list_rows(&account.account_id_hex, &classifier)?;
-        } else {
-            storage.ensure_chat_list_rows(&account.account_id_hex, &classifier)?;
+        match stale {
+            None if warmed => return Ok(()),
+            Some(group_ids) if warmed => {
+                for group_id_hex in group_ids {
+                    storage.refresh_chat_list_row(
+                        &account.account_id_hex,
+                        &group_id_hex,
+                        &classifier,
+                    )?;
+                }
+            }
+            _ => storage.ensure_chat_list_rows(&account.account_id_hex, &classifier)?,
         }
         self.chat_list_projection_warmed
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .insert(account.label.clone());
-        self.chat_list_projection_stale
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .remove(&account.label);
         Ok(())
     }
 

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -4703,10 +4703,10 @@ fn founding_create_leaves_reconstructable_welcome_index_off_response_path() {
             .lock()
             .unwrap()
             .remove("alice");
-        app.chat_list_projection_stale
-            .lock()
-            .unwrap()
-            .insert("alice".to_owned());
+        app.chat_list_projection_stale.lock().unwrap().insert(
+            "alice".to_owned(),
+            HashSet::from(["stale-group".to_owned()]),
+        );
 
         relay.block_next_publish();
         let created = runtime
@@ -4742,7 +4742,7 @@ fn founding_create_leaves_reconstructable_welcome_index_off_response_path() {
             app.chat_list_projection_stale
                 .lock()
                 .unwrap()
-                .contains("alice"),
+                .contains_key("alice"),
             "create refreshes only its returned row and must preserve a pre-existing full-list rebuild obligation"
         );
         assert!(
@@ -9054,7 +9054,7 @@ fn drop_account_caches_evicts_storage_and_directory_handles_and_warm_flags() {
         !app.chat_list_projection_stale
             .lock()
             .unwrap()
-            .contains(&alice.label)
+            .contains_key(&alice.label)
     );
 }
 

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -4705,7 +4705,7 @@ fn founding_create_leaves_reconstructable_welcome_index_off_response_path() {
             .remove("alice");
         app.chat_list_projection_stale.lock().unwrap().insert(
             "alice".to_owned(),
-            HashSet::from(["stale-group".to_owned()]),
+            HashMap::from([("stale-group".to_owned(), 1)]),
         );
 
         relay.block_next_publish();
@@ -17237,7 +17237,7 @@ async fn failed_chat_list_refresh_keeps_dirty_groups_for_the_next_read() {
 
     app.chat_list_projection_stale.lock().unwrap().insert(
         "alice".to_owned(),
-        HashSet::from(["stale-group".to_owned()]),
+        HashMap::from([("stale-group".to_owned(), 1)]),
     );
     app.close_storage().unwrap();
 
@@ -17249,8 +17249,51 @@ async fn failed_chat_list_refresh_keeps_dirty_groups_for_the_next_read() {
             .lock()
             .unwrap()
             .get("alice")
-            .is_some_and(|dirty| dirty.contains("stale-group")),
+            .is_some_and(|dirty| dirty.contains_key("stale-group")),
         "a failed refresh must leave the dirty group for the next read"
     );
     runtime.shutdown().await;
+}
+
+#[test]
+fn same_group_re_marked_during_refresh_stays_dirty() {
+    let dir = tempfile::tempdir().unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    app.mark_chat_list_stale("alice", HashSet::from(["g".to_owned()]));
+
+    // A refresh snapshots the obligation, then storage re-marks the same
+    // group before the snapshot is cleared. The newer mark must survive.
+    let snapshot = app
+        .chat_list_projection_stale
+        .lock()
+        .unwrap()
+        .get("alice")
+        .cloned()
+        .unwrap();
+    app.mark_chat_list_stale("alice", HashSet::from(["g".to_owned()]));
+    app.clear_refreshed_chat_list_groups("alice", &snapshot);
+    assert!(
+        app.chat_list_projection_stale
+            .lock()
+            .unwrap()
+            .get("alice")
+            .is_some_and(|dirty| dirty.contains_key("g")),
+        "a mark that raced the refresh must stay dirty"
+    );
+
+    // Without an intervening mark the snapshot clears the obligation.
+    let snapshot = app
+        .chat_list_projection_stale
+        .lock()
+        .unwrap()
+        .get("alice")
+        .cloned()
+        .unwrap();
+    app.clear_refreshed_chat_list_groups("alice", &snapshot);
+    assert!(
+        !app.chat_list_projection_stale
+            .lock()
+            .unwrap()
+            .contains_key("alice")
+    );
 }

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -17215,3 +17215,42 @@ async fn reconcile_repairs_stale_two_member_count_on_three_member_group_body() {
     );
     runtime.shutdown().await;
 }
+
+#[tokio::test]
+async fn failed_chat_list_refresh_keeps_dirty_groups_for_the_next_read() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+        .with_test_relay_client(relay.clone());
+    let runtime = MarmotAppRuntime::new(app.clone());
+    runtime.reconcile_accounts().await.unwrap();
+    app.chat_list("alice", true).unwrap();
+    assert!(
+        app.chat_list_projection_warmed
+            .lock()
+            .unwrap()
+            .contains("alice")
+    );
+
+    app.chat_list_projection_stale.lock().unwrap().insert(
+        "alice".to_owned(),
+        HashSet::from(["stale-group".to_owned()]),
+    );
+    app.close_storage().unwrap();
+
+    // The refresh cannot run against closed storage. The obligation must
+    // survive the error, or a warm account would serve stale rows forever.
+    assert!(app.chat_list("alice", true).is_err());
+    assert!(
+        app.chat_list_projection_stale
+            .lock()
+            .unwrap()
+            .get("alice")
+            .is_some_and(|dirty| dirty.contains("stale-group")),
+        "a failed refresh must leave the dirty group for the next read"
+    );
+    runtime.shutdown().await;
+}

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -806,82 +806,7 @@ impl SqliteAccountStorage {
             .collect::<Result<Vec<_>, _>>()
             .storage()?;
 
-        let mut group_statement = conn
-            .prepare_cached(
-                "SELECT group_id_hex, endpoint, profile_name, profile_description,
-                        image_hash_hex, image_key_hex, image_nonce_hex,
-                        image_upload_key_hex, image_media_type, admin_keys_hex,
-                        archived, pending_confirmation, welcomer_account_id_hex,
-                        via_welcome_message_id_hex, nostr_routing_last_epoch,
-                        prior_nostr_routes_json, self_membership, member_count
-                 FROM account_groups
-                 ORDER BY updated_at, group_id_hex",
-            )
-            .storage()?;
-        let raw_groups = group_statement
-            .query_map([], |row| {
-                Ok(RawStoredAccountGroup {
-                    group_id_hex: row.get(0)?,
-                    endpoint: row.get(1)?,
-                    profile_name: row.get(2)?,
-                    profile_description: row.get(3)?,
-                    image_hash_hex: row.get(4)?,
-                    image_key_hex: row.get(5)?,
-                    image_nonce_hex: row.get(6)?,
-                    image_upload_key_hex: row.get(7)?,
-                    image_media_type: row.get(8)?,
-                    admin_keys_hex: row.get(9)?,
-                    archived: row.get::<_, i64>(10)? != 0,
-                    pending_confirmation: row.get::<_, i64>(11)? != 0,
-                    welcomer_account_id_hex: row.get(12)?,
-                    via_welcome_message_id_hex: row.get(13)?,
-                    nostr_routing_last_epoch: row.get(14)?,
-                    prior_nostr_routes_json: row.get(15)?,
-                    self_membership: SelfMembership::from_storage(&row.get::<_, String>(16)?),
-                    member_count: row.get(17)?,
-                })
-            })
-            .storage()?
-            .collect::<Result<Vec<_>, _>>()
-            .storage()?;
-        drop(group_statement);
-
-        let mut components_by_group = all_account_group_components(&conn)?;
-        let mut members_by_group = load_direct_conversation_members(&conn)?;
-        let mut groups = Vec::with_capacity(raw_groups.len());
-        for raw in raw_groups {
-            let prior_nostr_routes = serde_json::from_str(&raw.prior_nostr_routes_json)
-                .map_err(|err| StorageError::Serialization(err.to_string()))?;
-            let components = components_by_group
-                .remove(&raw.group_id_hex)
-                .unwrap_or_default();
-            let direct_member_ids_hex = members_by_group.remove(&raw.group_id_hex);
-            groups.push(StoredAccountGroup {
-                group_id_hex: raw.group_id_hex,
-                endpoint: raw.endpoint,
-                profile_name: raw.profile_name,
-                profile_description: raw.profile_description,
-                image_hash_hex: raw.image_hash_hex,
-                image_key_hex: raw.image_key_hex,
-                image_nonce_hex: raw.image_nonce_hex,
-                image_upload_key_hex: raw.image_upload_key_hex,
-                image_media_type: raw.image_media_type,
-                admin_keys_hex: raw.admin_keys_hex,
-                archived: raw.archived,
-                pending_confirmation: raw.pending_confirmation,
-                member_count: raw.member_count.and_then(|value| value.try_into().ok()),
-                direct_member_ids_hex,
-                welcomer_account_id_hex: raw.welcomer_account_id_hex,
-                via_welcome_message_id_hex: raw.via_welcome_message_id_hex,
-                nostr_routing_last_epoch: raw
-                    .nostr_routing_last_epoch
-                    .try_into()
-                    .unwrap_or_default(),
-                prior_nostr_routes,
-                self_membership: raw.self_membership,
-                components,
-            });
-        }
+        let groups = stored_account_groups(&conn, None)?;
 
         Ok(StoredAccountState {
             label: label.to_owned(),
@@ -889,6 +814,20 @@ impl SqliteAccountStorage {
             last_transport_timestamp,
             groups,
         })
+    }
+
+    /// One stored group, or `None` when no row carries `group_id_hex`. Reads
+    /// only that group's row, components, and direct members; the full
+    /// projection load above materializes every group and the seen-event
+    /// window to answer the same question.
+    pub fn load_account_group(
+        &self,
+        label: &str,
+        group_id_hex: &str,
+    ) -> StorageResult<Option<StoredAccountGroup>> {
+        self.ensure_account_projection(label)?;
+        let conn = self.lock()?;
+        Ok(stored_account_groups(&conn, Some(group_id_hex))?.pop())
     }
 
     /// Persist one account-projection snapshot.
@@ -3432,22 +3371,120 @@ fn checkpoint_wal_truncate_after_secure_delete(conn: &Connection) -> StorageResu
     })
 }
 
+/// Account groups in projection order, or only `group_id_hex` when given.
+fn stored_account_groups(
+    conn: &rusqlite::Connection,
+    group_id_hex: Option<&str>,
+) -> StorageResult<Vec<StoredAccountGroup>> {
+    const COLUMNS: &str = "group_id_hex, endpoint, profile_name, profile_description,
+                        image_hash_hex, image_key_hex, image_nonce_hex,
+                        image_upload_key_hex, image_media_type, admin_keys_hex,
+                        archived, pending_confirmation, welcomer_account_id_hex,
+                        via_welcome_message_id_hex, nostr_routing_last_epoch,
+                        prior_nostr_routes_json, self_membership, member_count";
+    let all_sql = format!("SELECT {COLUMNS} FROM account_groups ORDER BY updated_at, group_id_hex");
+    let one_sql = format!("SELECT {COLUMNS} FROM account_groups WHERE group_id_hex = ?1");
+    let mut group_statement = conn
+        .prepare_cached(if group_id_hex.is_some() {
+            &one_sql
+        } else {
+            &all_sql
+        })
+        .storage()?;
+    let params: Vec<&dyn rusqlite::ToSql> = group_id_hex
+        .iter()
+        .map(|hex| hex as &dyn rusqlite::ToSql)
+        .collect();
+    let raw_groups = group_statement
+        .query_map(params.as_slice(), |row| {
+            Ok(RawStoredAccountGroup {
+                group_id_hex: row.get(0)?,
+                endpoint: row.get(1)?,
+                profile_name: row.get(2)?,
+                profile_description: row.get(3)?,
+                image_hash_hex: row.get(4)?,
+                image_key_hex: row.get(5)?,
+                image_nonce_hex: row.get(6)?,
+                image_upload_key_hex: row.get(7)?,
+                image_media_type: row.get(8)?,
+                admin_keys_hex: row.get(9)?,
+                archived: row.get::<_, i64>(10)? != 0,
+                pending_confirmation: row.get::<_, i64>(11)? != 0,
+                welcomer_account_id_hex: row.get(12)?,
+                via_welcome_message_id_hex: row.get(13)?,
+                nostr_routing_last_epoch: row.get(14)?,
+                prior_nostr_routes_json: row.get(15)?,
+                self_membership: SelfMembership::from_storage(&row.get::<_, String>(16)?),
+                member_count: row.get(17)?,
+            })
+        })
+        .storage()?
+        .collect::<Result<Vec<_>, _>>()
+        .storage()?;
+    drop(group_statement);
+
+    let mut components_by_group = all_account_group_components(conn, group_id_hex)?;
+    let mut members_by_group = load_direct_conversation_members(conn, group_id_hex)?;
+    let mut groups = Vec::with_capacity(raw_groups.len());
+    for raw in raw_groups {
+        let prior_nostr_routes = serde_json::from_str(&raw.prior_nostr_routes_json)
+            .map_err(|err| StorageError::Serialization(err.to_string()))?;
+        let components = components_by_group
+            .remove(&raw.group_id_hex)
+            .unwrap_or_default();
+        let direct_member_ids_hex = members_by_group.remove(&raw.group_id_hex);
+        groups.push(StoredAccountGroup {
+            group_id_hex: raw.group_id_hex,
+            endpoint: raw.endpoint,
+            profile_name: raw.profile_name,
+            profile_description: raw.profile_description,
+            image_hash_hex: raw.image_hash_hex,
+            image_key_hex: raw.image_key_hex,
+            image_nonce_hex: raw.image_nonce_hex,
+            image_upload_key_hex: raw.image_upload_key_hex,
+            image_media_type: raw.image_media_type,
+            admin_keys_hex: raw.admin_keys_hex,
+            archived: raw.archived,
+            pending_confirmation: raw.pending_confirmation,
+            member_count: raw.member_count.and_then(|value| value.try_into().ok()),
+            direct_member_ids_hex,
+            welcomer_account_id_hex: raw.welcomer_account_id_hex,
+            via_welcome_message_id_hex: raw.via_welcome_message_id_hex,
+            nostr_routing_last_epoch: raw.nostr_routing_last_epoch.try_into().unwrap_or_default(),
+            prior_nostr_routes,
+            self_membership: raw.self_membership,
+            components,
+        });
+    }
+    Ok(groups)
+}
+
 /// #762: load ALL account-group components in one ordered query, bucketed by
 /// group in Rust, instead of an N+1 per-group query during full-projection load.
 /// Ordered by `(group_id_hex, component_id)` so each group's components keep
 /// `component_id` order (matching the prior per-group `ORDER BY component_id`).
 fn all_account_group_components(
     conn: &rusqlite::Connection,
+    group_id_hex: Option<&str>,
 ) -> StorageResult<std::collections::HashMap<String, Vec<StoredAccountGroupComponent>>> {
     let mut statement = conn
-        .prepare_cached(
+        .prepare_cached(if group_id_hex.is_some() {
             "SELECT group_id_hex, component_id, component_name, component_data_hex
              FROM account_group_app_components
-             ORDER BY group_id_hex, component_id",
-        )
+             WHERE group_id_hex = ?1
+             ORDER BY component_id"
+        } else {
+            "SELECT group_id_hex, component_id, component_name, component_data_hex
+             FROM account_group_app_components
+             ORDER BY group_id_hex, component_id"
+        })
         .storage()?;
+    let params: Vec<&dyn rusqlite::ToSql> = group_id_hex
+        .iter()
+        .map(|hex| hex as &dyn rusqlite::ToSql)
+        .collect();
     let rows = statement
-        .query_map([], |row| {
+        .query_map(params.as_slice(), |row| {
             Ok((
                 row.get::<_, String>(0)?,
                 StoredAccountGroupComponent {
@@ -3774,16 +3811,26 @@ fn i64_to_u32(value: i64, column: usize) -> rusqlite::Result<u32> {
 
 fn load_direct_conversation_members(
     conn: &Connection,
+    group_id_hex: Option<&str>,
 ) -> StorageResult<HashMap<String, Vec<String>>> {
     let mut statement = conn
-        .prepare_cached(
+        .prepare_cached(if group_id_hex.is_some() {
             "SELECT group_id_hex, member_id_hex
              FROM direct_conversation_members
-             ORDER BY group_id_hex, member_id_hex",
-        )
+             WHERE group_id_hex = ?1
+             ORDER BY member_id_hex"
+        } else {
+            "SELECT group_id_hex, member_id_hex
+             FROM direct_conversation_members
+             ORDER BY group_id_hex, member_id_hex"
+        })
         .storage()?;
+    let params: Vec<&dyn rusqlite::ToSql> = group_id_hex
+        .iter()
+        .map(|hex| hex as &dyn rusqlite::ToSql)
+        .collect();
     let rows = statement
-        .query_map([], |row| {
+        .query_map(params.as_slice(), |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
         })
         .storage()?;


### PR DESCRIPTION
### Summary

Opening a conversation reads one group's projection row, and a received message marks only its own group's chat-list row for refresh.

### Context

group() went through groups(), which loaded the entire account projection: every group with components and direct members plus up to 16,384 seen-event ids, then searched for one id. The subscription layer fires the same call on every group event. Separately, any received message marked the whole chat-list projection stale, and the next chat_list() rebuilt every row inside a write transaction.

### What changed

A keyed load_account_group fetches one row with its components and members, and group() uses it. The engine-owned lifecycle fields are stamped by the helper groups() also uses. The stale marker becomes a set of dirty group ids per account; a warm projection refreshes only those rows through the existing per-row refresh, and a cold one still takes the full ensure path.

### Impact

Opening a conversation reads three keyed queries instead of eight table scans. A received message costs one row refresh instead of a rebuild of every row. Counted from the code, not timed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Chat lists now refresh only affected groups, improving responsiveness when updates are limited to specific conversations.
  - Opening an individual group loads its details more efficiently, especially for accounts with many groups.

- **Bug Fixes**
  - Pending group updates are preserved when a chat-list refresh fails or overlaps with newer changes.
  - Direct membership changes now correctly refresh the affected group in chat lists.
  - Group details and related members remain consistent when loaded individually or as part of a full list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->