### PR TITLE
Store the group record as MessagePack instead of JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,6 +2261,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
+dependencies = [
+ "hashbrown 0.17.0",
+]
+
+[[package]]
 name = "hax-lib"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5024,6 +5033,7 @@ dependencies = [
  "bitflags 2.13.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
+ "hashlink",
  "libsqlite3-sys",
  "smallvec",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5025,6 +5025,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5685,6 +5704,7 @@ dependencies = [
  "hex",
  "openmls",
  "openmls_traits",
+ "rmp-serde",
  "rusqlite",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ nostr-relay-builder = "0.44"
 # reqwest/rustls stack, so the SDK's record-time histogram API is not needed.
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["gen-tonic-messages", "metrics"] }
 prost = "0.14"
-rusqlite = { version = "0.40.1", default-features = false, features = ["bundled-sqlcipher-vendored-openssl", "trace"] }
+rusqlite = { version = "0.40.1", default-features = false, features = ["bundled-sqlcipher-vendored-openssl", "cache", "trace"] }
 tempfile = "3"
 
 # test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,15 +82,12 @@ unicode-properties = { version = "0.1", default-features = false, features = ["g
 # one emoji). Already in the tree via ratatui; declared here so wn-cli can depend
 # on it directly at the workspace-consistent version.
 unicode-segmentation = "1"
-unicode-normalization = "0.1"
 rand = "0.8"
 sha2 = "0.10"
 url = "2"
 psl = "2"
-bech32 = "0.11"
 chacha20poly1305 = "0.10"
 bytes = "1"
-scrypt = "0.11"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
 zeroize = "1"
 keyring-core = "1"
@@ -125,21 +122,17 @@ cgka-engine = { path = "crates/cgka-engine" }
 cgka-session = { path = "crates/cgka-session" }
 storage-sqlite = { path = "crates/storage-sqlite" }
 cgka-conformance-simulator = { path = "crates/cgka-conformance-simulator" }
-convergence-campaign-runner = { path = "crates/convergence-campaign-runner" }
 transport-nostr-peeler = { path = "crates/transport-nostr-peeler" }
 transport-nostr-adapter = { path = "crates/transport-nostr-adapter" }
 transport-quic-stream = { path = "crates/transport-quic-stream" }
 transport-quic-broker = { path = "crates/transport-quic-broker" }
 agent-stream-compose = { path = "crates/agent-stream-compose" }
 agent-control = { path = "crates/agent-control" }
-agent-connector = { path = "crates/agent-connector" }
 marmot-forensics = { path = "crates/marmot-forensics" }
 marmot-markdown = { path = "crates/marmot-markdown" }
 marmot-account = { path = "crates/marmot-account" }
 marmot-app = { path = "crates/marmot-app" }
-marmot-c = { path = "crates/marmot-c" }
 marmot-uniffi = { path = "crates/marmot-uniffi" }
-wn-cli = { path = "crates/cli" }
 marmot-terminal-harness = { path = "integrations/terminal-harness" }
 
 # hax-lib-macros 0.3.7 still declares the unmaintained proc-macro-error2

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -2271,7 +2271,7 @@ fn decode_convergence_policy(
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::sync::Arc;
 
     use async_trait::async_trait;
@@ -2385,7 +2385,7 @@ mod tests {
         }
     }
 
-    fn test_engine() -> crate::Engine<storage_sqlite::SqliteAccountStorage> {
+    pub(crate) fn test_engine() -> crate::Engine<storage_sqlite::SqliteAccountStorage> {
         let key = signing_key();
         let identity = key.verifying_key().to_bytes().to_vec();
         crate::EngineBuilder::new(storage_sqlite::SqliteAccountStorage::in_memory().unwrap())

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -146,6 +146,7 @@ pub struct Engine<S: StorageProvider> {
     /// Per-group state-machine owner. Every transition, pending-ref
     /// allocation, and fork-detection marker flows through this struct.
     pub(crate) epoch_manager: crate::epoch_manager::EpochManager,
+    pub(crate) mls_group_cache: crate::mls_group_cache::MlsGroupCache,
 
     /// Storage-layer identity of the origin commit behind each in-flight
     /// pending publish, so `do_confirm_published` can mark the sent commit
@@ -556,6 +557,7 @@ impl<S: StorageProvider> EngineBuilder<S> {
             wall_clock: self.wall_clock,
             maintenance_random: self.maintenance_random,
             epoch_manager: crate::epoch_manager::EpochManager::new(),
+            mls_group_cache: crate::mls_group_cache::MlsGroupCache::default(),
             pending_origin_commits: HashMap::new(),
             events_buf: pending_application_events.into(),
             auto_publish_buf: VecDeque::new(),
@@ -2943,28 +2945,23 @@ impl<S: StorageProvider> Engine<S> {
         self.update_stored_message_state(id, MessageState::Processed)
     }
 
-    /// One liveness-gated `MlsGroup::load` for read-only accessors. A missing
-    /// group maps to `UnknownGroup`.
-    fn live_mls_group(&self, group_id: &GroupId) -> Result<openmls::group::MlsGroup, EngineError> {
+    /// Liveness-gated read-only access to the group's `MlsGroup`, served from
+    /// the engine's group cache. A missing group maps to `UnknownGroup`.
+    fn with_live_mls_group<R>(
+        &self,
+        group_id: &GroupId,
+        f: impl FnOnce(&openmls::group::MlsGroup) -> Result<R, EngineError>,
+    ) -> Result<R, EngineError> {
         self.ensure_group_live(group_id)?;
-        let provider = crate::provider::EngineOpenMlsProvider::<S>::new(
-            &self.crypto,
-            self.storage.mls_storage(),
-        );
-        let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
-        openmls::group::MlsGroup::load(
-            <crate::provider::EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(&provider),
-            &mls_gid,
-        )
-        .map_err(|e| EngineError::Backend(format!("load: {e:?}")))?
-        .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))
+        self.with_mls_group(group_id, f)
     }
 
     /// Return the current Marmot admin policy keys mirrored from signed MLS
     /// group state.
     pub fn admin_pubkeys(&self, group_id: &GroupId) -> Result<Vec<[u8; 32]>, EngineError> {
-        let mls_group = self.live_mls_group(group_id)?;
-        let mut admins = crate::app_components::admins_of_group(&mls_group)?;
+        let mut admins = self.with_live_mls_group(group_id, |mls_group| {
+            crate::app_components::admins_of_group(mls_group)
+        })?;
         admins.sort();
         admins.dedup();
         Ok(admins)
@@ -3024,21 +3021,21 @@ impl<S: StorageProvider> Engine<S> {
         group_id: &GroupId,
         component_id: AppComponentId,
     ) -> Result<EpochId, EngineError> {
-        let mls_group = self.live_mls_group(group_id)?;
+        self.with_live_mls_group(group_id, |mls_group| {
+            let required_components =
+                crate::app_components::required_app_components_of_group(mls_group)?;
+            if !required_components.contains(component_id) {
+                return Err(EngineError::Other(format!(
+                    "group does not require app component {component_id:#06x}"
+                )));
+            }
 
-        let required_components =
-            crate::app_components::required_app_components_of_group(&mls_group)?;
-        if !required_components.contains(component_id) {
-            return Err(EngineError::Other(format!(
-                "group does not require app component {component_id:#06x}"
-            )));
-        }
-
-        if let Some(staged) = mls_group.pending_commit() {
-            Ok(EpochId(staged.group_context().epoch().as_u64()))
-        } else {
-            Ok(EpochId(mls_group.epoch().as_u64()))
-        }
+            if let Some(staged) = mls_group.pending_commit() {
+                Ok(EpochId(staged.group_context().epoch().as_u64()))
+            } else {
+                Ok(EpochId(mls_group.epoch().as_u64()))
+            }
+        })
     }
 }
 
@@ -3183,13 +3180,9 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
         // MemberValidationFailed) — never export its secrets.
         self.ensure_group_live(group_id)?;
         let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
-        let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
-        let mls_group = openmls::group::MlsGroup::load(
-            <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(&provider),
-            &mls_gid,
-        )
-        .map_err(|e| EngineError::Backend(format!("load: {e:?}")))?
-        .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
+        let mls_group = self
+            .take_mls_group(group_id)?
+            .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
         // When the group is in `PendingPublish`, the MLS group is at the
         // pre-stage epoch but the staged commit carries the projected
         // future state. Project so callers see the same epoch the rest of
@@ -3282,13 +3275,15 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
             crate::group_lifecycle::AGENT_TEXT_STREAM_EXPORTER_SNAPSHOT_KEY.to_string(),
             cgka_traits::SecretBytes::new(stream_secret),
         );
-        Ok(Box::new(crate::group_context_view::GroupContextView::new(
+        let view = crate::group_context_view::GroupContextView::new(
             EpochId(epoch),
             map,
             Some(crate::app_components::transport_group_id_of_group(
                 &mls_group,
             )?),
-        )))
+        );
+        self.return_mls_group(group_id, mls_group);
+        Ok(Box::new(view))
     }
 
     fn safe_export_secret(
@@ -3305,11 +3300,12 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
         group_id: &GroupId,
         component_id: AppComponentId,
     ) -> Result<Option<Vec<u8>>, EngineError> {
-        let mls_group = self.live_mls_group(group_id)?;
-        Ok(crate::app_components::app_component_data_of_group(
-            &mls_group,
-            component_id,
-        ))
+        self.with_live_mls_group(group_id, |mls_group| {
+            Ok(crate::app_components::app_component_data_of_group(
+                mls_group,
+                component_id,
+            ))
+        })
     }
 
     // One `MlsGroup::load` (13 storage reads + a ratchet-tree deserialize)
@@ -3319,13 +3315,14 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
         group_id: &GroupId,
         component_ids: &[AppComponentId],
     ) -> Result<Vec<Option<Vec<u8>>>, EngineError> {
-        let mls_group = self.live_mls_group(group_id)?;
-        Ok(component_ids
-            .iter()
-            .map(|component_id| {
-                crate::app_components::app_component_data_of_group(&mls_group, *component_id)
-            })
-            .collect())
+        self.with_live_mls_group(group_id, |mls_group| {
+            Ok(component_ids
+                .iter()
+                .map(|component_id| {
+                    crate::app_components::app_component_data_of_group(mls_group, *component_id)
+                })
+                .collect())
+        })
     }
 
     fn own_leaf_index(&self, group_id: &GroupId) -> Result<u32, EngineError> {

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -1349,15 +1349,7 @@ impl<S: StorageProvider> Engine<S> {
     }
 
     pub(crate) fn do_own_leaf_index(&self, group_id: &GroupId) -> Result<u32, EngineError> {
-        let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
-        let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
-        let mls_group = MlsGroup::load(
-            <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(&provider),
-            &mls_gid,
-        )
-        .map_err(|e| EngineError::Backend(format!("load: {e:?}")))?
-        .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
-        Ok(mls_group.own_leaf_index().u32())
+        self.with_mls_group(group_id, |mls_group| Ok(mls_group.own_leaf_index().u32()))
     }
 
     /// `constructable_capabilities` implementation.

--- a/crates/cgka-engine/src/lib.rs
+++ b/crates/cgka-engine/src/lib.rs
@@ -60,6 +60,7 @@ pub mod key_package;
 pub mod maintenance;
 pub(crate) mod message_disposition;
 pub mod message_processor;
+pub(crate) mod mls_group_cache;
 pub mod openmls_projection;
 pub mod pending_commit_guard;
 pub mod provider;

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -381,11 +381,7 @@ impl<S: StorageProvider> Engine<S> {
 
         // Load MlsGroup from storage.
         let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
-        let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
-        let mut mls_group = match MlsGroup::load(
-            <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(&provider),
-            &mls_gid,
-        ) {
+        let mut mls_group = match self.take_mls_group(&group_id) {
             Ok(Some(g)) => g,
             Ok(None) => {
                 self.persist_transport_message_for_existing_group(
@@ -1235,6 +1231,7 @@ impl<S: StorageProvider> Engine<S> {
                 // the content-derived id so a re-wrapped duplicate is caught
                 // before the durable lookup.
                 self.seen_message_ids.insert(msg.id.clone());
+                self.return_mls_group(&group_id, mls_group);
                 Ok(IngestOutcome::Processed)
             }
             ProcessedMessageContent::StagedCommitMessage(staged) => {
@@ -1607,6 +1604,7 @@ impl<S: StorageProvider> Engine<S> {
                 // the content-derived id so a re-wrapped duplicate commit is
                 // caught before the durable lookup.
                 self.seen_message_ids.insert(msg.id.clone());
+                self.return_mls_group(&group_id, mls_group);
                 Ok(IngestOutcome::Processed)
             }
             ProcessedMessageContent::ProposalMessage(queued) => {
@@ -1664,6 +1662,7 @@ impl<S: StorageProvider> Engine<S> {
                         self.convergence_now_ms(),
                     )?;
                 }
+                self.return_mls_group(&group_id, mls_group);
                 self.valid_proposal_groups.insert(group_id);
                 Ok(IngestOutcome::Processed)
             }

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -1004,21 +1004,28 @@ impl<S: StorageProvider> Engine<S> {
             );
         }
 
-        self.persist_openmls_wire_message(
-            &openmls_msg,
-            &group_id,
-            current_epoch,
-            MessageState::Created,
-        )?;
-
+        // The retained row and the secret-tree ratchet `process_message`
+        // writes share one durable unit: under `synchronous = FULL` every
+        // COMMIT is an fsync, and these were three per inbound message. The
+        // processing result leaves the closure as a value so a decrypt
+        // failure still commits the row the error branches below transition.
+        //
         // Process via MLS. Commits may contain AppDataUpdate proposals,
         // which require the application to compute the resulting
         // AppDataDictionary before OpenMLS stages the commit.
-        let processed = match if msg_content_type == ContentType::Commit {
-            process_commit_with_app_data_updates(&mut mls_group, &provider, proto)
-        } else {
-            mls_group.process_message(&provider, proto)
-        } {
+        let processed = match self.storage.with_transaction(|_storage| {
+            self.persist_openmls_wire_message(
+                &openmls_msg,
+                &group_id,
+                current_epoch,
+                MessageState::Created,
+            )?;
+            Ok::<_, EngineError>(if msg_content_type == ContentType::Commit {
+                process_commit_with_app_data_updates(&mut mls_group, &provider, proto)
+            } else {
+                mls_group.process_message(&provider, proto)
+            })
+        })? {
             Ok(p) => p,
             Err(e) if process_message_error_is_too_distant_in_the_past(&e) => {
                 // Refine the historical classification (mdk#339):

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -887,12 +887,16 @@ impl<S: StorageProvider> Engine<S> {
         let wrap_metadata =
             GroupMessageMetadata::application(app_event.created_at, source_retention_seconds);
 
-        let out: MlsMessageOut = mls_group
-            .create_message(&provider, &self.identity.signer, &payload)
-            .map_err(|e| EngineError::Backend(format!("create_message: {e:?}")))?;
-        let out_bytes = out
-            .tls_serialize_detached()
-            .map_err(|e| EngineError::Serialize(format!("{e:?}")))?;
+        // `create_message` ratchets the sender secret tree and writes it back;
+        // one transaction turns that write's two autocommits into one COMMIT
+        // (one fsync under `synchronous = FULL`).
+        let out_bytes = self.storage.with_transaction(|_storage| {
+            let out: MlsMessageOut = mls_group
+                .create_message(&provider, &self.identity.signer, &payload)
+                .map_err(|e| EngineError::Backend(format!("create_message: {e:?}")))?;
+            out.tls_serialize_detached()
+                .map_err(|e| EngineError::Serialize(format!("{e:?}")))
+        })?;
 
         let ctx = group_lifecycle::build_group_context_snapshot(&mls_group, &provider)?;
         let wrapped = self

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -849,15 +849,6 @@ impl<S: StorageProvider> Engine<S> {
         group_id: GroupId,
         payload: Vec<u8>,
     ) -> Result<SendResult, EngineError> {
-        let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
-        let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
-        let mut mls_group = MlsGroup::load(
-            <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(&provider),
-            &mls_gid,
-        )
-        .map_err(|e| EngineError::Backend(format!("load: {e:?}")))?
-        .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
-
         // Direct sending still requires Stable after convergence gating.
         if let Some(state) = self.epoch_manager.state(&group_id)
             && !matches!(state, EpochState::Stable { .. })
@@ -870,6 +861,11 @@ impl<S: StorageProvider> Engine<S> {
                 },
             ));
         }
+
+        let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
+        let mut mls_group = self
+            .take_mls_group(&group_id)?
+            .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
 
         let app_event =
             crate::app_payload::validate_app_payload_for_sender(&payload, self.identity.self_id())?;
@@ -920,6 +916,7 @@ impl<S: StorageProvider> Engine<S> {
             source_epoch,
             own_application_stamp,
         )?;
+        self.return_mls_group(&group_id, mls_group);
 
         Ok(SendResult::ApplicationMessage {
             msg: wrapped,

--- a/crates/cgka-engine/src/mls_group_cache.rs
+++ b/crates/cgka-engine/src/mls_group_cache.rs
@@ -1,0 +1,195 @@
+//! Loaded [`MlsGroup`]s kept across engine calls.
+//!
+//! `MlsGroup::load` is 13 storage reads plus a ratchet-tree decode that grows
+//! with the member count, and the send, receive, and group-read paths each
+//! paid it on every call. An entry is reused only while the storage backend's
+//! OpenMLS write generation is unchanged since the entry was stored, so a
+//! write through a freshly loaded group, a snapshot restore, or a rolled-back
+//! transaction invalidates it without any call-site bookkeeping.
+//!
+//! Protocol: `take` removes the entry for the duration of an operation and
+//! `return` stores it back only after the operation succeeded, when the object
+//! and storage are known to agree. An error path drops the object instead.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use cgka_traits::error::EngineError;
+use cgka_traits::storage::StorageProvider;
+use cgka_traits::types::GroupId;
+use openmls::group::MlsGroup;
+
+use crate::engine::Engine;
+
+/// ponytail: whole-map clear at the cap; an LRU only matters once an account
+/// actively works more groups than this at once.
+const MAX_CACHED_MLS_GROUPS: usize = 32;
+
+struct CachedMlsGroup {
+    generation: u64,
+    group: MlsGroup,
+}
+
+#[derive(Default)]
+pub(crate) struct MlsGroupCache {
+    entries: Mutex<HashMap<GroupId, CachedMlsGroup>>,
+    #[cfg(test)]
+    hits: std::sync::atomic::AtomicU64,
+}
+
+impl<S: StorageProvider> Engine<S> {
+    /// The group's `MlsGroup`: the cached object when nothing has written to
+    /// the OpenMLS store since it was stored, otherwise a fresh load. `None`
+    /// for an unknown group.
+    pub(crate) fn take_mls_group(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<Option<MlsGroup>, EngineError> {
+        if let Some(generation) = self.storage.mls_write_generation() {
+            let cached = self
+                .mls_group_cache
+                .entries
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .remove(group_id);
+            if let Some(cached) = cached
+                && cached.generation == generation
+            {
+                #[cfg(test)]
+                self.mls_group_cache
+                    .hits
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                return Ok(Some(cached.group));
+            }
+        }
+        let provider = crate::provider::EngineOpenMlsProvider::<S>::new(
+            &self.crypto,
+            self.storage.mls_storage(),
+        );
+        let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+        MlsGroup::load(
+            <crate::provider::EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(&provider),
+            &mls_gid,
+        )
+        .map_err(|e| EngineError::Backend(format!("load: {e:?}")))
+    }
+
+    /// Store `group` for reuse. Call only after an operation that left the
+    /// object and storage in agreement; drop the object on error paths.
+    pub(crate) fn return_mls_group(&self, group_id: &GroupId, group: MlsGroup) {
+        let Some(generation) = self.storage.mls_write_generation() else {
+            return;
+        };
+        let mut entries = self
+            .mls_group_cache
+            .entries
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if entries.len() >= MAX_CACHED_MLS_GROUPS && !entries.contains_key(group_id) {
+            entries.clear();
+        }
+        entries.insert(group_id.clone(), CachedMlsGroup { generation, group });
+    }
+
+    /// Run a read-only `f` against the group's `MlsGroup` and keep the object
+    /// cached afterwards. `f` must not write through the group.
+    pub(crate) fn with_mls_group<R>(
+        &self,
+        group_id: &GroupId,
+        f: impl FnOnce(&MlsGroup) -> Result<R, EngineError>,
+    ) -> Result<R, EngineError> {
+        let group = self
+            .take_mls_group(group_id)?
+            .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
+        let result = f(&group);
+        self.return_mls_group(group_id, group);
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::Ordering;
+
+    use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MarmotAppEvent};
+    use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, SendIntent};
+    use cgka_traits::error::EngineError;
+    use cgka_traits::storage::StorageProvider;
+
+    use crate::distributed_convergence::tests::test_engine;
+
+    #[tokio::test]
+    async fn cached_group_is_reused_until_storage_is_written_behind_it() {
+        let mut engine = test_engine();
+        let (group_id, _) = engine
+            .create_group(CreateGroupRequest {
+                name: "cache".into(),
+                description: String::new(),
+                members: vec![],
+                required_features: vec![],
+                app_components: vec![],
+                initial_admins: vec![],
+            })
+            .await
+            .unwrap();
+        let payload = MarmotAppEvent::new(
+            hex::encode(engine.self_id().as_slice()),
+            1_700_000_000,
+            MARMOT_APP_EVENT_KIND_CHAT,
+            vec![],
+            "cache",
+        )
+        .encode()
+        .unwrap();
+        async fn send(
+            engine: &mut crate::Engine<storage_sqlite::SqliteAccountStorage>,
+            group_id: &cgka_traits::types::GroupId,
+            payload: &[u8],
+        ) -> Result<(), EngineError> {
+            engine
+                .send(SendIntent::AppMessage {
+                    group_id: group_id.clone(),
+                    payload: payload.to_vec(),
+                })
+                .await
+                .map(|_| ())
+        }
+        let hits = |engine: &crate::Engine<storage_sqlite::SqliteAccountStorage>| {
+            engine.mls_group_cache.hits.load(Ordering::Relaxed)
+        };
+        let cached = |engine: &crate::Engine<storage_sqlite::SqliteAccountStorage>| {
+            engine.mls_group_cache.entries.lock().unwrap().len()
+        };
+
+        // Group creation reads the new group back through a cached accessor,
+        // so the entry may already exist; measure hits relative to here.
+        send(&mut engine, &group_id, &payload).await.unwrap();
+        assert_eq!(cached(&engine), 1, "a successful send stores the group");
+        let after_first_send = hits(&engine);
+
+        send(&mut engine, &group_id, &payload).await.unwrap();
+        assert_eq!(
+            hits(&engine),
+            after_first_send + 1,
+            "the next send reuses it"
+        );
+
+        // A rolled-back transaction counts as a write: whatever the cached
+        // object believes about storage can no longer be trusted.
+        let generation = engine.storage.mls_write_generation().unwrap();
+        engine
+            .storage
+            .with_transaction(|_| Err::<(), EngineError>(EngineError::Other("abort".into())))
+            .unwrap_err();
+        assert!(engine.storage.mls_write_generation().unwrap() > generation);
+
+        send(&mut engine, &group_id, &payload).await.unwrap();
+        assert_eq!(
+            hits(&engine),
+            after_first_send + 1,
+            "a foreign write forces a reload"
+        );
+        send(&mut engine, &group_id, &payload).await.unwrap();
+        assert_eq!(hits(&engine), after_first_send + 2);
+    }
+}

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -606,7 +606,10 @@ pub struct MarmotApp {
     shared_storage: Arc<Mutex<Option<SqliteSharedStorage>>>,
     account_state_ready: Arc<Mutex<HashSet<String>>>,
     chat_list_projection_warmed: Arc<Mutex<HashSet<String>>>,
-    chat_list_projection_stale: Arc<Mutex<HashSet<String>>>,
+    /// Per account label, the group ids whose chat-list row must be refreshed
+    /// before the next `chat_list()` answers. A single received message used
+    /// to mark the whole projection stale and rebuild every row.
+    chat_list_projection_stale: Arc<Mutex<HashMap<String, HashSet<String>>>>,
     audit_log_tracker_config: Arc<Mutex<AuditLogTrackerConfig>>,
     external_signers: Arc<Mutex<HashMap<String, RegisteredExternalSigner>>>,
     /// One signer-bound publisher per account. Setup publishes and the managed
@@ -1443,7 +1446,7 @@ impl MarmotApp {
             shared_storage: Arc::new(Mutex::new(None)),
             account_state_ready: Arc::new(Mutex::new(HashSet::new())),
             chat_list_projection_warmed: Arc::new(Mutex::new(HashSet::new())),
-            chat_list_projection_stale: Arc::new(Mutex::new(HashSet::new())),
+            chat_list_projection_stale: Arc::new(Mutex::new(HashMap::new())),
             audit_log_tracker_config: Arc::new(Mutex::new(AuditLogTrackerConfig::default())),
             external_signers: Arc::new(Mutex::new(HashMap::new())),
             account_publish_clients: Arc::new(Mutex::new(HashMap::new())),
@@ -1517,7 +1520,7 @@ impl MarmotApp {
             shared_storage: Arc::new(Mutex::new(None)),
             account_state_ready: Arc::new(Mutex::new(HashSet::new())),
             chat_list_projection_warmed: Arc::new(Mutex::new(HashSet::new())),
-            chat_list_projection_stale: Arc::new(Mutex::new(HashSet::new())),
+            chat_list_projection_stale: Arc::new(Mutex::new(HashMap::new())),
             audit_log_tracker_config: Arc::new(Mutex::new(AuditLogTrackerConfig::default())),
             external_signers: Arc::new(Mutex::new(HashMap::new())),
             account_publish_clients: Arc::new(Mutex::new(HashMap::new())),
@@ -3346,13 +3349,24 @@ impl MarmotApp {
     pub fn groups(&self, label: &str) -> Result<Vec<AppGroupRecord>, AppError> {
         self.ensure_account_state(label)?;
         let mut groups = self.load_state(label)?.groups;
-        // `leave_requested_at_ms` is not part of the stored projection, so stamp
-        // it from the engine-owned leave-request table here. This is the single
-        // population point for the group record: `visible_groups`, `group`, and
-        // `subscribe_chats` all read through this method.
+        self.stamp_group_lifecycle(label, &mut groups)?;
+        Ok(groups)
+    }
+
+    /// Fill the engine-owned lifecycle fields the stored projection does not
+    /// carry. `leave_requested_at_ms` comes from the leave-request table
+    /// because the engine clears those rows from paths that never notify the
+    /// app layer; the disband fields likewise read the engine's tables. This
+    /// is the single population point for the group record: `visible_groups`,
+    /// `group`, and `subscribe_chats` all read through it.
+    fn stamp_group_lifecycle(
+        &self,
+        label: &str,
+        groups: &mut [AppGroupRecord],
+    ) -> Result<(), AppError> {
         let pending = self.pending_leave_requests(label)?;
         if !pending.is_empty() {
-            for group in &mut groups {
+            for group in groups.iter_mut() {
                 group.leave_requested_at_ms = pending.get(&group.group_id_hex).copied();
             }
         }
@@ -3364,12 +3378,12 @@ impl MarmotApp {
             .into_iter()
             .map(|(group_id, _)| hex::encode(group_id.as_slice()))
             .collect::<HashSet<_>>();
-        for group in &mut groups {
+        for group in groups.iter_mut() {
             group.disbanding = disbanding.contains(&group.group_id_hex);
             group.disband_request = requests.get(&group.group_id_hex).cloned().map(Into::into);
             group.disbanded = disbanded.contains(&group.group_id_hex);
         }
-        Ok(groups)
+        Ok(())
     }
 
     /// Outstanding durable leave requests for this account, keyed by group id hex
@@ -3448,15 +3462,25 @@ impl MarmotApp {
             .collect())
     }
 
+    /// One group by id. Reads that group's projection row alone rather than
+    /// the whole account projection (every group plus the seen-event window),
+    /// which is what opening a conversation used to cost.
     pub fn group(
         &self,
         label: &str,
         group_id_hex: &str,
     ) -> Result<Option<AppGroupRecord>, AppError> {
-        Ok(self
-            .groups(label)?
-            .into_iter()
-            .find(|group| group.group_id_hex == group_id_hex))
+        self.ensure_account_state(label)?;
+        let Some(stored) = self
+            .account_storage(label)?
+            .load_account_group(label, group_id_hex)?
+        else {
+            return Ok(None);
+        };
+        let mut group = [conversions::app_group_from_stored_group(stored)?];
+        self.stamp_group_lifecycle(label, &mut group)?;
+        let [group] = group;
+        Ok(Some(group))
     }
 
     pub fn set_group_archived(
@@ -4711,11 +4735,24 @@ impl MarmotApp {
                 MAX_SEEN_EVENT_IDS,
                 TRANSPORT_CURSOR_MAX_FUTURE_SKEW.as_secs(),
             )?;
+        self.mark_chat_list_stale(
+            &state.label,
+            state
+                .groups
+                .iter()
+                .map(|group| group.group_id_hex.clone())
+                .collect(),
+        );
+        Ok(())
+    }
+
+    fn mark_chat_list_stale(&self, label: &str, group_ids_hex: HashSet<String>) {
         self.chat_list_projection_stale
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .insert(state.label.clone());
-        Ok(())
+            .entry(label.to_owned())
+            .or_default()
+            .extend(group_ids_hex);
     }
 
     fn save_state_delta_clearing_local_group_deletion_frontiers_and_acking_application_events(
@@ -4732,10 +4769,14 @@ impl MarmotApp {
                 frontiers_to_clear,
                 application_event_ids_to_ack,
             )?;
-        self.chat_list_projection_stale
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .insert(delta.label.clone());
+        self.mark_chat_list_stale(
+            &delta.label,
+            delta
+                .groups
+                .iter()
+                .map(|group| group.group_id_hex.clone())
+                .collect(),
+        );
         Ok(())
     }
 
@@ -4748,10 +4789,12 @@ impl MarmotApp {
     ) -> Result<ChatListRow, AppError> {
         let account = self.account_home().account(&delta.label)?;
         let classifier = Self::chat_list_mention_classifier(&account.account_id_hex);
-        let has_other_dirty_groups = delta
+        let other_dirty_groups: HashSet<String> = delta
             .groups
             .iter()
-            .any(|group| group.group_id_hex != group_id_hex);
+            .filter(|group| group.group_id_hex != group_id_hex)
+            .map(|group| group.group_id_hex.clone())
+            .collect();
         let mut row = self
             .account_storage(&delta.label)?
             .save_account_projection_delta_and_refresh_chat_list_row(
@@ -4771,11 +4814,8 @@ impl MarmotApp {
         // pre-existing stale marker, and add one if this delta also persisted
         // another dirty group; a later full-list query performs that rebuild.
         // A single-row refresh does not prove the full projection is warmed.
-        if has_other_dirty_groups {
-            self.chat_list_projection_stale
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .insert(delta.label.clone());
+        if !other_dirty_groups.is_empty() {
+            self.mark_chat_list_stale(&delta.label, other_dirty_groups);
         }
         Ok(row)
     }
@@ -4796,10 +4836,7 @@ impl MarmotApp {
             return Err(AppError::GroupDisbanding(group_id_hex.to_owned()));
         }
         let deleted = storage.delete_local_group_data(group_id_hex)?.did_delete();
-        self.chat_list_projection_stale
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .insert(label.to_owned());
+        self.mark_chat_list_stale(label, HashSet::from([normalized_group_id_hex]));
         self.chat_list_projection_warmed
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -4860,30 +4897,31 @@ impl MarmotApp {
             .chat_list_projection_stale
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .contains(&account.label);
+            .remove(&account.label);
         let warmed = self
             .chat_list_projection_warmed
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .contains(&account.label);
-        if warmed && !stale {
-            return Ok(());
-        }
         let storage = self.account_storage(&account.label)?;
         let classifier = Self::chat_list_mention_classifier(&account.account_id_hex);
-        if stale {
-            storage.refresh_chat_list_rows(&account.account_id_hex, &classifier)?;
-        } else {
-            storage.ensure_chat_list_rows(&account.account_id_hex, &classifier)?;
+        match stale {
+            None if warmed => return Ok(()),
+            Some(group_ids) if warmed => {
+                for group_id_hex in group_ids {
+                    storage.refresh_chat_list_row(
+                        &account.account_id_hex,
+                        &group_id_hex,
+                        &classifier,
+                    )?;
+                }
+            }
+            _ => storage.ensure_chat_list_rows(&account.account_id_hex, &classifier)?,
         }
         self.chat_list_projection_warmed
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .insert(account.label.clone());
-        self.chat_list_projection_stale
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .remove(&account.label);
         Ok(())
     }
 

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -4698,10 +4698,10 @@ fn founding_create_leaves_reconstructable_welcome_index_off_response_path() {
             .lock()
             .unwrap()
             .remove("alice");
-        app.chat_list_projection_stale
-            .lock()
-            .unwrap()
-            .insert("alice".to_owned());
+        app.chat_list_projection_stale.lock().unwrap().insert(
+            "alice".to_owned(),
+            HashSet::from(["stale-group".to_owned()]),
+        );
 
         relay.block_next_publish();
         let created = runtime
@@ -4737,7 +4737,7 @@ fn founding_create_leaves_reconstructable_welcome_index_off_response_path() {
             app.chat_list_projection_stale
                 .lock()
                 .unwrap()
-                .contains("alice"),
+                .contains_key("alice"),
             "create refreshes only its returned row and must preserve a pre-existing full-list rebuild obligation"
         );
         assert!(
@@ -8870,7 +8870,7 @@ fn drop_account_caches_evicts_storage_and_directory_handles_and_warm_flags() {
         !app.chat_list_projection_stale
             .lock()
             .unwrap()
-            .contains(&alice.label)
+            .contains_key(&alice.label)
     );
 }
 

--- a/crates/storage-sqlite/Cargo.toml
+++ b/crates/storage-sqlite/Cargo.toml
@@ -12,6 +12,7 @@ fs-private.workspace = true
 hex.workspace = true
 openmls.workspace = true
 openmls_traits.workspace = true
+rmp-serde = "1.3.1"
 rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -1428,7 +1428,7 @@ impl SqliteAccountStorage {
                     "account_groups",
                 ] {
                     deleted = deleted.saturating_add(
-                        tx.execute(
+                        tx.execute_cached(
                             &format!("DELETE FROM {table} WHERE group_id_hex = ?1"),
                             params![group_id_hex],
                         )

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -806,82 +806,7 @@ impl SqliteAccountStorage {
             .collect::<Result<Vec<_>, _>>()
             .storage()?;
 
-        let mut group_statement = conn
-            .prepare_cached(
-                "SELECT group_id_hex, endpoint, profile_name, profile_description,
-                        image_hash_hex, image_key_hex, image_nonce_hex,
-                        image_upload_key_hex, image_media_type, admin_keys_hex,
-                        archived, pending_confirmation, welcomer_account_id_hex,
-                        via_welcome_message_id_hex, nostr_routing_last_epoch,
-                        prior_nostr_routes_json, self_membership, member_count
-                 FROM account_groups
-                 ORDER BY updated_at, group_id_hex",
-            )
-            .storage()?;
-        let raw_groups = group_statement
-            .query_map([], |row| {
-                Ok(RawStoredAccountGroup {
-                    group_id_hex: row.get(0)?,
-                    endpoint: row.get(1)?,
-                    profile_name: row.get(2)?,
-                    profile_description: row.get(3)?,
-                    image_hash_hex: row.get(4)?,
-                    image_key_hex: row.get(5)?,
-                    image_nonce_hex: row.get(6)?,
-                    image_upload_key_hex: row.get(7)?,
-                    image_media_type: row.get(8)?,
-                    admin_keys_hex: row.get(9)?,
-                    archived: row.get::<_, i64>(10)? != 0,
-                    pending_confirmation: row.get::<_, i64>(11)? != 0,
-                    welcomer_account_id_hex: row.get(12)?,
-                    via_welcome_message_id_hex: row.get(13)?,
-                    nostr_routing_last_epoch: row.get(14)?,
-                    prior_nostr_routes_json: row.get(15)?,
-                    self_membership: SelfMembership::from_storage(&row.get::<_, String>(16)?),
-                    member_count: row.get(17)?,
-                })
-            })
-            .storage()?
-            .collect::<Result<Vec<_>, _>>()
-            .storage()?;
-        drop(group_statement);
-
-        let mut components_by_group = all_account_group_components(&conn)?;
-        let mut members_by_group = load_direct_conversation_members(&conn)?;
-        let mut groups = Vec::with_capacity(raw_groups.len());
-        for raw in raw_groups {
-            let prior_nostr_routes = serde_json::from_str(&raw.prior_nostr_routes_json)
-                .map_err(|err| StorageError::Serialization(err.to_string()))?;
-            let components = components_by_group
-                .remove(&raw.group_id_hex)
-                .unwrap_or_default();
-            let direct_member_ids_hex = members_by_group.remove(&raw.group_id_hex);
-            groups.push(StoredAccountGroup {
-                group_id_hex: raw.group_id_hex,
-                endpoint: raw.endpoint,
-                profile_name: raw.profile_name,
-                profile_description: raw.profile_description,
-                image_hash_hex: raw.image_hash_hex,
-                image_key_hex: raw.image_key_hex,
-                image_nonce_hex: raw.image_nonce_hex,
-                image_upload_key_hex: raw.image_upload_key_hex,
-                image_media_type: raw.image_media_type,
-                admin_keys_hex: raw.admin_keys_hex,
-                archived: raw.archived,
-                pending_confirmation: raw.pending_confirmation,
-                member_count: raw.member_count.and_then(|value| value.try_into().ok()),
-                direct_member_ids_hex,
-                welcomer_account_id_hex: raw.welcomer_account_id_hex,
-                via_welcome_message_id_hex: raw.via_welcome_message_id_hex,
-                nostr_routing_last_epoch: raw
-                    .nostr_routing_last_epoch
-                    .try_into()
-                    .unwrap_or_default(),
-                prior_nostr_routes,
-                self_membership: raw.self_membership,
-                components,
-            });
-        }
+        let groups = stored_account_groups(&conn, None)?;
 
         Ok(StoredAccountState {
             label: label.to_owned(),
@@ -889,6 +814,20 @@ impl SqliteAccountStorage {
             last_transport_timestamp,
             groups,
         })
+    }
+
+    /// One stored group, or `None` when no row carries `group_id_hex`. Reads
+    /// only that group's row, components, and direct members; the full
+    /// projection load above materializes every group and the seen-event
+    /// window to answer the same question.
+    pub fn load_account_group(
+        &self,
+        label: &str,
+        group_id_hex: &str,
+    ) -> StorageResult<Option<StoredAccountGroup>> {
+        self.ensure_account_projection(label)?;
+        let conn = self.lock()?;
+        Ok(stored_account_groups(&conn, Some(group_id_hex))?.pop())
     }
 
     /// Persist one account-projection snapshot.
@@ -3432,22 +3371,120 @@ fn checkpoint_wal_truncate_after_secure_delete(conn: &Connection) -> StorageResu
     })
 }
 
+/// Account groups in projection order, or only `group_id_hex` when given.
+fn stored_account_groups(
+    conn: &rusqlite::Connection,
+    group_id_hex: Option<&str>,
+) -> StorageResult<Vec<StoredAccountGroup>> {
+    const COLUMNS: &str = "group_id_hex, endpoint, profile_name, profile_description,
+                        image_hash_hex, image_key_hex, image_nonce_hex,
+                        image_upload_key_hex, image_media_type, admin_keys_hex,
+                        archived, pending_confirmation, welcomer_account_id_hex,
+                        via_welcome_message_id_hex, nostr_routing_last_epoch,
+                        prior_nostr_routes_json, self_membership, member_count";
+    let all_sql = format!("SELECT {COLUMNS} FROM account_groups ORDER BY updated_at, group_id_hex");
+    let one_sql = format!("SELECT {COLUMNS} FROM account_groups WHERE group_id_hex = ?1");
+    let mut group_statement = conn
+        .prepare_cached(if group_id_hex.is_some() {
+            &one_sql
+        } else {
+            &all_sql
+        })
+        .storage()?;
+    let params: Vec<&dyn rusqlite::ToSql> = group_id_hex
+        .iter()
+        .map(|hex| hex as &dyn rusqlite::ToSql)
+        .collect();
+    let raw_groups = group_statement
+        .query_map(params.as_slice(), |row| {
+            Ok(RawStoredAccountGroup {
+                group_id_hex: row.get(0)?,
+                endpoint: row.get(1)?,
+                profile_name: row.get(2)?,
+                profile_description: row.get(3)?,
+                image_hash_hex: row.get(4)?,
+                image_key_hex: row.get(5)?,
+                image_nonce_hex: row.get(6)?,
+                image_upload_key_hex: row.get(7)?,
+                image_media_type: row.get(8)?,
+                admin_keys_hex: row.get(9)?,
+                archived: row.get::<_, i64>(10)? != 0,
+                pending_confirmation: row.get::<_, i64>(11)? != 0,
+                welcomer_account_id_hex: row.get(12)?,
+                via_welcome_message_id_hex: row.get(13)?,
+                nostr_routing_last_epoch: row.get(14)?,
+                prior_nostr_routes_json: row.get(15)?,
+                self_membership: SelfMembership::from_storage(&row.get::<_, String>(16)?),
+                member_count: row.get(17)?,
+            })
+        })
+        .storage()?
+        .collect::<Result<Vec<_>, _>>()
+        .storage()?;
+    drop(group_statement);
+
+    let mut components_by_group = all_account_group_components(conn, group_id_hex)?;
+    let mut members_by_group = load_direct_conversation_members(conn, group_id_hex)?;
+    let mut groups = Vec::with_capacity(raw_groups.len());
+    for raw in raw_groups {
+        let prior_nostr_routes = serde_json::from_str(&raw.prior_nostr_routes_json)
+            .map_err(|err| StorageError::Serialization(err.to_string()))?;
+        let components = components_by_group
+            .remove(&raw.group_id_hex)
+            .unwrap_or_default();
+        let direct_member_ids_hex = members_by_group.remove(&raw.group_id_hex);
+        groups.push(StoredAccountGroup {
+            group_id_hex: raw.group_id_hex,
+            endpoint: raw.endpoint,
+            profile_name: raw.profile_name,
+            profile_description: raw.profile_description,
+            image_hash_hex: raw.image_hash_hex,
+            image_key_hex: raw.image_key_hex,
+            image_nonce_hex: raw.image_nonce_hex,
+            image_upload_key_hex: raw.image_upload_key_hex,
+            image_media_type: raw.image_media_type,
+            admin_keys_hex: raw.admin_keys_hex,
+            archived: raw.archived,
+            pending_confirmation: raw.pending_confirmation,
+            member_count: raw.member_count.and_then(|value| value.try_into().ok()),
+            direct_member_ids_hex,
+            welcomer_account_id_hex: raw.welcomer_account_id_hex,
+            via_welcome_message_id_hex: raw.via_welcome_message_id_hex,
+            nostr_routing_last_epoch: raw.nostr_routing_last_epoch.try_into().unwrap_or_default(),
+            prior_nostr_routes,
+            self_membership: raw.self_membership,
+            components,
+        });
+    }
+    Ok(groups)
+}
+
 /// #762: load ALL account-group components in one ordered query, bucketed by
 /// group in Rust, instead of an N+1 per-group query during full-projection load.
 /// Ordered by `(group_id_hex, component_id)` so each group's components keep
 /// `component_id` order (matching the prior per-group `ORDER BY component_id`).
 fn all_account_group_components(
     conn: &rusqlite::Connection,
+    group_id_hex: Option<&str>,
 ) -> StorageResult<std::collections::HashMap<String, Vec<StoredAccountGroupComponent>>> {
     let mut statement = conn
-        .prepare_cached(
+        .prepare_cached(if group_id_hex.is_some() {
             "SELECT group_id_hex, component_id, component_name, component_data_hex
              FROM account_group_app_components
-             ORDER BY group_id_hex, component_id",
-        )
+             WHERE group_id_hex = ?1
+             ORDER BY component_id"
+        } else {
+            "SELECT group_id_hex, component_id, component_name, component_data_hex
+             FROM account_group_app_components
+             ORDER BY group_id_hex, component_id"
+        })
         .storage()?;
+    let params: Vec<&dyn rusqlite::ToSql> = group_id_hex
+        .iter()
+        .map(|hex| hex as &dyn rusqlite::ToSql)
+        .collect();
     let rows = statement
-        .query_map([], |row| {
+        .query_map(params.as_slice(), |row| {
             Ok((
                 row.get::<_, String>(0)?,
                 StoredAccountGroupComponent {
@@ -3774,16 +3811,26 @@ fn i64_to_u32(value: i64, column: usize) -> rusqlite::Result<u32> {
 
 fn load_direct_conversation_members(
     conn: &Connection,
+    group_id_hex: Option<&str>,
 ) -> StorageResult<HashMap<String, Vec<String>>> {
     let mut statement = conn
-        .prepare_cached(
+        .prepare_cached(if group_id_hex.is_some() {
             "SELECT group_id_hex, member_id_hex
              FROM direct_conversation_members
-             ORDER BY group_id_hex, member_id_hex",
-        )
+             WHERE group_id_hex = ?1
+             ORDER BY member_id_hex"
+        } else {
+            "SELECT group_id_hex, member_id_hex
+             FROM direct_conversation_members
+             ORDER BY group_id_hex, member_id_hex"
+        })
         .storage()?;
+    let params: Vec<&dyn rusqlite::ToSql> = group_id_hex
+        .iter()
+        .map(|hex| hex as &dyn rusqlite::ToSql)
+        .collect();
     let rows = statement
-        .query_map([], |row| {
+        .query_map(params.as_slice(), |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
         })
         .storage()?;

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -1,3 +1,4 @@
+use crate::connection::CachedSql;
 use crate::{
     SQLITE_BIND_PARAMETER_CHUNK, SqliteAccountStorage, SqliteResultExt, bool_i64,
     connection::retry_on_busy,
@@ -457,7 +458,7 @@ struct RawStoredAccountGroup {
 impl SqliteAccountStorage {
     pub fn ensure_account_projection(&self, label: &str) -> StorageResult<()> {
         self.lock()?
-            .execute(
+            .execute_cached(
                 "INSERT INTO account_state (label, updated_at)
                  VALUES (?1, ?2)
                  ON CONFLICT(label) DO NOTHING",
@@ -484,7 +485,7 @@ impl SqliteAccountStorage {
                     StorageError::Serialization(format!("invalid epoch backfill group id: {error}"))
                 })?;
                 let stalled_epoch = u64_to_i64(intent.stalled_epoch)?;
-                conn.execute(
+                conn.execute_cached(
                     "INSERT INTO app_epoch_backfill_intents
                         (group_id, stalled_epoch, updated_at)
                      VALUES (?1, ?2, ?3)
@@ -506,7 +507,7 @@ impl SqliteAccountStorage {
     pub fn pending_epoch_backfill_intents(&self) -> StorageResult<Vec<StoredEpochBackfillIntent>> {
         let conn = self.lock()?;
         let mut statement = conn
-            .prepare(
+            .prepare_cached(
                 "SELECT group_id, stalled_epoch
                  FROM app_epoch_backfill_intents
                  ORDER BY updated_at, group_id",
@@ -545,7 +546,7 @@ impl SqliteAccountStorage {
                     StorageError::Serialization(format!("invalid epoch backfill group id: {error}"))
                 })?;
                 let stalled_epoch = u64_to_i64(intent.stalled_epoch)?;
-                conn.execute(
+                conn.execute_cached(
                     "DELETE FROM app_epoch_backfill_intents
                      WHERE group_id = ?1 AND stalled_epoch = ?2",
                     params![group_id, stalled_epoch],
@@ -561,7 +562,7 @@ impl SqliteAccountStorage {
         label: &str,
     ) -> StorageResult<Option<AccountDeliveryRecovery>> {
         let conn = self.lock()?;
-        conn.query_row(
+        conn.query_row_cached(
             "SELECT marker_token, pending_since, dropped_count
              FROM account_delivery_recovery
              WHERE account_label = ?1",
@@ -594,7 +595,7 @@ impl SqliteAccountStorage {
         let marker_token = i64::try_from(marker_token).unwrap_or(i64::MAX);
         let dropped_count = i64::try_from(dropped_count).unwrap_or(i64::MAX);
         let conn = self.lock()?;
-        conn.execute(
+        conn.execute_cached(
             "INSERT INTO account_delivery_recovery (
                 account_label, marker_token, pending_since, dropped_count
              ) VALUES (?1, ?2, ?3, ?4)
@@ -624,7 +625,7 @@ impl SqliteAccountStorage {
         let marker_token = i64::try_from(marker_token).unwrap_or(i64::MAX);
         let conn = self.lock()?;
         let cleared = conn
-            .execute(
+            .execute_cached(
                 "DELETE FROM account_delivery_recovery
                  WHERE account_label = ?1 AND marker_token = ?2",
                 params![label, marker_token],
@@ -653,7 +654,7 @@ impl SqliteAccountStorage {
                 let group_id = hex::decode(&entry.group_id_hex).map_err(|error| {
                     StorageError::Serialization(format!("invalid epoch stall group id: {error}"))
                 })?;
-                conn.execute(
+                conn.execute_cached(
                     "INSERT INTO app_epoch_stall_evidence
                         (group_id, stalled_epoch, fruitless_completions, fruitless_reported,
                          last_arm_at_ms, updated_at)
@@ -691,7 +692,7 @@ impl SqliteAccountStorage {
     pub fn epoch_stall_evidence(&self) -> StorageResult<Vec<StoredEpochStallEvidence>> {
         let conn = self.lock()?;
         let mut statement = conn
-            .prepare(
+            .prepare_cached(
                 "SELECT group_id, stalled_epoch, fruitless_completions, fruitless_reported, last_arm_at_ms
                  FROM app_epoch_stall_evidence
                  ORDER BY updated_at, group_id",
@@ -751,7 +752,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<Vec<StoredPendingGroupInvite>> {
         let conn = self.lock()?;
         let mut statement = conn
-            .prepare(
+            .prepare_cached(
                 "SELECT group_id_hex, welcomer_account_id_hex
                  FROM account_groups
                  WHERE pending_confirmation = 1 AND archived = 0
@@ -779,7 +780,7 @@ impl SqliteAccountStorage {
         self.ensure_account_projection(label)?;
         let conn = self.lock()?;
         let last_transport_timestamp = conn
-            .query_row(
+            .query_row_cached(
                 "SELECT last_transport_timestamp FROM account_state WHERE label = ?1",
                 params![label],
                 |row| row.get::<_, Option<i64>>(0),
@@ -788,7 +789,7 @@ impl SqliteAccountStorage {
             .and_then(|value| u64::try_from(value).ok());
 
         let mut seen_statement = conn
-            .prepare(
+            .prepare_cached(
                 "SELECT event_id FROM (
                     SELECT event_id, seen_at, rowid FROM seen_events
                     ORDER BY seen_at DESC, rowid DESC
@@ -806,7 +807,7 @@ impl SqliteAccountStorage {
             .storage()?;
 
         let mut group_statement = conn
-            .prepare(
+            .prepare_cached(
                 "SELECT group_id_hex, endpoint, profile_name, profile_description,
                         image_hash_hex, image_key_hex, image_nonce_hex,
                         image_upload_key_hex, image_media_type, admin_keys_hex,
@@ -1025,7 +1026,7 @@ impl SqliteAccountStorage {
         self.connection.with_transaction(|| {
             let conn = self.lock()?;
             for (group_id_hex, expected_frontier) in frontiers_to_clear {
-                conn.execute(
+                conn.execute_cached(
                     "DELETE FROM local_group_deletion_frontiers
                      WHERE group_id_hex = ?1 AND message_insert_order = ?2",
                     params![
@@ -1036,7 +1037,7 @@ impl SqliteAccountStorage {
                 .storage()?;
             }
             let stored_cursor = conn
-                .query_row(
+                .query_row_cached(
                     "SELECT last_transport_timestamp FROM account_state WHERE label = ?1",
                     params![&state.label],
                     |row| row.get::<_, Option<i64>>(0),
@@ -1051,7 +1052,7 @@ impl SqliteAccountStorage {
                 now,
                 max_future_skew_secs,
             );
-            conn.execute(
+            conn.execute_cached(
                 "INSERT INTO account_state (label, updated_at, last_transport_timestamp)
                  VALUES (?1, ?2, ?3)
                  ON CONFLICT(label) DO UPDATE SET
@@ -1068,14 +1069,14 @@ impl SqliteAccountStorage {
             let retained_start = state.seen_events.len().saturating_sub(max_seen_events);
             let mut inserted_seen_event = false;
             for event_id in &state.seen_events[retained_start..] {
-                let inserted = conn.execute(
+                let inserted = conn.execute_cached(
                     "INSERT OR IGNORE INTO seen_events (event_id, seen_at)
                      VALUES (?1, ?2)",
                     params![event_id, now_i64],
                 )
                 .storage()?;
                 if inserted == 0 {
-                    conn.execute(
+                    conn.execute_cached(
                         "UPDATE seen_events SET seen_at = ?2 WHERE event_id = ?1",
                         params![event_id, now_i64],
                     )
@@ -1088,7 +1089,7 @@ impl SqliteAccountStorage {
             // needs no prune. Full snapshot writes retain the historical
             // max-bound enforcement even when the supplied snapshot is empty.
             if replace_group_snapshot || inserted_seen_event {
-                conn.execute(
+                conn.execute_cached(
                     "DELETE FROM seen_events
                      WHERE event_id NOT IN (
                         SELECT event_id FROM seen_events
@@ -1104,7 +1105,7 @@ impl SqliteAccountStorage {
                 std::collections::HashSet::new()
             } else {
                 let mut statement = conn
-                    .prepare("SELECT group_id_hex FROM local_group_deletion_frontiers")
+                    .prepare_cached("SELECT group_id_hex FROM local_group_deletion_frontiers")
                     .storage()?;
                 statement
                     .query_map([], |row| row.get::<_, String>(0))
@@ -1147,7 +1148,7 @@ impl SqliteAccountStorage {
                 .filter(|group| !locally_deleted_group_ids.contains(&group.group_id_hex))
             {
                 let group_was_new = !conn
-                    .query_row(
+                    .query_row_cached(
                         "SELECT EXISTS(
                             SELECT 1 FROM account_groups WHERE group_id_hex = ?1
                          )",
@@ -1159,7 +1160,7 @@ impl SqliteAccountStorage {
                     i64::try_from(group.nostr_routing_last_epoch).unwrap_or(i64::MAX);
                 let prior_nostr_routes_json = serde_json::to_string(&group.prior_nostr_routes)
                     .map_err(|err| StorageError::Serialization(err.to_string()))?;
-                conn.execute(
+                conn.execute_cached(
                     "INSERT INTO account_groups (
                         group_id_hex, endpoint, profile_name, profile_description,
                         image_hash_hex, image_key_hex, image_nonce_hex,
@@ -1229,7 +1230,7 @@ impl SqliteAccountStorage {
 
                 if group_was_new {
                     let queued = conn
-                        .execute(
+                        .execute_cached(
                             "INSERT INTO pending_push_registration_shares (
                                 group_id_hex, token_fingerprint,
                                 registration_updated_at_ms, queued_at_ms,
@@ -1247,7 +1248,7 @@ impl SqliteAccountStorage {
                         )
                         .storage()?;
                     if queued > 0 {
-                        conn.execute("UPDATE push_registration SET last_shared_at_ms = NULL", [])
+                        conn.execute_cached("UPDATE push_registration SET last_shared_at_ms = NULL", [])
                             .storage()?;
                     }
                 }
@@ -1264,7 +1265,7 @@ impl SqliteAccountStorage {
                 )?;
             }
             for message_id in application_event_ids_to_ack {
-                conn.execute(
+                conn.execute_cached(
                     "DELETE FROM pending_application_events WHERE message_id = ?1",
                     params![message_id.as_slice()],
                 )
@@ -1308,7 +1309,7 @@ impl SqliteAccountStorage {
         self.connection.with_transaction(|| {
             let conn = self.lock()?;
             let already_indexed = conn
-                .query_row(
+                .query_row_cached(
                     "SELECT EXISTS(
                         SELECT 1 FROM direct_conversation_members WHERE group_id_hex = ?1
                      )",
@@ -1340,9 +1341,9 @@ impl SqliteAccountStorage {
     ) -> StorageResult<()> {
         self.connection.with_transaction(|| {
             let conn = self.lock()?;
-            conn.execute("DELETE FROM direct_conversation_members", [])
+            conn.execute_cached("DELETE FROM direct_conversation_members", [])
                 .storage()?;
-            conn.execute(
+            conn.execute_cached(
                 "DELETE FROM account_import_markers WHERE name = ?1",
                 params![marker_name],
             )
@@ -1394,7 +1395,7 @@ impl SqliteAccountStorage {
                 let mut deleted =
                     retire_all_encrypted_media_secrets_for_group_tx(&tx, group_id_hex)?;
                 let prior_nostr_routes_json = tx
-                    .query_row(
+                    .query_row_cached(
                         "SELECT prior_nostr_routes_json
                          FROM account_groups
                          WHERE group_id_hex = ?1",
@@ -1405,7 +1406,7 @@ impl SqliteAccountStorage {
                     .storage()?
                     .unwrap_or_else(|| "[]".to_owned());
                 deleted = deleted.saturating_add(
-                    tx.execute(
+                    tx.execute_cached(
                         "DELETE FROM pending_application_events WHERE group_id = ?1",
                         params![&group_id],
                     )
@@ -1435,7 +1436,7 @@ impl SqliteAccountStorage {
                     );
                 }
                 let (terminal, active, message_insert_order) = tx
-                    .query_row(
+                    .query_row_cached(
                         "SELECT
                             EXISTS(SELECT 1 FROM cgka_disband_tombstones WHERE group_id = ?1),
                             EXISTS(SELECT 1 FROM cgka_groups WHERE id = ?1),
@@ -1454,7 +1455,7 @@ impl SqliteAccountStorage {
                     )
                     .storage()?;
                 if active && !terminal {
-                    tx.execute(
+                    tx.execute_cached(
                         "INSERT INTO local_group_deletion_frontiers (
                             group_id_hex, message_insert_order, prior_nostr_routes_json
                          ) VALUES (?1, ?2, ?3)
@@ -1477,14 +1478,17 @@ impl SqliteAccountStorage {
                     .storage()?;
                 }
                 if terminal {
-                    tx.execute(
+                    tx.execute_cached(
                         "DELETE FROM local_group_deletion_frontiers WHERE group_id_hex = ?1",
                         params![hex::encode(&group_id)],
                     )
                     .storage()?;
                     deleted = deleted.saturating_add(
-                        tx.execute("DELETE FROM cgka_groups WHERE id = ?1", params![&group_id])
-                            .storage()?,
+                        tx.execute_cached(
+                            "DELETE FROM cgka_groups WHERE id = ?1",
+                            params![&group_id],
+                        )
+                        .storage()?,
                     );
                 }
                 if deleted > 0 {
@@ -1545,7 +1549,7 @@ impl SqliteAccountStorage {
     /// live, without trusting a remote sender's timestamp.
     pub fn local_group_deletion_frontier(&self, group_id_hex: &str) -> StorageResult<Option<u64>> {
         self.lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT message_insert_order
                  FROM local_group_deletion_frontiers
                  WHERE group_id_hex = ?1",
@@ -1572,7 +1576,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<Vec<StoredNostrRoute>> {
         let routes_json = self
             .lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT prior_nostr_routes_json
                  FROM local_group_deletion_frontiers
                  WHERE group_id_hex = ?1",
@@ -1604,7 +1608,7 @@ impl SqliteAccountStorage {
         self.connection.with_transaction(|| {
             let conn = self.lock()?;
             let Some(routes_json) = conn
-                .query_row(
+                .query_row_cached(
                     "SELECT prior_nostr_routes_json
                      FROM local_group_deletion_frontiers
                      WHERE group_id_hex = ?1",
@@ -1633,7 +1637,7 @@ impl SqliteAccountStorage {
             })?;
             let active_route_ids = {
                 let mut statement = conn
-                    .prepare(
+                    .prepare_cached(
                         "SELECT transport_group_id
                          FROM cgka_transport_group_routes
                          WHERE group_id = ?1",
@@ -1666,7 +1670,7 @@ impl SqliteAccountStorage {
             if retained_json == routes_json {
                 return Ok(());
             }
-            conn.execute(
+            conn.execute_cached(
                 "UPDATE local_group_deletion_frontiers
                  SET prior_nostr_routes_json = ?2
                  WHERE group_id_hex = ?1",
@@ -1690,7 +1694,7 @@ impl SqliteAccountStorage {
         })?;
         Ok(self
             .lock()?
-            .execute(
+            .execute_cached(
                 "DELETE FROM local_group_deletion_frontiers
                  WHERE group_id_hex = ?1
                    AND message_insert_order < (
@@ -1718,7 +1722,7 @@ impl SqliteAccountStorage {
             StorageError::Serialization(format!("invalid local group id: {error}"))
         })?;
         self.lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT EXISTS(
                     SELECT 1
                     FROM cgka_messages
@@ -1740,7 +1744,7 @@ impl SqliteAccountStorage {
     pub fn clear_local_group_deletion_frontier(&self, group_id_hex: &str) -> StorageResult<bool> {
         Ok(self
             .lock()?
-            .execute(
+            .execute_cached(
                 "DELETE FROM local_group_deletion_frontiers WHERE group_id_hex = ?1",
                 params![group_id_hex],
             )
@@ -1763,7 +1767,7 @@ impl SqliteAccountStorage {
         self.connection.with_transaction(|| {
             let conn = self.lock()?;
             let updated = conn
-                .execute(
+                .execute_cached(
                     "UPDATE account_groups
                      SET self_membership = ?2
                      WHERE group_id_hex = ?1",
@@ -1777,7 +1781,7 @@ impl SqliteAccountStorage {
                 SelfMembership::Member => {
                     let queued_at_ms = unix_now_ms();
                     let queued = conn
-                        .execute(
+                        .execute_cached(
                             "INSERT INTO pending_push_registration_shares (
                                 group_id_hex, token_fingerprint,
                                 registration_updated_at_ms, queued_at_ms,
@@ -1795,12 +1799,15 @@ impl SqliteAccountStorage {
                         )
                         .storage()?;
                     if queued > 0 {
-                        conn.execute("UPDATE push_registration SET last_shared_at_ms = NULL", [])
-                            .storage()?;
+                        conn.execute_cached(
+                            "UPDATE push_registration SET last_shared_at_ms = NULL",
+                            [],
+                        )
+                        .storage()?;
                     }
                 }
                 SelfMembership::Left | SelfMembership::Removed => {
-                    conn.execute(
+                    conn.execute_cached(
                         "DELETE FROM pending_push_registration_shares
                          WHERE group_id_hex = ?1",
                         params![group_id_hex],
@@ -1822,7 +1829,7 @@ impl SqliteAccountStorage {
     pub fn account_group_ids_defaulting_to_member(&self) -> StorageResult<Vec<String>> {
         let conn = self.lock()?;
         let mut statement = conn
-            .prepare(
+            .prepare_cached(
                 "SELECT group_id_hex
                  FROM account_groups
                  WHERE self_membership = 'member'
@@ -1844,7 +1851,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<Option<SelfMembership>> {
         let conn = self.lock()?;
         let value = conn
-            .query_row(
+            .query_row_cached(
                 "SELECT self_membership FROM account_groups WHERE group_id_hex = ?1",
                 params![group_id_hex],
                 |row| row.get::<_, String>(0),
@@ -1860,7 +1867,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<std::collections::HashMap<String, SelfMembership>> {
         let conn = self.lock()?;
         let mut statement = conn
-            .prepare("SELECT group_id_hex, self_membership FROM account_groups")
+            .prepare_cached("SELECT group_id_hex, self_membership FROM account_groups")
             .storage()?;
         let rows = statement
             .query_map([], |row| {
@@ -1923,7 +1930,7 @@ impl SqliteAccountStorage {
             values.push(Value::Integer(usize_to_i64(limit)?));
         }
         let conn = self.lock()?;
-        let mut statement = conn.prepare(&sql).storage()?;
+        let mut statement = conn.prepare_cached(&sql).storage()?;
         let rows = statement
             .query_map(params_from_iter(values.iter()), app_message_from_row)
             .storage()?;
@@ -1954,7 +1961,7 @@ impl SqliteAccountStorage {
     pub fn app_message_count(&self) -> StorageResult<usize> {
         let count = self
             .lock()?
-            .query_row("SELECT count(*) FROM app_events", [], |row| {
+            .query_row_cached("SELECT count(*) FROM app_events", [], |row| {
                 row.get::<_, i64>(0)
             })
             .storage()?;
@@ -2084,7 +2091,7 @@ impl SqliteAccountStorage {
     pub fn account_import_marker(&self, name: &str) -> StorageResult<bool> {
         let exists = self
             .lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT 1 FROM account_import_markers WHERE name = ?1",
                 params![name],
                 |_| Ok(()),
@@ -2097,7 +2104,7 @@ impl SqliteAccountStorage {
 
     pub fn mark_account_import_complete(&self, name: &str) -> StorageResult<()> {
         self.lock()?
-            .execute(
+            .execute_cached(
                 "INSERT INTO account_import_markers (name, completed_at_unix_seconds)
                  VALUES (?1, ?2)
                  ON CONFLICT(name) DO UPDATE SET
@@ -2115,7 +2122,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<AccountNotificationSettings> {
         self.ensure_notification_settings(account_label, account_id_hex)?;
         self.lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT account_label, account_id_hex, local_notifications_enabled,
                         native_push_enabled
                  FROM notification_settings
@@ -2141,7 +2148,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<AccountNotificationSettings> {
         self.ensure_notification_settings(account_label, account_id_hex)?;
         self.lock()?
-            .execute(
+            .execute_cached(
                 "UPDATE notification_settings
                  SET local_notifications_enabled = ?2, updated_at_ms = ?3
                  WHERE account_label = ?1",
@@ -2161,7 +2168,7 @@ impl SqliteAccountStorage {
         self.connection.with_transaction(|| {
             let conn = self.lock()?;
             let was_enabled = conn
-                .query_row(
+                .query_row_cached(
                     "SELECT native_push_enabled FROM notification_settings
                      WHERE account_label = ?1",
                     params![account_label],
@@ -2169,7 +2176,7 @@ impl SqliteAccountStorage {
                 )
                 .storage()?;
             let now_ms = unix_now_ms();
-            conn.execute(
+            conn.execute_cached(
                 "UPDATE notification_settings
                  SET native_push_enabled = ?2, updated_at_ms = ?3
                  WHERE account_label = ?1",
@@ -2178,7 +2185,7 @@ impl SqliteAccountStorage {
             .storage()?;
             if enabled && !was_enabled {
                 let queued = conn
-                    .execute(
+                    .execute_cached(
                         "INSERT INTO pending_push_registration_shares (
                             group_id_hex, token_fingerprint,
                             registration_updated_at_ms, queued_at_ms,
@@ -2199,12 +2206,15 @@ impl SqliteAccountStorage {
                     )
                     .storage()?;
                 if queued > 0 {
-                    conn.execute("UPDATE push_registration SET last_shared_at_ms = NULL", [])
-                        .storage()?;
+                    conn.execute_cached(
+                        "UPDATE push_registration SET last_shared_at_ms = NULL",
+                        [],
+                    )
+                    .storage()?;
                 }
             } else if !enabled {
                 let existing = conn
-                    .query_row(
+                    .query_row_cached(
                         "SELECT account_label, account_id_hex, platform, token_fingerprint,
                                 token_bytes, server_pubkey_hex, relay_hint, created_at_ms,
                                 updated_at_ms, last_shared_at_ms
@@ -2222,9 +2232,9 @@ impl SqliteAccountStorage {
                         now_ms,
                     )?;
                 }
-                conn.execute("DELETE FROM pending_push_registration_shares", [])
+                conn.execute_cached("DELETE FROM pending_push_registration_shares", [])
                     .storage()?;
-                conn.execute(
+                conn.execute_cached(
                     "DELETE FROM push_registration WHERE account_label = ?1",
                     params![account_label],
                 )
@@ -2249,7 +2259,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<AccountChatNotificationSettings> {
         let row = self
             .lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT muted_until_ms, updated_at_ms
                  FROM chat_notification_settings
                  WHERE group_id_hex = ?1",
@@ -2276,7 +2286,7 @@ impl SqliteAccountStorage {
         muted_until_ms: Option<i64>,
     ) -> StorageResult<AccountChatNotificationSettings> {
         self.lock()?
-            .execute(
+            .execute_cached(
                 "INSERT INTO chat_notification_settings (
                     group_id_hex, muted_until_ms, updated_at_ms
                  )
@@ -2295,7 +2305,7 @@ impl SqliteAccountStorage {
         group_id_hex: &str,
     ) -> StorageResult<AccountChatNotificationSettings> {
         self.lock()?
-            .execute(
+            .execute_cached(
                 "DELETE FROM chat_notification_settings WHERE group_id_hex = ?1",
                 params![group_id_hex],
             )
@@ -2309,7 +2319,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<Option<AccountStoredPushRegistration>> {
         let conn = self.lock()?;
         let mut statement = conn
-            .prepare(
+            .prepare_cached(
                 "SELECT account_label, account_id_hex, platform, token_fingerprint,
                         token_bytes, server_pubkey_hex, relay_hint, created_at_ms,
                         updated_at_ms, last_shared_at_ms
@@ -2358,9 +2368,9 @@ impl SqliteAccountStorage {
                     registration.updated_at_ms,
                 )?;
             }
-            conn.execute("DELETE FROM pending_push_registration_shares", [])
+            conn.execute_cached("DELETE FROM pending_push_registration_shares", [])
                 .storage()?;
-            conn.execute(
+            conn.execute_cached(
                 "INSERT INTO push_registration (
                         account_label, account_id_hex, platform, token_fingerprint,
                         token_bytes, server_pubkey_hex, relay_hint, created_at_ms,
@@ -2410,7 +2420,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<usize> {
         self.connection.with_transaction(|| {
             let conn = self.lock()?;
-            conn.execute(
+            conn.execute_cached(
                 "DELETE FROM pending_push_registration_shares
                  WHERE group_id_hex NOT IN (
                     SELECT group_id_hex FROM account_groups WHERE self_membership = 'member'
@@ -2418,7 +2428,7 @@ impl SqliteAccountStorage {
                 [],
             )
             .storage()?;
-            conn.execute(
+            conn.execute_cached(
                 "INSERT INTO pending_push_registration_shares (
                     group_id_hex, token_fingerprint, registration_updated_at_ms,
                     queued_at_ms, last_attempted_at_ms
@@ -2435,7 +2445,7 @@ impl SqliteAccountStorage {
             )
             .storage()?;
             let count = conn
-                .query_row(
+                .query_row_cached(
                     "SELECT COUNT(*) FROM pending_push_registration_shares
                      WHERE token_fingerprint = ?1
                        AND registration_updated_at_ms = ?2",
@@ -2445,7 +2455,7 @@ impl SqliteAccountStorage {
                 .storage()?;
             let count = i64_to_usize(count)?;
             if count > 0 {
-                conn.execute("UPDATE push_registration SET last_shared_at_ms = NULL", [])
+                conn.execute_cached("UPDATE push_registration SET last_shared_at_ms = NULL", [])
                     .storage()?;
             }
             Ok(count)
@@ -2459,7 +2469,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<Vec<String>> {
         let conn = self.lock()?;
         let mut statement = conn
-            .prepare(
+            .prepare_cached(
                 "SELECT group_id_hex
                  FROM pending_push_registration_shares
                  WHERE token_fingerprint = ?1
@@ -2485,7 +2495,7 @@ impl SqliteAccountStorage {
         attempted_at_ms: i64,
     ) -> StorageResult<()> {
         self.lock()?
-            .execute(
+            .execute_cached(
                 "UPDATE pending_push_registration_shares
                  SET last_attempted_at_ms = ?4
                  WHERE group_id_hex = ?1 AND token_fingerprint = ?2
@@ -2509,7 +2519,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<bool> {
         Ok(self
             .lock()?
-            .execute(
+            .execute_cached(
                 "DELETE FROM pending_push_registration_shares
                  WHERE group_id_hex = ?1 AND token_fingerprint = ?2
                    AND registration_updated_at_ms = ?3",
@@ -2528,7 +2538,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<bool> {
         Ok(self
             .lock()?
-            .execute(
+            .execute_cached(
                 "UPDATE push_registration
                  SET last_shared_at_ms = ?4
                  WHERE account_label = ?1
@@ -2562,12 +2572,12 @@ impl SqliteAccountStorage {
                     unix_now_ms(),
                 )?;
             }
-            conn.execute(
+            conn.execute_cached(
                 "DELETE FROM push_registration WHERE account_label = ?1",
                 params![account_label],
             )
             .storage()?;
-            conn.execute("DELETE FROM pending_push_registration_shares", [])
+            conn.execute_cached("DELETE FROM pending_push_registration_shares", [])
                 .storage()?;
             Ok(existing)
         })
@@ -2594,7 +2604,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<()> {
         self.connection.with_transaction(|| {
             let conn = self.lock()?;
-            conn.execute(
+            conn.execute_cached(
                 "DELETE FROM pending_push_registration_shares
                  WHERE group_id_hex = ?1",
                 params![group_id_hex],
@@ -2622,7 +2632,7 @@ impl SqliteAccountStorage {
         self.connection.with_transaction(|| {
             let conn = self.lock()?;
             let inserted = conn
-                .execute(
+                .execute_cached(
                     "INSERT INTO pending_push_registration_shares (
                     group_id_hex, token_fingerprint, registration_updated_at_ms,
                     queued_at_ms, last_attempted_at_ms
@@ -2645,7 +2655,7 @@ impl SqliteAccountStorage {
                 .storage()?
                 > 0;
             if inserted {
-                conn.execute(
+                conn.execute_cached(
                     "UPDATE push_registration
                      SET last_shared_at_ms = NULL
                      WHERE token_fingerprint = ?1 AND updated_at_ms = ?2",
@@ -2659,7 +2669,7 @@ impl SqliteAccountStorage {
 
     pub fn has_pending_push_registration_work(&self) -> StorageResult<bool> {
         self.lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT EXISTS(
                     SELECT 1 FROM pending_push_registration_shares
                     UNION ALL
@@ -2676,7 +2686,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<Vec<AccountPendingPushRegistrationRemoval>> {
         let conn = self.lock()?;
         let mut statement = conn
-            .prepare(
+            .prepare_cached(
                 "SELECT group_id_hex, account_label, account_id_hex, platform,
                         token_fingerprint, server_pubkey_hex, relay_hint,
                         registration_created_at_ms, registration_updated_at_ms,
@@ -2715,7 +2725,7 @@ impl SqliteAccountStorage {
         attempted_at_ms: i64,
     ) -> StorageResult<()> {
         self.lock()?
-            .execute(
+            .execute_cached(
                 "UPDATE pending_push_registration_removals
                  SET last_attempted_at_ms = ?6
                  WHERE group_id_hex = ?1 AND platform = ?2
@@ -2740,7 +2750,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<bool> {
         Ok(self
             .lock()?
-            .execute(
+            .execute_cached(
                 "DELETE FROM pending_push_registration_removals
                  WHERE group_id_hex = ?1 AND platform = ?2
                    AND server_pubkey_hex = ?3 AND token_fingerprint = ?4
@@ -2764,7 +2774,7 @@ impl SqliteAccountStorage {
     /// tombstones.
     pub fn upsert_group_push_token(&self, token: &AccountGroupPushToken) -> StorageResult<()> {
         let conn = self.lock()?;
-        conn.execute(
+        conn.execute_cached(
             "INSERT INTO group_push_tokens (
                     group_id_hex, member_id_hex, leaf_index, platform, token_fingerprint,
                     server_pubkey_hex, relay_hint, encrypted_token, owner_ts, owner_sig,
@@ -2825,7 +2835,7 @@ impl SqliteAccountStorage {
             if !strictly_newer(&tombstone) || !strictly_newer(&live) {
                 return Ok(false);
             }
-            tx.execute(
+            tx.execute_cached(
                 "INSERT INTO group_push_tokens (
                     group_id_hex, member_id_hex, leaf_index, platform, token_fingerprint,
                     server_pubkey_hex, relay_hint, encrypted_token, owner_ts, owner_sig,
@@ -2899,7 +2909,7 @@ impl SqliteAccountStorage {
                 return Ok(false);
             }
             delete_push_token(&tx, key)?;
-            tx.execute(
+            tx.execute_cached(
                 "INSERT INTO group_push_token_tombstones (
                     group_id_hex, member_id_hex, leaf_index, platform, server_pubkey_hex,
                     owner_ts, record_digest, created_at_ms
@@ -2933,7 +2943,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<Vec<AccountGroupPushToken>> {
         let conn = self.lock()?;
         let mut statement = conn
-            .prepare(
+            .prepare_cached(
                 "SELECT group_id_hex, member_id_hex, leaf_index, platform,
                         token_fingerprint, server_pubkey_hex, relay_hint,
                         encrypted_token, owner_ts, owner_sig, record_digest, updated_at_ms
@@ -2958,7 +2968,7 @@ impl SqliteAccountStorage {
         server_pubkey_hex: &str,
     ) -> StorageResult<()> {
         self.lock()?
-            .execute(
+            .execute_cached(
                 "DELETE FROM group_push_tokens
                  WHERE group_id_hex = ?1
                    AND member_id_hex = ?2
@@ -2989,13 +2999,13 @@ impl SqliteAccountStorage {
     ) -> StorageResult<()> {
         self.connection.with_transaction(|| -> StorageResult<()> {
             let conn = self.lock()?;
-            conn.execute(
+            conn.execute_cached(
                 "DELETE FROM group_push_tokens
                  WHERE group_id_hex = ?1 AND member_id_hex = ?2",
                 params![group_id_hex, member_id_hex],
             )
             .storage()?;
-            conn.execute(
+            conn.execute_cached(
                 "DELETE FROM group_push_token_tombstones
                  WHERE group_id_hex = ?1 AND member_id_hex = ?2",
                 params![group_id_hex, member_id_hex],
@@ -3052,7 +3062,7 @@ impl SqliteAccountStorage {
         account_id_hex: &str,
     ) -> StorageResult<()> {
         self.lock()?
-            .execute(
+            .execute_cached(
                 "INSERT INTO notification_settings (
                     account_label, account_id_hex, local_notifications_enabled,
                     native_push_enabled, updated_at_ms
@@ -3072,7 +3082,7 @@ fn queue_push_registration_removals_with_conn(
     registration: &AccountPushRegistration,
     queued_at_ms: i64,
 ) -> StorageResult<usize> {
-    conn.execute(
+    conn.execute_cached(
         "INSERT INTO pending_push_registration_removals (
             group_id_hex, account_label, account_id_hex, platform,
             token_fingerprint, server_pubkey_hex, relay_hint,
@@ -3106,7 +3116,7 @@ fn queue_push_registration_removals_with_conn(
     )
     .storage()?;
     let count = conn
-        .query_row(
+        .query_row_cached(
             "SELECT COUNT(*) FROM pending_push_registration_removals
              WHERE platform = ?1 AND server_pubkey_hex = ?2
                AND token_fingerprint = ?3 AND registration_updated_at_ms = ?4",
@@ -3128,7 +3138,7 @@ fn insert_push_registration_removal_with_conn(
     registration: &AccountPushRegistration,
     queued_at_ms: i64,
 ) -> StorageResult<()> {
-    conn.execute(
+    conn.execute_cached(
         "INSERT INTO pending_push_registration_removals (
             group_id_hex, account_label, account_id_hex, platform,
             token_fingerprint, server_pubkey_hex, relay_hint,
@@ -3217,7 +3227,7 @@ fn merged_transport_timestamp(
 }
 
 fn secure_delete_pragma(conn: &Connection) -> StorageResult<i64> {
-    conn.query_row("PRAGMA secure_delete", [], |row| row.get(0))
+    conn.query_row_cached("PRAGMA secure_delete", [], |row| row.get(0))
         .storage()
 }
 
@@ -3257,7 +3267,7 @@ fn secure_delete_intent(
     operation_kind: &str,
     scope: &str,
 ) -> StorageResult<Option<SecureDeleteIntent>> {
-    conn.query_row(
+    conn.query_row_cached(
         "SELECT intent_nonce, result_json
          FROM secure_delete_checkpoint_intents
          WHERE operation_kind = ?1 AND scope = ?2",
@@ -3279,7 +3289,7 @@ fn upsert_secure_delete_intent_tx(
     scope: &str,
     result_json: &str,
 ) -> StorageResult<()> {
-    tx.execute(
+    tx.execute_cached(
         "INSERT INTO secure_delete_checkpoint_intents (
             operation_kind, scope, intent_nonce, result_json
          ) VALUES (?1, ?2, randomblob(16), ?3)
@@ -3382,7 +3392,7 @@ where
             Err(error) => return Err(error),
         }
         let deleted = conn
-            .execute(
+            .execute_cached(
                 "DELETE FROM secure_delete_checkpoint_intents
                  WHERE operation_kind = ?1 AND scope = ?2
                    AND intent_nonce = ?3",
@@ -3407,7 +3417,7 @@ where
 fn checkpoint_wal_truncate_after_secure_delete(conn: &Connection) -> StorageResult<()> {
     retry_on_busy(|| {
         let (busy, _log_frames, _checkpointed_frames): (i64, i64, i64) = conn
-            .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| {
+            .query_row_cached("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| {
                 Ok((row.get(0)?, row.get(1)?, row.get(2)?))
             })
             .storage()?;
@@ -3430,7 +3440,7 @@ fn all_account_group_components(
     conn: &rusqlite::Connection,
 ) -> StorageResult<std::collections::HashMap<String, Vec<StoredAccountGroupComponent>>> {
     let mut statement = conn
-        .prepare(
+        .prepare_cached(
             "SELECT group_id_hex, component_id, component_name, component_data_hex
              FROM account_group_app_components
              ORDER BY group_id_hex, component_id",
@@ -3472,7 +3482,7 @@ fn delete_stale_text_keys(
     delete_prefix_params: &[Value],
     retained_keys: &std::collections::HashSet<&str>,
 ) -> StorageResult<usize> {
-    let mut statement = conn.prepare(existing_keys_sql).storage()?;
+    let mut statement = conn.prepare_cached(existing_keys_sql).storage()?;
     let existing_keys = statement
         .query_map(params_from_iter(existing_keys_params.iter()), |row| {
             row.get::<_, String>(0)
@@ -3516,7 +3526,7 @@ fn delete_stale_group_components(
     components: &[StoredAccountGroupComponent],
 ) -> StorageResult<()> {
     if components.is_empty() {
-        tx.execute(
+        tx.execute_cached(
             "DELETE FROM account_group_app_components WHERE group_id_hex = ?1",
             params![group_id_hex],
         )
@@ -3547,7 +3557,7 @@ fn upsert_group_component(
     component: &StoredAccountGroupComponent,
     now: i64,
 ) -> StorageResult<()> {
-    tx.execute(
+    tx.execute_cached(
         "INSERT INTO account_group_app_components (
             group_id_hex, component_id, component_name, component_data_hex, updated_at
          )
@@ -3665,7 +3675,7 @@ fn read_push_token_stamp(
     tx: &rusqlite::Transaction<'_>,
     key: PushTokenKey<'_>,
 ) -> StorageResult<Option<(i64, String)>> {
-    tx.query_row(
+    tx.query_row_cached(
         "SELECT owner_ts, record_digest FROM group_push_tokens
          WHERE group_id_hex = ?1 AND member_id_hex = ?2 AND leaf_index = ?3
            AND platform = ?4 AND server_pubkey_hex = ?5",
@@ -3686,7 +3696,7 @@ fn read_push_tombstone_stamp(
     tx: &rusqlite::Transaction<'_>,
     key: PushTokenKey<'_>,
 ) -> StorageResult<Option<(i64, String)>> {
-    tx.query_row(
+    tx.query_row_cached(
         "SELECT owner_ts, record_digest FROM group_push_token_tombstones
          WHERE group_id_hex = ?1 AND member_id_hex = ?2 AND leaf_index = ?3
            AND platform = ?4 AND server_pubkey_hex = ?5",
@@ -3704,7 +3714,7 @@ fn read_push_tombstone_stamp(
 }
 
 fn delete_push_token(tx: &rusqlite::Transaction<'_>, key: PushTokenKey<'_>) -> StorageResult<()> {
-    tx.execute(
+    tx.execute_cached(
         "DELETE FROM group_push_tokens
          WHERE group_id_hex = ?1 AND member_id_hex = ?2 AND leaf_index = ?3
            AND platform = ?4 AND server_pubkey_hex = ?5",
@@ -3724,7 +3734,7 @@ fn delete_push_tombstone(
     tx: &rusqlite::Transaction<'_>,
     key: PushTokenKey<'_>,
 ) -> StorageResult<()> {
-    tx.execute(
+    tx.execute_cached(
         "DELETE FROM group_push_token_tombstones
          WHERE group_id_hex = ?1 AND member_id_hex = ?2 AND leaf_index = ?3
            AND platform = ?4 AND server_pubkey_hex = ?5",
@@ -3766,7 +3776,7 @@ fn load_direct_conversation_members(
     conn: &Connection,
 ) -> StorageResult<HashMap<String, Vec<String>>> {
     let mut statement = conn
-        .prepare(
+        .prepare_cached(
             "SELECT group_id_hex, member_id_hex
              FROM direct_conversation_members
              ORDER BY group_id_hex, member_id_hex",
@@ -3802,7 +3812,7 @@ pub(crate) fn replace_direct_conversation_members_tx(
     member_ids_hex: Option<&[String]>,
     persist_direct: bool,
 ) -> StorageResult<()> {
-    conn.execute(
+    conn.execute_cached(
         "DELETE FROM direct_conversation_members WHERE group_id_hex = ?1",
         params![group_id_hex],
     )
@@ -3822,7 +3832,7 @@ pub(crate) fn replace_direct_conversation_members_tx(
         return Ok(());
     }
     for member_id_hex in member_ids_hex {
-        conn.execute(
+        conn.execute_cached(
             "INSERT OR IGNORE INTO direct_conversation_members (group_id_hex, member_id_hex)
              VALUES (?1, ?2)",
             params![group_id_hex, member_id_hex],

--- a/crates/storage-sqlite/src/agent_stream_sequences.rs
+++ b/crates/storage-sqlite/src/agent_stream_sequences.rs
@@ -1,5 +1,6 @@
 //! Durable, fail-closed publisher sequence reservations for QUIC previews.
 
+use crate::connection::CachedSql;
 use crate::{SqliteAccountStorage, SqliteResultExt, connection::retry_on_busy, unix_now_ms};
 use cgka_traits::storage::{StorageError, StorageResult};
 use rusqlite::{OptionalExtension, TransactionBehavior, params};
@@ -53,7 +54,7 @@ impl SqliteAccountStorage {
                 .transaction_with_behavior(TransactionBehavior::Immediate)
                 .storage()?;
             let row = tx
-                .query_row(
+                .query_row_cached(
                     "SELECT next_seq, transcript_hash, chunk_count,
                             reservation_token, disabled
                      FROM agent_stream_publisher_sequences
@@ -75,7 +76,7 @@ impl SqliteAccountStorage {
             let (first_seq, current_hash, current_chunks) = match row {
                 Some((next_seq, transcript_hash, chunk_count, reservation, disabled)) => {
                     if disabled || reservation.is_some() {
-                        tx.execute(
+                        tx.execute_cached(
                             "UPDATE agent_stream_publisher_sequences
                              SET disabled = 1, updated_at_ms = ?2
                              WHERE context_id = ?1",
@@ -113,7 +114,7 @@ impl SqliteAccountStorage {
                 }
                 None => {
                     let count = tx
-                        .query_row(
+                        .query_row_cached(
                             "SELECT count(*) FROM agent_stream_publisher_sequences",
                             [],
                             |row| row.get::<_, i64>(0),
@@ -126,7 +127,7 @@ impl SqliteAccountStorage {
                             "agent stream publisher state limit reached".to_owned(),
                         ));
                     }
-                    tx.execute(
+                    tx.execute_cached(
                         "INSERT INTO agent_stream_publisher_sequences (
                             context_id, next_seq, transcript_hash, chunk_count,
                             reservation_token, disabled, updated_at_ms
@@ -157,7 +158,7 @@ impl SqliteAccountStorage {
             let next_seq = first_seq.checked_add(request.record_count).ok_or_else(|| {
                 StorageError::Backend("agent stream publisher sequence exhausted".to_owned())
             })?;
-            tx.execute(
+            tx.execute_cached(
                 "UPDATE agent_stream_publisher_sequences
                  SET next_seq = ?2, transcript_hash = ?3, chunk_count = ?4,
                      reservation_token = ?5, updated_at_ms = ?6
@@ -195,7 +196,7 @@ impl SqliteAccountStorage {
             let changed = self
                 .connection
                 .lock()?
-                .execute(
+                .execute_cached(
                     "UPDATE agent_stream_publisher_sequences
              SET reservation_token = NULL, updated_at_ms = ?3
              WHERE context_id = ?1 AND reservation_token = ?2 AND disabled = 0",
@@ -217,7 +218,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<Option<AgentStreamPublisherState>> {
         self.connection
             .lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT next_seq, transcript_hash, chunk_count,
                         reservation_token IS NOT NULL OR disabled
                  FROM agent_stream_publisher_sequences

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -1,4 +1,5 @@
 use crate::account_projection::chat_mute_is_effective;
+use crate::connection::CachedSql;
 use crate::storage::disband_requests::{
     disband_requests_by_group_hex_tx, disbanding_group_ids_hex_tx,
     disbanding_group_ids_hex_with_requests_tx,
@@ -467,7 +468,7 @@ impl SqliteAccountStorage {
         }
         let conn = self.lock()?;
         let sql = format!("EXPLAIN QUERY PLAN {}", direct_conversation_candidate_sql());
-        let mut statement = conn.prepare(&sql).storage()?;
+        let mut statement = conn.prepare_cached(&sql).storage()?;
         statement
             .query_map(params![peer_account_id_hex], |row| row.get::<_, String>(3))
             .storage()?
@@ -483,7 +484,7 @@ impl SqliteAccountStorage {
     pub fn unindexed_direct_conversation_group_ids(&self) -> StorageResult<Vec<String>> {
         let conn = self.lock()?;
         let mut statement = conn
-            .prepare(
+            .prepare_cached(
                 "SELECT ag.group_id_hex
                  FROM account_groups AS ag
                  JOIN chat_list_rows AS row ON row.group_id_hex = ag.group_id_hex
@@ -520,7 +521,7 @@ impl SqliteAccountStorage {
         self.connection.with_transaction(|| {
             let conn = self.lock()?;
             let archived = conn
-                .query_row(
+                .query_row_cached(
                     "SELECT archived FROM account_groups WHERE group_id_hex = ?1",
                     params![group_id_hex],
                     |row| row.get::<_, i64>(0),
@@ -567,7 +568,7 @@ impl SqliteAccountStorage {
             let conn = self.lock()?;
             for group_id_hex in ordered_group_ids {
                 let exists = conn
-                    .query_row(
+                    .query_row_cached(
                         "SELECT EXISTS(
                             SELECT 1 FROM account_groups WHERE group_id_hex = ?1
                          )",
@@ -614,7 +615,7 @@ impl SqliteAccountStorage {
     /// `attention_only_conversations`.
     pub fn account_unread_total(&self) -> StorageResult<AccountUnreadTotal> {
         let conn = self.lock()?;
-        conn.query_row(
+        conn.query_row_cached(
             "SELECT COALESCE(SUM(row.unread_count), 0),
                     COUNT(CASE
                         WHEN row.unread_count > 0
@@ -783,7 +784,7 @@ impl SqliteAccountStorage {
                 // "mark unread" does not suddenly count the whole backlog.
                 insert_initial_read_state_tx(&conn, group_id_hex, manually_unread)?;
             } else {
-                conn.execute(
+                conn.execute_cached(
                     "UPDATE conversation_read_state
                      SET manually_marked_unread = ?2, updated_at = ?3
                      WHERE group_id_hex = ?1",
@@ -834,7 +835,7 @@ impl SqliteAccountStorage {
 
                 if should_advance {
                     let (order_class, order_primary, order_phase, order_at, _id) = target_order;
-                    conn.execute(
+                    conn.execute_cached(
                         "INSERT INTO conversation_read_state (
                             group_id_hex, last_read_message_id_hex, last_read_timeline_at,
                             last_read_order_class, last_read_order_primary,
@@ -867,7 +868,7 @@ impl SqliteAccountStorage {
             }
             // Explicitly marking a message read clears a manual-only reminder
             // even when the target does not advance the already-newer marker.
-            conn.execute(
+            conn.execute_cached(
                 "UPDATE conversation_read_state
                  SET manually_marked_unread = 0, updated_at = ?2
                  WHERE group_id_hex = ?1 AND manually_marked_unread != 0",
@@ -886,7 +887,7 @@ impl SqliteAccountStorage {
 
 fn pinned_chat_order_tx(tx: &Connection) -> Result<Vec<String>, ChatPinError> {
     let mut statement = tx
-        .prepare(
+        .prepare_cached(
             "SELECT group_id_hex
              FROM chat_pin_positions
              ORDER BY ordinal ASC, group_id_hex ASC",
@@ -904,9 +905,10 @@ fn rewrite_pinned_chat_order_tx(
     tx: &Connection,
     ordered_group_ids: &[String],
 ) -> Result<(), ChatPinError> {
-    tx.execute("DELETE FROM chat_pin_positions", []).storage()?;
+    tx.execute_cached("DELETE FROM chat_pin_positions", [])
+        .storage()?;
     for (ordinal, group_id_hex) in ordered_group_ids.iter().enumerate() {
-        tx.execute(
+        tx.execute_cached(
             "INSERT INTO chat_pin_positions (group_id_hex, ordinal)
              VALUES (?1, ?2)",
             params![
@@ -932,7 +934,7 @@ fn rebuild_all_chat_list_rows_tx(
     // Upsert in place so durable activity anchors survive a projection rebuild
     // after their preview rows have been securely pruned. Remove only true
     // orphans; normal account-group deletion already cascades this table.
-    tx.execute(
+    tx.execute_cached(
         "DELETE FROM chat_list_rows
          WHERE NOT EXISTS (
              SELECT 1 FROM account_groups AS ag
@@ -954,7 +956,7 @@ fn refresh_chat_list_row_tx(
     mention_classifier: &MentionClassifier<'_>,
 ) -> StorageResult<Option<ChatListRow>> {
     let Some(group) = account_group_tx(tx, group_id_hex)? else {
-        tx.execute(
+        tx.execute_cached(
             "DELETE FROM chat_list_rows WHERE group_id_hex = ?1",
             params![group_id_hex],
         )
@@ -1112,7 +1114,7 @@ struct LatestChatListMessage {
 
 fn chat_list_projection_version_tx(tx: &Connection) -> StorageResult<i64> {
     Ok(tx
-        .query_row(
+        .query_row_cached(
             "SELECT mention_counts_version FROM chat_list_projection_meta WHERE id = 1",
             [],
             |row| row.get::<_, i64>(0),
@@ -1123,7 +1125,7 @@ fn chat_list_projection_version_tx(tx: &Connection) -> StorageResult<i64> {
 }
 
 fn set_chat_list_projection_version_tx(tx: &Connection, version: i64) -> StorageResult<()> {
-    tx.execute(
+    tx.execute_cached(
         "UPDATE chat_list_projection_meta SET mention_counts_version = ?1 WHERE id = 1",
         params![version],
     )
@@ -1327,7 +1329,7 @@ fn chat_list_stored_unread_summaries_tx(
     tx: &Connection,
 ) -> StorageResult<Vec<(String, UnreadSummary)>> {
     let mut stmt = tx
-        .prepare(
+        .prepare_cached(
             "SELECT group_id_hex, unread_count, unread_mention_count,
                     first_unread_message_id_hex
              FROM chat_list_rows",
@@ -1393,7 +1395,7 @@ fn rebuild_chat_list_row_for_group_tx(
         )
         .fold(group.conversation_created_at, u64::max);
     let now = unix_now_seconds();
-    tx.execute(
+    tx.execute_cached(
         "INSERT INTO chat_list_rows (
             group_id_hex, archived, pending_confirmation, title, group_name,
             avatar_url,
@@ -1603,7 +1605,7 @@ fn unread_summary_tx(
         rusqlite::types::Value::Text(local_account_id_hex.to_owned()),
     ];
     query_params.extend(marker_params);
-    let mut scan_stmt = tx.prepare(&scan_sql).storage()?;
+    let mut scan_stmt = tx.prepare_cached(&scan_sql).storage()?;
     let mut scan_rows = scan_stmt
         .query(rusqlite::params_from_iter(query_params))
         .storage()?;
@@ -1645,7 +1647,7 @@ pub(crate) fn refresh_chat_list_unread_after_secure_prune_tx(
         read_state.as_ref(),
         mention_classifier,
     )?;
-    tx.execute(
+    tx.execute_cached(
         "UPDATE chat_list_rows
          SET unread_count = ?2,
              unread_mention_count = ?3,
@@ -1664,7 +1666,7 @@ pub(crate) fn refresh_chat_list_unread_after_secure_prune_tx(
 
 fn account_groups_tx(tx: &Connection) -> StorageResult<Vec<AccountGroupRow>> {
     let mut stmt = tx
-        .prepare(
+        .prepare_cached(
             "SELECT ag.group_id_hex, ag.archived, ag.pending_confirmation, ag.profile_name,
                     image_hash_hex, image_key_hex, image_nonce_hex,
                     image_upload_key_hex, image_media_type, avatar_url.component_data_hex,
@@ -1685,7 +1687,7 @@ fn account_groups_tx(tx: &Connection) -> StorageResult<Vec<AccountGroupRow>> {
 }
 
 fn account_group_tx(tx: &Connection, group_id_hex: &str) -> StorageResult<Option<AccountGroupRow>> {
-    tx.query_row(
+    tx.query_row_cached(
         "SELECT ag.group_id_hex, ag.archived, ag.pending_confirmation, ag.profile_name,
                 image_hash_hex, image_key_hex, image_nonce_hex,
                 image_upload_key_hex, image_media_type, avatar_url.component_data_hex,
@@ -1885,7 +1887,7 @@ fn insert_initial_read_state_tx(
     // activity there is no read anchor yet, so a subsequently recorded row
     // counts even when its sender timestamp predates this local interaction.
     let initialized_at = timeline_at.unwrap_or(0);
-    tx.execute(
+    tx.execute_cached(
         "INSERT INTO conversation_read_state (
             group_id_hex, last_read_message_id_hex, last_read_timeline_at,
             last_read_order_class, last_read_order_primary,
@@ -1914,7 +1916,7 @@ fn read_state_tx(
     tx: &Connection,
     group_id_hex: &str,
 ) -> StorageResult<Option<ConversationReadState>> {
-    tx.query_row(
+    tx.query_row_cached(
         "SELECT last_read_message_id_hex, last_read_timeline_at,
                 last_read_order_class, last_read_order_primary,
                 last_read_order_phase, last_read_order_at,
@@ -1965,7 +1967,7 @@ fn chat_list_rows_tx(tx: &Connection, query: ChatListQuery) -> StorageResult<Vec
         )
     };
     let now_ms = unix_now_ms();
-    let mut stmt = tx.prepare(&sql).storage()?;
+    let mut stmt = tx.prepare_cached(&sql).storage()?;
     let mut rows = stmt
         .query_map([], |row| chat_list_row_from_row(row, now_ms))
         .storage()?
@@ -2017,7 +2019,7 @@ fn direct_conversation_candidate_rows_tx(
     }
     let sql = direct_conversation_candidate_sql();
     let now_ms = unix_now_ms();
-    let mut stmt = tx.prepare(&sql).storage()?;
+    let mut stmt = tx.prepare_cached(&sql).storage()?;
     let mut rows = stmt
         .query_map(params![peer_account_id_hex], |row| {
             chat_list_row_from_row(row, now_ms)

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -1763,7 +1763,7 @@ fn latest_chat_list_activity_tx(
          ORDER BY {preview_order}
          LIMIT 1"
     );
-    tx.query_row(&sql, params![group_id_hex], |row| {
+    tx.query_row_cached(&sql, params![group_id_hex], |row| {
         Ok(LatestChatListMessage {
             preview: chat_list_message_from_row(row)?,
             canonical_order_prefix: (
@@ -2048,7 +2048,7 @@ fn chat_list_row_tx(tx: &Connection, group_id_hex: &str) -> StorageResult<Option
         "{CHAT_LIST_ROW_SELECT_AND_JOINS}
          WHERE row.group_id_hex = ?1"
     );
-    tx.query_row(&sql, params![group_id_hex], |row| {
+    tx.query_row_cached(&sql, params![group_id_hex], |row| {
         chat_list_row_from_row(row, now_ms)
     })
     .optional()

--- a/crates/storage-sqlite/src/codec.rs
+++ b/crates/storage-sqlite/src/codec.rs
@@ -72,6 +72,19 @@ impl SensitiveBytes {
     }
 }
 
+impl Write for SensitiveBytes {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        for byte in bytes {
+            self.push(*byte);
+        }
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
 impl AsRef<[u8]> for SensitiveBytes {
     fn as_ref(&self) -> &[u8] {
         self.as_slice()

--- a/crates/storage-sqlite/src/connection.rs
+++ b/crates/storage-sqlite/src/connection.rs
@@ -7,7 +7,7 @@ use cgka_traits::types::Backend;
 use std::fmt;
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 use std::thread::ThreadId;
 use std::time::Duration;
@@ -294,6 +294,9 @@ struct SharedConnectionInner {
     transaction_owner: Mutex<Option<ThreadId>>,
     transaction_unusable: Mutex<Option<String>>,
     transaction_released: Condvar,
+    /// Bumped before every write to `openmls_values` and on every rollback;
+    /// see `StorageProvider::mls_write_generation`.
+    openmls_writes: AtomicU64,
 }
 
 impl fmt::Debug for SharedConnection {
@@ -311,6 +314,7 @@ impl SharedConnection {
                 transaction_owner: Mutex::new(None),
                 transaction_unusable: Mutex::new(None),
                 transaction_released: Condvar::new(),
+                openmls_writes: AtomicU64::new(0),
             }),
         }
     }
@@ -386,6 +390,16 @@ impl SharedConnection {
         self.inner.transaction_released.notify_all();
     }
 
+    /// Record a write to the OpenMLS store. Called before the write so a
+    /// partial failure invalidates cached objects too.
+    pub(crate) fn note_openmls_write(&self) {
+        self.inner.openmls_writes.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn openmls_write_generation(&self) -> u64 {
+        self.inner.openmls_writes.load(Ordering::Relaxed)
+    }
+
     pub(crate) fn is_current_thread_transaction_owner(&self) -> bool {
         let current = std::thread::current().id();
         let owner = self
@@ -443,7 +457,7 @@ impl SharedConnection {
                     self.clear_transaction_owner();
                     Ok(value)
                 }
-                Err(commit_err) => match self.execute_transaction_boundary_with_retry("ROLLBACK") {
+                Err(commit_err) => match self.rollback_boundary_with_retry() {
                     Ok(()) => {
                         self.clear_transaction_owner();
                         Err(E::from(commit_err))
@@ -453,7 +467,7 @@ impl SharedConnection {
                     )))),
                 },
             },
-            Ok(Err(err)) => match self.execute_transaction_boundary_with_retry("ROLLBACK") {
+            Ok(Err(err)) => match self.rollback_boundary_with_retry() {
                 Ok(()) => {
                     self.clear_transaction_owner();
                     Err(err)
@@ -462,7 +476,7 @@ impl SharedConnection {
                     "sqlite transaction ROLLBACK failed after callback error ({rollback_err}); connection marked unusable",
                 )))),
             },
-            Err(payload) => match self.execute_transaction_boundary_with_retry("ROLLBACK") {
+            Err(payload) => match self.rollback_boundary_with_retry() {
                 Ok(()) => {
                     self.clear_transaction_owner();
                     std::panic::resume_unwind(payload);
@@ -514,6 +528,13 @@ impl SharedConnection {
     /// [`StorageError::Closed`], because that work was discarded. Reporting the
     /// rollback as a failure instead would latch the connection "unusable" and
     /// turn an orderly host suspension into a corruption-shaped error.
+    /// `ROLLBACK` discards OpenMLS writes the transaction made, so it counts
+    /// as a write for cache-validation purposes.
+    fn rollback_boundary_with_retry(&self) -> StorageResult<()> {
+        self.note_openmls_write();
+        self.execute_transaction_boundary_with_retry("ROLLBACK")
+    }
+
     fn execute_transaction_boundary_with_retry(&self, sql: &str) -> StorageResult<()> {
         retry_transaction_boundary(sql, || {
             let Ok(conn) = self.inner.connection.lock() else {
@@ -1015,6 +1036,10 @@ impl StorageProvider for SqliteAccountStorage {
 
     fn mls_storage(&self) -> &Self::Mls {
         &self.openmls
+    }
+
+    fn mls_write_generation(&self) -> Option<u64> {
+        Some(self.connection.openmls_write_generation())
     }
 
     fn maintenance_storage(&self) -> Option<&dyn cgka_traits::storage::MaintenanceStorage> {

--- a/crates/storage-sqlite/src/connection.rs
+++ b/crates/storage-sqlite/src/connection.rs
@@ -250,6 +250,36 @@ impl CloseableConnection {
     }
 }
 
+/// rusqlite's default statement cache holds 16 entries; this crate issues
+/// well over a hundred distinct statement texts on the engine paths alone.
+pub(crate) const PREPARED_STATEMENT_CACHE_CAPACITY: usize = 256;
+
+/// `Connection::execute` / `Connection::query_row` compile the SQL text on
+/// every call. Every statement this crate issues has a fixed text, so route
+/// the hot paths through the connection's prepared-statement cache instead.
+pub(crate) trait CachedSql {
+    fn execute_cached<P: rusqlite::Params>(&self, sql: &str, params: P) -> rusqlite::Result<usize>;
+
+    fn query_row_cached<T, P, F>(&self, sql: &str, params: P, f: F) -> rusqlite::Result<T>
+    where
+        P: rusqlite::Params,
+        F: FnOnce(&rusqlite::Row<'_>) -> rusqlite::Result<T>;
+}
+
+impl CachedSql for rusqlite::Connection {
+    fn execute_cached<P: rusqlite::Params>(&self, sql: &str, params: P) -> rusqlite::Result<usize> {
+        self.prepare_cached(sql)?.execute(params)
+    }
+
+    fn query_row_cached<T, P, F>(&self, sql: &str, params: P, f: F) -> rusqlite::Result<T>
+    where
+        P: rusqlite::Params,
+        F: FnOnce(&rusqlite::Row<'_>) -> rusqlite::Result<T>,
+    {
+        self.prepare_cached(sql)?.query_row(params, f)
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct SharedConnection {
     inner: Arc<SharedConnectionInner>,
@@ -489,7 +519,9 @@ impl SharedConnection {
             let Ok(conn) = self.inner.connection.lock() else {
                 return Err(BoundaryOutcome::Closed);
             };
-            conn.execute_batch(sql).map_err(BoundaryOutcome::Sqlite)
+            conn.execute_cached(sql, [])
+                .map(|_| ())
+                .map_err(BoundaryOutcome::Sqlite)
         })
     }
 
@@ -507,7 +539,8 @@ impl SharedConnection {
             self.inner
                 .connection
                 .lock()?
-                .execute_batch("BEGIN IMMEDIATE")
+                .execute_cached("BEGIN IMMEDIATE", [])
+                .map(|_| ())
                 .map_err(crate::codec::map_sqlite_error)
         })
     }
@@ -774,6 +807,7 @@ impl SqliteAccountStorage {
         options: SqliteStorageOptions,
     ) -> StorageResult<Self> {
         apply_operational_pragmas(&connection, &options)?;
+        connection.set_prepared_statement_cache_capacity(PREPARED_STATEMENT_CACHE_CAPACITY);
         migrations::run_all(&mut connection)?;
         let connection = SharedConnection::new(connection);
         let openmls = SqliteOpenMlsStorage::new(connection.clone());
@@ -832,7 +866,7 @@ fn apply_sqlcipher_key(connection: &rusqlite::Connection, key: &SqlCipherKey) ->
         .pragma_update(None, "key", key.as_secret_str())
         .storage()?;
     let _: i64 = connection
-        .query_row("SELECT count(*) FROM sqlite_master", [], |row| row.get(0))
+        .query_row_cached("SELECT count(*) FROM sqlite_master", [], |row| row.get(0))
         .storage()?;
     Ok(())
 }

--- a/crates/storage-sqlite/src/encrypted_media_secrets.rs
+++ b/crates/storage-sqlite/src/encrypted_media_secrets.rs
@@ -1,3 +1,4 @@
+use crate::connection::CachedSql;
 use std::collections::BTreeSet;
 
 use crate::{
@@ -138,7 +139,7 @@ WHERE group_id_hex = ?1
     ) -> StorageResult<bool> {
         Ok(self
             .lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT
                      EXISTS (
                          SELECT 1
@@ -203,7 +204,7 @@ pub(crate) fn replace_encrypted_media_secret_references_tx(
     // epoch. Always bind references to that durable value, not to a conflicting
     // replay's in-memory event.
     let source_epoch = tx
-        .query_row(
+        .query_row_cached(
             "SELECT source_epoch
              FROM app_events
              WHERE group_id_hex = ?1 AND message_id_hex = ?2",
@@ -233,7 +234,7 @@ pub(crate) fn replace_encrypted_media_secret_references_for_parts_tx(
 ) -> StorageResult<()> {
     let retiring_epochs =
         encrypted_media_secret_reference_epochs_for_message_tx(tx, group_id_hex, message_id_hex)?;
-    tx.execute(
+    tx.execute_cached(
         "DELETE FROM encrypted_media_epoch_secret_references
          WHERE group_id_hex = ?1 AND message_id_hex = ?2",
         params![group_id_hex, message_id_hex],
@@ -245,7 +246,7 @@ pub(crate) fn replace_encrypted_media_secret_references_for_parts_tx(
     {
         let source_epoch = u64_to_i64(source_epoch)?;
         for component_id in encrypted_media_component_ids(tags) {
-            tx.execute(
+            tx.execute_cached(
                 "INSERT INTO encrypted_media_epoch_secret_references (
                      group_id_hex, message_id_hex, component_id, source_epoch
                  ) VALUES (?1, ?2, ?3, ?4)",
@@ -257,7 +258,7 @@ pub(crate) fn replace_encrypted_media_secret_references_for_parts_tx(
                 ],
             )
             .storage()?;
-            tx.execute(
+            tx.execute_cached(
                 "UPDATE encrypted_media_epoch_secrets
                  SET retention_managed = 1
                  WHERE group_id_hex = ?1
@@ -278,7 +279,7 @@ fn encrypted_media_secret_reference_epochs_for_message_tx(
     message_id_hex: &str,
 ) -> StorageResult<BTreeSet<i64>> {
     let mut statement = tx
-        .prepare(
+        .prepare_cached(
             "SELECT DISTINCT source_epoch
              FROM encrypted_media_epoch_secret_references
              WHERE group_id_hex = ?1 AND message_id_hex = ?2",
@@ -304,7 +305,7 @@ pub(crate) fn retire_unreferenced_encrypted_media_secret_epochs_tx(
     let mut deleted = 0usize;
     for source_epoch in candidate_epochs {
         let referenced = tx
-            .query_row(
+            .query_row_cached(
                 "SELECT EXISTS (
                      SELECT 1
                      FROM encrypted_media_epoch_secret_references
@@ -319,7 +320,7 @@ pub(crate) fn retire_unreferenced_encrypted_media_secret_epochs_tx(
             continue;
         }
 
-        tx.execute(
+        tx.execute_cached(
             "INSERT INTO encrypted_media_epoch_secret_retirement_watermarks (
                  group_id_hex, retired_through_epoch, retired_at_unix_seconds
              ) VALUES (?1, ?2, ?3)
@@ -332,7 +333,7 @@ pub(crate) fn retire_unreferenced_encrypted_media_secret_epochs_tx(
             params![group_id_hex, source_epoch, unix_now_seconds_i64()],
         )
         .storage()?;
-        tx.execute(
+        tx.execute_cached(
             "UPDATE encrypted_media_epoch_secrets
              SET secret = zeroblob(length(secret))
              WHERE retention_managed = 1
@@ -342,7 +343,7 @@ pub(crate) fn retire_unreferenced_encrypted_media_secret_epochs_tx(
         )
         .storage()?;
         deleted = deleted.saturating_add(
-            tx.execute(
+            tx.execute_cached(
                 "DELETE FROM encrypted_media_epoch_secrets
                  WHERE retention_managed = 1
                    AND group_id_hex = ?1
@@ -365,7 +366,7 @@ pub(crate) fn retire_all_encrypted_media_secrets_for_group_tx(
     group_id_hex: &str,
 ) -> StorageResult<usize> {
     let has_group_data = tx
-        .query_row(
+        .query_row_cached(
             "SELECT
                  EXISTS (SELECT 1 FROM account_groups WHERE group_id_hex = ?1)
                  OR EXISTS (SELECT 1 FROM app_events WHERE group_id_hex = ?1)
@@ -385,7 +386,7 @@ pub(crate) fn retire_all_encrypted_media_secrets_for_group_tx(
         return Ok(0);
     }
 
-    tx.execute(
+    tx.execute_cached(
         "INSERT INTO encrypted_media_epoch_secret_retirement_watermarks (
              group_id_hex, retired_through_epoch, retired_at_unix_seconds
          ) VALUES (?1, ?2, ?3)
@@ -395,14 +396,14 @@ pub(crate) fn retire_all_encrypted_media_secrets_for_group_tx(
         params![group_id_hex, i64::MAX, unix_now_seconds_i64()],
     )
     .storage()?;
-    tx.execute(
+    tx.execute_cached(
         "UPDATE encrypted_media_epoch_secrets
          SET secret = zeroblob(length(secret))
          WHERE group_id_hex = ?1",
         params![group_id_hex],
     )
     .storage()?;
-    tx.execute(
+    tx.execute_cached(
         "DELETE FROM encrypted_media_epoch_secrets WHERE group_id_hex = ?1",
         params![group_id_hex],
     )

--- a/crates/storage-sqlite/src/message_drafts.rs
+++ b/crates/storage-sqlite/src/message_drafts.rs
@@ -1,3 +1,4 @@
+use crate::connection::CachedSql;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 
@@ -111,7 +112,7 @@ impl SqliteAccountStorage {
         let tx = conn.transaction().storage()?;
         let mut drafts = {
             let mut statement = tx
-                .prepare(
+                .prepare_cached(
                     "SELECT group_id_hex, content, reply_to_message_id_hex,
                             created_at_ms, updated_at_ms
                      FROM message_drafts
@@ -168,7 +169,7 @@ impl SqliteAccountStorage {
                 .transaction_with_behavior(TransactionBehavior::Immediate)
                 .storage()?;
             let group_exists = tx
-                .query_row(
+                .query_row_cached(
                     "SELECT EXISTS(SELECT 1 FROM account_groups WHERE group_id_hex = ?1)",
                     params![group_id_hex],
                     |row| row.get::<_, bool>(0),
@@ -177,7 +178,7 @@ impl SqliteAccountStorage {
             if !group_exists {
                 return Err(StorageError::NotFound);
             }
-            tx.execute(
+            tx.execute_cached(
                 "INSERT INTO message_drafts (
                     group_id_hex, content, reply_to_message_id_hex, created_at_ms, updated_at_ms
                  )
@@ -201,7 +202,7 @@ impl SqliteAccountStorage {
     /// Delete one draft and its cascading attachment rows.
     pub fn delete_message_draft(&self, group_id_hex: &str) -> StorageResult<()> {
         self.lock()?
-            .execute(
+            .execute_cached(
                 "DELETE FROM message_drafts WHERE group_id_hex = ?1",
                 params![group_id_hex],
             )
@@ -228,7 +229,7 @@ fn load_message_draft_attachment_summaries(
     group_id_hex: &str,
 ) -> StorageResult<Vec<StoredMessageDraftAttachmentSummary>> {
     let mut statement = conn
-        .prepare(
+        .prepare_cached(
             "SELECT attachment_id, file_name, media_type, length(plaintext)
              FROM message_draft_attachments
              WHERE group_id_hex = ?1
@@ -301,7 +302,7 @@ fn sync_message_draft_attachments(
         .ok_or_else(|| StorageError::Backend("too many message draft attachments".to_owned()))?;
 
     if !existing.is_empty() {
-        tx.execute(
+        tx.execute_cached(
             "UPDATE message_draft_attachments
              SET position = position + ?2
              WHERE group_id_hex = ?1",
@@ -315,7 +316,7 @@ fn sync_message_draft_attachments(
             .map_err(|_| StorageError::Backend("too many message draft attachments".to_owned()))?;
         match existing_by_id.get(attachment.id.as_str()) {
             Some(stored) if *stored == attachment => {
-                tx.execute(
+                tx.execute_cached(
                     "UPDATE message_draft_attachments
                      SET position = ?3
                      WHERE group_id_hex = ?1 AND attachment_id = ?2",
@@ -334,7 +335,7 @@ fn sync_message_draft_attachments(
 
     for attachment in &existing {
         if !incoming_ids.contains(attachment.id.as_str()) {
-            tx.execute(
+            tx.execute_cached(
                 "DELETE FROM message_draft_attachments
                  WHERE group_id_hex = ?1 AND attachment_id = ?2",
                 params![group_id_hex, attachment.id],
@@ -352,7 +353,7 @@ fn insert_message_draft_attachment(
     attachment: &StoredMessageDraftAttachment,
 ) -> StorageResult<()> {
     let waveform_samples = encoded_waveform_samples(attachment)?;
-    tx.execute(
+    tx.execute_cached(
         "INSERT INTO message_draft_attachments (
             group_id_hex, position, attachment_id, file_name, media_type,
             plaintext, dim, thumbhash, duration_seconds, waveform_samples_json
@@ -383,7 +384,7 @@ fn update_message_draft_attachment(
 ) -> StorageResult<()> {
     let waveform_samples = encoded_waveform_samples(attachment)?;
     if let Some(position) = position {
-        tx.execute(
+        tx.execute_cached(
             "UPDATE message_draft_attachments
              SET position = ?3, file_name = ?4, media_type = ?5, plaintext = ?6,
                  dim = ?7, thumbhash = ?8, duration_seconds = ?9,
@@ -404,7 +405,7 @@ fn update_message_draft_attachment(
         )
         .storage()?;
     } else {
-        tx.execute(
+        tx.execute_cached(
             "UPDATE message_draft_attachments
              SET file_name = ?3, media_type = ?4, plaintext = ?5, dim = ?6,
                  thumbhash = ?7, duration_seconds = ?8, waveform_samples_json = ?9
@@ -437,7 +438,7 @@ fn load_message_draft_attachments(
     group_id_hex: &str,
 ) -> StorageResult<Vec<StoredMessageDraftAttachment>> {
     let mut statement = conn
-        .prepare(
+        .prepare_cached(
             "SELECT attachment_id, file_name, media_type, plaintext, dim, thumbhash,
                     duration_seconds, waveform_samples_json
              FROM message_draft_attachments
@@ -485,7 +486,7 @@ fn load_message_draft(
     group_id_hex: &str,
 ) -> StorageResult<Option<StoredMessageDraft>> {
     let draft = conn
-        .query_row(
+        .query_row_cached(
             "SELECT content, reply_to_message_id_hex, created_at_ms, updated_at_ms
                  FROM message_drafts
                  WHERE group_id_hex = ?1",

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -110,6 +110,8 @@ mod migration_0054_transport_reconciliation_items;
 mod migration_0055_epoch_stall_evidence;
 #[path = "migrations/0056_chat_list_accepted_activity_high_water.rs"]
 mod migration_0056_chat_list_accepted_activity_high_water;
+#[path = "migrations/0057_openmls_values_cbor_encoding.rs"]
+mod migration_0057_openmls_values_cbor_encoding;
 #[cfg(test)]
 #[path = "migrations/test_support.rs"]
 mod test_support;
@@ -404,6 +406,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 56,
         name: "0056_chat_list_accepted_activity_high_water",
         apply: migration_0056_chat_list_accepted_activity_high_water::apply,
+    },
+    Migration {
+        version: 57,
+        name: "0057_openmls_values_cbor_encoding",
+        apply: migration_0057_openmls_values_cbor_encoding::apply,
     },
 ];
 
@@ -932,7 +939,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 56,
+                found: 57,
                 latest_supported: 46,
             }
         ));
@@ -988,7 +995,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 56,
+                found: 57,
                 latest_supported: 46,
             }
         ));
@@ -1292,7 +1299,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 56,
+                found: 57,
                 latest_supported: 46,
             }
         ));

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -112,6 +112,8 @@ mod migration_0055_epoch_stall_evidence;
 mod migration_0056_chat_list_accepted_activity_high_water;
 #[path = "migrations/0057_openmls_values_msgpack.rs"]
 mod migration_0057_openmls_values_msgpack;
+#[path = "migrations/0058_group_record_msgpack.rs"]
+mod migration_0058_group_record_msgpack;
 #[cfg(test)]
 #[path = "migrations/test_support.rs"]
 mod test_support;
@@ -411,6 +413,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 57,
         name: "0057_openmls_values_msgpack",
         apply: migration_0057_openmls_values_msgpack::apply,
+    },
+    Migration {
+        version: 58,
+        name: "0058_group_record_msgpack",
+        apply: migration_0058_group_record_msgpack::apply,
     },
 ];
 
@@ -939,7 +946,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 57,
+                found: 58,
                 latest_supported: 46,
             }
         ));
@@ -995,7 +1002,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 57,
+                found: 58,
                 latest_supported: 46,
             }
         ));
@@ -1299,7 +1306,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 57,
+                found: 58,
                 latest_supported: 46,
             }
         ));

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -110,8 +110,8 @@ mod migration_0054_transport_reconciliation_items;
 mod migration_0055_epoch_stall_evidence;
 #[path = "migrations/0056_chat_list_accepted_activity_high_water.rs"]
 mod migration_0056_chat_list_accepted_activity_high_water;
-#[path = "migrations/0057_openmls_values_cbor_encoding.rs"]
-mod migration_0057_openmls_values_cbor_encoding;
+#[path = "migrations/0057_openmls_values_msgpack.rs"]
+mod migration_0057_openmls_values_msgpack;
 #[cfg(test)]
 #[path = "migrations/test_support.rs"]
 mod test_support;
@@ -409,8 +409,8 @@ const MIGRATIONS: &[Migration] = &[
     },
     Migration {
         version: 57,
-        name: "0057_openmls_values_cbor_encoding",
-        apply: migration_0057_openmls_values_cbor_encoding::apply,
+        name: "0057_openmls_values_msgpack",
+        apply: migration_0057_openmls_values_msgpack::apply,
     },
 ];
 

--- a/crates/storage-sqlite/src/migrations/0057_openmls_values_cbor_encoding.rs
+++ b/crates/storage-sqlite/src/migrations/0057_openmls_values_cbor_encoding.rs
@@ -1,0 +1,15 @@
+//! Version marker for the CBOR encoding of `openmls_values`.
+//!
+//! Rows written from this version on start with a NUL-prefixed format tag and
+//! carry CBOR instead of a serde_json document. The table shape is
+//! unchanged and older rows stay readable, so this migration alters nothing;
+//! it exists so a build without the decoder refuses to open the database
+//! through `reject_unknown_future_migrations` instead of failing on the first
+//! group load.
+
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(crate) fn apply(_tx: &Transaction<'_>) -> StorageResult<()> {
+    Ok(())
+}

--- a/crates/storage-sqlite/src/migrations/0057_openmls_values_msgpack.rs
+++ b/crates/storage-sqlite/src/migrations/0057_openmls_values_msgpack.rs
@@ -1,7 +1,7 @@
-//! Version marker for the CBOR encoding of `openmls_values`.
+//! Version marker for the MessagePack encoding of `openmls_values`.
 //!
 //! Rows written from this version on start with a NUL-prefixed format tag and
-//! carry CBOR instead of a serde_json document. The table shape is
+//! carry MessagePack instead of a serde_json document. The table shape is
 //! unchanged and older rows stay readable, so this migration alters nothing;
 //! it exists so a build without the decoder refuses to open the database
 //! through `reject_unknown_future_migrations` instead of failing on the first

--- a/crates/storage-sqlite/src/migrations/0058_group_record_msgpack.rs
+++ b/crates/storage-sqlite/src/migrations/0058_group_record_msgpack.rs
@@ -1,0 +1,15 @@
+//! Version marker for the MessagePack encoding of `cgka_groups.record`.
+//!
+//! Rows written from this version on start with a NUL-prefixed format tag and
+//! carry MessagePack instead of a serde_json document. The table shape is
+//! unchanged and older rows stay readable, so this migration alters nothing;
+//! it exists so a build without the decoder refuses to open the database
+//! through `reject_unknown_future_migrations` instead of failing on the first
+//! group read.
+
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(crate) fn apply(_tx: &Transaction<'_>) -> StorageResult<()> {
+    Ok(())
+}

--- a/crates/storage-sqlite/src/openmls_storage.rs
+++ b/crates/storage-sqlite/src/openmls_storage.rs
@@ -2,6 +2,7 @@ mod labels;
 mod provider;
 mod value_store;
 
+use crate::connection::CachedSql;
 use crate::connection::SharedConnection;
 use cgka_traits::storage::{StorageError, StorageResult, StoredKeyPackageBundle};
 use cgka_traits::types::GroupId as MarmotGroupId;
@@ -42,7 +43,7 @@ impl SqliteOpenMlsStorage {
 
         let connection = self.connection.lock()?;
         let mut statement = connection
-            .prepare(
+            .prepare_cached(
                 "SELECT storage_key, value
                  FROM openmls_values
                  WHERE provider_version = ?1 AND label = ?2
@@ -70,7 +71,7 @@ impl SqliteOpenMlsStorage {
 
         let connection = self.connection.lock()?;
         connection
-            .execute(
+            .execute_cached(
                 "DELETE FROM openmls_values
                  WHERE provider_version = ?1 AND label = ?2 AND storage_key = ?3",
                 params![

--- a/crates/storage-sqlite/src/openmls_storage.rs
+++ b/crates/storage-sqlite/src/openmls_storage.rs
@@ -99,6 +99,10 @@ pub enum SqliteOpenMlsStorageError {
     Sqlite(#[from] rusqlite::Error),
     #[error("serialization failure: {0}")]
     Serialization(#[from] serde_json::Error),
+    #[error("encoding failure: {0}")]
+    Encode(#[from] rmp_serde::encode::Error),
+    #[error("decoding failure: {0}")]
+    Decode(#[from] rmp_serde::decode::Error),
     #[error("queued proposal reference was present without a queued proposal")]
     MissingQueuedProposal,
 }

--- a/crates/storage-sqlite/src/openmls_storage.rs
+++ b/crates/storage-sqlite/src/openmls_storage.rs
@@ -66,6 +66,7 @@ impl SqliteOpenMlsStorage {
     }
 
     pub(crate) fn delete_stored_key_package_bundle(&self, storage_key: &[u8]) -> StorageResult<()> {
+        self.connection.note_openmls_write();
         use openmls_traits::storage::CURRENT_VERSION;
         use rusqlite::params;
 

--- a/crates/storage-sqlite/src/openmls_storage/labels.rs
+++ b/crates/storage-sqlite/src/openmls_storage/labels.rs
@@ -40,6 +40,10 @@ impl OpenMlsValueLabel {
         self.sensitivity
     }
 
+    pub(in crate::openmls_storage) const fn is_key_package(self) -> bool {
+        matches!(self.bytes, b"KeyPackage")
+    }
+
     #[cfg(test)]
     pub(in crate::openmls_storage) const fn test_public(bytes: &'static [u8]) -> Self {
         Self::public(bytes)

--- a/crates/storage-sqlite/src/openmls_storage/value_store.rs
+++ b/crates/storage-sqlite/src/openmls_storage/value_store.rs
@@ -1,6 +1,7 @@
 use super::labels::{OpenMlsValueLabel, ValueSensitivity, build_key, build_key_legacy};
 use super::{SqliteOpenMlsStorage, SqliteOpenMlsStorageError};
 use crate::codec::{SensitiveBytes, serialize_sensitive_json};
+use crate::connection::CachedSql;
 use crate::connection::retry_on_busy;
 use openmls_traits::storage::{CURRENT_VERSION, Entity, Key};
 use rusqlite::{OptionalExtension, TransactionBehavior, params};
@@ -400,7 +401,7 @@ fn read_value_on_connection(
     label: OpenMlsValueLabel,
 ) -> Result<Option<SerializedBuffer>, SqliteOpenMlsStorageError> {
     Ok(conn
-        .query_row(
+        .query_row_cached(
             "SELECT value FROM openmls_values
              WHERE provider_version = ?1 AND storage_key = ?2",
             params![CURRENT_VERSION, storage_key],
@@ -418,7 +419,7 @@ fn write_value_on_connection(
     group_key: Option<&[u8]>,
     value: &[u8],
 ) -> Result<(), SqliteOpenMlsStorageError> {
-    conn.execute(
+    conn.execute_cached(
         "INSERT OR REPLACE INTO openmls_values
             (provider_version, label, storage_key, group_key, value)
          VALUES (?1, ?2, ?3, ?4, ?5)",
@@ -469,7 +470,7 @@ fn write_list_on_connection(
     list: &SerializedList,
 ) -> Result<(), SqliteOpenMlsStorageError> {
     let encoded = serialize_buffer(label, list)?;
-    conn.execute(
+    conn.execute_cached(
         "INSERT OR REPLACE INTO openmls_values
             (provider_version, label, storage_key, group_key, value)
          VALUES (?1, ?2, ?3, ?4, ?5)",
@@ -526,7 +527,7 @@ fn delete_value_on_connection(
     conn: &rusqlite::Connection,
     storage_key: &[u8],
 ) -> Result<(), SqliteOpenMlsStorageError> {
-    conn.execute(
+    conn.execute_cached(
         "DELETE FROM openmls_values
          WHERE provider_version = ?1 AND storage_key = ?2",
         params![CURRENT_VERSION, storage_key],
@@ -540,7 +541,7 @@ fn delete_group_labels_on_connection(
     labels: &[OpenMlsValueLabel],
 ) -> Result<(), SqliteOpenMlsStorageError> {
     for label in labels {
-        conn.execute(
+        conn.execute_cached(
             "DELETE FROM openmls_values
              WHERE provider_version = ?1 AND group_key = ?2 AND label = ?3",
             params![CURRENT_VERSION, group_key, label.as_bytes()],

--- a/crates/storage-sqlite/src/openmls_storage/value_store.rs
+++ b/crates/storage-sqlite/src/openmls_storage/value_store.rs
@@ -169,6 +169,7 @@ impl SqliteOpenMlsStorage {
         group_key: Option<Vec<u8>>,
         value: &SerializedBuffer,
     ) -> Result<(), SqliteOpenMlsStorageError> {
+        self.connection.note_openmls_write();
         let storage_key = build_key(label.as_bytes(), key.clone());
         let legacy_storage_key = build_key_legacy(label.as_bytes(), key);
         if self.connection.is_current_thread_transaction_owner() {
@@ -256,6 +257,7 @@ impl SqliteOpenMlsStorage {
         group_key: Option<Vec<u8>>,
         value: &T,
     ) -> Result<(), SqliteOpenMlsStorageError> {
+        self.connection.note_openmls_write();
         let storage_key = build_key(label.as_bytes(), key.clone());
         let legacy_storage_key = build_key_legacy(label.as_bytes(), key);
         if self.connection.is_current_thread_transaction_owner() {
@@ -299,6 +301,7 @@ impl SqliteOpenMlsStorage {
         group_key: Option<Vec<u8>>,
         value: &T,
     ) -> Result<(), SqliteOpenMlsStorageError> {
+        self.connection.note_openmls_write();
         let encoded = [
             serialize_buffer(label, value)?,
             encode_legacy_json(label, value)?,
@@ -408,6 +411,7 @@ impl SqliteOpenMlsStorage {
         label: OpenMlsValueLabel,
         key: Vec<u8>,
     ) -> Result<(), SqliteOpenMlsStorageError> {
+        self.connection.note_openmls_write();
         let storage_key = build_key(label.as_bytes(), key.clone());
         let legacy_storage_key = build_key_legacy(label.as_bytes(), key);
         if self.connection.is_current_thread_transaction_owner() {
@@ -443,6 +447,7 @@ impl SqliteOpenMlsStorage {
         group_id: &GroupId,
         labels: &[OpenMlsValueLabel],
     ) -> Result<(), SqliteOpenMlsStorageError> {
+        self.connection.note_openmls_write();
         let group_key = Self::group_key(group_id)?;
         // Wrap every label delete in a single transaction so the operation is
         // atomic. clear_proposal_queue deletes QUEUED_PROPOSAL_LABEL and

--- a/crates/storage-sqlite/src/openmls_storage/value_store.rs
+++ b/crates/storage-sqlite/src/openmls_storage/value_store.rs
@@ -8,6 +8,70 @@ use rusqlite::{OptionalExtension, TransactionBehavior, params};
 use serde::de::DeserializeOwned;
 use serde::{Serialize, Serializer};
 
+/// Leading bytes of a MessagePack-encoded value. Rows written before this
+/// encoding are serde_json documents, which never begin with NUL, so a read
+/// tells the two apart by this prefix and older rows keep decoding until
+/// their next write replaces them.
+///
+/// serde_json spelled every `Vec<u8>` as an array of decimal integers: four
+/// times the bytes on disk and a text integer parse per byte on every read.
+/// A 64-member ratchet tree was 111 KB of JSON, parsed twice per app-message
+/// send. MessagePack is self-describing, which OpenMLS's hand-written
+/// `Deserialize` impls require, so a positional format such as postcard
+/// cannot serve here.
+const VALUE_ENCODING_V2_PREFIX: [u8; 2] = [0x00, 0x02];
+
+/// Labels whose raw row bytes leave this crate and are parsed by the engine
+/// as serde_json (`cgka_engine::key_package` reads stored bundles through
+/// `StoredKeyPackageBundle::value`). Those stay JSON until that seam carries
+/// decoded values.
+const fn label_stays_json(label: OpenMlsValueLabel) -> bool {
+    label.is_key_package()
+}
+
+fn encode_public<T: Serialize + ?Sized>(
+    label: OpenMlsValueLabel,
+    value: &T,
+) -> Result<Vec<u8>, SqliteOpenMlsStorageError> {
+    if label_stays_json(label) {
+        return Ok(serde_json::to_vec(value)?);
+    }
+    let mut out = VALUE_ENCODING_V2_PREFIX.to_vec();
+    rmp_serde::encode::write(&mut out, value)?;
+    Ok(out)
+}
+
+fn encode_secret<T: Serialize + ?Sized>(
+    label: OpenMlsValueLabel,
+    value: &T,
+) -> Result<SensitiveBytes, SqliteOpenMlsStorageError> {
+    if label_stays_json(label) {
+        return Ok(serialize_sensitive_json(value)?);
+    }
+    let mut out = SensitiveBytes::with_capacity(256);
+    std::io::Write::write_all(&mut out, &VALUE_ENCODING_V2_PREFIX)
+        .expect("in-memory sensitive buffer write cannot fail");
+    rmp_serde::encode::write(&mut out, value)?;
+    Ok(out)
+}
+
+fn decode<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, SqliteOpenMlsStorageError> {
+    match bytes.strip_prefix(&VALUE_ENCODING_V2_PREFIX) {
+        Some(body) => Ok(rmp_serde::from_slice(body)?),
+        None => Ok(serde_json::from_slice(bytes)?),
+    }
+}
+
+/// The serde_json form of `value`, for matching list elements written before
+/// [`VALUE_ENCODING_V2_PREFIX`].
+fn encode_legacy_json<T: Serialize + ?Sized>(
+    label: OpenMlsValueLabel,
+    value: &T,
+) -> Result<SerializedBuffer, SqliteOpenMlsStorageError> {
+    let bytes = serde_json::to_vec(value)?;
+    Ok(SerializedBuffer::from_database(label, bytes))
+}
+
 enum SerializedBuffer {
     Public(Vec<u8>),
     Secret(SensitiveBytes),
@@ -34,8 +98,8 @@ fn serialize_buffer<T: Serialize + ?Sized>(
     value: &T,
 ) -> Result<SerializedBuffer, SqliteOpenMlsStorageError> {
     match label.sensitivity() {
-        ValueSensitivity::Public => Ok(SerializedBuffer::Public(serde_json::to_vec(value)?)),
-        ValueSensitivity::Secret => Ok(SerializedBuffer::Secret(serialize_sensitive_json(value)?)),
+        ValueSensitivity::Public => Ok(SerializedBuffer::Public(encode_public(label, value)?)),
+        ValueSensitivity::Secret => Ok(SerializedBuffer::Secret(encode_secret(label, value)?)),
     }
 }
 
@@ -50,29 +114,40 @@ impl SerializedList {
         bytes: &[u8],
     ) -> Result<Self, SqliteOpenMlsStorageError> {
         match label.sensitivity() {
-            ValueSensitivity::Public => Ok(Self::Public(serde_json::from_slice(bytes)?)),
-            ValueSensitivity::Secret => Ok(Self::Secret(serde_json::from_slice(bytes)?)),
+            ValueSensitivity::Public => Ok(Self::Public(decode(bytes)?)),
+            ValueSensitivity::Secret => Ok(Self::Secret(decode(bytes)?)),
         }
     }
 
-    fn push<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), SqliteOpenMlsStorageError> {
+    fn push<T: Serialize + ?Sized>(
+        &mut self,
+        label: OpenMlsValueLabel,
+        value: &T,
+    ) -> Result<(), SqliteOpenMlsStorageError> {
         match self {
-            Self::Public(values) => values.push(serde_json::to_vec(value)?),
-            Self::Secret(values) => values.push(serialize_sensitive_json(value)?),
+            Self::Public(values) => values.push(encode_public(label, value)?),
+            Self::Secret(values) => values.push(encode_secret(label, value)?),
         }
         Ok(())
     }
 
-    fn remove_matching(&mut self, encoded: &SerializedBuffer) {
-        fn remove<T: AsRef<[u8]>>(values: &mut Vec<T>, encoded: &[u8]) {
-            if let Some(pos) = values.iter().position(|stored| stored.as_ref() == encoded) {
+    /// Remove the first element equal to any of `encodings`. A list written
+    /// before the current encoding holds serde_json elements, so callers pass
+    /// both the current and the legacy form of the value.
+    fn remove_matching(&mut self, encodings: &[SerializedBuffer]) {
+        fn remove<T: AsRef<[u8]>>(values: &mut Vec<T>, encodings: &[SerializedBuffer]) {
+            if let Some(pos) = values.iter().position(|stored| {
+                encodings
+                    .iter()
+                    .any(|encoded| stored.as_ref() == encoded.as_slice())
+            }) {
                 values.remove(pos);
             }
         }
 
         match self {
-            Self::Public(values) => remove(values, encoded.as_slice()),
-            Self::Secret(values) => remove(values, encoded.as_slice()),
+            Self::Public(values) => remove(values, encodings),
+            Self::Secret(values) => remove(values, encodings),
         }
     }
 }
@@ -224,7 +299,10 @@ impl SqliteOpenMlsStorage {
         group_key: Option<Vec<u8>>,
         value: &T,
     ) -> Result<(), SqliteOpenMlsStorageError> {
-        let encoded = serialize_buffer(label, value)?;
+        let encoded = [
+            serialize_buffer(label, value)?,
+            encode_legacy_json(label, value)?,
+        ];
         let storage_key = build_key(label.as_bytes(), key.clone());
         let legacy_storage_key = build_key_legacy(label.as_bytes(), key);
         if self.connection.is_current_thread_transaction_owner() {
@@ -294,9 +372,7 @@ impl SqliteOpenMlsStorage {
             Some(value) => Some(value),
             None => read_value_on_connection(&conn, &legacy_storage_key, label)?,
         };
-        value
-            .map(|value| serde_json::from_slice(value.as_slice()).map_err(Into::into))
-            .transpose()
+        value.map(|value| decode(value.as_slice())).transpose()
     }
 
     pub(in crate::openmls_storage) fn read_group_entity<
@@ -316,13 +392,12 @@ impl SqliteOpenMlsStorage {
         key: Vec<u8>,
     ) -> Result<Vec<T>, SqliteOpenMlsStorageError> {
         match self.read_raw_list(label, &key)? {
-            Some(SerializedList::Public(values)) => values
-                .into_iter()
-                .map(|value| serde_json::from_slice(&value).map_err(Into::into))
-                .collect(),
+            Some(SerializedList::Public(values)) => {
+                values.into_iter().map(|value| decode(&value)).collect()
+            }
             Some(SerializedList::Secret(values)) => values
                 .into_iter()
-                .map(|value| serde_json::from_slice(value.as_slice()).map_err(Into::into))
+                .map(|value| decode(value.as_slice()))
                 .collect(),
             None => Ok(Vec::new()),
         }
@@ -499,7 +574,7 @@ fn append_entity_on_connection<T: Entity<CURRENT_VERSION>>(
         legacy_storage_key.as_slice(),
         label,
     )?;
-    list.push(value)?;
+    list.push(label, value)?;
     write_list_on_connection(conn, label, storage_key.as_slice(), group_key, &list)?;
     delete_value_on_connection(conn, legacy_storage_key.as_slice())
 }
@@ -510,7 +585,7 @@ fn remove_entity_on_connection(
     storage_key: Vec<u8>,
     legacy_storage_key: Vec<u8>,
     group_key: Option<&[u8]>,
-    encoded: &SerializedBuffer,
+    encoded: &[SerializedBuffer],
 ) -> Result<(), SqliteOpenMlsStorageError> {
     let mut list = list_values_with_legacy_fallback_on_connection(
         conn,
@@ -575,8 +650,12 @@ mod tests {
             SerializedBuffer::Secret(_)
         ));
 
+        // A list written by the serde_json era: elements are JSON documents.
         let mut list = SerializedList::deserialize(label, b"[[55],[56]]").unwrap();
-        let encoded = serialize_buffer(label, &TestEntity(7)).unwrap();
+        let encoded = [
+            serialize_buffer(label, &TestEntity(7)).unwrap(),
+            encode_legacy_json(label, &TestEntity(7)).unwrap(),
+        ];
         list.remove_matching(&encoded);
         match list {
             SerializedList::Secret(values) => {
@@ -592,15 +671,80 @@ mod tests {
     #[test]
     fn list_push_derives_buffer_ownership_from_the_existing_list() {
         let mut public = SerializedList::Public(Vec::new());
-        public.push(&TestEntity(7)).unwrap();
-        assert!(matches!(public, SerializedList::Public(values) if values == [b"7"]));
+        public
+            .push(OpenMlsValueLabel::test_public(b"P"), &TestEntity(7))
+            .unwrap();
+        assert!(matches!(public, SerializedList::Public(values) if values == [[0, 2, 7]]));
 
         let mut secret = SerializedList::Secret(Vec::new());
-        secret.push(&TestEntity(8)).unwrap();
+        secret
+            .push(OpenMlsValueLabel::test_secret(b"S"), &TestEntity(8))
+            .unwrap();
         assert!(matches!(
             secret,
-            SerializedList::Secret(values) if values.len() == 1 && values[0].as_slice() == b"8"
+            SerializedList::Secret(values) if values.len() == 1 && values[0].as_slice() == [0, 2, 8]
         ));
+    }
+
+    #[test]
+    fn values_decode_from_either_encoding_and_write_the_current_one() {
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Blob {
+            bytes: Vec<u8>,
+            epoch: u64,
+        }
+        let blob = Blob {
+            bytes: (0..=255).collect(),
+            epoch: 7,
+        };
+
+        let json = serde_json::to_vec(&blob).unwrap();
+        assert_eq!(decode::<Blob>(&json).unwrap(), blob);
+
+        let label = OpenMlsValueLabel::test_public(b"Blob");
+        let current = encode_public(label, &blob).unwrap();
+        assert!(current.starts_with(&VALUE_ENCODING_V2_PREFIX));
+        assert_eq!(decode::<Blob>(&current).unwrap(), blob);
+        assert!(current.len() < json.len());
+
+        let secret = encode_secret(OpenMlsValueLabel::test_secret(b"Blob"), &blob).unwrap();
+        assert_eq!(secret.as_slice(), current.as_slice());
+        assert!(decode::<Blob>(b"\x00\x02\xff").is_err());
+        assert!(decode::<Blob>(b"[[55],").is_err());
+    }
+
+    #[test]
+    fn stored_json_row_reads_back_and_is_rewritten_in_the_current_encoding() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let mls = &store.openmls;
+        let label = OpenMlsValueLabel::test_public(b"Legacy");
+
+        mls.write_value(
+            label,
+            b"k".to_vec(),
+            None,
+            serde_json::to_vec(&TestEntity(9)).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            mls.read_entity::<TestEntity>(label, b"k".to_vec()).unwrap(),
+            Some(TestEntity(9))
+        );
+
+        mls.write_entity(label, b"k".to_vec(), None, &TestEntity(10))
+            .unwrap();
+        let raw = read_value_on_connection(
+            &store.lock().unwrap(),
+            &build_key(label.as_bytes(), b"k".to_vec()),
+            label,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(raw.as_slice().starts_with(&VALUE_ENCODING_V2_PREFIX));
+        assert_eq!(
+            mls.read_entity::<TestEntity>(label, b"k".to_vec()).unwrap(),
+            Some(TestEntity(10))
+        );
     }
 
     #[test]

--- a/crates/storage-sqlite/src/pending_welcome_delivery.rs
+++ b/crates/storage-sqlite/src/pending_welcome_delivery.rs
@@ -1,3 +1,4 @@
+use crate::connection::CachedSql;
 use crate::{SqliteAccountStorage, SqliteResultExt, i64_to_u64, u64_to_i64};
 use cgka_traits::storage::StorageResult;
 use rusqlite::params;
@@ -46,7 +47,7 @@ impl SqliteAccountStorage {
         let mut conn = self.lock()?;
         let tx = conn.transaction().storage()?;
         for record in records {
-            tx.execute(
+            tx.execute_cached(
                 "INSERT INTO app_pending_welcome_delivery (
                     message_id_hex, group_id_hex, recipient_hex, recorded_at
                  )
@@ -74,7 +75,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<Vec<PendingWelcomeDeliveryRecord>> {
         let conn = self.lock()?;
         let mut stmt = conn
-            .prepare(
+            .prepare_cached(
                 "SELECT message_id_hex, group_id_hex, recipient_hex, recorded_at
                  FROM app_pending_welcome_delivery
                  ORDER BY recorded_at ASC, message_id_hex ASC",
@@ -105,7 +106,7 @@ impl SqliteAccountStorage {
     /// Clear the pending welcome delivery for `message_id_hex`, if any.
     pub fn clear_pending_welcome_delivery(&self, message_id_hex: &str) -> StorageResult<()> {
         self.lock()?
-            .execute(
+            .execute_cached(
                 "DELETE FROM app_pending_welcome_delivery WHERE message_id_hex = ?1",
                 params![message_id_hex],
             )

--- a/crates/storage-sqlite/src/prepared_group_image_upload.rs
+++ b/crates/storage-sqlite/src/prepared_group_image_upload.rs
@@ -1,3 +1,4 @@
+use crate::connection::CachedSql;
 use std::fmt;
 
 use crate::{SqliteAccountStorage, SqliteResultExt, i64_to_u64, u64_to_i64};
@@ -105,14 +106,14 @@ impl SqliteAccountStorage {
         let consumed_cutoff = record
             .updated_at
             .saturating_sub(CONSUMED_PREPARED_GROUP_IMAGE_UPLOAD_TTL_SECONDS);
-        tx.execute(
+        tx.execute_cached(
             "DELETE FROM app_prepared_group_image_upload
              WHERE (state != 'consumed' AND updated_at < ?1)
                 OR (state = 'consumed' AND updated_at < ?2)",
             params![u64_to_i64(active_cutoff)?, u64_to_i64(consumed_cutoff)?],
         )
         .storage()?;
-        tx.execute(
+        tx.execute_cached(
             "DELETE FROM app_prepared_group_image_upload
              WHERE upload_id IN (
                  SELECT upload_id FROM app_prepared_group_image_upload
@@ -128,7 +129,7 @@ impl SqliteAccountStorage {
         )
         .storage()?;
         let active_count: i64 = tx
-            .query_row(
+            .query_row_cached(
                 "SELECT COUNT(*) FROM app_prepared_group_image_upload WHERE state != 'consumed'",
                 [],
                 |row| row.get(0),
@@ -141,7 +142,7 @@ impl SqliteAccountStorage {
                 "prepared group image upload capacity reached ({MAX_ACTIVE_PREPARED_GROUP_IMAGE_UPLOADS})"
             )));
         }
-        tx.execute(
+        tx.execute_cached(
             "INSERT INTO app_prepared_group_image_upload (
                     upload_id, state, component_data, encrypted_blob, upload_secret,
                     group_id_hex, attempt_count, last_error_kind, recorded_at, updated_at
@@ -166,7 +167,7 @@ impl SqliteAccountStorage {
         upload_id: &str,
     ) -> StorageResult<Option<PreparedGroupImageUploadRecord>> {
         let conn = self.lock()?;
-        conn.query_row(
+        conn.query_row_cached(
             "SELECT upload_id, state, component_data, encrypted_blob, upload_secret,
                     group_id_hex, attempt_count, last_error_kind, recorded_at, updated_at
              FROM app_prepared_group_image_upload
@@ -185,7 +186,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<Vec<PreparedGroupImageUploadRecord>> {
         let conn = self.lock()?;
         let mut statement = conn
-            .prepare(
+            .prepare_cached(
                 "SELECT upload_id, state, component_data, encrypted_blob, upload_secret,
                         group_id_hex, attempt_count, last_error_kind, recorded_at, updated_at
                  FROM app_prepared_group_image_upload
@@ -207,7 +208,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<()> {
         let changed = self
             .lock()?
-            .execute(
+            .execute_cached(
                 "UPDATE app_prepared_group_image_upload
                  SET state = 'uploaded', attempt_count = attempt_count + 1,
                      last_error_kind = NULL, updated_at = ?2
@@ -229,7 +230,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<()> {
         let changed = self
             .lock()?
-            .execute(
+            .execute_cached(
                 "UPDATE app_prepared_group_image_upload
                  SET state = 'failed', attempt_count = attempt_count + 1,
                      last_error_kind = ?2, updated_at = ?3
@@ -252,7 +253,7 @@ impl SqliteAccountStorage {
         let mut conn = self.lock()?;
         let tx = conn.transaction().storage()?;
         let changed = tx
-            .execute(
+            .execute_cached(
                 "UPDATE app_prepared_group_image_upload
                  SET state = 'consumed', group_id_hex = ?2,
                      component_data = X'', encrypted_blob = NULL,
@@ -263,7 +264,7 @@ impl SqliteAccountStorage {
             .storage()?;
         if changed == 0 {
             let raw = tx
-                .query_row(
+                .query_row_cached(
                     "SELECT upload_id, state, component_data, encrypted_blob, upload_secret,
                             group_id_hex, attempt_count, last_error_kind, recorded_at, updated_at
                      FROM app_prepared_group_image_upload WHERE upload_id = ?1",
@@ -282,7 +283,7 @@ impl SqliteAccountStorage {
                 ));
             }
         }
-        tx.execute(
+        tx.execute_cached(
             "DELETE FROM app_prepared_group_image_upload
              WHERE upload_id IN (
                  SELECT upload_id FROM app_prepared_group_image_upload

--- a/crates/storage-sqlite/src/shared.rs
+++ b/crates/storage-sqlite/src/shared.rs
@@ -1,3 +1,4 @@
+use crate::connection::CachedSql;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
@@ -156,7 +157,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
             let tx = conn
                 .transaction_with_behavior(TransactionBehavior::Immediate)
                 .storage()?;
-            tx.execute(
+            tx.execute_cached(
                 "INSERT INTO directory_users (
                 account_id_hex, npub, profile_json, relay_lists_json, key_package_json,
                 event_id_hex, event_kind, event_created_at
@@ -182,13 +183,13 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
                 ],
             )
             .storage()?;
-            tx.execute(
+            tx.execute_cached(
                 "DELETE FROM directory_user_follows WHERE account_id_hex = ?1",
                 params![&record.account_id_hex],
             )
             .storage()?;
             for (position, follow) in record.follows.iter().enumerate() {
-                tx.execute(
+                tx.execute_cached(
                     "INSERT OR IGNORE INTO directory_user_follows (
                     account_id_hex, follow_account_id_hex, position, event_id_hex, event_created_at
                  )
@@ -214,7 +215,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
         let mut conn = self.lock()?;
         let tx = conn.transaction().storage()?;
         let Some(mut record) = tx
-            .query_row(
+            .query_row_cached(
                 "SELECT account_id_hex, npub, profile_json, relay_lists_json,
                         key_package_json, event_id_hex, event_kind, event_created_at
                  FROM directory_users
@@ -241,7 +242,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
             return Ok(None);
         };
         let mut stmt = tx
-            .prepare(
+            .prepare_cached(
                 "SELECT follow_account_id_hex FROM directory_user_follows
                  WHERE account_id_hex = ?1
                  ORDER BY position, follow_account_id_hex",
@@ -281,7 +282,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
             std::collections::HashMap::new();
         {
             let mut stmt = tx
-                .prepare(
+                .prepare_cached(
                     "SELECT account_id_hex, follow_account_id_hex FROM directory_user_follows
                      WHERE account_id_hex IN (
                          SELECT account_id_hex FROM directory_users
@@ -304,7 +305,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
             }
         }
         let mut stmt = tx
-            .prepare(
+            .prepare_cached(
                 "SELECT account_id_hex, npub, profile_json, relay_lists_json,
                         key_package_json, event_id_hex, event_kind, event_created_at
                  FROM directory_users
@@ -355,7 +356,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
     pub fn relay_telemetry_settings(&self) -> StorageResult<StoredRelayTelemetrySettings> {
         self.ensure_relay_telemetry_settings()?;
         self.lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT export_enabled, export_interval_seconds
                  FROM relay_telemetry_settings
                  WHERE id = 1",
@@ -377,7 +378,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
     ) -> StorageResult<()> {
         retry_on_busy(|| {
             self.lock()?
-                .execute(
+                .execute_cached(
                     "INSERT INTO relay_telemetry_settings (
                     id, export_enabled, export_interval_seconds, updated_at_ms
                  )
@@ -399,7 +400,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
 
     pub fn telemetry_install_id(&self) -> StorageResult<Option<String>> {
         self.lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT install_id
                  FROM telemetry_install
                  WHERE id = 1",
@@ -413,7 +414,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
     pub fn set_telemetry_install_id(&self, install_id: &str) -> StorageResult<()> {
         retry_on_busy(|| {
             self.lock()?
-                .execute(
+                .execute_cached(
                     "INSERT INTO telemetry_install (id, install_id, updated_at_ms)
                  VALUES (1, ?1, ?2)
                  ON CONFLICT(id) DO UPDATE SET
@@ -429,7 +430,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
     pub fn audit_log_settings(&self) -> StorageResult<StoredAuditLogSettings> {
         self.ensure_audit_log_settings()?;
         self.lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT enabled
                  FROM audit_log_settings
                  WHERE id = 1",
@@ -446,7 +447,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
     pub fn set_audit_log_settings(&self, settings: &StoredAuditLogSettings) -> StorageResult<()> {
         retry_on_busy(|| {
             self.lock()?
-                .execute(
+                .execute_cached(
                     "INSERT INTO audit_log_settings (id, enabled, updated_at_ms)
                  VALUES (1, ?1, ?2)
                  ON CONFLICT(id) DO UPDATE SET
@@ -463,7 +464,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
     fn table_columns(&self, table: &str) -> Vec<String> {
         let conn = self.lock().unwrap();
         let mut stmt = conn
-            .prepare(&format!("PRAGMA table_info({table})"))
+            .prepare_cached(&format!("PRAGMA table_info({table})"))
             .unwrap();
         stmt.query_map([], |row| row.get::<_, String>(1))
             .unwrap()
@@ -478,7 +479,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
     fn ensure_relay_telemetry_settings(&self) -> StorageResult<()> {
         retry_on_busy(|| {
             self.lock()?
-                .execute(
+                .execute_cached(
                     "INSERT INTO relay_telemetry_settings (
                     id, export_enabled, export_interval_seconds, updated_at_ms
                  )
@@ -494,7 +495,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
     fn clear_legacy_relay_telemetry_endpoint(conn: &rusqlite::Connection) -> StorageResult<()> {
         let columns = {
             let mut stmt = conn
-                .prepare("PRAGMA table_info(relay_telemetry_settings)")
+                .prepare_cached("PRAGMA table_info(relay_telemetry_settings)")
                 .storage()?;
             stmt.query_map([], |row| row.get::<_, String>(1))
                 .storage()?
@@ -502,7 +503,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
                 .storage()?
         };
         if columns.iter().any(|column| column == "otlp_endpoint") {
-            conn.execute(
+            conn.execute_cached(
                 "UPDATE relay_telemetry_settings SET otlp_endpoint = NULL",
                 [],
             )
@@ -514,7 +515,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
     fn ensure_audit_log_settings(&self) -> StorageResult<()> {
         retry_on_busy(|| {
             self.lock()?
-                .execute(
+                .execute_cached(
                     "INSERT INTO audit_log_settings (
                     id, enabled, updated_at_ms
                  )

--- a/crates/storage-sqlite/src/storage/account_device_signer.rs
+++ b/crates/storage-sqlite/src/storage/account_device_signer.rs
@@ -1,3 +1,4 @@
+use crate::connection::CachedSql;
 use crate::{SqliteAccountStorage, SqliteResultExt, deserialize, serialize};
 use cgka_traits::storage::{AccountDeviceSignerBinding, AccountDeviceSignerStorage, StorageResult};
 use cgka_traits::types::MemberId;
@@ -6,7 +7,7 @@ use rusqlite::{OptionalExtension, params};
 impl AccountDeviceSignerStorage for SqliteAccountStorage {
     fn put_account_device_signer(&self, binding: &AccountDeviceSignerBinding) -> StorageResult<()> {
         self.lock()?
-            .execute(
+            .execute_cached(
                 "INSERT OR REPLACE INTO cgka_account_device_signers (marmot_identity, record)
                  VALUES (?1, ?2)",
                 params![binding.marmot_identity.as_slice(), serialize(binding)?],
@@ -21,7 +22,7 @@ impl AccountDeviceSignerStorage for SqliteAccountStorage {
     ) -> StorageResult<Option<AccountDeviceSignerBinding>> {
         let record: Option<Vec<u8>> = self
             .lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT record FROM cgka_account_device_signers WHERE marmot_identity = ?1",
                 params![marmot_identity.as_slice()],
                 |row| row.get(0),

--- a/crates/storage-sqlite/src/storage/capabilities.rs
+++ b/crates/storage-sqlite/src/storage/capabilities.rs
@@ -1,3 +1,4 @@
+use crate::connection::CachedSql;
 use crate::{SqliteAccountStorage, SqliteResultExt, deserialize, serialize};
 use cgka_traits::capabilities::{
     Capability, CapabilityRequirement, Feature, GroupCapabilities, RequirementLevel,
@@ -61,7 +62,7 @@ impl CapabilityStorage for SqliteAccountStorage {
     fn register_feature(&self, feature: Feature, req: CapabilityRequirement) -> StorageResult<()> {
         let row = CapabilityRequirementRow::from(&req);
         self.lock()?
-            .execute(
+            .execute_cached(
                 "INSERT OR REPLACE INTO cgka_features (feature, requirement)
                  VALUES (?1, ?2)",
                 params![feature.0, serialize(&row)?],
@@ -76,7 +77,7 @@ impl CapabilityStorage for SqliteAccountStorage {
     ) -> StorageResult<Option<CapabilityRequirement>> {
         let record: Option<Vec<u8>> = self
             .lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT requirement FROM cgka_features WHERE feature = ?1",
                 params![feature.0],
                 |row| row.get(0),
@@ -95,7 +96,7 @@ impl CapabilityStorage for SqliteAccountStorage {
         capabilities: GroupCapabilities,
     ) -> StorageResult<()> {
         self.lock()?
-            .execute(
+            .execute_cached(
                 "INSERT OR REPLACE INTO cgka_member_capabilities
                     (group_id, member_id, capabilities)
                  VALUES (?1, ?2, ?3)",
@@ -116,7 +117,7 @@ impl CapabilityStorage for SqliteAccountStorage {
     ) -> StorageResult<Option<GroupCapabilities>> {
         let record: Option<Vec<u8>> = self
             .lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT capabilities FROM cgka_member_capabilities
                  WHERE group_id = ?1 AND member_id = ?2",
                 params![group_id.as_slice(), member_id.as_slice()],

--- a/crates/storage-sqlite/src/storage/convergence_passes.rs
+++ b/crates/storage-sqlite/src/storage/convergence_passes.rs
@@ -1,3 +1,4 @@
+use crate::connection::CachedSql;
 use crate::{SqliteAccountStorage, SqliteResultExt, deserialize, serialize};
 use cgka_traits::convergence_pass::DurableConvergencePass;
 use cgka_traits::storage::{ConvergencePassStorage, StorageResult};
@@ -11,7 +12,7 @@ impl ConvergencePassStorage for SqliteAccountStorage {
     ) -> StorageResult<Option<DurableConvergencePass>> {
         let encoded: Option<Vec<u8>> = self
             .lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT record FROM cgka_convergence_passes WHERE group_id = ?1",
                 params![group_id.as_slice()],
                 |row| row.get(0),
@@ -24,7 +25,7 @@ impl ConvergencePassStorage for SqliteAccountStorage {
     fn put_convergence_pass(&self, pass: &DurableConvergencePass) -> StorageResult<()> {
         let record = serialize(pass)?;
         self.lock()?
-            .execute(
+            .execute_cached(
                 "INSERT INTO cgka_convergence_passes (group_id, record)
                  VALUES (?1, ?2)
                  ON CONFLICT(group_id) DO UPDATE SET record = excluded.record",
@@ -37,7 +38,7 @@ impl ConvergencePassStorage for SqliteAccountStorage {
     fn list_convergence_passes(&self) -> StorageResult<Vec<DurableConvergencePass>> {
         let connection = self.lock()?;
         let mut statement = connection
-            .prepare("SELECT record FROM cgka_convergence_passes ORDER BY group_id")
+            .prepare_cached("SELECT record FROM cgka_convergence_passes ORDER BY group_id")
             .storage()?;
         let rows = statement
             .query_map([], |row| row.get::<_, Vec<u8>>(0))
@@ -47,7 +48,7 @@ impl ConvergencePassStorage for SqliteAccountStorage {
 
     fn delete_convergence_pass(&self, group_id: &GroupId) -> StorageResult<()> {
         self.lock()?
-            .execute(
+            .execute_cached(
                 "DELETE FROM cgka_convergence_passes WHERE group_id = ?1",
                 params![group_id.as_slice()],
             )

--- a/crates/storage-sqlite/src/storage/convergence_policy.rs
+++ b/crates/storage-sqlite/src/storage/convergence_policy.rs
@@ -1,3 +1,4 @@
+use crate::connection::CachedSql;
 use crate::{SqliteAccountStorage, SqliteResultExt};
 use cgka_traits::storage::{ConvergencePolicyStorage, StorageResult};
 use cgka_traits::types::GroupId;
@@ -6,7 +7,7 @@ use rusqlite::{OptionalExtension, params};
 impl ConvergencePolicyStorage for SqliteAccountStorage {
     fn put_convergence_policy(&self, group_id: &GroupId, policy: &[u8]) -> StorageResult<()> {
         self.lock()?
-            .execute(
+            .execute_cached(
                 "INSERT OR REPLACE INTO cgka_convergence_policies (group_id, policy)
                  VALUES (?1, ?2)",
                 params![group_id.as_slice(), policy],
@@ -17,7 +18,7 @@ impl ConvergencePolicyStorage for SqliteAccountStorage {
 
     fn convergence_policy(&self, group_id: &GroupId) -> StorageResult<Option<Vec<u8>>> {
         self.lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT policy FROM cgka_convergence_policies WHERE group_id = ?1",
                 params![group_id.as_slice()],
                 |row| row.get(0),

--- a/crates/storage-sqlite/src/storage/deferred_peel_generations.rs
+++ b/crates/storage-sqlite/src/storage/deferred_peel_generations.rs
@@ -1,3 +1,4 @@
+use crate::connection::CachedSql;
 use crate::{SqliteAccountStorage, SqliteResultExt, deserialize, serialize};
 use cgka_traits::storage::{DeferredPeelGeneration, DeferredPeelGenerationStorage, StorageResult};
 use cgka_traits::types::GroupId;
@@ -10,7 +11,7 @@ impl DeferredPeelGenerationStorage for SqliteAccountStorage {
     ) -> StorageResult<Option<DeferredPeelGeneration>> {
         let encoded: Option<Vec<u8>> = self
             .lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT record FROM cgka_deferred_peel_generations WHERE group_id = ?1",
                 params![group_id.as_slice()],
                 |row| row.get(0),
@@ -26,7 +27,7 @@ impl DeferredPeelGenerationStorage for SqliteAccountStorage {
     ) -> StorageResult<()> {
         let record = serialize(generation)?;
         self.lock()?
-            .execute(
+            .execute_cached(
                 "INSERT INTO cgka_deferred_peel_generations (group_id, record)
                  VALUES (?1, ?2)
                  ON CONFLICT(group_id) DO UPDATE SET record = excluded.record",
@@ -38,7 +39,7 @@ impl DeferredPeelGenerationStorage for SqliteAccountStorage {
 
     fn delete_deferred_peel_generation(&self, group_id: &GroupId) -> StorageResult<()> {
         self.lock()?
-            .execute(
+            .execute_cached(
                 "DELETE FROM cgka_deferred_peel_generations WHERE group_id = ?1",
                 params![group_id.as_slice()],
             )

--- a/crates/storage-sqlite/src/storage/disband_requests.rs
+++ b/crates/storage-sqlite/src/storage/disband_requests.rs
@@ -1,3 +1,4 @@
+use crate::connection::CachedSql;
 use crate::{SqliteAccountStorage, SqliteResultExt, deserialize, serialize};
 use cgka_traits::DisbandTombstone;
 use cgka_traits::storage::{
@@ -17,7 +18,7 @@ pub(crate) fn disband_requests_by_group_hex_tx(
     tx: &Connection,
 ) -> StorageResult<HashMap<String, DisbandRequest>> {
     let mut statement = tx
-        .prepare("SELECT group_id, record FROM cgka_disband_requests")
+        .prepare_cached("SELECT group_id, record FROM cgka_disband_requests")
         .storage()?;
     let rows = statement
         .query_map([], |row| {
@@ -49,7 +50,7 @@ pub(crate) fn disbanding_group_ids_hex_with_requests_tx(
         })
         .collect::<HashSet<_>>();
     let mut statement = tx
-        .prepare("SELECT DISTINCT group_id FROM cgka_disband_candidates")
+        .prepare_cached("SELECT DISTINCT group_id FROM cgka_disband_candidates")
         .storage()?;
     let candidate_group_ids = statement
         .query_map([], |row| row.get::<_, Vec<u8>>(0))
@@ -76,7 +77,7 @@ impl DisbandRequestStorage for SqliteAccountStorage {
     fn put_disband_request(&self, request: &DisbandRequest) -> StorageResult<()> {
         let serialized = serialize(request)?;
         self.lock()?
-            .execute(
+            .execute_cached(
                 "INSERT OR REPLACE INTO cgka_disband_requests (group_id, record)
                  VALUES (?1, ?2)",
                 params![request.group_id.as_slice(), serialized],
@@ -87,7 +88,7 @@ impl DisbandRequestStorage for SqliteAccountStorage {
 
     fn disband_request(&self, group_id: &GroupId) -> StorageResult<Option<DisbandRequest>> {
         self.lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT record FROM cgka_disband_requests WHERE group_id = ?1",
                 params![group_id.as_slice()],
                 |row| row.get::<_, Vec<u8>>(0),
@@ -100,7 +101,7 @@ impl DisbandRequestStorage for SqliteAccountStorage {
 
     fn clear_disband_request(&self, group_id: &GroupId) -> StorageResult<()> {
         self.lock()?
-            .execute(
+            .execute_cached(
                 "DELETE FROM cgka_disband_requests WHERE group_id = ?1",
                 params![group_id.as_slice()],
             )
@@ -112,7 +113,7 @@ impl DisbandRequestStorage for SqliteAccountStorage {
 impl DisbandCandidateStorage for SqliteAccountStorage {
     fn put_disband_candidate(&self, candidate: &DisbandCandidate) -> StorageResult<()> {
         self.lock()?
-            .execute(
+            .execute_cached(
                 "INSERT OR REPLACE INTO cgka_disband_candidates (group_id, commit_id, record)
                  VALUES (?1, ?2, ?3)",
                 params![
@@ -131,7 +132,7 @@ impl DisbandCandidateStorage for SqliteAccountStorage {
         commit_id: &MessageId,
     ) -> StorageResult<Option<DisbandCandidate>> {
         self.lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT record FROM cgka_disband_candidates
                  WHERE group_id = ?1 AND commit_id = ?2",
                 params![group_id.as_slice(), commit_id.as_slice()],
@@ -146,7 +147,7 @@ impl DisbandCandidateStorage for SqliteAccountStorage {
     fn list_disband_candidates(&self, group_id: &GroupId) -> StorageResult<Vec<DisbandCandidate>> {
         let conn = self.lock()?;
         let mut stmt = conn
-            .prepare(
+            .prepare_cached(
                 "SELECT record FROM cgka_disband_candidates
                  WHERE group_id = ?1 ORDER BY rowid",
             )
@@ -164,7 +165,7 @@ impl DisbandCandidateStorage for SqliteAccountStorage {
 
     fn clear_disband_candidates(&self, group_id: &GroupId) -> StorageResult<()> {
         self.lock()?
-            .execute(
+            .execute_cached(
                 "DELETE FROM cgka_disband_candidates WHERE group_id = ?1",
                 params![group_id.as_slice()],
             )
@@ -187,7 +188,7 @@ impl DisbandTombstoneStorage for SqliteAccountStorage {
         // so OR it forward from any row already present.
         let conn = self.lock()?;
         let previously_announced = conn
-            .query_row(
+            .query_row_cached(
                 "SELECT record FROM cgka_disband_tombstones WHERE group_id = ?1",
                 params![group_id.as_slice()],
                 |row| row.get::<_, Vec<u8>>(0),
@@ -205,7 +206,7 @@ impl DisbandTombstoneStorage for SqliteAccountStorage {
         } else {
             serialize(tombstone)?
         };
-        conn.execute(
+        conn.execute_cached(
             "INSERT OR REPLACE INTO cgka_disband_tombstones (group_id, record)
              VALUES (?1, ?2)",
             params![group_id.as_slice(), record],
@@ -216,7 +217,7 @@ impl DisbandTombstoneStorage for SqliteAccountStorage {
 
     fn disband_tombstone(&self, group_id: &GroupId) -> StorageResult<Option<DisbandTombstone>> {
         self.lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT record FROM cgka_disband_tombstones WHERE group_id = ?1",
                 params![group_id.as_slice()],
                 |row| row.get::<_, Vec<u8>>(0),
@@ -230,7 +231,9 @@ impl DisbandTombstoneStorage for SqliteAccountStorage {
     fn list_disband_tombstones(&self) -> StorageResult<Vec<(GroupId, DisbandTombstone)>> {
         let conn = self.lock()?;
         let mut stmt = conn
-            .prepare("SELECT group_id, record FROM cgka_disband_tombstones ORDER BY group_id")
+            .prepare_cached(
+                "SELECT group_id, record FROM cgka_disband_tombstones ORDER BY group_id",
+            )
             .storage()?;
         let rows = stmt
             .query_map([], |row| {
@@ -249,7 +252,7 @@ impl DisbandTombstoneStorage for SqliteAccountStorage {
         // read-modify-write cannot interleave with a concurrent caller.
         let conn = self.lock()?;
         let Some(record) = conn
-            .query_row(
+            .query_row_cached(
                 "SELECT record FROM cgka_disband_tombstones WHERE group_id = ?1",
                 params![group_id.as_slice()],
                 |row| row.get::<_, Vec<u8>>(0),
@@ -264,7 +267,7 @@ impl DisbandTombstoneStorage for SqliteAccountStorage {
             return Ok(());
         }
         tombstone.announced = true;
-        conn.execute(
+        conn.execute_cached(
             "UPDATE cgka_disband_tombstones SET record = ?2 WHERE group_id = ?1",
             params![group_id.as_slice(), serialize(&tombstone)?],
         )

--- a/crates/storage-sqlite/src/storage/groups.rs
+++ b/crates/storage-sqlite/src/storage/groups.rs
@@ -40,6 +40,7 @@ impl GroupStorage for SqliteAccountStorage {
     }
 
     fn delete_group(&self, id: &GroupId) -> StorageResult<()> {
+        self.connection.note_openmls_write();
         let mls_group_key = mls_group_key(id)?;
         let mut conn = self.lock()?;
         let tx = conn.transaction().storage()?;

--- a/crates/storage-sqlite/src/storage/groups.rs
+++ b/crates/storage-sqlite/src/storage/groups.rs
@@ -1,3 +1,4 @@
+use crate::connection::CachedSql;
 use crate::openmls_storage::mls_group_key;
 use crate::{SqliteAccountStorage, SqliteResultExt, deserialize, epoch_to_i64, serialize};
 use cgka_traits::group::Group;
@@ -8,7 +9,7 @@ use rusqlite::{OptionalExtension, params};
 impl GroupStorage for SqliteAccountStorage {
     fn put_group(&self, group: &Group) -> StorageResult<()> {
         self.lock()?
-            .execute(
+            .execute_cached(
                 "INSERT INTO cgka_groups (id, epoch, record)
                  VALUES (?1, ?2, ?3)
                  ON CONFLICT(id) DO UPDATE SET
@@ -27,7 +28,7 @@ impl GroupStorage for SqliteAccountStorage {
     fn get_group(&self, id: &GroupId) -> StorageResult<Group> {
         let record: Vec<u8> = self
             .lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT record FROM cgka_groups WHERE id = ?1",
                 params![id.as_slice()],
                 |row| row.get(0),
@@ -42,7 +43,7 @@ impl GroupStorage for SqliteAccountStorage {
         let mls_group_key = mls_group_key(id)?;
         let mut conn = self.lock()?;
         let tx = conn.transaction().storage()?;
-        tx.execute(
+        tx.execute_cached(
             "DELETE FROM transport_reconciliation_items
              WHERE route_kind = 1 AND route_id IN (
                  SELECT transport_group_id
@@ -52,7 +53,7 @@ impl GroupStorage for SqliteAccountStorage {
             params![id.as_slice()],
         )
         .storage()?;
-        tx.execute(
+        tx.execute_cached(
             "DELETE FROM transport_reconciliation_route_state
              WHERE route_kind = 1 AND route_id IN (
                  SELECT transport_group_id
@@ -62,7 +63,7 @@ impl GroupStorage for SqliteAccountStorage {
             params![id.as_slice()],
         )
         .storage()?;
-        tx.execute(
+        tx.execute_cached(
             "DELETE FROM transport_reconciliation_scheduler
              WHERE singleton = 1 AND route_kind = 1 AND route_id IN (
                  SELECT transport_group_id
@@ -73,7 +74,7 @@ impl GroupStorage for SqliteAccountStorage {
         )
         .storage()?;
         let deleted = tx
-            .execute(
+            .execute_cached(
                 "DELETE FROM cgka_groups WHERE id = ?1",
                 params![id.as_slice()],
             )
@@ -81,12 +82,12 @@ impl GroupStorage for SqliteAccountStorage {
         if deleted == 0 {
             return Err(StorageError::NotFound);
         }
-        tx.execute(
+        tx.execute_cached(
             "DELETE FROM pending_application_events WHERE group_id = ?1",
             params![id.as_slice()],
         )
         .storage()?;
-        tx.execute(
+        tx.execute_cached(
             "DELETE FROM openmls_values WHERE provider_version = ?1 AND group_key = ?2",
             params![openmls_traits::storage::CURRENT_VERSION, mls_group_key],
         )
@@ -98,7 +99,7 @@ impl GroupStorage for SqliteAccountStorage {
     fn list_groups(&self) -> StorageResult<Vec<GroupId>> {
         let conn = self.lock()?;
         let mut stmt = conn
-            .prepare("SELECT id FROM cgka_groups ORDER BY id")
+            .prepare_cached("SELECT id FROM cgka_groups ORDER BY id")
             .storage()?;
         stmt.query_map([], |row| row.get::<_, Vec<u8>>(0).map(GroupId::new))
             .storage()?
@@ -109,7 +110,7 @@ impl GroupStorage for SqliteAccountStorage {
     fn list_group_records(&self) -> StorageResult<Vec<Group>> {
         let conn = self.lock()?;
         let mut stmt = conn
-            .prepare("SELECT record FROM cgka_groups ORDER BY id")
+            .prepare_cached("SELECT record FROM cgka_groups ORDER BY id")
             .storage()?;
         let records = stmt
             .query_map([], |row| row.get::<_, Vec<u8>>(0))

--- a/crates/storage-sqlite/src/storage/groups.rs
+++ b/crates/storage-sqlite/src/storage/groups.rs
@@ -1,10 +1,40 @@
 use crate::connection::CachedSql;
 use crate::openmls_storage::mls_group_key;
-use crate::{SqliteAccountStorage, SqliteResultExt, deserialize, epoch_to_i64, serialize};
+use crate::{SqliteAccountStorage, SqliteResultExt, epoch_to_i64};
 use cgka_traits::group::Group;
 use cgka_traits::storage::{GroupStorage, StorageError, StorageResult, TransportGroupRoute};
 use cgka_traits::types::{EpochId, GroupId};
 use rusqlite::{OptionalExtension, params};
+use serde::Serialize;
+
+/// Leading bytes of a MessagePack-encoded `cgka_groups.record`. Rows written
+/// before this encoding are serde_json documents, which never begin with NUL,
+/// so a read tells the two apart by this prefix and older rows keep decoding
+/// until their next `put_group` replaces them.
+///
+/// serde_json spelled each member's id and credential as an array of decimal
+/// integers, and the engine reads the record several times per send and per
+/// inbound message. Structs are written as maps rather than positional arrays
+/// so `#[serde(default)]` fields added later stay readable either way.
+const RECORD_ENCODING_V2_PREFIX: [u8; 2] = [0x00, 0x02];
+
+pub(crate) fn encode_group(group: &Group) -> StorageResult<Vec<u8>> {
+    let mut out = RECORD_ENCODING_V2_PREFIX.to_vec();
+    let mut serializer = rmp_serde::Serializer::new(&mut out).with_struct_map();
+    group
+        .serialize(&mut serializer)
+        .map_err(|e| StorageError::Serialization(e.to_string()))?;
+    Ok(out)
+}
+
+pub(crate) fn decode_group(bytes: &[u8]) -> StorageResult<Group> {
+    match bytes.strip_prefix(&RECORD_ENCODING_V2_PREFIX) {
+        Some(body) => {
+            rmp_serde::from_slice(body).map_err(|e| StorageError::Serialization(e.to_string()))
+        }
+        None => crate::deserialize(bytes),
+    }
+}
 
 impl GroupStorage for SqliteAccountStorage {
     fn put_group(&self, group: &Group) -> StorageResult<()> {
@@ -18,7 +48,7 @@ impl GroupStorage for SqliteAccountStorage {
                 params![
                     group.id.as_slice(),
                     epoch_to_i64(group.epoch)?,
-                    serialize(group)?
+                    encode_group(group)?
                 ],
             )
             .storage()?;
@@ -36,7 +66,7 @@ impl GroupStorage for SqliteAccountStorage {
             .optional()
             .storage()?
             .ok_or(StorageError::NotFound)?;
-        deserialize(&record)
+        decode_group(&record)
     }
 
     fn delete_group(&self, id: &GroupId) -> StorageResult<()> {
@@ -118,7 +148,7 @@ impl GroupStorage for SqliteAccountStorage {
             .storage()?
             .collect::<Result<Vec<_>, _>>()
             .storage()?;
-        records.iter().map(|record| deserialize(record)).collect()
+        records.iter().map(|record| decode_group(record)).collect()
     }
 
     fn put_transport_group_route(
@@ -166,6 +196,49 @@ mod tests {
     };
     use cgka_traits::types::{EpochId, MemberId};
     use openmls_traits::storage::StorageProvider as OpenMlsStorageProvider;
+
+    #[test]
+    fn group_record_roundtrips_through_messagepack() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let mut group = sample_group(gid(1), 7, 3);
+        group.disbanded = Some(cgka_traits::group::DisbandTombstone {
+            epoch: EpochId(7),
+            actor: MemberId::new(vec![1; 32]),
+            origin_commit_id: None,
+            commit_digest: [9; 32],
+            local_was_committer_leaf: true,
+            former_members: group.members.clone(),
+            announced: false,
+        });
+        store.put_group(&group).unwrap();
+        let record: Vec<u8> = store
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT record FROM cgka_groups WHERE id = ?1",
+                [group.id.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(&record[..2], &[0x00, 0x02]);
+        assert_eq!(store.get_group(&group.id).unwrap(), group);
+    }
+
+    #[test]
+    fn group_record_written_as_json_still_decodes() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let group = sample_group(gid(1), 7, 3);
+        store
+            .lock()
+            .unwrap()
+            .execute(
+                "INSERT INTO cgka_groups (id, epoch, record) VALUES (?1, 7, ?2)",
+                rusqlite::params![group.id.as_slice(), crate::serialize(&group).unwrap()],
+            )
+            .unwrap();
+        assert_eq!(store.get_group(&group.id).unwrap(), group);
+        assert_eq!(store.list_group_records().unwrap(), vec![group]);
+    }
 
     #[test]
     fn list_group_records_returns_every_stored_record() {

--- a/crates/storage-sqlite/src/storage/leave_requests.rs
+++ b/crates/storage-sqlite/src/storage/leave_requests.rs
@@ -1,3 +1,4 @@
+use crate::connection::CachedSql;
 use crate::{SqliteAccountStorage, SqliteResultExt, deserialize, serialize};
 use cgka_traits::storage::{LeaveRequest, LeaveRequestStorage, StorageResult};
 use cgka_traits::types::GroupId;
@@ -21,7 +22,7 @@ pub(crate) fn pending_leave_requests_by_group_hex_tx(
     tx: &Connection,
 ) -> StorageResult<HashMap<String, u64>> {
     let mut statement = tx
-        .prepare("SELECT group_id, record FROM cgka_leave_requests")
+        .prepare_cached("SELECT group_id, record FROM cgka_leave_requests")
         .storage()?;
     let rows = statement
         .query_map([], |row| {
@@ -54,7 +55,7 @@ impl LeaveRequestStorage for SqliteAccountStorage {
     fn put_leave_request(&self, request: &LeaveRequest) -> StorageResult<()> {
         let serialized = serialize(request)?;
         self.lock()?
-            .execute(
+            .execute_cached(
                 "INSERT OR REPLACE INTO cgka_leave_requests (group_id, record)
                  VALUES (?1, ?2)",
                 params![request.group_id.as_slice(), serialized],
@@ -65,7 +66,7 @@ impl LeaveRequestStorage for SqliteAccountStorage {
 
     fn leave_request(&self, group_id: &GroupId) -> StorageResult<Option<LeaveRequest>> {
         self.lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT record FROM cgka_leave_requests WHERE group_id = ?1",
                 params![group_id.as_slice()],
                 |row| row.get::<_, Vec<u8>>(0),
@@ -78,7 +79,7 @@ impl LeaveRequestStorage for SqliteAccountStorage {
 
     fn clear_leave_request(&self, group_id: &GroupId) -> StorageResult<()> {
         self.lock()?
-            .execute(
+            .execute_cached(
                 "DELETE FROM cgka_leave_requests WHERE group_id = ?1",
                 params![group_id.as_slice()],
             )

--- a/crates/storage-sqlite/src/storage/maintenance.rs
+++ b/crates/storage-sqlite/src/storage/maintenance.rs
@@ -1,3 +1,4 @@
+use crate::connection::CachedSql;
 use crate::connection::retry_on_busy;
 use crate::{SqliteAccountStorage, SqliteResultExt, deserialize, serialize};
 use cgka_traits::maintenance::{
@@ -123,7 +124,7 @@ impl MaintenanceStorage for SqliteAccountStorage {
     fn periodic_maintenance_policy(&self) -> StorageResult<PeriodicMaintenancePolicy> {
         let value: i64 = self
             .lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT periodic_policy FROM cgka_maintenance_settings WHERE singleton = 1",
                 [],
                 |row| row.get(0),
@@ -148,7 +149,7 @@ impl MaintenanceStorage for SqliteAccountStorage {
         };
         write(self, || {
             self.lock()?
-                .execute(
+                .execute_cached(
                     "UPDATE cgka_maintenance_settings
                      SET periodic_policy = ?1
                      WHERE singleton = 1",
@@ -288,7 +289,7 @@ fn list_ordered_records<T: serde::de::DeserializeOwned>(
 ) -> StorageResult<Vec<T>> {
     let sql = format!("SELECT record FROM {table} ORDER BY insert_order");
     let connection = store.lock()?;
-    let mut statement = connection.prepare(&sql).storage()?;
+    let mut statement = connection.prepare_cached(&sql).storage()?;
     let records = statement
         .query_map([], |row| row.get::<_, Vec<u8>>(0))
         .storage()?
@@ -304,7 +305,7 @@ fn list_ordered_records_for_group<T: serde::de::DeserializeOwned>(
 ) -> StorageResult<Vec<T>> {
     let sql = format!("SELECT record FROM {table} WHERE group_id = ?1 ORDER BY insert_order");
     let connection = store.lock()?;
-    let mut statement = connection.prepare(&sql).storage()?;
+    let mut statement = connection.prepare_cached(&sql).storage()?;
     let records = statement
         .query_map(params![group_id.as_slice()], |row| row.get::<_, Vec<u8>>(0))
         .storage()?

--- a/crates/storage-sqlite/src/storage/member_validation_cache.rs
+++ b/crates/storage-sqlite/src/storage/member_validation_cache.rs
@@ -1,3 +1,4 @@
+use crate::connection::CachedSql;
 use crate::{SqliteAccountStorage, SqliteResultExt};
 use cgka_traits::storage::{MemberValidationCacheStorage, StorageResult};
 use cgka_traits::types::GroupId;
@@ -6,7 +7,7 @@ use rusqlite::{OptionalExtension, params};
 impl MemberValidationCacheStorage for SqliteAccountStorage {
     fn put_validated_tree_marker(&self, group_id: &GroupId, marker: &[u8]) -> StorageResult<()> {
         self.lock()?
-            .execute(
+            .execute_cached(
                 "INSERT OR REPLACE INTO cgka_member_validation_cache (group_id, marker)
                  VALUES (?1, ?2)",
                 params![group_id.as_slice(), marker],
@@ -17,7 +18,7 @@ impl MemberValidationCacheStorage for SqliteAccountStorage {
 
     fn validated_tree_marker(&self, group_id: &GroupId) -> StorageResult<Option<Vec<u8>>> {
         self.lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT marker FROM cgka_member_validation_cache WHERE group_id = ?1",
                 params![group_id.as_slice()],
                 |row| row.get(0),

--- a/crates/storage-sqlite/src/storage/messages.rs
+++ b/crates/storage-sqlite/src/storage/messages.rs
@@ -1,4 +1,5 @@
 use super::snapshots;
+use crate::connection::CachedSql;
 use crate::connection::retry_on_busy;
 use crate::{
     SqliteAccountStorage, SqliteResultExt, deserialize, epoch_to_i64, i64_to_u64,
@@ -55,7 +56,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<StorageFormatBenchSizes> {
         let conn = self.lock()?;
         let message_value_bytes = conn
-            .query_row(
+            .query_row_cached(
                 "SELECT length(id) + length(group_id) + coalesce(length(payload), 0) +
                         coalesce(length(record), 0) + coalesce(length(deferred_peel), 0)
                  FROM cgka_messages WHERE id = ?1",
@@ -66,7 +67,7 @@ impl SqliteAccountStorage {
             .storage()?
             .ok_or(StorageError::NotFound)?;
         let largest_snapshot_bytes = conn
-            .query_row(
+            .query_row_cached(
                 "SELECT max(length(snapshot)) FROM cgka_group_snapshots WHERE group_id = ?1",
                 params![group_id.as_slice()],
                 |row| row.get::<_, Option<i64>>(0),
@@ -105,7 +106,7 @@ impl SqliteAccountStorage {
                 .storage()?;
             let rows = {
                 let mut statement = tx
-                    .prepare(&format!(
+                    .prepare_cached(&format!(
                         "SELECT {MESSAGE_COLUMNS} FROM cgka_messages
                          WHERE storage_format = 1
                          ORDER BY insert_order
@@ -134,7 +135,7 @@ impl SqliteAccountStorage {
                 }
             }
             let has_more = tx
-                .query_row(
+                .query_row_cached(
                     "SELECT EXISTS(
                         SELECT 1 FROM cgka_messages WHERE storage_format = 1
                      )",
@@ -288,7 +289,7 @@ impl MessageStorage for SqliteAccountStorage {
             state_placeholders(states)
         );
         let conn = self.lock()?;
-        let mut stmt = conn.prepare(&sql).storage()?;
+        let mut stmt = conn.prepare_cached(&sql).storage()?;
         let records = stmt
             .query_map(
                 rusqlite::params_from_iter(state_query_params(
@@ -327,7 +328,7 @@ impl MessageStorage for SqliteAccountStorage {
         let write = || {
             let conn = self.lock()?;
             let inserted = conn
-                .execute(
+                .execute_cached(
                     "INSERT INTO pending_application_events (
                         message_id, group_id, message_insert_order, record
                      )
@@ -340,7 +341,7 @@ impl MessageStorage for SqliteAccountStorage {
                 .storage()?;
             if inserted == 0 {
                 let existing = conn
-                    .query_row(
+                    .query_row_cached(
                         "SELECT record FROM pending_application_events WHERE message_id = ?1",
                         params![message_id.as_slice()],
                         |row| row.get::<_, Vec<u8>>(0),
@@ -367,7 +368,7 @@ impl MessageStorage for SqliteAccountStorage {
     fn list_pending_application_events(&self) -> StorageResult<Vec<GroupEvent>> {
         let conn = self.lock()?;
         let mut statement = conn
-            .prepare(
+            .prepare_cached(
                 "SELECT record
                  FROM pending_application_events
                  ORDER BY message_insert_order, message_id",
@@ -385,7 +386,7 @@ impl MessageStorage for SqliteAccountStorage {
         let delete = || {
             let conn = self.lock()?;
             for id in ids {
-                conn.execute(
+                conn.execute_cached(
                     "DELETE FROM pending_application_events WHERE message_id = ?1",
                     params![id.as_slice()],
                 )
@@ -435,12 +436,12 @@ impl MessageStorage for SqliteAccountStorage {
         retry_on_busy(|| {
             self.connection.with_transaction(|| {
                 let conn = self.lock()?;
-                conn.execute(
+                conn.execute_cached(
                     "INSERT OR IGNORE INTO cgka_ingress_dedup (id) VALUES (?1)",
                     params![id.as_slice()],
                 )
                 .storage()?;
-                conn.execute(
+                conn.execute_cached(
                     "DELETE FROM cgka_ingress_dedup
                      WHERE insert_order NOT IN (
                         SELECT insert_order FROM cgka_ingress_dedup
@@ -456,7 +457,7 @@ impl MessageStorage for SqliteAccountStorage {
 
     fn has_ingress_dedup_marker(&self, id: &MessageId) -> StorageResult<bool> {
         self.lock()?
-            .query_row(
+            .query_row_cached(
                 "SELECT EXISTS(SELECT 1 FROM cgka_ingress_dedup WHERE id = ?1)",
                 params![id.as_slice()],
                 |row| row.get(0),
@@ -540,7 +541,7 @@ fn list_messages_on_connection(
     include_insert_order: Option<&mut Vec<i64>>,
 ) -> StorageResult<Vec<MessageRecord>> {
     let mut statement = conn
-        .prepare(&format!(
+        .prepare_cached(&format!(
             "SELECT insert_order, {MESSAGE_COLUMNS} FROM cgka_messages
              WHERE group_id = ?1 AND epoch >= ?2
              ORDER BY insert_order"
@@ -594,7 +595,7 @@ pub(super) fn put_message_on_connection(
 ) -> StorageResult<()> {
     let deferred_peel = record.deferred_peel.as_ref().map(serialize).transpose()?;
     match insert_order {
-        None => conn.execute(
+        None => conn.execute_cached(
             "INSERT INTO cgka_messages (
                  id, group_id, epoch, state, storage_format, record, payload, deferred_peel
              ) VALUES (?1, ?2, ?3, ?4, ?5, NULL, ?6, ?7)
@@ -616,7 +617,7 @@ pub(super) fn put_message_on_connection(
                 deferred_peel,
             ],
         ),
-        Some(insert_order) => conn.execute(
+        Some(insert_order) => conn.execute_cached(
             "INSERT INTO cgka_messages (
                  insert_order, id, group_id, epoch, state, storage_format,
                  record, payload, deferred_peel
@@ -675,7 +676,7 @@ fn update_message_state_on_connection(
     new_state: MessageState,
 ) -> StorageResult<()> {
     let storage_format: i64 = conn
-        .query_row(
+        .query_row_cached(
             "SELECT storage_format FROM cgka_messages WHERE id = ?1",
             params![id.as_slice()],
             |row| row.get(0),
@@ -684,7 +685,7 @@ fn update_message_state_on_connection(
         .storage()?
         .ok_or(StorageError::NotFound)?;
     let changed = if storage_format == NORMALIZED_MESSAGE_STORAGE_FORMAT {
-        conn.execute(
+        conn.execute_cached(
             "UPDATE cgka_messages
              SET state = ?1,
                  deferred_peel = CASE WHEN ?1 = ?2 THEN deferred_peel ELSE NULL END
@@ -725,12 +726,12 @@ fn update_message_state_on_connection(
 /// Delete a protocol message and its not-yet-acknowledged application event on
 /// the same connection/transaction so neither row can outlive the other.
 fn delete_message_on_connection(conn: &rusqlite::Connection, id: &MessageId) -> StorageResult<()> {
-    conn.execute(
+    conn.execute_cached(
         "DELETE FROM pending_application_events WHERE message_id = ?1",
         params![id.as_slice()],
     )
     .storage()?;
-    conn.execute(
+    conn.execute_cached(
         "DELETE FROM cgka_messages WHERE id = ?1",
         params![id.as_slice()],
     )

--- a/crates/storage-sqlite/src/storage/outbound.rs
+++ b/crates/storage-sqlite/src/storage/outbound.rs
@@ -1,3 +1,4 @@
+use crate::connection::CachedSql;
 use crate::connection::retry_on_busy;
 use crate::{SqliteAccountStorage, SqliteResultExt, created_at_to_i64, deserialize, serialize};
 use cgka_traits::OutboundFanout;
@@ -17,7 +18,7 @@ impl OutboundIntentStorage for SqliteAccountStorage {
         let created_at = created_at_to_i64(record.created_at_ms)?;
         let write = || {
             let conn = self.lock()?;
-            conn.execute(
+            conn.execute_cached(
                 "INSERT INTO cgka_queued_outbound (id, group_id, created_at_ms, record)
                  VALUES (?1, ?2, ?3, ?4)
                  ON CONFLICT(id) DO UPDATE SET
@@ -47,7 +48,7 @@ impl OutboundIntentStorage for SqliteAccountStorage {
     ) -> StorageResult<Vec<QueuedOutboundIntent>> {
         let conn = self.lock()?;
         let mut stmt = conn
-            .prepare(
+            .prepare_cached(
                 "SELECT record FROM cgka_queued_outbound
                  WHERE group_id = ?1
                  ORDER BY insert_order",
@@ -67,7 +68,7 @@ impl OutboundIntentStorage for SqliteAccountStorage {
         // whole statement is safe to retry on transient lock contention.
         let delete = || {
             self.lock()?
-                .execute(
+                .execute_cached(
                     "DELETE FROM cgka_queued_outbound WHERE id = ?1",
                     params![id.as_slice()],
                 )
@@ -91,7 +92,7 @@ impl OutboundFanoutStorage for SqliteAccountStorage {
         let write = || {
             let conn = self.lock()?;
             let previous = conn
-                .query_row(
+                .query_row_cached(
                     "SELECT record FROM cgka_outbound_fanout WHERE message_id = ?1",
                     params![fanout.message_id().as_slice()],
                     |row| row.get::<_, Vec<u8>>(0),
@@ -107,7 +108,7 @@ impl OutboundFanoutStorage for SqliteAccountStorage {
                     )
                 })?;
             }
-            conn.execute(
+            conn.execute_cached(
                 "INSERT INTO cgka_outbound_fanout (message_id, group_id, record)
                  VALUES (?1, ?2, ?3)
                  ON CONFLICT(message_id) DO UPDATE SET
@@ -132,7 +133,7 @@ impl OutboundFanoutStorage for SqliteAccountStorage {
     fn outbound_fanout(&self, message_id: &MessageId) -> StorageResult<Option<OutboundFanout>> {
         let conn = self.lock()?;
         let record = conn
-            .query_row(
+            .query_row_cached(
                 "SELECT record FROM cgka_outbound_fanout WHERE message_id = ?1",
                 params![message_id.as_slice()],
                 |row| row.get::<_, Vec<u8>>(0),
@@ -145,7 +146,7 @@ impl OutboundFanoutStorage for SqliteAccountStorage {
     fn list_outbound_fanouts(&self) -> StorageResult<Vec<OutboundFanout>> {
         let conn = self.lock()?;
         let mut stmt = conn
-            .prepare(
+            .prepare_cached(
                 "SELECT record FROM cgka_outbound_fanout
                  ORDER BY insert_order",
             )
@@ -164,7 +165,7 @@ impl OutboundFanoutStorage for SqliteAccountStorage {
     ) -> StorageResult<Vec<OutboundFanout>> {
         let conn = self.lock()?;
         let mut stmt = conn
-            .prepare(
+            .prepare_cached(
                 "SELECT record FROM cgka_outbound_fanout
                  WHERE group_id = ?1
                  ORDER BY insert_order",
@@ -181,7 +182,7 @@ impl OutboundFanoutStorage for SqliteAccountStorage {
     fn delete_outbound_fanout(&self, message_id: &MessageId) -> StorageResult<()> {
         let delete = || {
             self.lock()?
-                .execute(
+                .execute_cached(
                     "DELETE FROM cgka_outbound_fanout WHERE message_id = ?1",
                     params![message_id.as_slice()],
                 )

--- a/crates/storage-sqlite/src/storage/snapshots.rs
+++ b/crates/storage-sqlite/src/storage/snapshots.rs
@@ -34,6 +34,7 @@ pub(super) fn rollback(
     group_id: &GroupId,
     name: &str,
 ) -> StorageResult<()> {
+    store.connection.note_openmls_write();
     restore::rollback(store, group_id, name)
 }
 
@@ -42,6 +43,7 @@ pub(super) fn rollback_group_state(
     group_id: &GroupId,
     name: &str,
 ) -> StorageResult<()> {
+    store.connection.note_openmls_write();
     restore::rollback_group_state(store, group_id, name)
 }
 
@@ -98,6 +100,7 @@ pub(crate) fn import_replay(
     group_id: &GroupId,
     snapshot: &[u8],
 ) -> StorageResult<()> {
+    store.connection.note_openmls_write();
     restore::import(store, group_id, snapshot)
 }
 

--- a/crates/storage-sqlite/src/storage/snapshots/capture.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/capture.rs
@@ -5,6 +5,7 @@ use super::rows::{
 };
 #[cfg(feature = "test-conformance-replay")]
 use super::rows::{REPLAY_SNAPSHOT_VERSION, ReplaySnapshot};
+use crate::connection::CachedSql;
 use crate::openmls_storage::mls_group_key;
 #[cfg(feature = "test-conformance-replay")]
 use crate::serialize;
@@ -59,7 +60,7 @@ fn create_on_connection(
 ) -> StorageResult<()> {
     let snapshot = capture_snapshot(conn, group_id, scope)?;
     let snapshot_blob = snapshot_format::encode(&snapshot)?;
-    conn.execute(
+    conn.execute_cached(
         "INSERT OR REPLACE INTO cgka_group_snapshots (group_id, name, snapshot)
              VALUES (?1, ?2, ?3)",
         params![group_id.as_slice(), name, snapshot_blob.as_slice()],
@@ -75,7 +76,7 @@ fn capture_snapshot(
 ) -> StorageResult<Snapshot> {
     let mls_group_key = mls_group_key(group_id)?;
     let group_blob: Vec<u8> = conn
-        .query_row(
+        .query_row_cached(
             "SELECT record FROM cgka_groups WHERE id = ?1",
             params![group_id.as_slice()],
             |row| row.get(0),
@@ -113,7 +114,7 @@ pub(super) fn capture_group_state(
 ) -> StorageResult<GroupStateCheckpoint> {
     let mls_group_key = mls_group_key(group_id)?;
     let group_blob: Vec<u8> = conn
-        .query_row(
+        .query_row_cached(
             "SELECT record FROM cgka_groups WHERE id = ?1",
             params![group_id.as_slice()],
             |row| row.get(0),
@@ -134,7 +135,7 @@ pub(super) fn capture_group_state(
 pub(super) fn export(store: &SqliteAccountStorage, group_id: &GroupId) -> StorageResult<Vec<u8>> {
     let conn = store.lock()?;
     let convergence_pass = conn
-        .query_row(
+        .query_row_cached(
             "SELECT record FROM cgka_convergence_passes WHERE group_id = ?1",
             params![group_id.as_slice()],
             |row| row.get::<_, Vec<u8>>(0),
@@ -167,7 +168,7 @@ fn queued_outbound(
     group_id: &GroupId,
 ) -> StorageResult<Vec<OrderedQueuedOutbound>> {
     let mut stmt = tx
-        .prepare(
+        .prepare_cached(
             "SELECT insert_order, record FROM cgka_queued_outbound
              WHERE group_id = ?1
              ORDER BY insert_order",
@@ -195,7 +196,7 @@ fn member_capabilities(
     group_id: &GroupId,
 ) -> StorageResult<Vec<MemberCapabilitiesSnapshot>> {
     let mut stmt = tx
-        .prepare(
+        .prepare_cached(
             "SELECT member_id, capabilities FROM cgka_member_capabilities
              WHERE group_id = ?1
              ORDER BY member_id",
@@ -222,7 +223,7 @@ fn convergence_policy(
     tx: &rusqlite::Connection,
     group_id: &GroupId,
 ) -> StorageResult<Option<Vec<u8>>> {
-    tx.query_row(
+    tx.query_row_cached(
         "SELECT policy FROM cgka_convergence_policies WHERE group_id = ?1",
         params![group_id.as_slice()],
         |row| row.get(0),
@@ -235,7 +236,7 @@ fn validated_tree_marker(
     tx: &rusqlite::Connection,
     group_id: &GroupId,
 ) -> StorageResult<Option<Vec<u8>>> {
-    tx.query_row(
+    tx.query_row_cached(
         "SELECT marker FROM cgka_member_validation_cache WHERE group_id = ?1",
         params![group_id.as_slice()],
         |row| row.get(0),
@@ -249,7 +250,7 @@ fn openmls_values(
     mls_group_key: &[u8],
 ) -> StorageResult<Vec<OpenMlsValueSnapshot>> {
     let mut stmt = tx
-        .prepare(
+        .prepare_cached(
             "SELECT label, storage_key, group_key, value FROM openmls_values
              WHERE provider_version = ?1 AND group_key = ?2
              ORDER BY storage_key",

--- a/crates/storage-sqlite/src/storage/snapshots/capture.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/capture.rs
@@ -9,6 +9,7 @@ use crate::connection::CachedSql;
 use crate::openmls_storage::mls_group_key;
 #[cfg(feature = "test-conformance-replay")]
 use crate::serialize;
+use crate::storage::groups::decode_group;
 use crate::storage::messages::ordered_messages_on_connection;
 use crate::{
     SqliteAccountStorage, SqliteResultExt, codec::SensitiveBytes, connection::retry_on_busy,
@@ -84,7 +85,7 @@ fn capture_snapshot(
         .optional()
         .storage()?
         .ok_or(StorageError::NotFound)?;
-    let group = deserialize(&group_blob)?;
+    let group = decode_group(&group_blob)?;
     let (messages, queued_outbound) = match scope {
         SnapshotScope::Full => (
             Some(messages(conn, group_id)?),
@@ -124,7 +125,7 @@ pub(super) fn capture_group_state(
         .ok_or(StorageError::NotFound)?;
 
     Ok(GroupStateCheckpoint {
-        group: deserialize(&group_blob)?,
+        group: decode_group(&group_blob)?,
         member_caps: member_capabilities(conn, group_id)?,
         validated_tree_marker: validated_tree_marker(conn, group_id)?,
         openmls_values: openmls_values(conn, &mls_group_key)?,

--- a/crates/storage-sqlite/src/storage/snapshots/checkpoints.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/checkpoints.rs
@@ -1,4 +1,5 @@
 use super::{capture, format as snapshot_format, restore};
+use crate::connection::CachedSql;
 use crate::{
     SqliteAccountStorage, SqliteResultExt, codec::SensitiveBytes, connection::retry_on_busy,
     epoch_to_i64,
@@ -34,7 +35,7 @@ fn create_on_connection(
     let state = capture::capture_group_state(conn, group_id)?;
     let blob = snapshot_format::encode_checkpoint(&state)?;
     let existing = conn
-        .query_row(
+        .query_row_cached(
             "SELECT resulting_epoch, checkpoint
              FROM cgka_group_state_checkpoints
              WHERE group_id = ?1 AND checkpoint_id = ?2",
@@ -56,7 +57,7 @@ fn create_on_connection(
         }
         return Err(StorageError::AlreadyExists);
     }
-    conn.execute(
+    conn.execute_cached(
         "INSERT INTO cgka_group_state_checkpoints
             (group_id, checkpoint_id, resulting_epoch, checkpoint)
          VALUES (?1, ?2, ?3, ?4)",
@@ -96,7 +97,7 @@ fn restore_on_connection(
     checkpoint_id: &str,
 ) -> StorageResult<()> {
     let blob = SensitiveBytes::new(
-        conn.query_row(
+        conn.query_row_cached(
             "SELECT checkpoint FROM cgka_group_state_checkpoints
              WHERE group_id = ?1 AND checkpoint_id = ?2",
             params![group_id.as_slice(), checkpoint_id],
@@ -116,7 +117,7 @@ pub(super) fn list_group_state_checkpoints(
 ) -> StorageResult<Vec<GroupStateCheckpointRef>> {
     let conn = store.lock()?;
     let mut stmt = conn
-        .prepare(
+        .prepare_cached(
             "SELECT checkpoint_id, resulting_epoch
              FROM cgka_group_state_checkpoints
              WHERE group_id = ?1
@@ -149,7 +150,7 @@ pub(super) fn release_group_state_checkpoint(
     let delete = || {
         let deleted = store
             .lock()?
-            .execute(
+            .execute_cached(
                 "DELETE FROM cgka_group_state_checkpoints
                  WHERE group_id = ?1 AND checkpoint_id = ?2",
                 params![group_id.as_slice(), checkpoint_id],

--- a/crates/storage-sqlite/src/storage/snapshots/lifecycle.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/lifecycle.rs
@@ -1,3 +1,4 @@
+use crate::connection::CachedSql;
 use crate::{SqliteAccountStorage, SqliteResultExt};
 use cgka_traits::storage::{StorageError, StorageResult};
 use cgka_traits::types::GroupId;
@@ -6,7 +7,7 @@ use rusqlite::params;
 pub(super) fn list(store: &SqliteAccountStorage, group_id: &GroupId) -> StorageResult<Vec<String>> {
     let conn = store.lock()?;
     let mut stmt = conn
-        .prepare(
+        .prepare_cached(
             "SELECT name FROM cgka_group_snapshots
                  WHERE group_id = ?1
                  ORDER BY name",
@@ -25,7 +26,7 @@ pub(super) fn release(
 ) -> StorageResult<()> {
     let changed = store
         .lock()?
-        .execute(
+        .execute_cached(
             "DELETE FROM cgka_group_snapshots
                  WHERE group_id = ?1 AND name = ?2",
             params![group_id.as_slice(), name],

--- a/crates/storage-sqlite/src/storage/snapshots/restore.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/restore.rs
@@ -9,6 +9,7 @@ use crate::connection::CachedSql;
 #[cfg(feature = "test-conformance-replay")]
 use crate::deserialize;
 use crate::openmls_storage::mls_group_key;
+use crate::storage::groups::encode_group;
 use crate::storage::messages::put_message_on_connection;
 use crate::{
     SqliteAccountStorage, SqliteResultExt, codec::SensitiveBytes, connection::retry_on_busy,
@@ -201,7 +202,7 @@ fn group(conn: &rusqlite::Connection, group_id: &GroupId, group: &Group) -> Stor
         params![
             group_id.as_slice(),
             epoch_to_i64(group.epoch)?,
-            serialize(group)?
+            encode_group(group)?
         ],
     )
     .storage()?;

--- a/crates/storage-sqlite/src/storage/snapshots/restore.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/restore.rs
@@ -5,6 +5,7 @@ use super::rows::{
 };
 #[cfg(feature = "test-conformance-replay")]
 use super::rows::{REPLAY_SNAPSHOT_VERSION, ReplaySnapshot};
+use crate::connection::CachedSql;
 #[cfg(feature = "test-conformance-replay")]
 use crate::deserialize;
 use crate::openmls_storage::mls_group_key;
@@ -81,7 +82,7 @@ fn rollback_snapshot(
     scope: RestoreScope,
 ) -> StorageResult<()> {
     let snapshot_blob = SensitiveBytes::new(
-        conn.query_row(
+        conn.query_row_cached(
             "SELECT snapshot FROM cgka_group_snapshots
                  WHERE group_id = ?1 AND name = ?2",
             params![group_id.as_slice(), name],
@@ -138,13 +139,13 @@ fn convergence_pass(
     group_id: &GroupId,
     pass: Option<&cgka_traits::convergence_pass::DurableConvergencePass>,
 ) -> StorageResult<()> {
-    conn.execute(
+    conn.execute_cached(
         "DELETE FROM cgka_convergence_passes WHERE group_id = ?1",
         params![group_id.as_slice()],
     )
     .storage()?;
     if let Some(pass) = pass {
-        conn.execute(
+        conn.execute_cached(
             "INSERT INTO cgka_convergence_passes (group_id, record) VALUES (?1, ?2)",
             params![group_id.as_slice(), serialize(pass)?],
         )
@@ -191,7 +192,7 @@ pub(super) fn restore_group_state(
 }
 
 fn group(conn: &rusqlite::Connection, group_id: &GroupId, group: &Group) -> StorageResult<()> {
-    conn.execute(
+    conn.execute_cached(
         "INSERT INTO cgka_groups (id, epoch, record)
              VALUES (?1, ?2, ?3)
              ON CONFLICT(id) DO UPDATE SET
@@ -212,7 +213,7 @@ fn messages(
     group_id: &GroupId,
     messages: &[OrderedMessage],
 ) -> StorageResult<()> {
-    conn.execute(
+    conn.execute_cached(
         "DELETE FROM cgka_messages WHERE group_id = ?1",
         params![group_id.as_slice()],
     )
@@ -223,7 +224,7 @@ fn messages(
     // A full snapshot replaces this group's protocol messages. Preserve
     // pending application deliveries whose source messages were restored, but
     // remove outbox rows for messages that the rollback discarded.
-    conn.execute(
+    conn.execute_cached(
         "DELETE FROM pending_application_events
          WHERE group_id = ?1
            AND NOT EXISTS (
@@ -243,13 +244,13 @@ fn queued_outbound(
     group_id: &GroupId,
     queued_outbound: &[OrderedQueuedOutbound],
 ) -> StorageResult<()> {
-    conn.execute(
+    conn.execute_cached(
         "DELETE FROM cgka_queued_outbound WHERE group_id = ?1",
         params![group_id.as_slice()],
     )
     .storage()?;
     for queued in queued_outbound {
-        conn.execute(
+        conn.execute_cached(
             "INSERT INTO cgka_queued_outbound
                 (insert_order, id, group_id, created_at_ms, record)
              VALUES (?1, ?2, ?3, ?4, ?5)",
@@ -271,13 +272,13 @@ fn member_capabilities(
     group_id: &GroupId,
     member_caps: &[MemberCapabilitiesSnapshot],
 ) -> StorageResult<()> {
-    conn.execute(
+    conn.execute_cached(
         "DELETE FROM cgka_member_capabilities WHERE group_id = ?1",
         params![group_id.as_slice()],
     )
     .storage()?;
     for caps in member_caps {
-        conn.execute(
+        conn.execute_cached(
             "INSERT INTO cgka_member_capabilities (group_id, member_id, capabilities)
              VALUES (?1, ?2, ?3)",
             params![
@@ -296,13 +297,13 @@ fn convergence_policy(
     group_id: &GroupId,
     policy: Option<&[u8]>,
 ) -> StorageResult<()> {
-    conn.execute(
+    conn.execute_cached(
         "DELETE FROM cgka_convergence_policies WHERE group_id = ?1",
         params![group_id.as_slice()],
     )
     .storage()?;
     if let Some(policy) = policy {
-        conn.execute(
+        conn.execute_cached(
             "INSERT INTO cgka_convergence_policies (group_id, policy)
              VALUES (?1, ?2)",
             params![group_id.as_slice(), policy],
@@ -317,13 +318,13 @@ fn validated_tree_marker(
     group_id: &GroupId,
     marker: Option<&[u8]>,
 ) -> StorageResult<()> {
-    conn.execute(
+    conn.execute_cached(
         "DELETE FROM cgka_member_validation_cache WHERE group_id = ?1",
         params![group_id.as_slice()],
     )
     .storage()?;
     if let Some(marker) = marker {
-        conn.execute(
+        conn.execute_cached(
             "INSERT INTO cgka_member_validation_cache (group_id, marker)
              VALUES (?1, ?2)",
             params![group_id.as_slice(), marker],
@@ -338,14 +339,14 @@ fn openmls_values(
     mls_group_key: &[u8],
     values: &[OpenMlsValueSnapshot],
 ) -> StorageResult<()> {
-    conn.execute(
+    conn.execute_cached(
         "DELETE FROM openmls_values
          WHERE provider_version = ?1 AND group_key = ?2",
         params![openmls_traits::storage::CURRENT_VERSION, mls_group_key],
     )
     .storage()?;
     for value in values {
-        conn.execute(
+        conn.execute_cached(
             "INSERT INTO openmls_values
                 (provider_version, label, storage_key, group_key, value)
              VALUES (?1, ?2, ?3, ?4, ?5)",

--- a/crates/storage-sqlite/src/storage/transport_routes.rs
+++ b/crates/storage-sqlite/src/storage/transport_routes.rs
@@ -6,6 +6,7 @@
 //! lets the engine retire prior routes once the retained-history window moves
 //! past them. The `GroupStorage` impl in `groups.rs` delegates here.
 
+use crate::connection::CachedSql;
 use crate::{SqliteAccountStorage, SqliteResultExt, epoch_to_i64, i64_to_u64};
 use cgka_traits::storage::{StorageResult, TransportGroupRoute};
 use cgka_traits::types::{EpochId, GroupId};
@@ -19,7 +20,7 @@ pub(super) fn put(
 ) -> StorageResult<()> {
     store
         .lock()?
-        .execute(
+        .execute_cached(
             "INSERT INTO cgka_transport_group_routes (transport_group_id, group_id, source_epoch)
              VALUES (?1, ?2, ?3)
              ON CONFLICT(transport_group_id) DO UPDATE SET
@@ -38,7 +39,7 @@ pub(super) fn put(
 pub(super) fn list(store: &SqliteAccountStorage) -> StorageResult<Vec<TransportGroupRoute>> {
     let conn = store.lock()?;
     let mut statement = conn
-        .prepare(
+        .prepare_cached(
             "SELECT transport_group_id, group_id, source_epoch
              FROM cgka_transport_group_routes",
         )
@@ -71,25 +72,25 @@ pub(super) fn delete_route(
 ) -> StorageResult<()> {
     store.connection.with_transaction(|| {
         let conn = store.lock()?;
-        conn.execute(
+        conn.execute_cached(
             "DELETE FROM transport_reconciliation_items
          WHERE route_kind = 1 AND route_id = ?1",
             params![transport_group_id],
         )
         .storage()?;
-        conn.execute(
+        conn.execute_cached(
             "DELETE FROM transport_reconciliation_route_state
          WHERE route_kind = 1 AND route_id = ?1",
             params![transport_group_id],
         )
         .storage()?;
-        conn.execute(
+        conn.execute_cached(
             "DELETE FROM transport_reconciliation_scheduler
          WHERE singleton = 1 AND route_kind = 1 AND route_id = ?1",
             params![transport_group_id],
         )
         .storage()?;
-        conn.execute(
+        conn.execute_cached(
             "DELETE FROM cgka_transport_group_routes WHERE transport_group_id = ?1",
             params![transport_group_id],
         )
@@ -105,7 +106,7 @@ pub(super) fn delete_below_epoch(
 ) -> StorageResult<()> {
     store.connection.with_transaction(|| {
         let conn = store.lock()?;
-        conn.execute(
+        conn.execute_cached(
             "DELETE FROM transport_reconciliation_items
          WHERE route_kind = 1 AND route_id IN (
              SELECT transport_group_id
@@ -115,7 +116,7 @@ pub(super) fn delete_below_epoch(
             params![group_id.as_slice(), epoch_to_i64(cutoff)?],
         )
         .storage()?;
-        conn.execute(
+        conn.execute_cached(
             "DELETE FROM transport_reconciliation_route_state
          WHERE route_kind = 1 AND route_id IN (
              SELECT transport_group_id
@@ -125,7 +126,7 @@ pub(super) fn delete_below_epoch(
             params![group_id.as_slice(), epoch_to_i64(cutoff)?],
         )
         .storage()?;
-        conn.execute(
+        conn.execute_cached(
             "DELETE FROM transport_reconciliation_scheduler
          WHERE singleton = 1 AND route_kind = 1 AND route_id IN (
              SELECT transport_group_id
@@ -135,7 +136,7 @@ pub(super) fn delete_below_epoch(
             params![group_id.as_slice(), epoch_to_i64(cutoff)?],
         )
         .storage()?;
-        conn.execute(
+        conn.execute_cached(
             "DELETE FROM cgka_transport_group_routes
              WHERE group_id = ?1 AND source_epoch < ?2",
             params![group_id.as_slice(), epoch_to_i64(cutoff)?],
@@ -151,7 +152,7 @@ pub(super) fn delete_for_group(
 ) -> StorageResult<()> {
     store.connection.with_transaction(|| {
         let conn = store.lock()?;
-        conn.execute(
+        conn.execute_cached(
             "DELETE FROM transport_reconciliation_items
          WHERE route_kind = 1 AND route_id IN (
              SELECT transport_group_id
@@ -161,7 +162,7 @@ pub(super) fn delete_for_group(
             params![group_id.as_slice()],
         )
         .storage()?;
-        conn.execute(
+        conn.execute_cached(
             "DELETE FROM transport_reconciliation_route_state
          WHERE route_kind = 1 AND route_id IN (
              SELECT transport_group_id
@@ -171,7 +172,7 @@ pub(super) fn delete_for_group(
             params![group_id.as_slice()],
         )
         .storage()?;
-        conn.execute(
+        conn.execute_cached(
             "DELETE FROM transport_reconciliation_scheduler
          WHERE singleton = 1 AND route_kind = 1 AND route_id IN (
              SELECT transport_group_id
@@ -181,7 +182,7 @@ pub(super) fn delete_for_group(
             params![group_id.as_slice()],
         )
         .storage()?;
-        conn.execute(
+        conn.execute_cached(
             "DELETE FROM cgka_transport_group_routes WHERE group_id = ?1",
             params![group_id.as_slice()],
         )

--- a/crates/storage-sqlite/src/storage/welcomes.rs
+++ b/crates/storage-sqlite/src/storage/welcomes.rs
@@ -1,3 +1,4 @@
+use crate::connection::CachedSql;
 use crate::{
     SqliteAccountStorage, SqliteResultExt, connection::retry_on_busy, deserialize, serialize,
 };
@@ -9,7 +10,7 @@ use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
 impl WelcomeStorage for SqliteAccountStorage {
     fn put_welcome(&self, welcome: &PendingWelcome) -> StorageResult<()> {
         self.lock()?
-            .execute(
+            .execute_cached(
                 "INSERT OR REPLACE INTO cgka_welcomes (message_id, group_id, record)
                  VALUES (?1, ?2, ?3)",
                 params![
@@ -41,7 +42,7 @@ impl WelcomeStorage for SqliteAccountStorage {
     fn list_welcomes(&self) -> StorageResult<Vec<PendingWelcome>> {
         let conn = self.lock()?;
         let mut stmt = conn
-            .prepare("SELECT record FROM cgka_welcomes ORDER BY rowid")
+            .prepare_cached("SELECT record FROM cgka_welcomes ORDER BY rowid")
             .storage()?;
         let records = stmt
             .query_map([], |row| row.get::<_, Vec<u8>>(0))
@@ -68,7 +69,7 @@ impl WelcomeStorage for SqliteAccountStorage {
 
 fn take_welcome_on_connection(conn: &Connection, id: &MessageId) -> StorageResult<PendingWelcome> {
     let record: Vec<u8> = conn
-        .query_row(
+        .query_row_cached(
             "SELECT record FROM cgka_welcomes WHERE message_id = ?1",
             params![id.as_slice()],
             |row| row.get(0),
@@ -77,7 +78,7 @@ fn take_welcome_on_connection(conn: &Connection, id: &MessageId) -> StorageResul
         .storage()?
         .ok_or(StorageError::NotFound)?;
     let welcome = deserialize(&record)?;
-    conn.execute(
+    conn.execute_cached(
         "DELETE FROM cgka_welcomes WHERE message_id = ?1",
         params![id.as_slice()],
     )

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -747,7 +747,7 @@ impl SqliteAccountStorage {
         self.connection.with_transaction(|| {
             let conn = self.lock()?;
             if conn
-                .query_row(
+                .query_row_cached(
                     &format!(
                         "SELECT 1 FROM app_events
                          WHERE {CLEARABLE_LOCAL_PUBLISH_FAILURE_PREDICATE}"
@@ -776,7 +776,7 @@ impl SqliteAccountStorage {
             let before =
                 timeline_records_by_ids_tx(&conn, group_id_hex, affected_message_ids.clone())?;
             let cleared = conn
-                .execute(
+                .execute_cached(
                     &format!(
                         "UPDATE app_events
                          SET invalidated = 0, invalidation_reason = NULL
@@ -1484,7 +1484,7 @@ fn refresh_chat_list_last_message_after_secure_prune_tx(
          LIMIT 1",
     );
     let latest = tx
-        .query_row(&sql, params![group_id_hex], |row| {
+        .query_row_cached(&sql, params![group_id_hex], |row| {
             Ok((
                 row.get::<_, String>(0)?,
                 row.get::<_, String>(1)?,

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -1,3 +1,4 @@
+use crate::connection::CachedSql;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use crate::{
@@ -431,7 +432,7 @@ impl SqliteAccountStorage {
         self.connection.with_transaction(|| {
             let conn = self.lock()?;
             let existing_source: Option<Option<String>> = conn
-                .query_row(
+                .query_row_cached(
                     "SELECT source_message_id_hex
                      FROM app_events
                      WHERE group_id_hex = ?1
@@ -452,7 +453,7 @@ impl SqliteAccountStorage {
             // badge without re-reading the row.
             let publishes_held_send = existing_source.is_none() && source_message_id_hex.is_some();
             let updated = conn
-                .execute(
+                .execute_cached(
                     "UPDATE app_events
                      SET source_message_id_hex = COALESCE(source_message_id_hex, ?3),
                          source_epoch = COALESCE(source_epoch, ?4),
@@ -562,7 +563,7 @@ impl SqliteAccountStorage {
             };
             let mut affected_message_ids = new_affected_message_ids.clone();
             affected_message_ids.extend(existing_affected_message_ids.iter().cloned());
-            conn.execute(
+            conn.execute_cached(
                 "INSERT INTO app_events (
                     group_id_hex, message_id_hex, source_message_id_hex, source_epoch, direction, sender,
                     plaintext, kind, tags_json, recorded_at, received_at, origin_commit_id,
@@ -838,7 +839,7 @@ impl SqliteAccountStorage {
             // invalidation reason nor produces a redundant projection update.
             let rows: Vec<(String, String, u64, Vec<Vec<String>>)> = {
                 let mut stmt = conn
-                    .prepare(
+                    .prepare_cached(
                         "SELECT group_id_hex, message_id_hex, kind, tags_json
                          FROM app_events
                          WHERE origin_commit_id = ?1 AND invalidated = 0",
@@ -877,7 +878,7 @@ impl SqliteAccountStorage {
             }
             let before =
                 timeline_records_by_ids_tx(&conn, &group_id_hex, affected_message_ids.clone())?;
-            conn.execute(
+            conn.execute_cached(
                 "UPDATE app_events
                  SET invalidated = 1, invalidation_reason = ?2
                  WHERE origin_commit_id = ?1 AND invalidated = 0",
@@ -936,7 +937,7 @@ impl SqliteAccountStorage {
             let conn = self.lock()?;
             let rows: Vec<(String, u64, Vec<Vec<String>>)> = {
                 let mut stmt = conn
-                    .prepare(
+                    .prepare_cached(
                         "SELECT message_id_hex, kind, tags_json
                          FROM app_events
                          WHERE group_id_hex = ?1
@@ -975,7 +976,7 @@ impl SqliteAccountStorage {
             }
             let before =
                 timeline_records_by_ids_tx(&conn, group_id_hex, affected_message_ids.clone())?;
-            conn.execute(
+            conn.execute_cached(
                 "UPDATE app_events
                  SET invalidated = 1, invalidation_reason = ?2
                  WHERE group_id_hex = ?1
@@ -1122,7 +1123,7 @@ impl SqliteAccountStorage {
                 method = "message_timeline"
             )
             .entered();
-            let mut stmt = conn.prepare(&sql).storage()?;
+            let mut stmt = conn.prepare_cached(&sql).storage()?;
             stmt.query_map(
                 rusqlite::params_from_iter(params.iter()),
                 timeline_record_from_row,
@@ -1170,7 +1171,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<Option<TimelineMessageRecord>> {
         let conn = self.lock()?;
         let mut message = conn
-            .query_row(
+            .query_row_cached(
                 "SELECT timeline.message_id_hex, timeline.source_message_id_hex, timeline.source_epoch,
                         source.retention_seconds, source.retention_expires_at,
                         timeline.direction, timeline.group_id_hex, timeline.sender,
@@ -1208,7 +1209,7 @@ impl SqliteAccountStorage {
         message_id_hex: &str,
     ) -> StorageResult<Option<TimelineMessageTarget>> {
         let conn = self.lock()?;
-        conn.query_row(
+        conn.query_row_cached(
             "SELECT sender, plaintext, kind, deleted, invalidation_status
              FROM message_timeline
              WHERE group_id_hex = ?1 AND message_id_hex = ?2
@@ -1235,12 +1236,12 @@ pub(crate) fn rebuild_message_timeline_for_group_tx(
 ) -> StorageResult<()> {
     let events = app_events_for_rebuild_tx(tx, group_id_hex)?;
     let (rows, stream_starts) = project_group_events(events);
-    tx.execute(
+    tx.execute_cached(
         "DELETE FROM message_timeline WHERE group_id_hex = ?1",
         params![group_id_hex],
     )
     .storage()?;
-    tx.execute(
+    tx.execute_cached(
         "DELETE FROM agent_stream_starts WHERE group_id_hex = ?1",
         params![group_id_hex],
     )
@@ -1267,7 +1268,7 @@ pub(crate) fn secure_prune_app_events_before_tx(
     mention_classifier: &crate::chat_list::MentionClassifier<'_>,
 ) -> StorageResult<SecurePruneAppEventsResult> {
     debug_assert_eq!(
-        tx.query_row("PRAGMA secure_delete", [], |row| row.get::<_, i64>(0))
+        tx.query_row_cached("PRAGMA secure_delete", [], |row| row.get::<_, i64>(0))
             .unwrap_or(0),
         1,
         "secure_delete must be ON before the prune transaction is opened"
@@ -1293,7 +1294,7 @@ pub(crate) fn secure_prune_expired_app_events_tx(
     mention_classifier: &crate::chat_list::MentionClassifier<'_>,
 ) -> StorageResult<SecurePruneAppEventsResult> {
     debug_assert_eq!(
-        tx.query_row("PRAGMA secure_delete", [], |row| row.get::<_, i64>(0))
+        tx.query_row_cached("PRAGMA secure_delete", [], |row| row.get::<_, i64>(0))
             .unwrap_or(0),
         1,
         "secure_delete must be ON before the prune transaction is opened"
@@ -1414,7 +1415,7 @@ fn retain_pruned_chat_activity_tx(
                )
            )"
     );
-    let mut statement = tx.prepare(&sql).storage()?;
+    let mut statement = tx.prepare_cached(&sql).storage()?;
     let mut latest_pruned_activity = None;
     let mut accepted_activity_insert_order = None;
     for message_id_hex in pruned_message_ids {
@@ -1431,7 +1432,7 @@ fn retain_pruned_chat_activity_tx(
         }
     }
     if latest_pruned_activity.is_some() || accepted_activity_insert_order.is_some() {
-        tx.execute(
+        tx.execute_cached(
             "UPDATE chat_list_rows
              SET retained_activity_sort_at = MAX(retained_activity_sort_at, ?2),
                  activity_sort_at = MAX(activity_sort_at, ?2),
@@ -1509,7 +1510,7 @@ fn refresh_chat_list_last_message_after_secure_prune_tx(
         delivery_state,
     )) = latest
     {
-        tx.execute(
+        tx.execute_cached(
             "UPDATE chat_list_rows
              SET last_message_id_hex = ?1,
                  last_message_sender = ?2,
@@ -1546,7 +1547,7 @@ fn refresh_chat_list_last_message_after_secure_prune_tx(
         )
         .storage()?;
     } else {
-        tx.execute(
+        tx.execute_cached(
             "UPDATE chat_list_rows
              SET last_message_id_hex = NULL,
                  last_message_sender = NULL,
@@ -1579,7 +1580,7 @@ fn app_event_projection_parts_tx(
     group_id_hex: &str,
     message_id_hex: &str,
 ) -> StorageResult<Option<(u64, Vec<Vec<String>>)>> {
-    tx.query_row(
+    tx.query_row_cached(
         "SELECT kind, tags_json
          FROM app_events
          WHERE group_id_hex = ?1 AND message_id_hex = ?2",
@@ -1605,7 +1606,7 @@ fn upsert_message_timeline_projection_for_message_tx(
     group_id_hex: &str,
     message_id_hex: &str,
 ) -> StorageResult<()> {
-    tx.execute(
+    tx.execute_cached(
         "DELETE FROM agent_stream_starts
          WHERE group_id_hex = ?1 AND message_id_hex = ?2",
         params![group_id_hex, message_id_hex],
@@ -1615,7 +1616,7 @@ fn upsert_message_timeline_projection_for_message_tx(
     let Some((row, stream_start)) =
         project_single_message_timeline_tx(tx, group_id_hex, message_id_hex)?
     else {
-        tx.execute(
+        tx.execute_cached(
             "DELETE FROM message_timeline
              WHERE group_id_hex = ?1 AND message_id_hex = ?2",
             params![group_id_hex, message_id_hex],
@@ -1637,7 +1638,7 @@ fn project_single_message_timeline_tx(
     message_id_hex: &str,
 ) -> StorageResult<Option<(TimelineRow, Option<StreamStartRow>)>> {
     let Some(event) = tx
-        .query_row(
+        .query_row_cached(
             "SELECT group_id_hex, message_id_hex, source_message_id_hex, source_epoch, direction, sender,
                     plaintext, kind, tags_json, recorded_at, received_at,
                     invalidated, invalidation_reason, moderation_grant
@@ -1698,7 +1699,7 @@ fn project_single_message_timeline_tx(
 /// so existing edges for this modifier are deleted first and re-inserted from
 /// the event's current tags, keeping edges consistent with any tag change.
 fn upsert_message_modifier_edges_tx(tx: &Connection, event: &StoredAppEvent) -> StorageResult<()> {
-    tx.execute(
+    tx.execute_cached(
         "DELETE FROM message_modifier_edges
          WHERE group_id_hex = ?1 AND modifier_message_id_hex = ?2",
         params![&event.group_id_hex, &event.message_id_hex],
@@ -1713,7 +1714,7 @@ fn upsert_message_modifier_edges_tx(tx: &Connection, event: &StoredAppEvent) -> 
     let kind = u64_to_i64(event.kind)?;
     let recorded_at = u64_to_i64(event.recorded_at)?;
     for target in tag_values(&event.tags, EVENT_REF_TAG) {
-        tx.execute(
+        tx.execute_cached(
             "INSERT OR IGNORE INTO message_modifier_edges (
                 group_id_hex, modifier_message_id_hex, target_message_id_hex,
                 kind, sender, recorded_at
@@ -1835,7 +1836,7 @@ fn deleted_reaction_ids_for_target_tx(
                 .iter()
                 .map(|reaction| rusqlite::types::Value::Text(reaction.message_id_hex.clone())),
         );
-        let mut stmt = tx.prepare(&sql).storage()?;
+        let mut stmt = tx.prepare_cached(&sql).storage()?;
         let chunk_pairs = stmt
             .query_map(params_from_iter(values.iter()), |row| {
                 Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
@@ -1873,7 +1874,7 @@ fn app_events_targeting_message_tx(
     // indexed join is equivalent to the former JSON `LIKE` scan plus Rust-side
     // re-filter, without either. Ordering is preserved byte-for-byte.
     let mut stmt = tx
-        .prepare(
+        .prepare_cached(
             "SELECT app_events.group_id_hex, app_events.message_id_hex, app_events.source_message_id_hex,
                     app_events.source_epoch, app_events.direction, app_events.sender,
                     app_events.plaintext, app_events.kind, app_events.tags_json,
@@ -1901,7 +1902,7 @@ fn app_events_targeting_message_tx(
 }
 
 fn upsert_message_timeline_row_tx(tx: &Connection, row: &TimelineRow) -> StorageResult<()> {
-    tx.execute(
+    tx.execute_cached(
         "INSERT INTO message_timeline (
             group_id_hex, message_id_hex, source_message_id_hex, source_epoch, direction, sender,
             plaintext, kind, tags_json, timeline_at, received_at,
@@ -1960,7 +1961,7 @@ fn upsert_message_timeline_row_tx(tx: &Connection, row: &TimelineRow) -> Storage
         row.timeline_at,
         &row.message_id_hex,
     );
-    tx.execute(
+    tx.execute_cached(
         "UPDATE conversation_read_state
          SET last_read_timeline_at = ?3,
              last_read_order_class = ?4,
@@ -1985,7 +1986,7 @@ fn upsert_message_timeline_row_tx(tx: &Connection, row: &TimelineRow) -> Storage
 }
 
 fn upsert_agent_stream_start_tx(tx: &Connection, start: &StreamStartRow) -> StorageResult<()> {
-    tx.execute(
+    tx.execute_cached(
         "INSERT INTO agent_stream_starts (
             group_id_hex, message_id_hex, source_message_id_hex, sender, stream_id_hex,
             tags_json, started_at, received_at
@@ -2022,7 +2023,7 @@ fn app_events_for_rebuild_tx(
     // `project_group_events` skips applying invalidated modifier events (reactions,
     // deletes) so a losing-branch event never mutates canonical content.
     let mut stmt = tx
-        .prepare(
+        .prepare_cached(
             "SELECT group_id_hex, message_id_hex, source_message_id_hex, source_epoch, direction, sender,
                     plaintext, kind, tags_json, recorded_at, received_at,
                     invalidated, invalidation_reason, moderation_grant
@@ -2043,7 +2044,7 @@ fn app_events_before_cutoff_tx(
     cutoff_recorded_at: u64,
 ) -> StorageResult<Vec<PrunedAppEvent>> {
     let mut stmt = tx
-        .prepare(
+        .prepare_cached(
             "SELECT message_id_hex, kind, source_epoch, tags_json
              FROM app_events
              WHERE group_id_hex = ?1
@@ -2082,7 +2083,7 @@ fn expired_app_events_tx(
     now: u64,
 ) -> StorageResult<Vec<PrunedAppEvent>> {
     let mut stmt = tx
-        .prepare(
+        .prepare_cached(
             "SELECT message_id_hex, kind, source_epoch, tags_json
              FROM app_events
              WHERE group_id_hex = ?1
@@ -2638,7 +2639,7 @@ fn reply_message_ids_for_targets_tx(
         let mut values = Vec::<rusqlite::types::Value>::with_capacity(chunk.len() + 1);
         values.push(rusqlite::types::Value::Text(group_id_hex.to_owned()));
         values.extend(chunk.iter().cloned().map(rusqlite::types::Value::Text));
-        let mut stmt = tx.prepare(&sql).storage()?;
+        let mut stmt = tx.prepare_cached(&sql).storage()?;
         let chunk_ids = stmt
             .query_map(params_from_iter(values.iter()), |row| row.get(0))
             .storage()?
@@ -2655,7 +2656,7 @@ fn reaction_target_message_id_tx(
     message_id_hex: &str,
 ) -> StorageResult<Option<String>> {
     let row: Option<(u64, Vec<Vec<String>>)> = tx
-        .query_row(
+        .query_row_cached(
             "SELECT kind, tags_json
              FROM app_events
              WHERE group_id_hex = ?1 AND message_id_hex = ?2",
@@ -2715,7 +2716,7 @@ fn timeline_records_by_ids_tx(
         let mut params = Vec::<rusqlite::types::Value>::with_capacity(chunk.len() + 1);
         params.push(rusqlite::types::Value::Text(group_id_hex.to_owned()));
         params.extend(chunk.iter().cloned().map(rusqlite::types::Value::Text));
-        let mut stmt = tx.prepare(&sql).storage()?;
+        let mut stmt = tx.prepare_cached(&sql).storage()?;
         let chunk_messages = stmt
             .query_map(params_from_iter(params.iter()), timeline_record_from_row)
             .storage()?
@@ -2734,7 +2735,7 @@ fn timeline_order_cursor_tx(
     message_id_hex: &str,
 ) -> StorageResult<OwnedTimelineOrderKey> {
     let row = tx
-        .query_row(
+        .query_row_cached(
             "SELECT source_message_id_hex, source_epoch, invalidation_status,
                     kind, timeline_at, message_id_hex
              FROM message_timeline
@@ -3417,7 +3418,7 @@ fn load_reply_previews(
             let mut params = Vec::<rusqlite::types::Value>::with_capacity(chunk.len() + 1);
             params.push(rusqlite::types::Value::Text(group_id_hex.clone()));
             params.extend(chunk.iter().cloned().map(rusqlite::types::Value::Text));
-            let mut stmt = conn.prepare(&sql).storage()?;
+            let mut stmt = conn.prepare_cached(&sql).storage()?;
             let group_previews = stmt
                 .query_map(params_from_iter(params.iter()), reply_preview_from_row)
                 .storage()?

--- a/crates/storage-sqlite/src/transport_reconciliation.rs
+++ b/crates/storage-sqlite/src/transport_reconciliation.rs
@@ -1,5 +1,6 @@
 //! Durable, account-private NIP-77 set-reconciliation inventory.
 
+use crate::connection::CachedSql;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::{SqliteAccountStorage, SqliteResultExt, connection::retry_on_busy};
@@ -57,7 +58,7 @@ fn route_state_floor_tx(
     route_id: &[u8],
     configured_floor: i64,
 ) -> StorageResult<i64> {
-    tx.execute(
+    tx.execute_cached(
         "INSERT INTO transport_reconciliation_route_state (
              route_kind, route_id, inventory_since
          ) VALUES (?1, ?2, ?3)
@@ -66,13 +67,13 @@ fn route_state_floor_tx(
         params![route_kind, route_id, configured_floor],
     )
     .storage()?;
-    tx.execute(
+    tx.execute_cached(
         "DELETE FROM transport_reconciliation_items
          WHERE route_kind = ?1 AND route_id = ?2 AND created_at < ?3",
         params![route_kind, route_id, configured_floor],
     )
     .storage()?;
-    tx.query_row(
+    tx.query_row_cached(
         "SELECT inventory_since
          FROM transport_reconciliation_route_state
          WHERE route_kind = ?1 AND route_id = ?2",
@@ -84,7 +85,7 @@ fn route_state_floor_tx(
 
 fn compact_route_tx(tx: &Transaction<'_>, route_kind: i64, route_id: &[u8]) -> StorageResult<()> {
     let overflow_cutoff = tx
-        .query_row(
+        .query_row_cached(
             "SELECT created_at
              FROM transport_reconciliation_items
              WHERE route_kind = ?1 AND route_id = ?2
@@ -107,13 +108,13 @@ fn compact_route_tx(tx: &Transaction<'_>, route_kind: i64, route_id: &[u8]) -> S
         return Ok(());
     };
     let compacted_floor = overflow_cutoff.saturating_add(1);
-    tx.execute(
+    tx.execute_cached(
         "DELETE FROM transport_reconciliation_items
          WHERE route_kind = ?1 AND route_id = ?2 AND created_at < ?3",
         params![route_kind, route_id, compacted_floor],
     )
     .storage()?;
-    tx.execute(
+    tx.execute_cached(
         "UPDATE transport_reconciliation_route_state
          SET inventory_since = MAX(inventory_since, ?3)
          WHERE route_kind = ?1 AND route_id = ?2",
@@ -154,7 +155,7 @@ impl SqliteAccountStorage {
             let inventory_since =
                 route_state_floor_tx(&tx, route_kind, route_id, configured_floor)?;
             if created_at >= inventory_since {
-                tx.execute(
+                tx.execute_cached(
                     "INSERT OR IGNORE INTO transport_reconciliation_items (
                          route_kind, route_id, event_id, created_at
                      ) VALUES (?1, ?2, ?3, ?4)",
@@ -190,7 +191,7 @@ impl SqliteAccountStorage {
                 route_state_floor_tx(&tx, route_kind, route_id, configured_floor)?;
             compact_route_tx(&tx, route_kind, route_id)?;
             let inventory_since = tx
-                .query_row(
+                .query_row_cached(
                     "SELECT inventory_since
                      FROM transport_reconciliation_route_state
                      WHERE route_kind = ?1 AND route_id = ?2",
@@ -200,7 +201,7 @@ impl SqliteAccountStorage {
                 .storage()?
                 .max(inventory_since);
             let mut statement = tx
-                .prepare(
+                .prepare_cached(
                     "SELECT event_id, created_at
                      FROM transport_reconciliation_items
                      WHERE route_kind = ?1 AND route_id = ?2 AND created_at >= ?3
@@ -250,7 +251,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<Option<TransportReconciliationRoute>> {
         let conn = self.connection.lock()?;
         let row = conn
-            .query_row(
+            .query_row_cached(
                 "SELECT route_kind, route_id
                  FROM transport_reconciliation_scheduler
                  WHERE singleton = 1",
@@ -284,7 +285,7 @@ impl SqliteAccountStorage {
         retry_on_busy(|| {
             self.connection
                 .lock()?
-                .execute(
+                .execute_cached(
                     "INSERT INTO transport_reconciliation_scheduler (
                          singleton, route_kind, route_id
                      ) VALUES (1, ?1, ?2)

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -787,6 +787,17 @@ pub trait StorageProvider:
     /// `OpenMlsProvider`-shaped objects for MLS operations.
     fn mls_storage(&self) -> &Self::Mls;
 
+    /// Count of writes to the OpenMLS state store, when the backend tracks
+    /// them. The engine keeps loaded `MlsGroup`s across calls and reuses one
+    /// only while this value equals the value observed when it was stored;
+    /// `None` disables that reuse. A tracking backend must change the count on
+    /// every write to the OpenMLS store, including transaction rollbacks and
+    /// snapshot restores that bypass the OpenMLS provider, so a cached object
+    /// can never outlive the state it was loaded from.
+    fn mls_write_generation(&self) -> Option<u64> {
+        None
+    }
+
     /// Optional account-device maintenance store.
     ///
     /// This is accessor composition for the same reason as `mls_storage()`:


### PR DESCRIPTION
### Summary

The group record in `cgka_groups` is written as MessagePack, and rows written before this change still decode.

### Context

Every record was a serde_json document. Each member's id and credential are byte vectors, which serde_json spells as arrays of decimal integers with a text integer parse per byte on every read. After #1646 moved the OpenMLS value store off JSON, this parse was half of a warm 64-member send, because the engine reads the record several times per send and per inbound message.

### What changed

New rows carry the same two-byte NUL prefix `openmls_values` uses, followed by MessagePack with structs as maps so fields added later with serde defaults stay readable. Prefix-less rows decode as JSON and move to the new encoding on their next write, so no rewrite is needed. Snapshot capture and restore go through the same codec. A no-op migration marks the version so an older build refuses the database up front.

### Impact

Warm app-message send, in-memory SQLCipher, on top of #1648: 16 members 555 to 398 µs, 64 members 887 to 531 µs. Inbound 64-member app message 369 to 275 µs.
