### PR TITLE
Read the group record once per send gate

### DIFF
--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -1015,17 +1015,22 @@ impl<S: StorageProvider> Engine<S> {
                     context: Some(context.clone()),
                     kind: crate::audit_helpers::send_outcome_event(intent_kind, send_result),
                 });
-                for (msg_id, expectation) in
-                    self.recipient_expectation_records(&recipient_group_id, send_result)
-                {
-                    self.recorder.record(AuditRecord {
-                        group_ref: group_ref.clone(),
-                        context: Some(context.clone()),
-                        kind: AuditEventKind::RecipientExpectation {
-                            msg_id,
-                            expectation,
-                        },
-                    });
+                // Recipient expectations read the group record and admin
+                // policy just to describe the send; skip that work when no
+                // recorder consumes it.
+                if self.recorder.is_enabled() {
+                    for (msg_id, expectation) in
+                        self.recipient_expectation_records(&recipient_group_id, send_result)
+                    {
+                        self.recorder.record(AuditRecord {
+                            group_ref: group_ref.clone(),
+                            context: Some(context.clone()),
+                            kind: AuditEventKind::RecipientExpectation {
+                                msg_id,
+                                expectation,
+                            },
+                        });
+                    }
                 }
             }
             Err(err) => {
@@ -2261,6 +2266,44 @@ impl<S: StorageProvider> Engine<S> {
         self.epoch_manager
             .restore_unrecoverable(group_id.clone(), group.epoch);
         Ok(true)
+    }
+
+    /// The removed and unrecoverable gates every send passes at acceptance and
+    /// again before preparation, answered from one group-record read instead
+    /// of one per gate. Order matches the split checks: a removed copy reports
+    /// `Removed` even when it is also halted.
+    pub(crate) fn refuse_removed_or_halted(
+        &mut self,
+        group_id: &GroupId,
+        intent: &SendIntent,
+    ) -> Result<(), EngineError> {
+        let group = match self.storage.get_group(group_id) {
+            Ok(group) => group,
+            Err(StorageError::NotFound) => return Ok(()),
+            Err(err) => return Err(EngineError::Storage(err)),
+        };
+        if group.removed {
+            return Err(EngineError::InvalidTransition(
+                cgka_traits::engine_state::InvalidTransition {
+                    from: "Removed",
+                    to: crate::audit_helpers::send_intent_kind_str(intent),
+                    reason: "local group copy is marked removed (self-evicted)",
+                },
+            ));
+        }
+        if self.epoch_manager.is_unrecoverable(group_id) {
+            return Err(EngineError::GroupUnrecoverableRepairRequired {
+                group_id: group_id.clone(),
+            });
+        }
+        if !group.unrecoverable {
+            return Ok(());
+        }
+        self.epoch_manager
+            .restore_unrecoverable(group_id.clone(), group.epoch);
+        Err(EngineError::GroupUnrecoverableRepairRequired {
+            group_id: group_id.clone(),
+        })
     }
 
     /// Clear ONLY the live OpenMLS group state for `group_id`, leaving every

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -624,29 +624,15 @@ impl<S: StorageProvider> Engine<S> {
                 },
             ));
         }
