### PR TITLE
Add offline catch-up pressure scenario family

### DIFF
--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -108,6 +108,11 @@ Git commit; require a clean build and retain the exact source revision plus comm
     are ordered by execution cost because campaign selection is prefix-only; race arms must retain at least two active
     committers, and bounded decryptability probes must preserve late-join/re-add and roster-tail representatives.
 
+- **Module:** `src/offline_catchup_family.rs`
+  - **Role:** Replay-stable retained-relay backlog catalog. Keeps a founding member offline until the terminal phase,
+    scales application and commit volume independently, varies relay order/duplication and recovery shape, and requires
+    exact payload multiplicity, canonical equality, input closure, and post-recovery decryptability.
+
 - **Module:** `src/stateful_generator.rs`
   - **Role:** Legality-aware product journey generation into canonical Scenario IR v3. Tracks membership, admins,
     connectivity, profile, epoch, and application delivery; alternates late-membership engine cases with founding-member

--- a/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
+++ b/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
@@ -261,6 +261,20 @@ late-join/re-add and roster-tail representatives. The ordinary lane executes 10-
 incremental-join canaries. The suite compiles all 54 catalog shapes but does not execute large/xlarge cases in the
 normal PR path.
 
+### `generate_offline_catchup_pressure_family(seed, cases)`
+
+Generates a replay-stable retained-relay catalog for large terminal catch-up. Bob is a founding member, goes offline
+before workload generation, and reconnects only after every application and state commit has been retained. Four
+cost-ordered volume blocks contain 24/96/384/1,024 application messages and 4/8/12/16 commit rounds. Six arms cover
+natural and reverse history, duplicate replay, incremental plus full repair, restart after sync but before processing,
+and competing commit waves.
+
+`tests/offline_catchup_family.rs` pins same-seed determinism, different-seed variation, prefix stability, registration,
+profile provenance, every volume/recovery arm, terminal-only reconnect, the pre-catch-up zero-delivery boundary, the
+post-catch-up exact-one boundary, full Bob payload multiplicity, exact canonical equivalence, no pending work, active
+decryptability, and encrypted file-backed natural/duplicate canaries. The ordinary test lane executes only two
+24-message cases; larger blocks belong in isolated manual or scheduled campaigns.
+
 ### `cross-route-restart-permutations/v1`
 
 This bounded current-build catalog adds one reviewed durable reopen to the shared four-party cross-route scenario.

--- a/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
+++ b/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
@@ -266,14 +266,15 @@ normal PR path.
 Generates a replay-stable retained-relay catalog for large terminal catch-up. Bob is a founding member, goes offline
 before workload generation, and reconnects only after every application and state commit has been retained. Four
 cost-ordered volume blocks contain 24/96/384/1,024 application messages and 4/8/12/16 commit rounds. Six arms cover
-natural and reverse history, duplicate replay, incremental plus full repair, restart after sync but before processing,
-and competing commit waves.
+natural and reverse history, reverse three-copy replay, natural two-copy incremental plus full repair, reverse two-copy
+restart after sync but before processing, and reverse three-copy competing commit waves.
 
 `tests/offline_catchup_family.rs` pins same-seed determinism, different-seed variation, prefix stability, registration,
-profile provenance, every volume/recovery arm, terminal-only reconnect, the pre-catch-up zero-delivery boundary, the
-post-catch-up exact-one boundary, full Bob payload multiplicity, exact canonical equivalence, no pending work, active
-decryptability, and encrypted file-backed natural/duplicate canaries. The ordinary test lane executes only two
-24-message cases; larger blocks belong in isolated manual or scheduled campaigns.
+profile provenance (including exact distinct-committer and retained-copy counts), every volume/recovery arm,
+terminal-only reconnect, the pre-catch-up zero-delivery boundary, the post-catch-up exact-one boundary, full Bob payload
+multiplicity, exact canonical equivalence, no pending work, active decryptability, and encrypted file-backed
+natural/duplicate canaries. The ordinary test lane executes only two 24-message cases; larger blocks belong in isolated
+manual or scheduled campaigns.
 
 ### `cross-route-restart-permutations/v1`
 

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -472,11 +472,19 @@ for every surviving member and also require global quiescence.
 `generate_offline_catchup_pressure_family(seed, cases)` specializes the production symptom where a founding member is
 offline for nearly the complete scenario and then processes a large retained-relay history at the end. Cost-ordered
 blocks contain 24, 96, 384, and 1,024 application messages interleaved with epoch commits. Six arms vary natural versus
-reverse history, duplicate replay, incremental plus full repair, restart before backlog processing, and competing
-commit waves. Terminal expectations require Bob's exact payload multiset, exact canonical equality, no pending work,
-and an active decryptability probe after recovery.
+reverse history, reverse three-copy replay, natural two-copy incremental plus full repair, reverse two-copy restart
+before backlog processing, and reverse three-copy competing commit waves. Terminal expectations require Bob's exact
+payload multiset, exact canonical equality, no pending work, and an active decryptability probe after recovery.
 
-Run the family directly:
+Run a stateful chat journey directly:
+
+```sh
+cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report -- \
+  --family chat-journey/v1 --seed 42 --cases 10 \
+  --out target/chat-journey-reports --storage file --strict-oracle
+```
+
+Run the offline catch-up family directly:
 
 ```sh
 cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report -- \

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -469,12 +469,28 @@ Terminal expectations pin the modeled epoch, roster size, profile, admin set, pe
 active decryptability. Membership cases scope `NoPendingWork` to founding members; retained-history cases require it
 for every surviving member and also require global quiescence.
 
+`generate_offline_catchup_pressure_family(seed, cases)` specializes the production symptom where a founding member is
+offline for nearly the complete scenario and then processes a large retained-relay history at the end. Cost-ordered
+blocks contain 24, 96, 384, and 1,024 application messages interleaved with epoch commits. Six arms vary natural versus
+reverse history, duplicate replay, incremental plus full repair, restart before backlog processing, and competing
+commit waves. Terminal expectations require Bob's exact payload multiset, exact canonical equality, no pending work,
+and an active decryptability probe after recovery.
+
 Run the family directly:
 
 ```sh
 cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report -- \
-  --family chat-journey/v1 --seed 42 --cases 10 \
-  --out target/chat-journey-reports --storage file --strict-oracle
+  --family offline-catchup-pressure/v1 --seed 42 --cases 18 \
+  --out target/offline-catchup-reports --storage file --strict-oracle
+```
+
+For isolated high-volume catch-up discovery:
+
+```sh
+cargo run -p cgka-conformance-simulator --bin cgka-conformance-campaign --locked -- \
+  --family offline-catchup-pressure/v1 --seed 42 --cases 18 \
+  --case-timeout-secs 300 --storage file \
+  --out target/offline-catchup-seed-42
 ```
 
 Send/leave and convergence-chaos reliability cases finish with a global transport/mailbox drain, an exact observation,

--- a/crates/cgka-conformance-simulator/RUNNING_CAMPAIGNS.md
+++ b/crates/cgka-conformance-simulator/RUNNING_CAMPAIGNS.md
@@ -147,10 +147,11 @@ generator tests already compile all 54 shapes without running the expensive larg
 
 For `offline-catchup-pressure/v1`, six consecutive cases form one volume block: 24, 96, 384, then 1,024 application
 messages, interleaved with 4, 8, 12, then 16 commit rounds. Each block covers natural full history, reverse history,
-reverse history with three copies, incremental followed by full repair, restart after sync but before processing, and
-reverse/duplicated history containing competing commit waves. Cases `0..5` are the smoke block, `0..11` run through
-96 messages, `0..17` through 384, and `0..23` complete the 1,024-message catalog. Every case uses the retained-relay
-subject and keeps Bob offline until the final catch-up phase. Use the isolated file-backed runner for volume campaigns:
+reverse history with three copies, natural two-copy incremental followed by full repair, reverse two-copy restart after
+sync but before processing, and reverse three-copy history containing competing commit waves. Cases `0..5` are the
+smoke block, `0..11` run through 96 messages, `0..17` through 384, and `0..23` complete the 1,024-message catalog. Every
+case uses the retained-relay subject and keeps Bob offline until the final catch-up phase. Use the isolated file-backed
+runner for volume campaigns:
 
 ```sh
 cargo run -p cgka-conformance-simulator --bin cgka-conformance-campaign --locked -- \

