### PR TITLE
Fix partial directory subscription sync state

### DIFF
--- a/crates/marmot-app/src/directory/mod.rs
+++ b/crates/marmot-app/src/directory/mod.rs
@@ -23,4 +23,6 @@ pub use search::{
     OFF_GRAPH_SEARCH_RADIUS, SearchUpdateTrigger, UserSearchParams, UserSearchSubscription,
     UserSearchUpdate, sort_user_search_results,
 };
+#[cfg(test)]
+pub(crate) use sync::DirectorySyncBatch;
 pub(crate) use sync::{DirectorySyncHandle, DirectorySyncPlan};

--- a/crates/marmot-app/src/relay_plane/directory.rs
+++ b/crates/marmot-app/src/relay_plane/directory.rs
@@ -267,6 +267,48 @@ impl DirectoryRelayPlane {
         (to_add, to_remove)
     }
 
+    /// Record the validation filter immediately after its SDK subscription is
+    /// created, so a later batch failure cannot leave that live subscription
+    /// unknown to [`Self::accepts_live_event`].
+    pub(crate) async fn record_subscription_filter(
+        &self,
+        subscription_id: String,
+        filter: DirectorySubscriptionFilter,
+    ) -> bool {
+        let mut state = self.state.lock().await;
+        let created = state
+            .active_subscriptions
+            .insert(subscription_id, filter)
+            .is_none();
+        if created {
+            state.subscriptions_created += 1;
+        }
+        created
+    }
+
+    /// Complete a subscription sync whose newly created filters were already
+    /// recorded as their SDK subscriptions succeeded.
+    pub(crate) async fn complete_subscription_sync(
+        &self,
+        desired: HashMap<String, DirectorySubscriptionFilter>,
+        subscriptions_created: usize,
+    ) -> Result<DirectorySubscriptionSyncSummary, String> {
+        let mut state = self.state.lock().await;
+        let removed = state
+            .active_subscriptions
+            .keys()
+            .filter(|id| !desired.contains_key(*id))
+            .count();
+        state.completed_subscription_syncs += 1;
+        state.subscriptions_removed += removed;
+        state.active_subscriptions = desired;
+        Ok(DirectorySubscriptionSyncSummary {
+            active_subscriptions: state.active_subscriptions.len(),
+            subscriptions_created,
+            subscriptions_removed: removed,
+        })
+    }
+
     /// Replace the active directory subscriptions with the supplied
     /// `(subscription_id, filter)` plan, returning the lifecycle summary.
     ///