-        // Terminal gate before queueing: a local copy marked removed (realized
-        // self-eviction) must never accept or queue outbound work. Checked
-        // again in `do_send_ready` so queued-intent drains for a copy removed
-        // after queueing hit the same deterministic error.
-        if self.group_record_is_removed(&group_id)? {
-            return Err(EngineError::InvalidTransition(
-                cgka_traits::engine_state::InvalidTransition {
-                    from: "Removed",
-                    to: crate::audit_helpers::send_intent_kind_str(intent),
-                    reason: "local group copy is marked removed (self-evicted)",
-                },
-            ));
-        }
-        // mdk#971: durable Unrecoverable halt — sync into memory and refuse
-        // outbound work until a verified repair path clears the marker.
-        if self.sync_unrecoverable_halt_from_storage(&group_id)? {
-            // mdk#1177: typed, not `InvalidTransition`. A halted group is a
-            // durable condition whose only exit is another member's repair
-            // Welcome, so the host has something to tell the user and act on —
-            // that is not an engine bug, which is what `InvalidTransition`
-            // denotes.
-            return Err(EngineError::GroupUnrecoverableRepairRequired { group_id });
-        }
+        // Terminal gates before queueing: a local copy marked removed (realized
+        // self-eviction) must never accept or queue outbound work, and a
+        // durable Unrecoverable halt (mdk#971) is synced into memory and
+        // refused until a verified repair path clears the marker. The halt is
+        // typed rather than `InvalidTransition` (mdk#1177): its only exit is
+        // another member's repair Welcome, so the host has something to tell
+        // the user. Checked again in `do_send_ready` so queued-intent drains
+        // for a copy removed after queueing hit the same deterministic error.
+        self.refuse_removed_or_halted(&group_id, intent)?;
         if self.disbanding_in_progress(&group_id)? {
             return Err(EngineError::InvalidTransition(
                 cgka_traits::engine_state::InvalidTransition {

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -45,24 +45,12 @@ impl<S: StorageProvider> Engine<S> {
         // here (not just `do_send`) so queued-intent drains hit the same
         // deterministic terminal error. Every intent kind is blocked,
         // including `Leave` — there is nothing left to leave.
-        if self.group_record_is_removed(&group_id)? {
-            return Err(EngineError::InvalidTransition(
-                cgka_traits::engine_state::InvalidTransition {
-                    from: "Removed",
-                    to: crate::audit_helpers::send_intent_kind_str(&intent),
-                    reason: "local group copy is marked removed (self-evicted)",
-                },
-            ));
-        }
+        //
         // Queued drains call this method directly, bypassing `do_send`.
-        // Recheck the durable lifecycle marker here so no outbound work can
-        // escape an `Unrecoverable` halt after restart.
-        if self.sync_unrecoverable_halt_from_storage(&group_id)? {
-            // Same condition and same typed error as the `validate_send_acceptance`
-            // gate (mdk#1177): a drain reaching a halted group must not report it
-            // differently just because it bypassed `do_send`.
-            return Err(EngineError::GroupUnrecoverableRepairRequired { group_id });
-        }
+        // Recheck the durable `Unrecoverable` marker from the same record
+        // read so no outbound work can escape a halt after restart, with the
+        // same typed error as the `validate_send_acceptance` gate (mdk#1177).
+        self.refuse_removed_or_halted(&group_id, &intent)?;
         // Queued-intent drains call this method directly. A disband request or
         // inbound terminal candidate can arrive after an ordinary intent was
         // queued, so the durable gate must be repeated here before dispatch.

--- a/crates/cgka-engine/src/mls_group_cache.rs
+++ b/crates/cgka-engine/src/mls_group_cache.rs
@@ -112,7 +112,7 @@ mod tests {
     use std::sync::atomic::Ordering;
 
     use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MarmotAppEvent};
-    use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, SendIntent};
+    use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, SendIntent, SendResult};
     use cgka_traits::error::EngineError;
     use cgka_traits::storage::StorageProvider;
 
@@ -121,7 +121,7 @@ mod tests {
     #[tokio::test]
     async fn cached_group_is_reused_until_storage_is_written_behind_it() {
         let mut engine = test_engine();
-        let (group_id, _) = engine
+        let (group_id, created) = engine
             .create_group(CreateGroupRequest {
                 name: "cache".into(),
                 description: String::new(),
@@ -132,6 +132,12 @@ mod tests {
             })
             .await
             .unwrap();
+        // Until the founding publish is confirmed the group is not Stable and
+        // every app message queues without touching the MlsGroup.
+        let SendResult::GroupCreated { pending, .. } = created else {
+            panic!("legacy-profile creation returns GroupCreated");
+        };
+        engine.confirm_published(pending).await.unwrap();
         let payload = MarmotAppEvent::new(
             hex::encode(engine.self_id().as_slice()),
             1_700_000_000,
@@ -152,7 +158,12 @@ mod tests {
                     payload: payload.to_vec(),
                 })
                 .await
-                .map(|_| ())
+                .map(|result| {
+                    assert!(
+                        matches!(result, SendResult::ApplicationMessage { .. }),
+                        "a queued send would not touch the MlsGroup"
+                    );
+                })
         }
         let hits = |engine: &crate::Engine<storage_sqlite::SqliteAccountStorage>| {
             engine.mls_group_cache.hits.load(Ordering::Relaxed)


### PR DESCRIPTION
### Summary

A send reads the group record three times instead of eight.

### Context

Two of the reads served the audit trail alone: recipient expectations load the record and the admin policy to describe the send even when the recorder is the no-op default. Four came from the removed and unrecoverable gates, which each re-read the record at acceptance and again before preparation.

### What changed

Recipient-expectation rows are skipped when no recorder consumes them. Both terminal gates are answered from one record read at each of the two gate sites, keeping the check order so a removed copy still reports Removed when it is also halted. The two sites stay separate because convergence runs between them.

The MlsGroup cache test from #1647 never exercised the send path: its sends queued behind an unconfirmed founding publish, and every hit it counted came from the audit load this change skips. It now confirms the creation and asserts each send produced an application message.

### Impact

Warm app-message send on top of the MessagePack record: 0 members 256 to 254 µs, 64 members 531 to 407 µs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved outbound message validation for removed groups and groups requiring unrecoverable-state repair.
  - Ensured these conditions return consistent, actionable errors before messages are queued or sent.
  - Synchronized durable unrecoverable status with group state to prevent sending from halted groups.

- **Diagnostics**
  - Recipient-expectation audit records are now generated only when forensic recording is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->