--- a/crates/cgka-conformance-simulator/RUNNING_CAMPAIGNS.md
+++ b/crates/cgka-conformance-simulator/RUNNING_CAMPAIGNS.md
@@ -128,6 +128,7 @@ one case cannot erase the remaining cases, and the summary contains real child-p
 | `adversarial-reliability/v1` | Named real-world and resource-pressure workload catalog |
 | `bounded-convergence-pressure/v1` | Finite self-update/profile/admin pressure under a bounded quiescence contract |
 | `large-group-pressure/v1` | Explicit 10–200 member, admin-population, committer-width, traffic, growth, and churn profiles |
+| `offline-catchup-pressure/v1` | Founding member returns only after a retained 24–1,024-message backlog plus commit pressure |
 | `cross-route-restart-permutations/v1` | Twelve public app-runtime restart boundaries in the four-party route scenario |
 | `cross-route-exact-restart-permutations/v1` | Exact/private engine companion to the public restart catalog |
 | `chat-journey/v1` | Legality-aware product journeys: membership, profile, app traffic, offline/catch-up, and restart |
@@ -143,6 +144,20 @@ anchor, `--cases 36` through the 64-member anchor, and `--cases 54` only as a de
 Run `cargo test -p cgka-conformance-simulator --test large_group_family --locked` for the ordinary 10-member
 application and retained-join canaries. Prefer the isolated file-backed campaign runner for broader execution;
 generator tests already compile all 54 shapes without running the expensive large/xlarge blocks.
+
+For `offline-catchup-pressure/v1`, six consecutive cases form one volume block: 24, 96, 384, then 1,024 application
+messages, interleaved with 4, 8, 12, then 16 commit rounds. Each block covers natural full history, reverse history,
+reverse history with three copies, incremental followed by full repair, restart after sync but before processing, and
+reverse/duplicated history containing competing commit waves. Cases `0..5` are the smoke block, `0..11` run through
+96 messages, `0..17` through 384, and `0..23` complete the 1,024-message catalog. Every case uses the retained-relay
+subject and keeps Bob offline until the final catch-up phase. Use the isolated file-backed runner for volume campaigns:
+
+```sh
+cargo run -p cgka-conformance-simulator --bin cgka-conformance-campaign --locked -- \
+  --family offline-catchup-pressure/v1 --seed 42 --cases 18 \
+  --case-timeout-secs 300 --storage file \
+  --out target/convergence-manual/offline-catchup-seed-42
+```
 
 ## Running vectors and adapter comparisons
 

--- a/crates/cgka-conformance-simulator/SCALING_CAMPAIGNS.md
+++ b/crates/cgka-conformance-simulator/SCALING_CAMPAIGNS.md
@@ -172,8 +172,8 @@ it enforces a named motif, has a distinct subject or budget, or needs a focused 
 
 High-value motifs that should drive future profiles include:
 
-- an offline founding member returning to a large application/commit backlog while group profile and membership
-  change;
+- an offline founding member returning to a large application/commit backlog while group state changes (implemented
+  as the retained-relay `offline-catchup-pressure/v1` family; membership-changing extensions remain future work);
 - sustained application traffic interspersed with proposals, commits, administrator handoff, removals, and re-adds;
 - bounded self-update pressure racing administrator/profile commits, with explicit input closure;
 - restart after publication acceptance, ingest, freeze, selection, application, confirmation, rollback, or retained

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -892,11 +892,14 @@ cost-ordered six-arm blocks contain 24/96/384/1,024 application messages interle
 The competing-wave arm publishes two same-epoch group-state commits per round.
 
 Each block covers natural full-history recovery, reverse full history, reverse history with three returned copies,
-incremental followed by full repair, restart after history sync but before processing, and reverse/duplicated competing
-commit waves. A pre-reconnect assertion proves Bob has not received the first backlog payload; the terminal phase
-requires the last payload exactly once, the complete backlog payload multiset exactly once, exact canonical equality,
-no pending work, and active bidirectional decryptability involving Bob. The family always selects the retained-relay
-subject so reconnect means a durable history query rather than healing an in-memory packet partition.
+natural two-copy incremental followed by full repair, reverse two-copy restart after history sync but before
+processing, and reverse three-copy competing commit waves. A pre-reconnect assertion proves Bob has not received the
+first backlog payload; the terminal phase requires the last payload exactly once, the complete backlog payload multiset
+exactly once, exact canonical equality, no pending work, and active bidirectional decryptability involving Bob. The
+family always selects the retained-relay subject so reconnect means a durable history query rather than healing an
+in-memory packet partition.
+
+### General Simulator Integrity Checks
 
 These tests keep the simulator machinery honest.
 

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -884,6 +884,20 @@ The app-witness “multi-parent” sentinel means one MLS commit consuming multi
 atomically. MLS still has exactly one prior group-state parent; the campaign does not claim that incompatible MLS state
 branches can be merged.
 
+### Offline Catch-up Pressure Catalog
+
+`offline-catchup-pressure/v1` (generator version `1`, workload-profile version `1`) keeps Bob, a founding group member,
+offline until the terminal phase while Alice, Carol, and David publish a retained application/commit backlog. Four
+cost-ordered six-arm blocks contain 24/96/384/1,024 application messages interleaved with 4/8/12/16 commit rounds.
+The competing-wave arm publishes two same-epoch group-state commits per round.
+
+Each block covers natural full-history recovery, reverse full history, reverse history with three returned copies,
+incremental followed by full repair, restart after history sync but before processing, and reverse/duplicated competing
+commit waves. A pre-reconnect assertion proves Bob has not received the first backlog payload; the terminal phase
+requires the last payload exactly once, the complete backlog payload multiset exactly once, exact canonical equality,
+no pending work, and active bidirectional decryptability involving Bob. The family always selects the retained-relay
+subject so reconnect means a durable history query rather than healing an in-memory packet partition.
+
 These tests keep the simulator machinery honest.
 
 - `canonical_vector_fixtures_match_generated_traces` checks that every top-level JSON scenario vector still matches its