--- a/crates/marmot-app/src/relay_plane/mod.rs
+++ b/crates/marmot-app/src/relay_plane/mod.rs
@@ -1010,6 +1010,7 @@ impl MarmotRelayPlane {
         // into the directory cache when it matches an active subscription's
         // requested authors and kinds (mdk#709).
         let mut desired = HashMap::with_capacity(plan.batches.len());
+        let mut subscriptions_created = 0;
         for batch in &plan.batches {
             let authors = batch
                 .authors
@@ -1028,10 +1029,9 @@ impl MarmotRelayPlane {
             // Canonical lowercase hex matches the `event.pubkey` form a forwarded
             // SDK event carries, so the membership check is exact.
             let filter_authors = authors.iter().map(PublicKey::to_hex).collect::<Vec<_>>();
-            desired.insert(
-                batch.subscription_id.clone(),
-                DirectorySubscriptionFilter::new(filter_authors, batch.kinds.clone()),
-            );
+            let validation_filter =
+                DirectorySubscriptionFilter::new(filter_authors, batch.kinds.clone());
+            desired.insert(batch.subscription_id.clone(), validation_filter.clone());
             if !to_add.contains(&batch.subscription_id) {
                 continue;
             }
@@ -1052,9 +1052,18 @@ impl MarmotRelayPlane {
                 )
                 .await
                 .map_err(|err| format!("directory subscription subscribe: {err}"))?;
+            subscriptions_created += usize::from(
+                self.inner
+                    .directory
+                    .record_subscription_filter(batch.subscription_id.clone(), validation_filter)
+                    .await,
+            );
         }
 
-        self.inner.directory.replace_subscriptions(desired).await
+        self.inner
+            .directory
+            .complete_subscription_sync(desired, subscriptions_created)
+            .await
     }
 
     pub async fn shutdown(&self) {

--- a/crates/marmot-app/src/relay_plane/tests.rs
+++ b/crates/marmot-app/src/relay_plane/tests.rs
@@ -11,6 +11,7 @@ use transport_nostr_adapter::{NostrRelayEvent, NostrSubscription};
 use transport_nostr_peeler::{KIND_MARMOT_GROUP_MESSAGE, NOSTR_SOURCE, NostrPeelerError};
 
 use crate::config::{RelayTelemetryResource, RelayTelemetryRuntimeConfig};
+use crate::directory::DirectorySyncBatch;
 
 use super::*;
 
@@ -1585,6 +1586,63 @@ async fn directory_plane_with_active_subscription(
         .await
         .expect("active subscription is recorded");
     directory
+}
+
+#[tokio::test]
+async fn directory_sync_keeps_filter_for_subscription_created_before_later_error() {
+    let relay = nostr_relay_builder::MockRelay::run().await.unwrap();
+    let relay_url = relay.url().await.to_string();
+    let relay_plane = MarmotRelayPlane::full_history_with_loopback(true);
+    let author = "11".repeat(32);
+    let subscription_id = "directory_users_0_first".to_owned();
+    let plan = DirectorySyncPlan {
+        endpoints: vec![TransportEndpoint(relay_url)],
+        watched_user_count: 2,
+        batches: vec![
+            DirectorySyncBatch {
+                subscription_id: subscription_id.clone(),
+                authors: vec![author.clone()],
+                kinds: vec![0],
+                since: None,
+            },
+            DirectorySyncBatch {
+                subscription_id: "directory_users_1_invalid".to_owned(),
+                authors: vec!["not-a-public-key".to_owned()],
+                kinds: vec![0],
+                since: None,
+            },
+        ],
+    };
+
+    let err = relay_plane
+        .sync_directory_user_subscriptions(plan, false)
+        .await
+        .expect_err("the invalid later batch must fail the sync");
+    assert_eq!(err, "invalid directory author");
+
+    let sdk_subscriptions = relay_plane
+        .inner
+        .transport
+        .sdk_relay_client
+        .as_ref()
+        .unwrap()
+        .client()
+        .subscriptions()
+        .await;
+    assert!(
+        sdk_subscriptions.contains_key(&SubscriptionId::new(subscription_id.clone())),
+        "the first SDK subscription must be live before the later batch fails"
+    );
+    assert!(
+        relay_plane
+            .inner
+            .directory
+            .accepts_live_event(&subscription_id, &author, 0)
+            .await,
+        "the validation filter must be committed for every live SDK subscription"
+    );
+
+    relay_plane.shutdown().await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- record each directory validation filter as soon as its SDK subscription succeeds, so a later batch failure cannot leave live events failing the admission gate
- preserve lifecycle accounting while the final successful sync still replaces the complete desired filter map

## Test plan
- [x] New test failed before the fix and passes after
- [x] `cargo test -p marmot-app --lib relay_plane::tests::`
- [x] `just fast-ci`
- [ ] `cargo test -p marmot-app` (882 passed; 6 unrelated epoch-backfill tests failed, with an exact failure reproduced on unmodified `origin/master`)

Fixes #943


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved directory subscription synchronization so successfully created subscriptions are retained when a later batch fails validation.
  - Preserved active subscription filters during synchronization, preventing valid subscriptions from being unintentionally lost.
  - Added more accurate tracking and reporting of newly created subscriptions and synchronization results.
- **Tests**
  - Added coverage for preserving valid subscriptions and filters after subsequent synchronization errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->