### PR TITLE
Serialize byte ids and credentials as byte strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,6 +962,7 @@ dependencies = [
  "insta",
  "openmls_traits",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sha2 0.10.9",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ hmac = "0.12"
 libc = "0.2"
 hkdf = "0.12"
 serde = { version = "1", features = ["derive"] }
+serde_bytes = "0.11"
 serde_json = "1"
 serde_yaml_ng = "0.10"
 clap = { version = "4.6", features = ["derive"] }

--- a/crates/storage-sqlite/src/storage/groups.rs
+++ b/crates/storage-sqlite/src/storage/groups.rs
@@ -224,6 +224,18 @@ mod tests {
         assert_eq!(store.get_group(&group.id).unwrap(), group);
     }
 
+    /// MessagePack rows written before the ids carried `serde_bytes` spell
+    /// each byte vector as an array of integers; the byte-string visitor
+    /// must still accept that form.
+    #[test]
+    fn group_record_with_integer_array_bytes_still_decodes() {
+        let group = sample_group(gid(1), 7, 3);
+        let as_arrays = serde_json::to_value(&group).unwrap();
+        let mut record = vec![0x00, 0x02];
+        record.extend(rmp_serde::to_vec_named(&as_arrays).unwrap());
+        assert_eq!(super::decode_group(&record).unwrap(), group);
+    }
+
     #[test]
     fn group_record_written_as_json_still_decodes() {
         let store = SqliteAccountStorage::in_memory().unwrap();

--- a/crates/traits/Cargo.toml
+++ b/crates/traits/Cargo.toml
@@ -11,6 +11,7 @@ description = "Shared traits and cross-boundary value types for the CGKA engine,
 async-trait.workspace = true
 thiserror.workspace = true
 serde = { workspace = true }
+serde_bytes.workspace = true
 serde_json.workspace = true
 hex.workspace = true
 url.workspace = true

--- a/crates/traits/src/group.rs
+++ b/crates/traits/src/group.rs
@@ -130,5 +130,6 @@ pub struct DisbandTombstone {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Member {
     pub id: MemberId,
+    #[serde(with = "serde_bytes")]
     pub credential: Vec<u8>,
 }

--- a/crates/traits/src/types.rs
+++ b/crates/traits/src/types.rs
@@ -11,8 +11,11 @@ use std::fmt;
 macro_rules! byte_id {
     ($(#[$meta:meta])* $name:ident) => {
         $(#[$meta])*
+        // `serde_bytes` lets binary formats carry the id as one byte string
+        // instead of an element-per-byte sequence; serde_json still writes
+        // and reads the same integer array either way.
         #[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-        pub struct $name(Vec<u8>);
+        pub struct $name(#[serde(with = "serde_bytes")] Vec<u8>);
 
         impl $name {
             pub fn new(bytes: impl Into<Vec<u8>>) -> Self {
@@ -91,4 +94,19 @@ impl fmt::Display for EpochId {
 pub enum Backend {
     /// SQLCipher-backed SQLite persistence. See `storage-sqlite`.
     Sqlite,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MemberId;
+
+    /// JSON rows written before the ids carried `serde_bytes` are integer
+    /// arrays; the attribute must keep reading and writing that form.
+    #[test]
+    fn byte_id_json_form_is_an_integer_array() {
+        let id = MemberId::new(vec![0, 7, 255]);
+        let json = serde_json::to_string(&id).unwrap();
+        assert_eq!(json, "[0,7,255]");
+        assert_eq!(serde_json::from_str::<MemberId>(&json).unwrap(), id);
+    }
 }


### PR DESCRIPTION
### Summary

The id newtypes and `Member::credential` serialize as byte strings in binary formats.

### Context

They are `Vec<u8>` with derived serde impls, so every format sees a sequence and decodes it one element at a time. In the MessagePack group record that per-element decode was over half of a record read at 64 members.

### What changed

The fields carry `serde_bytes`. serde_json writes and reads the same integer array as before, so JSON rows, vectors, and fixtures are unaffected; a test pins that form. MessagePack rows already written with integer arrays decode through the byte-buffer visitor's sequence path, also under test. `serde_bytes` is a single-purpose crate from the serde author with no dependencies beyond serde.

### Impact

Warm app-message send on top of the single gate read: 64 members 407 to 342 µs. Inbound 64-member app message 280 to 251 µs.
