### PR TITLE
Fix large Blossom upload timeout retry path

### DIFF
--- a/crates/agent-connector/AGENTS.md
+++ b/crates/agent-connector/AGENTS.md
@@ -44,7 +44,7 @@ several files in the same crate); methods shared across those files are `pub(cra
 - `src/reconcile_telemetry.rs` — privacy-safe aggregate counters for the background reconciliation loops
   (`ReconcileTelemetry` on the connector: passes, outcomes, accounts/candidate rows considered) plus the
   `ReconcileSource` label used on per-pass tracing events (mdk#1380).
-- `src/error.rs` — `ConnectorError` and its `code`/`client_message`/`privacy_safe_code` projections.
+- `src/error.rs` — `ConnectorError` and its `code`/`client_message`/`retryable`/`privacy_safe_code` projections.
 - `src/socket.rs` — socket path/bind/hardening (`default_socket_path`, `bind_connector_socket*`, stale-socket recovery).
 - `src/allowlist.rs` — `AllowlistStore`/`AllowlistRecord` per-account invite-policy and welcomer-allowlist persistence.
 - `src/stream_session.rs` — `StreamSessionStore`/`ActiveStreamSession`, the persisted

--- a/crates/agent-connector/src/bootstrap.rs
+++ b/crates/agent-connector/src/bootstrap.rs
@@ -473,7 +473,7 @@ fn ensure_response_type(
     expected: &'static str,
 ) -> Result<(), BootstrapError> {
     if matches!(envelope.payload, AgentControlResponse::Error { .. }) {
-        let AgentControlResponse::Error { code, message } = &envelope.payload else {
+        let AgentControlResponse::Error { code, message, .. } = &envelope.payload else {
             unreachable!()
         };
         return Err(BootstrapError::ControlRejected {

--- a/crates/agent-connector/src/connection.rs
+++ b/crates/agent-connector/src/connection.rs
@@ -91,6 +91,7 @@ impl AgentConnector {
                         AgentControlResponse::Error {
                             code: "server_busy".to_owned(),
                             message: "agent connector subscription capacity is busy".to_owned(),
+                            retryable: true,
                         },
                     );
                     write_control_frame(&mut write_half, &response).await?;
@@ -141,6 +142,7 @@ impl AgentConnector {
         AgentControlResponse::Error {
             code: err.code().to_owned(),
             message: err.client_message().to_owned(),
+            retryable: err.retryable(),
         }
     }
 
@@ -528,6 +530,7 @@ impl AgentConnector {
             other => Ok(AgentControlResponse::Error {
                 code: "unsupported_request".to_owned(),
                 message: unsupported_request_message(&other).to_owned(),
+                retryable: false,
             }),
         }
     }

--- a/crates/agent-connector/src/error.rs
+++ b/crates/agent-connector/src/error.rs
@@ -53,6 +53,7 @@ impl ConnectorError {
         match self {
             Self::AccountHome(_) => "account_home_error",
             Self::App(AppError::ReactionNotFound) => "reaction_not_found",
+            Self::App(AppError::MediaUploadTimedOut) => "media_upload_timeout",
             Self::App(_) => "app_error",
             Self::Control(_) => "control_error",
             Self::Hex(_) => "invalid_hex",
@@ -101,8 +102,16 @@ impl ConnectorError {
             }
             Self::Io(_) => "connector I/O failed",
             Self::App(AppError::ReactionNotFound) => "no matching reaction to remove",
+            Self::App(AppError::MediaUploadTimedOut) => "media upload timed out before publication",
             Self::AccountHome(_) | Self::App(_) => "connector request failed",
         }
+    }
+
+    pub fn retryable(&self) -> bool {
+        matches!(
+            self,
+            Self::SendInProgress | Self::App(AppError::MediaUploadTimedOut)
+        )
     }
 
     pub fn privacy_safe_code(&self) -> &'static str {

--- a/crates/agent-connector/src/lib.rs
+++ b/crates/agent-connector/src/lib.rs
@@ -420,7 +420,10 @@ pub async fn serve_socket(config: AgentConnectorConfig) -> Result<(), ConnectorE
                 agent_control::AgentControlResponse::Error {
                     code: "server_busy".to_owned(),
                     message: "agent connector connection capacity is busy".to_owned(),
-                    retryable: true,
+                    // Admission happens before any request frame is read, so
+                    // this response cannot carry a request id. Do not promise
+                    // application-level retryability on an uncorrelated frame.
+                    retryable: false,
                 },
             );
             let _ = crate::connection::write_control_frame_with_timeout(

--- a/crates/agent-connector/src/lib.rs
+++ b/crates/agent-connector/src/lib.rs
@@ -420,6 +420,7 @@ pub async fn serve_socket(config: AgentConnectorConfig) -> Result<(), ConnectorE
                 agent_control::AgentControlResponse::Error {
                     code: "server_busy".to_owned(),
                     message: "agent connector connection capacity is busy".to_owned(),
+                    retryable: true,
                 },
             );
             let _ = crate::connection::write_control_frame_with_timeout(

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -200,6 +200,48 @@ fn inbound_subscription_quota_preserves_one_shot_capacity() {
     );
 }
 
+#[tokio::test]
+async fn subscription_capacity_error_echoes_request_id_and_is_retryable() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("dev").join("wn-agent.sock");
+    let mut connector = AgentConnector::open(test_config(
+        dir.path(),
+        socket.clone(),
+        Vec::new(),
+        false,
+        false,
+    ))
+    .unwrap();
+    connector.subscription_limiter = std::sync::Arc::new(tokio::sync::Semaphore::new(0));
+    let listener = bind_connector_socket(&socket).unwrap();
+    let server = tokio::spawn(async move { connector.serve_once(&listener).await });
+
+    let client = UnixStream::connect(&socket).await.unwrap();
+    let (client_read, mut client_write) = tokio::io::split(client);
+    let mut client_read = BufReader::new(client_read);
+    let request = AgentControlEnvelope::request(
+        Some("req-subscription-busy".to_owned()),
+        AgentControlRequest::SubscribeInbound {
+            account_id_hex: None,
+            group_id_hex: None,
+        },
+    );
+    write_frame(&mut client_write, &request).await.unwrap();
+
+    let response: AgentControlEnvelope<AgentControlResponse> =
+        read_envelope(&mut client_read).await.unwrap().unwrap();
+    assert_eq!(response.id.as_deref(), Some("req-subscription-busy"));
+    assert!(matches!(
+        response.payload,
+        AgentControlResponse::Error {
+            ref code,
+            retryable: true,
+            ..
+        } if code == "server_busy"
+    ));
+    server.await.unwrap().unwrap();
+}
+
 #[test]
 fn poisoned_connector_store_mutex_recovers_inner_state() {
     let mutex = std::sync::Arc::new(std::sync::Mutex::new(vec![1]));
@@ -1345,9 +1387,14 @@ async fn connector_socket_caps_concurrent_connections() {
             .expect("busy response should not time out")
             .expect("busy response should be a valid frame")
             .expect("busy response should not be empty");
+    assert_eq!(refused_response.id, None);
     assert!(matches!(
         refused_response.payload,
-        AgentControlResponse::Error { ref code, .. } if code == "server_busy"
+        AgentControlResponse::Error {
+            ref code,
+            retryable: false,
+            ..
+        } if code == "server_busy"
     ));
 
     // Dropping the held connection frees the permit for a new connection.

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -104,6 +104,18 @@ fn send_in_progress_has_a_distinct_retry_contract() {
         error.client_message(),
         "matching send is still in progress; retry with the same idempotency key"
     );
+    assert!(error.retryable());
+}
+
+#[test]
+fn send_media_timeout_is_retryable_before_publication() {
+    let error = crate::ConnectorError::App(marmot_app::AppError::MediaUploadTimedOut);
+    assert_eq!(error.code(), "media_upload_timeout");
+    assert_eq!(
+        error.client_message(),
+        "media upload timed out before publication"
+    );
+    assert!(error.retryable());
 }
 
 #[test]

--- a/crates/agent-control/src/lib.rs
+++ b/crates/agent-control/src/lib.rs
@@ -427,6 +427,8 @@ pub enum AgentControlResponse {
     Error {
         code: String,
         message: String,
+        #[serde(default)]
+        retryable: bool,
     },
     AccountList {
         accounts: Vec<AgentControlAccount>,
@@ -1762,6 +1764,32 @@ mod tests {
             let round_tripped: AgentControlResponse = serde_json::from_value(value).unwrap();
             assert_eq!(round_tripped, response);
         }
+    }
+
+    #[test]
+    fn control_error_preserves_server_retryability() {
+        let value = serde_json::json!({
+            "type": "error",
+            "code": "media_upload_timeout",
+            "message": "media upload timed out before publication",
+            "retryable": true,
+        });
+
+        let response: AgentControlResponse = serde_json::from_value(value).unwrap();
+        let round_tripped = serde_json::to_value(response).unwrap();
+
+        assert_eq!(round_tripped["retryable"], true);
+
+        let legacy_value = serde_json::json!({
+            "type": "error",
+            "code": "app_error",
+            "message": "connector request failed",
+        });
+        let legacy: AgentControlResponse = serde_json::from_value(legacy_value).unwrap();
+        let AgentControlResponse::Error { retryable, .. } = legacy else {
+            panic!("expected error response");
+        };
+        assert!(!retryable);
     }
 
     fn account() -> String {

--- a/crates/agent-control/src/lib.rs
+++ b/crates/agent-control/src/lib.rs
@@ -427,6 +427,8 @@ pub enum AgentControlResponse {
     Error {
         code: String,
         message: String,
+        /// Whether retrying the same operation is safe. Missing legacy fields
+        /// default to false so compatibility never widens retry behavior.
         #[serde(default)]
         retryable: bool,
     },

--- a/crates/cgka-conformance-simulator/src/app_runtime.rs
+++ b/crates/cgka-conformance-simulator/src/app_runtime.rs
@@ -1451,6 +1451,7 @@ fn app_error(error: AppError) -> SubjectError {
         | AppError::RelayDirectory(_)
         | AppError::Publish(_)
         | AppError::BlobStore(_)
+        | AppError::MediaUploadTimedOut
         | AppError::AuditLogUpload(_)
         | AppError::ExternalSignerUnavailable(_)
         | AppError::BlockingTask(_) => SubjectFailureCategory::Resource,

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -1132,6 +1132,7 @@ fn read_marker_error_code(error: &AppError) -> &'static str {
         }
         AppError::InvalidEncryptedMedia(_) => "read_marker_failed:invalid_encrypted_media",
         AppError::BlobStore(_) => "read_marker_failed:blob_store",
+        AppError::MediaUploadTimedOut => "read_marker_failed:media_upload_timed_out",
         AppError::UnsafeMediaFetch(_) => "read_marker_failed:unsafe_media_fetch",
         AppError::InvalidAppMessagePayload(_) => "read_marker_failed:invalid_app_message_payload",
         AppError::InvalidPushToken(_) => "read_marker_failed:invalid_push_token",

--- a/crates/marmot-app/src/error.rs
+++ b/crates/marmot-app/src/error.rs
@@ -141,6 +141,11 @@ pub enum AppError {
     InvalidEncryptedMedia(String),
     #[error("blob store request failed: {0}")]
     BlobStore(String),
+    /// A Blossom upload exhausted its bounded transfer/response budget before
+    /// the caller had a valid media descriptor. No message publication can
+    /// begin until this operation succeeds, so connector callers may retry.
+    #[error("media upload timed out")]
+    MediaUploadTimedOut,
     /// Pre-dial rejection for untrusted profile/media fetch URLs (SSRF boundary).
     #[error("unsafe media fetch: {0}")]
     UnsafeMediaFetch(String),
@@ -272,6 +277,7 @@ impl AppError {
             Self::InvalidAgentTextStreamPolicy(_) => "invalid_agent_text_stream_policy",
             Self::InvalidEncryptedMedia(_) => "invalid_encrypted_media",
             Self::BlobStore(_) => "blob_store",
+            Self::MediaUploadTimedOut => "media_upload_timed_out",
             Self::UnsafeMediaFetch(_) => "unsafe_media_fetch",
             Self::InvalidAppMessagePayload(_) => "invalid_app_message_payload",
             Self::InvalidPushToken(_) => "invalid_push_token",

--- a/crates/marmot-app/src/media/blossom.rs
+++ b/crates/marmot-app/src/media/blossom.rs
@@ -690,12 +690,7 @@ async fn media_http_client_for_url(
     url: &Url,
     allow_loopback_http: bool,
 ) -> Result<reqwest::Client, AppError> {
-    validate_blossom_fetch_url(url, allow_loopback_http)
-        .map_err(|err| AppError::BlobStore(format!("unsafe Blossom URL: {err}")))?;
-    let allow_loopback = url.scheme() == "http"
-        && allow_loopback_http
-        && url.host().map(is_loopback_host).unwrap_or(false);
-    let pin = resolve_media_host(url, allow_loopback).await?;
+    let pin = resolve_pinned_media_host_for_url(url, allow_loopback_http).await?;
     build_pinned_media_http_client(pin)
 }
 
@@ -703,13 +698,20 @@ async fn media_http_upload_client_for_url(
     url: &Url,
     allow_loopback_http: bool,
 ) -> Result<reqwest::Client, AppError> {
+    let pin = resolve_pinned_media_host_for_url(url, allow_loopback_http).await?;
+    build_pinned_media_upload_client(pin)
+}
+
+async fn resolve_pinned_media_host_for_url(
+    url: &Url,
+    allow_loopback_http: bool,
+) -> Result<Option<(String, Vec<SocketAddr>)>, AppError> {
     validate_blossom_fetch_url(url, allow_loopback_http)
         .map_err(|err| AppError::BlobStore(format!("unsafe Blossom URL: {err}")))?;
     let allow_loopback = url.scheme() == "http"
         && allow_loopback_http
         && url.host().map(is_loopback_host).unwrap_or(false);
-    let pin = resolve_media_host(url, allow_loopback).await?;
-    build_pinned_media_upload_client(pin)
+    resolve_media_host(url, allow_loopback).await
 }
 
 fn build_pinned_media_http_client(

--- a/crates/marmot-app/src/media/blossom.rs
+++ b/crates/marmot-app/src/media/blossom.rs
@@ -264,7 +264,7 @@ pub(crate) async fn upload_blossom_blob_with_content_type(
 ) -> Result<String, AppError> {
     let (upload_url, server_host) = blossom_upload_endpoint(server)?;
     let authorization = blossom_authorization_header(signer, &server_host, blob_hash_hex).await?;
-    let client = media_http_client_for_url(&upload_url, allow_loopback_http).await?;
+    let client = media_http_upload_client_for_url(&upload_url, allow_loopback_http).await?;
     let response = client
         .put(upload_url.clone())
         .timeout(MEDIA_BLOB_TRANSFER_TIMEOUT)
@@ -274,13 +274,20 @@ pub(crate) async fn upload_blossom_blob_with_content_type(
         .body(blob)
         .send()
         .await
-        .map_err(reqwest_blob_error)?;
+        .map_err(reqwest_upload_error)?;
     if !response.status().is_success() {
         return Err(blossom_upload_status_error(response).await);
     }
-    let descriptor_body = read_limited_blossom_body(response, MAX_BLOSSOM_DESCRIPTOR_BYTES)
-        .await
-        .map_err(|_| AppError::BlobStore("upload descriptor exceeds size limit".into()))?;
+    let descriptor_body =
+        match read_limited_blossom_upload_body(response, MAX_BLOSSOM_DESCRIPTOR_BYTES).await {
+            Ok(body) => body,
+            Err(AppError::MediaUploadTimedOut) => return Err(AppError::MediaUploadTimedOut),
+            Err(_) => {
+                return Err(AppError::BlobStore(
+                    "upload descriptor exceeds size limit".into(),
+                ));
+            }
+        };
     let descriptor = serde_json::from_slice::<BlossomBlobDescriptor>(&descriptor_body)
         .map_err(|_| AppError::BlobStore("upload returned an invalid descriptor".into()))?;
     if let Some(sha256) = descriptor.sha256.as_deref()
@@ -318,7 +325,7 @@ async fn blossom_upload_status_error(response: reqwest::Response) -> AppError {
         .get("X-Reason")
         .and_then(|value| value.to_str().ok())
         .and_then(privacy_safe_server_reason);
-    let body = read_limited_blossom_body(response, MAX_BLOSSOM_ERROR_BODY_BYTES)
+    let body = read_limited_blossom_upload_body(response, MAX_BLOSSOM_ERROR_BODY_BYTES)
         .await
         .ok();
     let body_reason = body
@@ -678,6 +685,7 @@ fn same_registrable_domain(left: &str, right: &str) -> bool {
     }
 }
 
+#[cfg(test)]
 async fn media_http_client_for_url(
     url: &Url,
     allow_loopback_http: bool,
@@ -691,26 +699,48 @@ async fn media_http_client_for_url(
     build_pinned_media_http_client(pin)
 }
 
+async fn media_http_upload_client_for_url(
+    url: &Url,
+    allow_loopback_http: bool,
+) -> Result<reqwest::Client, AppError> {
+    validate_blossom_fetch_url(url, allow_loopback_http)
+        .map_err(|err| AppError::BlobStore(format!("unsafe Blossom URL: {err}")))?;
+    let allow_loopback = url.scheme() == "http"
+        && allow_loopback_http
+        && url.host().map(is_loopback_host).unwrap_or(false);
+    let pin = resolve_media_host(url, allow_loopback).await?;
+    build_pinned_media_upload_client(pin)
+}
+
 fn build_pinned_media_http_client(
     pin: Option<(String, Vec<SocketAddr>)>,
 ) -> Result<reqwest::Client, AppError> {
-    build_pinned_media_http_client_from_builder(reqwest::Client::builder(), pin)
+    build_pinned_media_http_client_from_builder(reqwest::Client::builder(), pin, true)
+}
+
+fn build_pinned_media_upload_client(
+    pin: Option<(String, Vec<SocketAddr>)>,
+) -> Result<reqwest::Client, AppError> {
+    build_pinned_media_http_client_from_builder(reqwest::Client::builder(), pin, false)
 }
 
 fn build_pinned_media_http_client_from_builder(
     builder: reqwest::ClientBuilder,
     pin: Option<(String, Vec<SocketAddr>)>,
+    apply_read_timeout: bool,
 ) -> Result<reqwest::Client, AppError> {
     let mut builder = builder
         .redirect(reqwest::redirect::Policy::none())
         .connect_timeout(MEDIA_HTTP_CONNECT_TIMEOUT)
-        .read_timeout(MEDIA_HTTP_READ_TIMEOUT)
         .timeout(MEDIA_HTTP_TOTAL_TIMEOUT)
         .no_proxy()
         .no_gzip()
         .no_brotli()
         .no_zstd()
         .no_deflate();
+    if apply_read_timeout {
+        builder = builder.read_timeout(MEDIA_HTTP_READ_TIMEOUT);
+    }
     if let Some((domain, addrs)) = pin {
         builder = builder.resolve_to_addrs(&domain, &addrs);
     }
@@ -726,7 +756,7 @@ pub(super) fn build_pinned_media_http_client_with_proxy_for_test(
 ) -> Result<reqwest::Client, AppError> {
     let proxy = reqwest::Proxy::all(proxy_url)
         .map_err(|_| AppError::BlobStore("failed to configure test HTTP proxy".into()))?;
-    build_pinned_media_http_client_from_builder(reqwest::Client::builder().proxy(proxy), pin)
+    build_pinned_media_http_client_from_builder(reqwest::Client::builder().proxy(proxy), pin, true)
 }
 
 async fn resolve_media_host(
@@ -770,6 +800,18 @@ pub(crate) async fn read_limited_blossom_body(
     max_bytes: u64,
 ) -> Result<Vec<u8>, AppError> {
     read_limited_blossom_body_until(response, max_bytes, None).await
+}
+
+async fn read_limited_blossom_upload_body(
+    response: reqwest::Response,
+    max_bytes: u64,
+) -> Result<Vec<u8>, AppError> {
+    tokio::time::timeout(
+        MEDIA_HTTP_READ_TIMEOUT,
+        read_limited_blossom_body(response, max_bytes),
+    )
+    .await
+    .map_err(|_| AppError::MediaUploadTimedOut)?
 }
 
 async fn read_limited_blossom_body_until(
@@ -916,5 +958,13 @@ fn reqwest_blob_error(err: reqwest::Error) -> AppError {
         AppError::BlobStore("invalid response body".into())
     } else {
         AppError::BlobStore("request failed".into())
+    }
+}
+
+fn reqwest_upload_error(err: reqwest::Error) -> AppError {
+    if err.is_timeout() {
+        AppError::MediaUploadTimedOut
+    } else {
+        reqwest_blob_error(err)
     }
 }

--- a/crates/marmot-app/src/media/mod.rs
+++ b/crates/marmot-app/src/media/mod.rs
@@ -676,6 +676,8 @@ async fn upload_blossom_blob_with_fallback(
         }
     }
     if timed_out {
+        // Any pre-publication timeout keeps the aggregate safely retryable,
+        // even when another fallback also returned a terminal rejection.
         return Err(AppError::MediaUploadTimedOut);
     }
     Err(AppError::BlobStore(format!(

--- a/crates/marmot-app/src/media/mod.rs
+++ b/crates/marmot-app/src/media/mod.rs
@@ -652,6 +652,7 @@ async fn upload_blossom_blob_with_fallback(
     allow_loopback_http: bool,
 ) -> Result<String, AppError> {
     let mut failures = Vec::new();
+    let mut timed_out = false;
     for (idx, server) in servers.iter().enumerate() {
         match upload_blossom_blob(
             server,
@@ -664,12 +665,18 @@ async fn upload_blossom_blob_with_fallback(
         {
             Ok(url) => return Ok(url),
             Err(AppError::ExternalSignerRejected) => return Err(AppError::ExternalSignerRejected),
-            Err(err) => failures.push(format!(
-                "server {}: {}",
-                idx + 1,
-                upload_error_summary(&err)
-            )),
+            Err(err) => {
+                timed_out |= matches!(err, AppError::MediaUploadTimedOut);
+                failures.push(format!(
+                    "server {}: {}",
+                    idx + 1,
+                    upload_error_summary(&err)
+                ));
+            }
         }
+    }
+    if timed_out {
+        return Err(AppError::MediaUploadTimedOut);
     }
     Err(AppError::BlobStore(format!(
         "upload failed for all Blossom servers: {}",
@@ -682,6 +689,7 @@ fn upload_error_summary(err: &AppError) -> String {
         AppError::BlobStore(message)
         | AppError::InvalidEncryptedMedia(message)
         | AppError::InvalidAppMessagePayload(message) => message.clone(),
+        AppError::MediaUploadTimedOut => "request timed out".to_owned(),
         // `upload_blossom_blob` should currently surface upload failures through
         // the privacy-scrubbed variants above. Keep this fallback as a defensive
         // catch-all only; do not route URL-bearing transport errors here without

--- a/crates/marmot-app/src/media/tests.rs
+++ b/crates/marmot-app/src/media/tests.rs
@@ -512,6 +512,64 @@ fn spawn_hashing_upload_response(response: Vec<u8>) -> (String, mpsc::Receiver<(
     (format!("http://{addr}"), rx)
 }
 
+#[derive(Clone, Copy)]
+enum SlowUploadIngest {
+    PauseAfterFirstChunk(Duration),
+    Continuous { delay_per_chunk: Duration },
+}
+
+fn spawn_slow_upload_response(ingest: SlowUploadIngest) -> (String, mpsc::Receiver<u64>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind slow upload test server");
+    let addr = listener.local_addr().expect("slow upload test server addr");
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("accept slow upload");
+        let mut stream = BufReader::new(stream);
+        let mut content_length = None;
+        loop {
+            let mut line = String::new();
+            stream.read_line(&mut line).expect("read upload header");
+            if line == "\r\n" {
+                break;
+            }
+            if let Some(value) = line
+                .strip_prefix("content-length:")
+                .or_else(|| line.strip_prefix("Content-Length:"))
+            {
+                content_length = Some(value.trim().parse::<u64>().expect("content length"));
+            }
+        }
+        let content_length = content_length.expect("upload content length header");
+        let mut received = 0_u64;
+        let mut buffer = [0_u8; 64 * 1024];
+        while received < content_length {
+            let take = (content_length - received).min(buffer.len() as u64) as usize;
+            let Ok(count) = stream.read(&mut buffer[..take]) else {
+                return;
+            };
+            if count == 0 {
+                return;
+            }
+            received += count as u64;
+            match ingest {
+                SlowUploadIngest::PauseAfterFirstChunk(delay) if received == count as u64 => {
+                    thread::sleep(delay);
+                }
+                SlowUploadIngest::Continuous { delay_per_chunk } => {
+                    thread::sleep(delay_per_chunk);
+                }
+                SlowUploadIngest::PauseAfterFirstChunk(_) => {}
+            }
+        }
+        stream
+            .get_mut()
+            .write_all(&http_json_response("{}"))
+            .expect("write slow upload descriptor");
+        tx.send(received).expect("report slow upload body");
+    });
+    (format!("http://{addr}"), rx)
+}
+
 pub(super) fn http_redirect_response(location: &str) -> Vec<u8> {
     format!(
         "HTTP/1.1 302 Found\r\nLocation: {location}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
@@ -659,6 +717,48 @@ async fn blossom_fallback_reuses_the_identical_encrypted_body() {
     .expect("second Blossom endpoint should accept the retry body");
 
     assert_eq!(first_body.recv().unwrap(), second_body.recv().unwrap());
+}
+
+#[tokio::test]
+async fn blossom_upload_allows_response_gap_longer_than_read_timeout() {
+    let (server, received) = spawn_slow_upload_response(SlowUploadIngest::PauseAfterFirstChunk(
+        Duration::from_secs(16),
+    ));
+    let encrypted = bytes::Bytes::from(vec![0x5a; 40_405_416]);
+    let encrypted_hash = hex::encode(Sha256::digest(&encrypted));
+
+    upload_blossom_blob(
+        &server,
+        encrypted.clone(),
+        &encrypted_hash,
+        &signing_keys(),
+        true,
+    )
+    .await
+    .expect("a bounded upload may wait more than the response read timeout while sending");
+
+    assert_eq!(received.recv().unwrap(), encrypted.len() as u64);
+}
+
+#[tokio::test]
+async fn blossom_upload_allows_continuous_slow_body_ingest() {
+    let (server, received) = spawn_slow_upload_response(SlowUploadIngest::Continuous {
+        delay_per_chunk: Duration::from_millis(30),
+    });
+    let encrypted = bytes::Bytes::from(vec![0x5a; 40_405_416]);
+    let encrypted_hash = hex::encode(Sha256::digest(&encrypted));
+
+    upload_blossom_blob(
+        &server,
+        encrypted.clone(),
+        &encrypted_hash,
+        &signing_keys(),
+        true,
+    )
+    .await
+    .expect("continuous request-body progress may exceed the response read timeout");
+
+    assert_eq!(received.recv().unwrap(), encrypted.len() as u64);
 }
 
 #[tokio::test]

--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -1711,10 +1711,13 @@ class MarmotAgentControlClient:
     def _raise_if_error(envelope: Dict[str, Any]) -> None:
         if envelope.get("type") == "error":
             code = str(envelope.get("code") or "agent_control_error")
+            retryable = envelope.get("retryable")
+            if not isinstance(retryable, bool):
+                retryable = code == "send_in_progress"
             raise AgentControlError(
                 str(envelope.get("message") or "agent control error"),
                 code=code,
-                retryable=code == "send_in_progress",
+                retryable=retryable,
             )
 
 

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -400,6 +400,20 @@ class AgentControlClientTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(raised.exception.code, "send_in_progress")
         self.assertTrue(raised.exception.retryable)
 
+    def test_error_envelope_preserves_server_retryability(self):
+        with self.assertRaises(self.adapter.AgentControlError) as raised:
+            self.adapter.MarmotAgentControlClient._raise_if_error(
+                {
+                    "type": "error",
+                    "code": "media_upload_timeout",
+                    "message": "media upload timed out before publication",
+                    "retryable": True,
+                }
+            )
+
+        self.assertEqual(raised.exception.code, "media_upload_timeout")
+        self.assertTrue(raised.exception.retryable)
+
     async def test_timeline_reads_write_exact_message_and_cursor_requests(self):
         requests = []
 
@@ -5083,7 +5097,7 @@ class MediaSupportTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(result.error, "Marmot outbound media staging failed")
             self.assertNotIn(str(staged_path), "\n".join(logs.output))
 
-    async def test_multiple_images_retry_reuses_staged_paths_and_idempotency_key(self):
+    async def test_send_media_timeout_is_retryable_before_publication(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             first = root / "first.png"
@@ -5094,20 +5108,25 @@ class MediaSupportTests(unittest.IsolatedAsyncioTestCase):
             class FakeClient:
                 def __init__(self):
                     self.calls = []
+                    self.publications = 0
 
                 async def send_media(self, account, group, attachments, **kwargs):
                     self.calls.append(
                         ([item["path"] for item in attachments], kwargs["idempotency_key"])
                     )
                     if len(self.calls) == 1:
-                        raise self_error(
-                            "timed out",
-                            code="request_timed_out",
-                            retryable=True,
+                        self_client._raise_if_error(
+                            {
+                                "type": "error",
+                                "code": "media_upload_timeout",
+                                "message": "media upload timed out before publication",
+                                "retryable": True,
+                            }
                         )
+                    self.publications += 1
                     return {"type": "final_sent", "message_ids_hex": ["99" * 32]}
 
-            self_error = self.adapter_module.AgentControlError
+            self_client = self.adapter_module.MarmotAgentControlClient
             fake_client = FakeClient()
             adapter = self.adapter_module.MarmotPlatformAdapter(
                 self.config_cls(
@@ -5130,6 +5149,7 @@ class MediaSupportTests(unittest.IsolatedAsyncioTestCase):
 
             self.assertEqual(len(fake_client.calls), 2)
             self.assertEqual(fake_client.calls[0], fake_client.calls[1])
+            self.assertEqual(fake_client.publications, 1)
             self.assertEqual(list(adapter._outbound_media_dir.iterdir()), [])
 
     async def test_multiple_images_waits_past_retry_budget_for_in_progress_send(self):

--- a/integrations/terminal-harness/src/bridge.rs
+++ b/integrations/terminal-harness/src/bridge.rs
@@ -3663,6 +3663,7 @@ mod tests {
                         AgentControlResponse::Error {
                             code: "download_failed".to_owned(),
                             message: "unavailable".to_owned(),
+                            retryable: false,
                         },
                         false,
                     ),
@@ -4033,6 +4034,7 @@ mod tests {
                         agent_control::AgentControlResponse::Error {
                             code: "temporary_failure".to_owned(),
                             message: "retry later".to_owned(),
+                            retryable: false,
                         }
                     }
                     (1, agent_control::AgentControlRequest::SendAgentActivity { .. }) => {

--- a/integrations/terminal-harness/src/test_support.rs
+++ b/integrations/terminal-harness/src/test_support.rs
@@ -331,7 +331,7 @@ async fn send_control_request(
         return Err("control response id mismatch".into());
     }
     match response.payload {
-        AgentControlResponse::Error { code, message } => {
+        AgentControlResponse::Error { code, message, .. } => {
             Err(format!("control request rejected: {code}: {message}").into())
         }
         payload => Ok(payload),


### PR DESCRIPTION
## Summary

- give Blossom uploads a dedicated pinned HTTP client policy that keeps the 5-second connect and 15-minute request bounds without inheriting the download-side 15-second read-idle timeout
- retain separate 15-second, size-bounded reads for the small Blossom descriptor and error response bodies
- preserve timeout identity through endpoint fallback as the privacy-safe `media_upload_timeout` control error with an explicit server-owned `retryable` field
- make Hermes honor server retryability while preserving legacy `send_in_progress` behavior, staged paths, and idempotency keys

## Verification

- `just fast-ci`
- `cargo test -p agent-control`
- `cargo test -p marmot-app media::tests`
- `cargo test -p agent-connector`
- `cargo test -p marmot-terminal-harness`
- focused Hermes retry/publication regression
- both 40,405,416-byte upload regressions pass after exceeding the former 15-second boundary

The full local `marmot-app` suite reached 881 passing tests and six unrelated epoch-backfill failures; a representative exact test reproduces unchanged from clean `origin/master` at `1fd198be`. The full Hermes suite has one unrelated pre-existing media-preflight message assertion failure in untouched code; the new timeout and same-artifact retry tests pass.

The immutable patch-release and installer verification step remains a manual release operation and is intentionally not part of this source-change commit.

Fixes #1585

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media upload reliability by distinguishing upload timeouts from other failures.
  * Uploads continue through fallback servers after a timeout and provide a clear, privacy-safe error if all attempts fail.
  * Slow uploads and delayed responses are handled more reliably without failing prematurely.

* **Improvements**
  * Error responses now indicate whether retrying is appropriate.
  * Retry behavior is preserved across integrations, including media upload retries, while preventing duplicate publication.
  * Connection-capacity errors now accurately indicate when retrying is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->