### PR TITLE
docs(engine): pin why rollback withdrawals stay wide and sweep lineage stays dropped

### DIFF
--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -2029,6 +2029,20 @@ impl<S: StorageProvider> Engine<S> {
             {
                 continue;
             }
+            // Deliberately NOT gated on the commit having been applied locally.
+            // `pre_apply` reads `Created` for a rival this device buffered, the
+            // pass materialized, and branch selection put on the losing side —
+            // and that announces too. Narrowing to `Processed` would be the
+            // wrong trade in both directions. The wide signal is inert where it
+            // has nothing to retract: `origin_commit_id` is stamped only on rows
+            // synthesized from an applied commit's `GroupStateChanged`, so every
+            // consumer keyed on that id (the timeline withdrawal, the
+            // last-verdict filter in the app's `project_group_system_rows`,
+            // `mark_evolution_superseded`) matches nothing for a commit that was
+            // never applied. And the pair is the only portable statement that a
+            // NAMED commit lost selection, which is what a peer holding no branch
+            // of its own records as its share of the fleet's agreement about a
+            // fork's outcome.
             let invalidated_commit_id = message_id_from_hex(&deferred.message_id)?;
             // The stored record's epoch is the commit's source epoch (the fork
             // it lost). A missing record falls back to the selected branch's

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -2106,6 +2106,16 @@ impl<S: StorageProvider> Engine<S> {
             .ingest_group_message_from_sweep(&msg, group_id.as_slice().to_vec(), sweep)
             .await
         {
+            // Still unreadable: the row keeps its place in the retry lifecycle
+            // and the caller charges its budget. The verdict's `lineage` is
+            // dropped on purpose. There is exactly one lineage site
+            // (`Self::deferral_lineage`, reached from the single deferral return
+            // in `ingest_group_message_from_sweep`), and it answers about the
+            // GROUP's stored commit graph rather than about this row — so a
+            // sweep can only ever restate what live ingest already reported for
+            // this group, over rows the app's stall detector counted when they
+            // first arrived. Routing it out would re-count that evidence, not
+            // sharpen it.
             Ok(IngestOutcome::TransportDeferred { .. }) => Ok(false),
             Ok(IngestOutcome::ResourceRefused {
                 resource: InboundResourceLimit::TransportDeferredCapacity,

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -3656,6 +3656,17 @@ async fn convergence_pass_that_keeps_the_own_commit_emits_no_own_withdrawal() {
         local.drain_events().is_empty(),
         "buffering the rival must not be application-visible"
     );
+    // The withdrawal below names a commit this device never applied. Pinning the
+    // pre-pass state makes that deliberate: `emit_rolled_back_commits` reads the
+    // pre-apply state only to suppress a repeat announcement, never to require
+    // prior local application, so narrowing it to `Processed` would silence the
+    // pair a non-adopting peer records as its share of the fleet's agreement
+    // about which commit lost.
+    assert_eq!(
+        f.local_storage.get_message(&competing_id).unwrap().state,
+        MessageState::Created,
+        "the rival must reach the settling pass never having been applied"
+    );
 
     drive_convergence(&mut local, &f, &competing_id).await;
     assert_eq!(settled_branch(&local, &f), Branch::Own);


### PR DESCRIPTION
docs(engine): pin why a losing rival is withdrawn and a sweep deferral is not routed

#1602 follow-ups (b) and (c) both dissolved on re-derivation; record the constraints that make them so, so the seams are not re-narrowed.

(b) emit_rolled_back_commits is deliberately not gated on prior local application: pre_apply reads Created for a materialized-but-never-adopted rival, and the pair it announces is inert where no origin_commit_id row exists while being the only portable statement that a named commit lost selection. fork_detection now asserts the rival's pre-pass state so the fact is executable.

(c) The sweep's re-peel has no stronger lineage to route: both paths reach the single deferral_lineage site, which answers about the group's stored commit graph, so a sweep can only restate what live ingest reported over rows the stall detector already counted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how branch-selection rollback events are handled for deferred commits, including cases where a commit was not previously applied.
  - Documented retry behavior for unreadable deferred items and clarified how their processing history is maintained.

- **Tests**
  - Added validation confirming that an unselected competing commit remains unapplied before convergence, improving coverage for rollback and convergence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->