--- a/crates/cgka-conformance-simulator/src/bin/cgka-conformance-campaign.rs
+++ b/crates/cgka-conformance-simulator/src/bin/cgka-conformance-campaign.rs
@@ -619,6 +619,9 @@ mod tests {
             "convergence-chaos/v1",
             "admin-churn/v1",
             "adversarial-reliability/v1",
+            "bounded-convergence-pressure/v1",
+            "large-group-pressure/v1",
+            "offline-catchup-pressure/v1",
             "cross-route-exact-restart-permutations/v1",
             "cross-route-restart-permutations/v1",
             "chat-journey/v1",
@@ -637,6 +640,15 @@ mod tests {
                 "admin-churn/v1" => cgka_conformance_simulator::generate_admin_churn_family(42, 4),
                 "adversarial-reliability/v1" => {
                     cgka_conformance_simulator::generate_adversarial_reliability_family(42, 4)
+                }
+                "bounded-convergence-pressure/v1" => {
+                    cgka_conformance_simulator::generate_bounded_convergence_pressure_family(42, 4)
+                }
+                "large-group-pressure/v1" => {
+                    cgka_conformance_simulator::generate_large_group_pressure_family(42, 4)
+                }
+                "offline-catchup-pressure/v1" => {
+                    cgka_conformance_simulator::generate_offline_catchup_pressure_family(42, 4)
                 }
                 "cross-route-exact-restart-permutations/v1" => {
                     cgka_conformance_simulator::generate_cross_route_exact_restart_permutation_family(

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -172,6 +172,9 @@ pub fn generate_family_case(
         crate::LARGE_GROUP_PRESSURE_FAMILY => {
             crate::generate_large_group_pressure_case(seed, case_index)
         }
+        crate::OFFLINE_CATCHUP_PRESSURE_FAMILY => {
+            crate::generate_offline_catchup_pressure_case(seed, case_index)
+        }
         "cross-route-restart-permutations/v1" => {
             generate_cross_route_restart_permutation_case(seed, case_index)
         }
@@ -3578,7 +3581,7 @@ fn confirmed(step_index: usize, client: &str, pending: &str) -> TraceExpectation
 /// functions of the case, so these expectations are delivery-schedule
 /// invariant, and they give the strict oracle its `CreateGroup` /
 /// `PublishConfirm` stimulus coverage without hand-maintained step indices.
-fn push_labelled_confirmation_expectations(
+pub(crate) fn push_labelled_confirmation_expectations(
     scenario: &ScenarioSpec,
     expected: &mut Vec<TraceExpectation>,
 ) {
@@ -4017,7 +4020,7 @@ fn send_leave_case(rng: &mut StdRng, case_index: u64) -> (ScenarioSpec, Vec<Trac
 /// strict black-box assertion. The extra drain is deliberate: exact state and
 /// quiescence are sampled only after every attached client has had a final
 /// chance to consume retained transport.
-fn add_strict_reliability_oracle(
+pub(crate) fn add_strict_reliability_oracle(
     scenario: &mut ScenarioSpec,
     expected: &mut Vec<TraceExpectation>,
 ) {

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -33,6 +33,7 @@ mod large_group_family;
 pub mod lifecycle_model;
 pub mod mutation_adequacy;
 pub mod node_protocol;
+mod offline_catchup_family;
 pub mod oracle;
 mod pending_work;
 pub mod policy_cases;
@@ -121,6 +122,11 @@ pub use large_group_family::{
     LARGE_GROUP_PRESSURE_FAMILY, LARGE_GROUP_PRESSURE_GENERATOR_VERSION,
     LARGE_GROUP_PRESSURE_PROFILE_VERSION, generate_large_group_pressure_case,
     generate_large_group_pressure_family,
+};
+pub use offline_catchup_family::{
+    OFFLINE_CATCHUP_PRESSURE_FAMILY, OFFLINE_CATCHUP_PRESSURE_GENERATOR_VERSION,
+    OFFLINE_CATCHUP_PRESSURE_PROFILE_VERSION, generate_offline_catchup_pressure_case,
+    generate_offline_catchup_pressure_family,
 };
 pub use oracle::{
     BehaviorEvidenceSummary, CoverageMatrixEntry, OracleBehavior, OracleCoverageWarning,

--- a/crates/cgka-conformance-simulator/src/offline_catchup_family.rs
+++ b/crates/cgka-conformance-simulator/src/offline_catchup_family.rs
@@ -16,8 +16,11 @@ use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use rand::{Rng, SeedableRng};
 
+/// Stable family identifier recorded in generated inputs and reports.
 pub const OFFLINE_CATCHUP_PRESSURE_FAMILY: &str = "offline-catchup-pressure/v1";
+/// Generator revision for replaying an exact seeded case.
 pub const OFFLINE_CATCHUP_PRESSURE_GENERATOR_VERSION: &str = "1";
+/// Workload-profile schema revision emitted by this family.
 pub const OFFLINE_CATCHUP_PRESSURE_PROFILE_VERSION: &str = "1";
 
 const ARM_COUNT: u64 = 6;
@@ -72,6 +75,7 @@ enum CatchupArm {
 }
 
 impl CatchupArm {
+    /// Maps consecutive case indices onto the six recovery shapes.
     fn from_index(case_index: u64) -> Self {
         match case_index % ARM_COUNT {
             0 => Self::NaturalFullHistory,
@@ -83,6 +87,7 @@ impl CatchupArm {
         }
     }
 
+    /// Returns the replay-stable arm label used in scenario metadata.
     fn name(self) -> &'static str {
         match self {
             Self::NaturalFullHistory => "natural-full-history",
@@ -94,6 +99,7 @@ impl CatchupArm {
         }
     }
 
+    /// Selects the retained-relay ordering applied during catch-up.
     fn relay_order(self) -> ScenarioRelayOrderV2 {
         match self {
             Self::NaturalFullHistory | Self::IncrementalThenFull => ScenarioRelayOrderV2::Natural,
@@ -101,6 +107,7 @@ impl CatchupArm {
         }
     }
 
+    /// Returns how many copies of each matching retained event a query returns.
     fn duplicate_copies(self) -> usize {
         match self {
             Self::ReverseDuplicateHistory | Self::CompetingCommitWaves => 3,
@@ -109,15 +116,13 @@ impl CatchupArm {
         }
     }
 
-    fn active_committer_count(self) -> usize {
-        if self == Self::CompetingCommitWaves {
-            2
-        } else {
-            3
-        }
+    /// Names the recovery shape and exact retained-event multiplicity.
+    fn disruption(self) -> String {
+        format!("{}/copies-{}", self.name(), self.duplicate_copies())
     }
 }
 
+/// Generates a stable prefix of offline catch-up pressure cases.
 pub fn generate_offline_catchup_pressure_family(
     seed: u64,
     cases: usize,
@@ -127,6 +132,7 @@ pub fn generate_offline_catchup_pressure_family(
         .collect()
 }
 
+/// Generates one replay-stable offline catch-up pressure case.
 pub fn generate_offline_catchup_pressure_case(seed: u64, case_index: u64) -> GeneratedScenarioCase {
     let mut rng = StdRng::seed_from_u64(seed ^ 0x0FF1_1ECA_7C4D_0001 ^ case_index.rotate_left(29));
     let arm = CatchupArm::from_index(case_index);
@@ -162,6 +168,7 @@ pub fn generate_offline_catchup_pressure_case(seed: u64, case_index: u64) -> Gen
     let mut remaining_messages = volume.application_messages;
     let mut message_index = 0_usize;
     let mut workload_commit_count = 0_usize;
+    let mut active_committers = std::collections::BTreeSet::new();
     let active_senders = ["alice", "carol", "david"];
 
     for round in 0..volume.commit_rounds {
@@ -188,6 +195,7 @@ pub fn generate_offline_catchup_pressure_case(seed: u64, case_index: u64) -> Gen
             1
         };
         for (branch, committer) in committers.iter().take(commits_this_round).enumerate() {
+            active_committers.insert(*committer);
             let pending = format!("state-{round}-{branch}");
             steps.push(ScenarioStep::UpdateGroupData {
                 client: (*committer).into(),
@@ -314,11 +322,11 @@ pub fn generate_offline_catchup_pressure_case(seed: u64, case_index: u64) -> Gen
             initial_admin_count: clients.len(),
             final_admin_count: clients.len(),
             committer_mode: if arm == CatchupArm::CompetingCommitWaves {
-                "rival-2".into()
+                "rival-pair-per-round".into()
             } else {
                 "rotating-sequential".into()
             },
-            active_committer_count: arm.active_committer_count(),
+            active_committer_count: active_committers.len(),
             traffic_profile: format!(
                 "offline-backlog-{}-applications",
                 volume.application_messages
@@ -326,7 +334,7 @@ pub fn generate_offline_catchup_pressure_case(seed: u64, case_index: u64) -> Gen
             application_message_count: volume.application_messages,
             workload_commit_count,
             formation: "founding-member-before-offline".into(),
-            disruption: arm.name().into(),
+            disruption: arm.disruption(),
         }),
         subject: GeneratedSubjectKind::RetainedRelay,
         scenario,
@@ -334,6 +342,7 @@ pub fn generate_offline_catchup_pressure_case(seed: u64, case_index: u64) -> Gen
     }
 }
 
+/// Appends one retained-history query followed by a processing tick.
 fn sync_and_tick(steps: &mut Vec<ScenarioStep>, sync: ScenarioRelaySyncModeV2) {
     steps.push(ScenarioStep::SyncRelayHistory {
         clients: vec![OFFLINE_CLIENT.into()],
@@ -344,6 +353,7 @@ fn sync_and_tick(steps: &mut Vec<ScenarioStep>, sync: ScenarioRelaySyncModeV2) {
     });
 }
 
+/// Builds an accepted acknowledgement for one named publication.
 fn accepted_publication(client: &str, publication: &str) -> ScenarioStep {
     ScenarioStep::AcknowledgeOutbound {
         client: client.into(),
@@ -353,6 +363,7 @@ fn accepted_publication(client: &str, publication: &str) -> ScenarioStep {
     }
 }
 
+/// Builds an accepted acknowledgement for every pending outbound artifact.
 fn accept_all_outbound(client: &str) -> ScenarioStep {
     ScenarioStep::AcknowledgeOutbound {
         client: client.into(),
@@ -362,6 +373,7 @@ fn accept_all_outbound(client: &str) -> ScenarioStep {
     }
 }
 
+/// Builds the explicit four-client, retain-all relay topology used by the family.
 fn retained_relay_topology(clients: &[String]) -> ScenarioTopologyV2 {
     ScenarioTopologyV2 {
         accounts: clients
@@ -398,6 +410,7 @@ fn retained_relay_topology(clients: &[String]) -> ScenarioTopologyV2 {
     }
 }
 
+/// Converts a fixed array of labels into owned scenario strings.
 fn labels<const N: usize>(items: [&str; N]) -> Vec<String> {
     items.into_iter().map(String::from).collect()
 }

--- a/crates/cgka-conformance-simulator/src/offline_catchup_family.rs
+++ b/crates/cgka-conformance-simulator/src/offline_catchup_family.rs
@@ -1,0 +1,403 @@
+//! Deterministic high-volume retained-history catch-up workloads.
+//!
+//! Every case makes a founding member offline before the workload, retains the
+//! complete event stream in a relay, and reconnects that member only in the
+//! terminal phase. Volume, commit pressure, relay ordering/duplication, and
+//! recovery shape are explicit replay metadata.
+
+use crate::family::{add_strict_reliability_oracle, push_labelled_confirmation_expectations};
+use crate::{
+    GeneratedScenarioCase, GeneratedSubjectKind, GeneratedWorkloadProfileV1, ScenarioAccountV2,
+    ScenarioAssertionV2, ScenarioDeviceV2, ScenarioOutboundSelection, ScenarioPredicateV2,
+    ScenarioProcessV2, ScenarioRelayOrderV2, ScenarioRelaySyncModeV2, ScenarioRelayV2,
+    ScenarioSpec, ScenarioStep, ScenarioTopologyV2, SubjectOutboundOutcome, TraceExpectation,
+};
+use rand::rngs::StdRng;
+use rand::seq::SliceRandom;
+use rand::{Rng, SeedableRng};
+
+pub const OFFLINE_CATCHUP_PRESSURE_FAMILY: &str = "offline-catchup-pressure/v1";
+pub const OFFLINE_CATCHUP_PRESSURE_GENERATOR_VERSION: &str = "1";
+pub const OFFLINE_CATCHUP_PRESSURE_PROFILE_VERSION: &str = "1";
+
+const ARM_COUNT: u64 = 6;
+const OFFLINE_CLIENT: &str = "bob";
+const RELAY_ID: &str = "relay:offline-catchup";
+
+#[derive(Clone, Copy)]
+struct VolumeProfile {
+    name: &'static str,
+    tier: &'static str,
+    application_messages: usize,
+    commit_rounds: usize,
+}
+
+// Prefix selection stays useful: ordinary tests execute the first block,
+// while manual campaigns opt into the larger retained histories deliberately.
+const VOLUME_PROFILES: [VolumeProfile; 4] = [
+    VolumeProfile {
+        name: "smoke-24",
+        tier: "smoke",
+        application_messages: 24,
+        commit_rounds: 4,
+    },
+    VolumeProfile {
+        name: "medium-96",
+        tier: "medium",
+        application_messages: 96,
+        commit_rounds: 8,
+    },
+    VolumeProfile {
+        name: "large-384",
+        tier: "large",
+        application_messages: 384,
+        commit_rounds: 12,
+    },
+    VolumeProfile {
+        name: "xlarge-1024",
+        tier: "xlarge",
+        application_messages: 1_024,
+        commit_rounds: 16,
+    },
+];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CatchupArm {
+    NaturalFullHistory,
+    ReverseFullHistory,
+    ReverseDuplicateHistory,
+    IncrementalThenFull,
+    RestartBeforeProcessing,
+    CompetingCommitWaves,
+}
+
+impl CatchupArm {
+    fn from_index(case_index: u64) -> Self {
+        match case_index % ARM_COUNT {
+            0 => Self::NaturalFullHistory,
+            1 => Self::ReverseFullHistory,
+            2 => Self::ReverseDuplicateHistory,
+            3 => Self::IncrementalThenFull,
+            4 => Self::RestartBeforeProcessing,
+            _ => Self::CompetingCommitWaves,
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::NaturalFullHistory => "natural-full-history",
+            Self::ReverseFullHistory => "reverse-full-history",
+            Self::ReverseDuplicateHistory => "reverse-duplicate-history",
+            Self::IncrementalThenFull => "incremental-then-full",
+            Self::RestartBeforeProcessing => "restart-before-processing",
+            Self::CompetingCommitWaves => "competing-commit-waves",
+        }
+    }
+
+    fn relay_order(self) -> ScenarioRelayOrderV2 {
+        match self {
+            Self::NaturalFullHistory | Self::IncrementalThenFull => ScenarioRelayOrderV2::Natural,
+            _ => ScenarioRelayOrderV2::Reverse,
+        }
+    }
+
+    fn duplicate_copies(self) -> usize {
+        match self {
+            Self::ReverseDuplicateHistory | Self::CompetingCommitWaves => 3,
+            Self::IncrementalThenFull | Self::RestartBeforeProcessing => 2,
+            _ => 1,
+        }
+    }
+
+    fn active_committer_count(self) -> usize {
+        if self == Self::CompetingCommitWaves {
+            2
+        } else {
+            3
+        }
+    }
+}
+
+pub fn generate_offline_catchup_pressure_family(
+    seed: u64,
+    cases: usize,
+) -> Vec<GeneratedScenarioCase> {
+    (0..cases)
+        .map(|case_index| generate_offline_catchup_pressure_case(seed, case_index as u64))
+        .collect()
+}
+
+pub fn generate_offline_catchup_pressure_case(seed: u64, case_index: u64) -> GeneratedScenarioCase {
+    let mut rng = StdRng::seed_from_u64(seed ^ 0x0FF1_1ECA_7C4D_0001 ^ case_index.rotate_left(29));
+    let arm = CatchupArm::from_index(case_index);
+    let volume_slot = usize::try_from(case_index / ARM_COUNT).expect("case index fits usize")
+        % VOLUME_PROFILES.len();
+    let volume = VOLUME_PROFILES[volume_slot];
+    let clients = labels(["alice", OFFLINE_CLIENT, "carol", "david"]);
+    let online_clients = labels(["alice", "carol", "david"]);
+
+    let mut steps = vec![
+        ScenarioStep::CreateGroup {
+            creator: "alice".into(),
+            name: format!("offline-catchup-{case_index}"),
+            invitees: labels([OFFLINE_CLIENT, "carol", "david"]),
+            required_features: vec![],
+            initial_admins: Some(clients.clone()),
+            pending: "create".into(),
+        },
+        accepted_publication("alice", "create"),
+        ScenarioStep::DeliverAll,
+        ScenarioStep::Tick {
+            clients: labels([OFFLINE_CLIENT, "carol", "david"]),
+        },
+        ScenarioStep::ClearEvents {
+            clients: clients.clone(),
+        },
+        ScenarioStep::SetClientOffline {
+            client: OFFLINE_CLIENT.into(),
+        },
+    ];
+
+    let mut bob_payloads = Vec::with_capacity(volume.application_messages + 2);
+    let mut remaining_messages = volume.application_messages;
+    let mut message_index = 0_usize;
+    let mut workload_commit_count = 0_usize;
+    let active_senders = ["alice", "carol", "david"];
+
+    for round in 0..volume.commit_rounds {
+        let rounds_left = volume.commit_rounds - round;
+        let messages_this_round = remaining_messages.div_ceil(rounds_left);
+        for _ in 0..messages_this_round {
+            let sender = active_senders[rng.gen_range(0..active_senders.len())];
+            let payload = format!("offline-catchup:{case_index}:{message_index}:{sender}");
+            bob_payloads.push(payload.clone());
+            steps.push(ScenarioStep::SendAppMessage {
+                sender: sender.into(),
+                payload,
+            });
+            steps.push(accept_all_outbound(sender));
+            message_index += 1;
+        }
+        remaining_messages -= messages_this_round;
+
+        let mut committers = active_senders;
+        committers.shuffle(&mut rng);
+        let commits_this_round = if arm == CatchupArm::CompetingCommitWaves {
+            2
+        } else {
+            1
+        };
+        for (branch, committer) in committers.iter().take(commits_this_round).enumerate() {
+            let pending = format!("state-{round}-{branch}");
+            steps.push(ScenarioStep::UpdateGroupData {
+                client: (*committer).into(),
+                name: format!("offline-catchup-{case_index}-round-{round}-branch-{branch}"),
+                pending: pending.clone(),
+            });
+            steps.push(accepted_publication(committer, &pending));
+            workload_commit_count += 1;
+        }
+        steps.push(ScenarioStep::DeliverAll);
+        steps.push(ScenarioStep::Tick {
+            clients: online_clients.clone(),
+        });
+    }
+    debug_assert_eq!(message_index, volume.application_messages);
+    debug_assert_eq!(remaining_messages, 0);
+
+    let first_payload = bob_payloads.first().expect("non-empty workload").clone();
+    steps.push(ScenarioStep::Assert {
+        assertion: ScenarioAssertionV2::Exactly {
+            predicate: ScenarioPredicateV2::PayloadCount {
+                client: OFFLINE_CLIENT.into(),
+                payload: first_payload,
+                count: 0,
+            },
+        },
+    });
+
+    if arm.relay_order() != ScenarioRelayOrderV2::Natural || arm.duplicate_copies() != 1 {
+        steps.push(ScenarioStep::ConfigureRelay {
+            relay: RELAY_ID.into(),
+            order: arm.relay_order(),
+            duplicate_copies: arm.duplicate_copies(),
+        });
+    }
+    steps.push(ScenarioStep::ReconnectClient {
+        client: OFFLINE_CLIENT.into(),
+    });
+    match arm {
+        CatchupArm::IncrementalThenFull => {
+            sync_and_tick(&mut steps, ScenarioRelaySyncModeV2::Incremental);
+            sync_and_tick(&mut steps, ScenarioRelaySyncModeV2::FullHistory);
+        }
+        CatchupArm::RestartBeforeProcessing => {
+            steps.push(ScenarioStep::SyncRelayHistory {
+                clients: vec![OFFLINE_CLIENT.into()],
+                sync: ScenarioRelaySyncModeV2::Incremental,
+            });
+            steps.push(ScenarioStep::RestartClient {
+                client: OFFLINE_CLIENT.into(),
+            });
+            sync_and_tick(&mut steps, ScenarioRelaySyncModeV2::FullHistory);
+        }
+        _ => sync_and_tick(&mut steps, ScenarioRelaySyncModeV2::FullHistory),
+    }
+
+    let last_payload = bob_payloads.last().expect("non-empty workload").clone();
+    steps.push(ScenarioStep::Assert {
+        // One catch-up tick starts processing, but the deliberately bounded
+        // engine may need several scheduler turns to drain a large retained
+        // history. Keep the exact-one predicate while granting a deterministic
+        // number of progress turns before declaring the client stuck.
+        assertion: ScenarioAssertionV2::Eventually {
+            predicate: ScenarioPredicateV2::PayloadCount {
+                client: OFFLINE_CLIENT.into(),
+                payload: last_payload,
+                count: 1,
+            },
+            max_iterations: 128,
+        },
+    });
+
+    let probe_clients = labels(["alice", OFFLINE_CLIENT, "carol"]);
+    let probe_step_index = steps.len();
+    steps.push(ScenarioStep::ProbeBidirectionalDecryptability {
+        clients: probe_clients.clone(),
+    });
+    bob_payloads.extend(
+        probe_clients
+            .iter()
+            .filter(|sender| sender.as_str() != OFFLINE_CLIENT)
+            .map(|sender| format!("cgka-decryptability-probe/v1/{probe_step_index}/{sender}")),
+    );
+
+    let mut scenario = ScenarioSpec {
+        name: format!(
+            "{OFFLINE_CATCHUP_PRESSURE_FAMILY}/case-{case_index}/{}/{}",
+            volume.name,
+            arm.name()
+        ),
+        spec_version: "2".into(),
+        clients: clients.clone(),
+        topology: retained_relay_topology(&clients),
+        steps,
+    };
+    let mut expected_outcomes = vec![
+        TraceExpectation::ClientsConverged {
+            clients: clients.clone(),
+            epoch: None,
+            member_count: Some(clients.len()),
+        },
+        TraceExpectation::ApplicationPayloadMultiset {
+            client: OFFLINE_CLIENT.into(),
+            payloads: bob_payloads,
+        },
+        TraceExpectation::ClientsBidirectionallyDecryptable {
+            clients: probe_clients,
+        },
+    ];
+    push_labelled_confirmation_expectations(&scenario, &mut expected_outcomes);
+    add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
+
+    GeneratedScenarioCase {
+        family_name: OFFLINE_CATCHUP_PRESSURE_FAMILY.into(),
+        generator_version: OFFLINE_CATCHUP_PRESSURE_GENERATOR_VERSION.into(),
+        seed,
+        case_index,
+        workload_profile: Some(GeneratedWorkloadProfileV1 {
+            name: format!("{}/{}", volume.name, arm.name()),
+            version: OFFLINE_CATCHUP_PRESSURE_PROFILE_VERSION.into(),
+            size_tier: volume.tier.into(),
+            member_count: clients.len(),
+            admin_regime: "all-members".into(),
+            initial_admin_count: clients.len(),
+            final_admin_count: clients.len(),
+            committer_mode: if arm == CatchupArm::CompetingCommitWaves {
+                "rival-2".into()
+            } else {
+                "rotating-sequential".into()
+            },
+            active_committer_count: arm.active_committer_count(),
+            traffic_profile: format!(
+                "offline-backlog-{}-applications",
+                volume.application_messages
+            ),
+            application_message_count: volume.application_messages,
+            workload_commit_count,
+            formation: "founding-member-before-offline".into(),
+            disruption: arm.name().into(),
+        }),
+        subject: GeneratedSubjectKind::RetainedRelay,
+        scenario,
+        expected_outcomes,
+    }
+}
+
+fn sync_and_tick(steps: &mut Vec<ScenarioStep>, sync: ScenarioRelaySyncModeV2) {
+    steps.push(ScenarioStep::SyncRelayHistory {
+        clients: vec![OFFLINE_CLIENT.into()],
+        sync,
+    });
+    steps.push(ScenarioStep::Tick {
+        clients: vec![OFFLINE_CLIENT.into()],
+    });
+}
+
+fn accepted_publication(client: &str, publication: &str) -> ScenarioStep {
+    ScenarioStep::AcknowledgeOutbound {
+        client: client.into(),
+        publication: Some(publication.into()),
+        selection: ScenarioOutboundSelection::All,
+        outcome: SubjectOutboundOutcome::Accepted,
+    }
+}
+
+fn accept_all_outbound(client: &str) -> ScenarioStep {
+    ScenarioStep::AcknowledgeOutbound {
+        client: client.into(),
+        publication: None,
+        selection: ScenarioOutboundSelection::All,
+        outcome: SubjectOutboundOutcome::Accepted,
+    }
+}
+
+fn retained_relay_topology(clients: &[String]) -> ScenarioTopologyV2 {
+    ScenarioTopologyV2 {
+        accounts: clients
+            .iter()
+            .map(|client| ScenarioAccountV2 {
+                id: format!("account:{client}"),
+                roles: vec!["member".into()],
+            })
+            .collect(),
+        devices: clients
+            .iter()
+            .map(|client| ScenarioDeviceV2 {
+                id: format!("device:{client}"),
+                account: format!("account:{client}"),
+                process: format!("process:{client}"),
+                client: client.clone(),
+            })
+            .collect(),
+        processes: clients
+            .iter()
+            .map(|client| ScenarioProcessV2 {
+                id: format!("process:{client}"),
+                binary_version: "mdk-current".into(),
+                policy_version: "marmot-convergence-v1".into(),
+                relays: vec![RELAY_ID.into()],
+            })
+            .collect(),
+        groups: vec![],
+        relays: vec![ScenarioRelayV2 {
+            id: RELAY_ID.into(),
+            implementation_version: "memory/v1".into(),
+            policy_version: "retain-all/v1".into(),
+        }],
+    }
+}
+
+fn labels<const N: usize>(items: [&str; N]) -> Vec<String> {
+    items.into_iter().map(String::from).collect()
+}

--- a/crates/cgka-conformance-simulator/src/report.rs
+++ b/crates/cgka-conformance-simulator/src/report.rs
@@ -707,7 +707,7 @@ fn next_value(
 }
 
 pub fn report_usage() -> &'static str {
-    "Usage: cgka-conformance-simulator-report [--replay-capsule FILE | --generated-input FILE ... [--adapter engine|retained-relay|app-runtime] | --vectors FILE_OR_DIR ... | --family send-leave/v1|convergence-e2e-delivery/v1|convergence-chaos/v1|admin-churn/v1|adversarial-reliability/v1|bounded-convergence-pressure/v1|cross-route-restart-permutations/v1|cross-route-exact-restart-permutations/v1|chat-journey/v1 --seed N --cases N] [--out DIR] [--storage memory|file] [--strict-oracle|--allow-weak-oracle] [--capture-sensitive-replay]"
+    "Usage: cgka-conformance-simulator-report [--replay-capsule FILE | --generated-input FILE ... [--adapter engine|retained-relay|app-runtime] | --vectors FILE_OR_DIR ... | --family send-leave/v1|convergence-e2e-delivery/v1|convergence-chaos/v1|admin-churn/v1|adversarial-reliability/v1|bounded-convergence-pressure/v1|large-group-pressure/v1|offline-catchup-pressure/v1|cross-route-restart-permutations/v1|cross-route-exact-restart-permutations/v1|chat-journey/v1 --seed N --cases N] [--out DIR] [--storage memory|file] [--strict-oracle|--allow-weak-oracle] [--capture-sensitive-replay]"
 }
 
 #[cfg(test)]

--- a/crates/cgka-conformance-simulator/tests/AGENTS.md
+++ b/crates/cgka-conformance-simulator/tests/AGENTS.md
@@ -37,6 +37,11 @@ determinism, reachability, interaction-coverage, and promotion checks when addin
     oracles, exact retained-join pending-work classification, sampled delivery/decryptability coverage, and the normal
     mid-size application and incremental-join executable canaries.
 
+- **File:** `offline_catchup_family.rs`
+  - **Owns:** Deterministic offline-backlog volume/recovery profiles, retained-relay enforcement, terminal-only
+    reconnect, exact backlog multiplicity, strict pending-work/equivalence/decryptability oracles, and file-backed
+    executable canaries.
+
 - **File:** `mutation_adequacy.rs`
   - **Owns:** Exact executable mutation catalog coverage, kill assertions, and drift-checking the human-readable
     verification-layer matrix.

--- a/crates/cgka-conformance-simulator/tests/offline_catchup_family.rs
+++ b/crates/cgka-conformance-simulator/tests/offline_catchup_family.rs
@@ -64,6 +64,33 @@ fn complete_catalog_covers_volume_relay_and_recovery_boundaries() {
                     .count(),
                 profile.workload_commit_count
             );
+            let distinct_committers = case
+                .scenario
+                .steps
+                .iter()
+                .filter_map(|step| match step {
+                    ScenarioStep::UpdateGroupData { client, .. } => Some(client.clone()),
+                    _ => None,
+                })
+                .collect::<BTreeSet<_>>();
+            assert_eq!(profile.active_committer_count, distinct_committers.len());
+            assert_eq!(
+                profile.committer_mode,
+                if case.case_index % 6 == 5 {
+                    "rival-pair-per-round"
+                } else {
+                    "rotating-sequential"
+                }
+            );
+            let expected_copies = [1, 1, 3, 2, 2, 3]
+                [usize::try_from(case.case_index % 6).expect("arm index fits usize")];
+            assert_eq!(
+                profile.disruption,
+                format!(
+                    "{}/copies-{expected_copies}",
+                    case.scenario.name.rsplit('/').next().unwrap()
+                )
+            );
             compile_scenario(&case.scenario)
                 .unwrap_or_else(|error| panic!("{}: {error}", case.scenario.name));
         }
@@ -93,6 +120,14 @@ fn complete_catalog_covers_volume_relay_and_recovery_boundaries() {
         )));
         assert!(block[3].scenario.steps.iter().any(|step| matches!(
             step,
+            ScenarioStep::ConfigureRelay {
+                order: ScenarioRelayOrderV2::Natural,
+                duplicate_copies: 2,
+                ..
+            }
+        )));
+        assert!(block[3].scenario.steps.iter().any(|step| matches!(
+            step,
             ScenarioStep::SyncRelayHistory {
                 sync: ScenarioRelaySyncModeV2::Incremental,
                 ..
@@ -102,6 +137,14 @@ fn complete_catalog_covers_volume_relay_and_recovery_boundaries() {
             step,
             ScenarioStep::SyncRelayHistory {
                 sync: ScenarioRelaySyncModeV2::FullHistory,
+                ..
+            }
+        )));
+        assert!(block[4].scenario.steps.iter().any(|step| matches!(
+            step,
+            ScenarioStep::ConfigureRelay {
+                order: ScenarioRelayOrderV2::Reverse,
+                duplicate_copies: 2,
                 ..
             }
         )));

--- a/crates/cgka-conformance-simulator/tests/offline_catchup_family.rs
+++ b/crates/cgka-conformance-simulator/tests/offline_catchup_family.rs
@@ -1,0 +1,289 @@
+use std::collections::BTreeSet;
+
+use cgka_conformance_simulator::{
+    GeneratedScenarioInputV1, GeneratedSubjectKind, HarnessStorageMode,
+    OFFLINE_CATCHUP_PRESSURE_FAMILY, OFFLINE_CATCHUP_PRESSURE_GENERATOR_VERSION,
+    OFFLINE_CATCHUP_PRESSURE_PROFILE_VERSION, ScenarioAssertionV2, ScenarioPredicateV2,
+    ScenarioRelayOrderV2, ScenarioRelaySyncModeV2, ScenarioStep, TraceExpectation,
+    compile_scenario, generate_family_case, generate_offline_catchup_pressure_case,
+    generate_offline_catchup_pressure_family, resolve_scenario_input_bytes,
+    run_generated_case_report_with_storage_mode,
+};
+
+const COMPLETE_PROFILE_CASES: usize = 24;
+
+#[test]
+fn offline_catchup_profiles_are_deterministic_prefix_stable_and_registered() {
+    let seed = 0x000f_f11e;
+    let short = generate_offline_catchup_pressure_family(seed, 6);
+    let long = generate_offline_catchup_pressure_family(seed, 12);
+
+    assert_eq!(short, generate_offline_catchup_pressure_family(seed, 6));
+    assert_eq!(short, long[..short.len()]);
+    assert_ne!(short, generate_offline_catchup_pressure_family(seed + 1, 6));
+    for (case_index, case) in short.iter().enumerate() {
+        assert_eq!(
+            case,
+            &generate_family_case(OFFLINE_CATCHUP_PRESSURE_FAMILY, seed, case_index as u64,)
+                .expect("offline catch-up family is registered")
+        );
+    }
+}
+
+#[test]
+fn complete_catalog_covers_volume_relay_and_recovery_boundaries() {
+    let cases = generate_offline_catchup_pressure_family(2026, COMPLETE_PROFILE_CASES);
+    let expected_volumes = [24, 96, 384, 1_024];
+
+    for (volume_slot, expected_volume) in expected_volumes.into_iter().enumerate() {
+        let block = &cases[(volume_slot * 6)..((volume_slot + 1) * 6)];
+        for case in block {
+            let profile = case.workload_profile.as_ref().expect("profile metadata");
+            assert_eq!(case.subject, GeneratedSubjectKind::RetainedRelay);
+            assert_eq!(profile.application_message_count, expected_volume);
+            assert_eq!(profile.member_count, 4);
+            assert_eq!(case.family_name, OFFLINE_CATCHUP_PRESSURE_FAMILY);
+            assert_eq!(
+                case.generator_version,
+                OFFLINE_CATCHUP_PRESSURE_GENERATOR_VERSION
+            );
+            assert_eq!(profile.version, OFFLINE_CATCHUP_PRESSURE_PROFILE_VERSION);
+            assert_eq!(
+                case.scenario
+                    .steps
+                    .iter()
+                    .filter(|step| matches!(step, ScenarioStep::SendAppMessage { .. }))
+                    .count(),
+                expected_volume
+            );
+            assert_eq!(
+                case.scenario
+                    .steps
+                    .iter()
+                    .filter(|step| matches!(step, ScenarioStep::UpdateGroupData { .. }))
+                    .count(),
+                profile.workload_commit_count
+            );
+            compile_scenario(&case.scenario)
+                .unwrap_or_else(|error| panic!("{}: {error}", case.scenario.name));
+        }
+
+        assert!(
+            !block[0]
+                .scenario
+                .steps
+                .iter()
+                .any(|step| matches!(step, ScenarioStep::ConfigureRelay { .. }))
+        );
+        assert!(block[1].scenario.steps.iter().any(|step| matches!(
+            step,
+            ScenarioStep::ConfigureRelay {
+                order: ScenarioRelayOrderV2::Reverse,
+                duplicate_copies: 1,
+                ..
+            }
+        )));
+        assert!(block[2].scenario.steps.iter().any(|step| matches!(
+            step,
+            ScenarioStep::ConfigureRelay {
+                order: ScenarioRelayOrderV2::Reverse,
+                duplicate_copies: 3,
+                ..
+            }
+        )));
+        assert!(block[3].scenario.steps.iter().any(|step| matches!(
+            step,
+            ScenarioStep::SyncRelayHistory {
+                sync: ScenarioRelaySyncModeV2::Incremental,
+                ..
+            }
+        )));
+        assert!(block[3].scenario.steps.iter().any(|step| matches!(
+            step,
+            ScenarioStep::SyncRelayHistory {
+                sync: ScenarioRelaySyncModeV2::FullHistory,
+                ..
+            }
+        )));
+        assert!(block[4].scenario.steps.iter().any(|step| matches!(
+            step,
+            ScenarioStep::RestartClient { client } if client == "bob"
+        )));
+        assert_eq!(
+            block[5]
+                .scenario
+                .steps
+                .iter()
+                .filter(|step| matches!(step, ScenarioStep::UpdateGroupData { .. }))
+                .count(),
+            block[0]
+                .scenario
+                .steps
+                .iter()
+                .filter(|step| matches!(step, ScenarioStep::UpdateGroupData { .. }))
+                .count()
+                * 2
+        );
+    }
+}
+
+#[test]
+fn every_case_keeps_bob_offline_until_the_terminal_catchup_and_has_strict_oracles() {
+    for case in generate_offline_catchup_pressure_family(7, COMPLETE_PROFILE_CASES) {
+        let offline_index = case
+            .scenario
+            .steps
+            .iter()
+            .position(|step| {
+                matches!(
+                    step,
+                    ScenarioStep::SetClientOffline { client } if client == "bob"
+                )
+            })
+            .expect("offline boundary");
+        let reconnect_index = case
+            .scenario
+            .steps
+            .iter()
+            .position(|step| {
+                matches!(
+                    step,
+                    ScenarioStep::ReconnectClient { client } if client == "bob"
+                )
+            })
+            .expect("reconnect boundary");
+        let last_workload_index = case
+            .scenario
+            .steps
+            .iter()
+            .rposition(|step| {
+                matches!(
+                    step,
+                    ScenarioStep::SendAppMessage { .. } | ScenarioStep::UpdateGroupData { .. }
+                )
+            })
+            .expect("workload action");
+        assert!(offline_index < last_workload_index);
+        assert!(last_workload_index < reconnect_index);
+        assert!(reconnect_index * 4 > case.scenario.steps.len() * 3);
+
+        assert!(
+            case.scenario.steps[..reconnect_index]
+                .iter()
+                .any(|step| matches!(
+                    step,
+                    ScenarioStep::Assert {
+                        assertion: ScenarioAssertionV2::Exactly {
+                            predicate: ScenarioPredicateV2::PayloadCount {
+                                client,
+                                count: 0,
+                                ..
+                            }
+                        }
+                    } if client == "bob"
+                ))
+        );
+        assert!(
+            case.scenario.steps[reconnect_index..]
+                .iter()
+                .any(|step| matches!(
+                    step,
+                    ScenarioStep::Assert {
+                        assertion: ScenarioAssertionV2::Eventually {
+                            predicate: ScenarioPredicateV2::PayloadCount {
+                                client,
+                                count: 1,
+                                ..
+                            },
+                            max_iterations: 128,
+                        }
+                    } if client == "bob"
+                ))
+        );
+
+        let clients = case
+            .scenario
+            .clients
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        assert!(case.expected_outcomes.iter().any(|expectation| matches!(
+            expectation,
+            TraceExpectation::ClientsExactlyEquivalent { clients: exact }
+                if exact.iter().cloned().collect::<BTreeSet<_>>() == clients
+        )));
+        assert!(case.expected_outcomes.iter().any(|expectation| matches!(
+            expectation,
+            TraceExpectation::NoPendingWork { clients: pending }
+                if pending.iter().cloned().collect::<BTreeSet<_>>() == clients
+        )));
+        assert!(case.expected_outcomes.iter().any(|expectation| matches!(
+            expectation,
+            TraceExpectation::ClientsBidirectionallyDecryptable { clients }
+                if clients.contains(&"bob".to_string())
+        )));
+        let expected_payloads = case
+            .workload_profile
+            .as_ref()
+            .expect("profile")
+            .application_message_count
+            + 2;
+        assert!(case.expected_outcomes.iter().any(|expectation| matches!(
+            expectation,
+            TraceExpectation::ApplicationPayloadMultiset { client, payloads }
+                if client == "bob" && payloads.len() == expected_payloads
+        )));
+    }
+}
+
+#[test]
+fn workload_profile_survives_generated_input_replay_provenance() {
+    let case = generate_offline_catchup_pressure_case(42, 12);
+    let bytes = serde_json::to_vec(&GeneratedScenarioInputV1::new(case.clone())).unwrap();
+    let resolved = resolve_scenario_input_bytes(&bytes).expect("generated input resolves");
+    assert_eq!(resolved.generated_case.as_ref(), Some(&case));
+    assert_eq!(
+        resolved
+            .provenance
+            .generated
+            .expect("generated provenance")
+            .workload_profile,
+        case.workload_profile
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn smoke_natural_and_duplicate_history_cases_pass_file_backed_strict_oracles() {
+    for case_index in [0, 2] {
+        let case = generate_offline_catchup_pressure_case(2026, case_index);
+        let report = run_generated_case_report_with_storage_mode(
+            &case,
+            None,
+            HarnessStorageMode::TempFileBackedSqlite,
+        )
+        .await
+        .unwrap_or_else(|error| panic!("{}: {error}", case.scenario.name));
+        assert!(
+            report.expectation_failures.is_empty(),
+            "{} expectation failures: {:#?}",
+            case.scenario.name,
+            report.expectation_failures
+        );
+        assert!(
+            report.invariant_failures.is_empty(),
+            "{} invariant failures: {:#?}",
+            case.scenario.name,
+            report.invariant_failures
+        );
+        assert!(report.relay_sync_observations.iter().any(|observation| {
+            observation.client == "bob"
+                && matches!(observation.mode, ScenarioRelaySyncModeV2::FullHistory)
+                && observation.unique_events_returned
+                    > case
+                        .workload_profile
+                        .as_ref()
+                        .expect("profile")
+                        .application_message_count
+        }));
+    }
+}


### PR DESCRIPTION
## Summary

- add `offline-catchup-pressure/v1`, a deterministic retained-relay family that keeps a founding member offline until the terminal catch-up phase
- scale the retained workload through 24, 96, 384, and 1,024 application messages interleaved with 4, 8, 12, and 16 commit rounds
- cover six recovery shapes per volume tier with explicit replay multiplicity: natural single-copy history, reverse single-copy history, reverse three-copy history, natural two-copy incremental-then-full repair, reverse two-copy restart-before-processing, and reverse three-copy competing commit waves
- require exact backlog multiplicity, canonical equality, no pending work, and active post-recovery bidirectional decryptability
- register the family with the report and isolated campaign runners and document cost-ordered campaign selection

## Test posture

The ordinary test lane compiles the complete 24-case catalog, pins the emitted distinct-committer and retained-copy profile metadata, and executes two encrypted file-backed 24-message canaries. The medium, large, and xlarge profiles remain explicit campaign work so normal PR tests do not acquire a multi-minute high-volume workload.

## Discovery results

The initial file-backed campaign ran 78 executions across seeds 9101 through 9104. It produced 46 clean completions and 32 bounded timeouts. The failures were reproduced, reduced, and filed separately:

- #1650 — exact full-history redelivery beyond the rewind horizon leaves an already-processed commit pending
- #1651 — the harness turns bounded convergence continuation into an error after eight passes
- #1652 — generated-case minimization can consume the process deadline and hide the original failure

This PR adds the discovery workload and regression surface; it does not close those defects.

## Validation

- `just fast-ci`
- `cargo test -p cgka-conformance-simulator --locked`
- `git diff --check origin/master...HEAD`

Refs #1650
Refs #1651
Refs #1652


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic offline catch-up pressure scenarios covering retained relay history, synchronization, restart recovery, duplicated or reordered history, and competing commit waves.
  * Added multiple workload sizes and recovery variants with checks for convergence, payload recovery, quiescence, and bidirectional decryption.
  * Registered the new scenario family for generation and campaign execution.

* **Documentation**
  * Added usage guidance, scenario catalogs, campaign instructions, and testing coverage documentation.

* **Tests**
  * Added comprehensive generation, boundary, sequencing, trace, provenance, and SQLite execution coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
