### PR TITLE
Bound generated-case minimization and preserve failures

### DIFF
--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -634,8 +634,9 @@ greedy minimizer that removes removable delivery/app steps only when the semanti
 action type, and failure kind) still reproduces. The complete fingerprint, including the state digest, remains in the
 capsule for diagnosis. Report artifacts, fixture candidates, and failure capsules are written before reduction starts;
 completed minimization metadata replaces them atomically, so interruption leaves a complete original artifact rather
-than a truncated or missing one. Status is `complete`, `budget_exhausted`, `not_reproducible`, or `skipped`; a durable
-`pending` status identifies a worker interrupted during reduction.
+than a truncated or missing one. The process campaign removes replacement temporaries owned by a reaped worker and
+records cleanup failures as artifact-integrity errors. Status is `complete`, `budget_exhausted`, `not_reproducible`, or
+`skipped`; a durable `pending` status identifies a worker interrupted during reduction.
 
 Reduction defaults to a 30-second wall-clock budget, 256 total reproduction trials, and five seconds per trial. The
 report and isolated campaign CLIs accept `--minimization-wall-time-secs`, `--minimization-max-trials`, and

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -629,9 +629,18 @@ IR before launching the external driver.
 - `invariant_failures` — compatibility field mirroring expectation failures by kind and message.
 
 `run_generated_case_report(case, expected_trace)` adds generated-family metadata: family name, generator version, seed,
-case index, and an optional `minimized_case` field. Failing generated cases run a conservative greedy minimizer that
-removes removable delivery/app steps only when the semantic failure identity (classification, action type, and failure
-kind) still reproduces. The complete fingerprint, including the state digest, remains in the capsule for diagnosis.
+case index, minimization status, and an optional `minimized_case` field. Failing generated cases run a conservative
+greedy minimizer that removes removable delivery/app steps only when the semantic failure identity (classification,
+action type, and failure kind) still reproduces. The complete fingerprint, including the state digest, remains in the
+capsule for diagnosis. Report artifacts, fixture candidates, and failure capsules are written before reduction starts;
+completed minimization metadata replaces them atomically, so interruption leaves a complete original artifact rather
+than a truncated or missing one. Status is `complete`, `budget_exhausted`, `not_reproducible`, or `skipped`; a durable
+`pending` status identifies a worker interrupted during reduction.
+
+Reduction defaults to a 30-second wall-clock budget, 256 total reproduction trials, and five seconds per trial. The
+report and isolated campaign CLIs accept `--minimization-wall-time-secs`, `--minimization-max-trials`, and
+`--minimization-trial-timeout-secs` when a different diagnostic budget is intentional. Budget exhaustion never changes
+the original scenario failure classification.
 Generated report runs on the generator-recorded subject also write a sibling `*-fixture.v1.json` candidate. Adapter
 override runs deliberately do not, because their observed trace is an A/B result rather than an adapter-neutral source
 of truth. Cases with semantic expectations keep those expectations; cases without them use the observed trace as an

--- a/crates/cgka-conformance-simulator/RUNNING_CAMPAIGNS.md
+++ b/crates/cgka-conformance-simulator/RUNNING_CAMPAIGNS.md
@@ -118,7 +118,9 @@ provenance, and writes `process-campaign.v1.json`. This is the preferred local d
 one case cannot erase the remaining cases, and the summary contains real child-process resource measurements.
 The worker also saves the original report, fixture candidate, and failure capsule before optional semantic reduction.
 The campaign summary records each case's minimization status and classifies a process deadline as scenario execution,
-minimization, or later post-processing when enough durable evidence exists to tell them apart.
+minimization, or later post-processing when enough durable evidence exists to tell them apart. After reaping a worker,
+the parent removes any same-worker atomic-replacement temporaries; cleanup failures are retained as artifact-integrity
+errors rather than leaving undeclared evidence behind.
 
 Semantic reduction defaults to 30 seconds overall, 256 reproduction trials, and five seconds per trial. Override these
 with `--minimization-wall-time-secs`, `--minimization-max-trials`, and

--- a/crates/cgka-conformance-simulator/RUNNING_CAMPAIGNS.md
+++ b/crates/cgka-conformance-simulator/RUNNING_CAMPAIGNS.md
@@ -116,6 +116,14 @@ cargo run -p cgka-conformance-simulator --bin cgka-conformance-campaign --locked
 The parent saves each input before spawning its worker, kills and reaps deadline failures, verifies artifact
 provenance, and writes `process-campaign.v1.json`. This is the preferred local discovery boundary: a panic or hang in
 one case cannot erase the remaining cases, and the summary contains real child-process resource measurements.
+The worker also saves the original report, fixture candidate, and failure capsule before optional semantic reduction.
+The campaign summary records each case's minimization status and classifies a process deadline as scenario execution,
+minimization, or later post-processing when enough durable evidence exists to tell them apart.
+
+Semantic reduction defaults to 30 seconds overall, 256 reproduction trials, and five seconds per trial. Override these
+with `--minimization-wall-time-secs`, `--minimization-max-trials`, and
+`--minimization-trial-timeout-secs`. A `budget_exhausted` status is a bounded post-processing result, not a scenario
+timeout, and the original failure artifacts remain authoritative.
 
 ## Choosing a generated family
 

--- a/crates/cgka-conformance-simulator/SCALING_CAMPAIGNS.md
+++ b/crates/cgka-conformance-simulator/SCALING_CAMPAIGNS.md
@@ -217,6 +217,10 @@ Each isolated shard writes `process-campaign.v1.json`; treat the shard summaries
 one evidence set. An aggregate summary must derive totals and slowest/resource extrema from every included shard, not
 only a subset. Keep the exact source revision and command matrix beside the artifacts.
 
+Aggregate scenario timeouts separately from minimization/post-processing outcomes. A case whose report records
+`budget_exhausted` completed its original scenario and exhausted only the bounded reducer; a worker deadline with a
+durable `pending` minimization record is likewise distinct from a scenario-execution timeout with no report.
+
 Campaign artifacts can grow quickly. Retain:
 
 - all failed/timed-out/signaled cases and their exact inputs;

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -960,14 +960,21 @@ These tests keep the simulator machinery honest.
   after an artifact reached a recipient mailbox;
   `exposed_welcome_prevents_partial_commit_retraction_and_rollback` applies the same rule to the complete
   commit/Welcome publication so a failed rollback cannot partially mutate transport state.
-- `failing_generated_case_records_a_minimized_reproducer` checks that semantic failure identity lets a failing
-  generated case remove an entire irrelevant application-message storm even though action indices and the full state
-  digest change. The minimized case remains diagnostic metadata; fixture candidates retain the original executed
-  scenario so they cannot silently reproduce a different terminal state under the same broad failure kind.
+- `completed_minimizer_removes_irrelevant_message_storm_and_reproduces` deterministically checks that completed
+  reduction removes an entire irrelevant application-message storm and retains the synthetic failure trigger.
+- `failing_generated_case_records_bounded_minimization_outcome` checks the engine-backed semantic failure identity and
+  replays any best-so-far reduced case. The minimized case remains diagnostic metadata; fixture candidates retain the
+  original executed scenario so they cannot silently reproduce a different terminal state under the same broad
+  failure kind.
 - `expensive_reproducer_exhausts_the_minimization_budget_after_the_original_run` checks that one completed synthetic
   reproduction followed by an expensive trial stops at the per-trial budget with `budget_exhausted`.
 - `minimization_budget_exhaustion_preserves_the_original_failure_artifacts` checks that bounded reduction retains the
   original failure kind in the report and portable capsule and keeps the original fixture candidate durable.
+- `cleanup_removes_only_temporaries_owned_by_the_reaped_worker` checks that campaign cleanup removes report and
+  sensitive-capsule replacement files for the exact worker PID without touching another worker's files.
+- `interrupted_minimization_preserves_original_artifacts_and_summary_phase` launches the real worker path, waits for
+  durable original failure artifacts, reaps it during minimization, and records `pending` plus a `minimization` timeout
+  phase in the process summary schema.
 - `failed_campaign_capsule_contains_a_replayable_tick_witness` checks that a real report campaign exports a sensitive
   recipient checkpoint plus exact mailbox bytes and that both the replay API and report CLI reproduce its fingerprint.
 - `tests/generated_policy_cases.rs` checks that Tamarin-derived branch selector cases match the Rust selector across

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -964,6 +964,10 @@ These tests keep the simulator machinery honest.
   generated case remove an entire irrelevant application-message storm even though action indices and the full state
   digest change. The minimized case remains diagnostic metadata; fixture candidates retain the original executed
   scenario so they cannot silently reproduce a different terminal state under the same broad failure kind.
+- `expensive_reproducer_exhausts_the_minimization_budget_after_the_original_run` checks that one completed synthetic
+  reproduction followed by an expensive trial stops at the per-trial budget with `budget_exhausted`.
+- `minimization_budget_exhaustion_preserves_the_original_failure_artifacts` checks that bounded reduction retains the
+  original failure kind in the report and portable capsule and keeps the original fixture candidate durable.
 - `failed_campaign_capsule_contains_a_replayable_tick_witness` checks that a real report campaign exports a sensitive
   recipient checkpoint plus exact mailbox bytes and that both the replay API and report CLI reproduce its fingerprint.
 - `tests/generated_policy_cases.rs` checks that Tamarin-derived branch selector cases match the Rust selector across

--- a/crates/cgka-conformance-simulator/src/bin/cgka-conformance-campaign.rs
+++ b/crates/cgka-conformance-simulator/src/bin/cgka-conformance-campaign.rs
@@ -155,39 +155,19 @@ async fn run() -> Result<ExitCode, Box<dyn Error>> {
         }
         let started = Instant::now();
         let child = command.spawn()?;
+        let worker_pid = child.id();
         let usage = wait_with_usage(child, args.case_timeout)?;
-        let inspection = inspect_case_artifacts(&case, &paths, &usage);
-        observations.push(ProcessCaseMeasurementV1 {
+        let mut inspection = inspect_case_artifacts(&case, &paths, &usage);
+        inspection
+            .integrity_errors
+            .extend(cleanup_worker_temporary_artifacts(&paths, worker_pid));
+        observations.push(build_case_measurement(
             case_index,
-            generated_input: paths.generated_input,
-            report: paths.report,
-            fixture_candidate: paths
-                .fixture_candidate
-                .exists()
-                .then_some(paths.fixture_candidate),
-            failure_capsule: paths
-                .failure_capsule
-                .exists()
-                .then_some(paths.failure_capsule),
-            sensitive_replay_capsule: paths
-                .sensitive_replay_capsule
-                .exists()
-                .then_some(paths.sensitive_replay_capsule),
-            exit_code: usage.exit_code,
-            signal: usage.signal,
-            timed_out: usage.timed_out,
-            timeout_phase: inspection.timeout_phase,
-            minimization_status: inspection.minimization_status,
-            wall_us: elapsed_us(started.elapsed()),
-            user_cpu_us: usage.user_cpu_us,
-            system_cpu_us: usage.system_cpu_us,
-            peak_rss_bytes: usage.peak_rss_bytes,
-            database_bytes: inspection.database_bytes,
-            filesystem_block_write_lower_bound_bytes: usage
-                .filesystem_block_write_lower_bound_bytes,
-            unavailable_process_fields: usage.unavailable_process_fields,
-            artifact_integrity_errors: inspection.integrity_errors,
-        });
+            paths,
+            usage,
+            inspection,
+            started.elapsed(),
+        ));
     }
     let failed = observations.iter().any(|case| {
         case.timed_out
@@ -340,6 +320,98 @@ fn inspect_case_artifacts(
         database_bytes,
         timeout_phase,
         minimization_status,
+    }
+}
+
+/// Removes same-process atomic-replacement files that can survive a forced
+/// worker termination, returning integrity errors for anything not cleaned.
+fn cleanup_worker_temporary_artifacts(paths: &CaseArtifactPaths, worker_pid: u32) -> Vec<String> {
+    let Some(parent) = paths.report.parent() else {
+        return vec!["temporary_artifact_parent_missing".into()];
+    };
+    let marker = format!(".tmp-{worker_pid}-");
+    let prefixes = [
+        &paths.report,
+        &paths.failure_capsule,
+        &paths.sensitive_replay_capsule,
+    ]
+    .into_iter()
+    .filter_map(|path| path.file_name())
+    .map(|name| {
+        let mut prefix = name.as_encoded_bytes().to_vec();
+        prefix.extend_from_slice(marker.as_bytes());
+        prefix
+    })
+    .collect::<Vec<_>>();
+    let entries = match std::fs::read_dir(parent) {
+        Ok(entries) => entries,
+        Err(error) => return vec![format!("temporary_artifact_scan_failed:{error}")],
+    };
+    let mut errors = Vec::new();
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                errors.push(format!("temporary_artifact_scan_failed:{error}"));
+                continue;
+            }
+        };
+        let name = entry.file_name();
+        if !prefixes
+            .iter()
+            .any(|prefix| name.as_encoded_bytes().starts_with(prefix))
+        {
+            continue;
+        }
+        let path = entry.path();
+        if let Err(error) = std::fs::remove_file(&path) {
+            errors.push(format!(
+                "temporary_artifact_cleanup_failed:{}:{error}",
+                path.display()
+            ));
+        }
+    }
+    errors
+}
+
+/// Maps reaped process usage and durable artifact inspection into the schema
+/// written to the process-campaign summary.
+fn build_case_measurement(
+    case_index: usize,
+    paths: CaseArtifactPaths,
+    usage: ChildUsage,
+    inspection: CaseArtifactInspection,
+    elapsed: Duration,
+) -> ProcessCaseMeasurementV1 {
+    ProcessCaseMeasurementV1 {
+        case_index,
+        generated_input: paths.generated_input,
+        report: paths.report,
+        fixture_candidate: paths
+            .fixture_candidate
+            .exists()
+            .then_some(paths.fixture_candidate),
+        failure_capsule: paths
+            .failure_capsule
+            .exists()
+            .then_some(paths.failure_capsule),
+        sensitive_replay_capsule: paths
+            .sensitive_replay_capsule
+            .exists()
+            .then_some(paths.sensitive_replay_capsule),
+        exit_code: usage.exit_code,
+        signal: usage.signal,
+        timed_out: usage.timed_out,
+        timeout_phase: inspection.timeout_phase,
+        minimization_status: inspection.minimization_status,
+        wall_us: elapsed_us(elapsed),
+        user_cpu_us: usage.user_cpu_us,
+        system_cpu_us: usage.system_cpu_us,
+        peak_rss_bytes: usage.peak_rss_bytes,
+        database_bytes: inspection.database_bytes,
+        filesystem_block_write_lower_bound_bytes: usage.filesystem_block_write_lower_bound_bytes,
+        unavailable_process_fields: usage.unavailable_process_fields,
+        artifact_integrity_errors: inspection.integrity_errors,
     }
 }
 
@@ -856,6 +928,210 @@ mod tests {
             .to_string();
         assert!(error.contains("unsupported family unknown/v1"));
         assert!(!out.exists());
+    }
+
+    #[test]
+    fn cleanup_removes_only_temporaries_owned_by_the_reaped_worker() {
+        let root = tempfile::tempdir().expect("temporary campaign root");
+        let case = generate_family_case("send-leave/v1", 42, 0).expect("case generates");
+        let paths = case_artifact_paths(root.path(), &case);
+        let report_temporary = replacement_temporary_path(&paths.report, 4242, 0);
+        let replay_temporary = replacement_temporary_path(&paths.sensitive_replay_capsule, 4242, 1);
+        let unrelated_temporary = replacement_temporary_path(&paths.report, 7777, 0);
+        for path in [&report_temporary, &replay_temporary, &unrelated_temporary] {
+            fs_private::write_private(path, b"private temporary artifact")
+                .expect("temporary artifact writes");
+        }
+
+        assert!(cleanup_worker_temporary_artifacts(&paths, 4242).is_empty());
+        assert!(!report_temporary.exists());
+        assert!(!replay_temporary.exists());
+        assert!(unrelated_temporary.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn interrupted_minimization_preserves_original_artifacts_and_summary_phase() {
+        let root = tempfile::tempdir().expect("temporary campaign root");
+        let out = root.path().join("interrupted");
+        fs_private::create_dir_all_private(&out).expect("private output directory");
+        let case = interrupted_minimization_case();
+        let paths = case_artifact_paths(&out, &case);
+        fs_private::write_private(
+            &paths.generated_input,
+            &serde_json::to_vec_pretty(&GeneratedScenarioInputV1::new(case.clone()))
+                .expect("generated input serializes"),
+        )
+        .expect("generated input writes");
+
+        let mut child = Command::new(std::env::current_exe().expect("test executable path"))
+            .args([
+                "--ignored",
+                "--exact",
+                "tests::interrupted_minimization_worker_fixture",
+            ])
+            .env("CGKA_INTERRUPTED_WORKER_INPUT", &paths.generated_input)
+            .env("CGKA_INTERRUPTED_WORKER_OUT", &out)
+            .spawn()
+            .expect("worker fixture starts");
+        let worker_pid = child.id();
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let pending_report = loop {
+            if let Ok(bytes) = std::fs::read(&paths.report)
+                && let Ok(report) = serde_json::from_slice::<ScenarioReport>(&bytes)
+                && report.metadata.generated.as_ref().map(|generated| {
+                    generated.minimization.status == GeneratedScenarioMinimizationStatus::Pending
+                }) == Some(true)
+                && paths.fixture_candidate.is_file()
+                && cgka_conformance_simulator::read_failure_capsule(&paths.failure_capsule).is_ok()
+            {
+                break report;
+            }
+            if let Some(status) = child.try_wait().expect("worker status reads") {
+                panic!("worker exited before interruption evidence was durable: {status}");
+            }
+            if Instant::now() >= deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("worker did not publish pending minimization evidence");
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        };
+
+        assert!(
+            pending_report
+                .expectation_failures
+                .iter()
+                .any(|failure| failure.kind == "client_state_mismatch")
+        );
+        let usage = wait_with_usage(child, Duration::ZERO).expect("worker is killed and reaped");
+        assert!(usage.timed_out);
+        let mut inspection = inspect_case_artifacts(&case, &paths, &usage);
+        inspection
+            .integrity_errors
+            .extend(cleanup_worker_temporary_artifacts(&paths, worker_pid));
+        assert!(inspection.integrity_errors.is_empty());
+        let measurement =
+            build_case_measurement(0, paths, usage, inspection, Duration::from_millis(1));
+        let summary = ProcessCampaignReportV1 {
+            schema_version: "1".into(),
+            family: case.family_name,
+            seed: case.seed,
+            storage: "memory".into(),
+            case_timeout_ms: 1,
+            capture_sensitive_replay: false,
+            minimization_wall_time_ms: 300_000,
+            minimization_max_trials: 10_000,
+            minimization_trial_timeout_ms: 60_000,
+            cases: vec![measurement],
+        };
+        let value = serde_json::to_value(summary).expect("campaign summary serializes");
+        assert_eq!(value["cases"][0]["timed_out"], true);
+        assert_eq!(value["cases"][0]["minimization_status"], "pending");
+        assert_eq!(value["cases"][0]["timeout_phase"], "minimization");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    #[ignore = "process fixture launched by interrupted_minimization_preserves_original_artifacts_and_summary_phase"]
+    async fn interrupted_minimization_worker_fixture() {
+        let input = PathBuf::from(
+            std::env::var_os("CGKA_INTERRUPTED_WORKER_INPUT").expect("worker fixture input path"),
+        );
+        let out = PathBuf::from(
+            std::env::var_os("CGKA_INTERRUPTED_WORKER_OUT").expect("worker fixture output path"),
+        );
+        let result = run_worker(&Args {
+            family: "interrupted-minimization/v1".into(),
+            seed: 0,
+            cases: 1,
+            out,
+            storage: HarnessStorageMode::InMemorySqlite,
+            case_timeout: Duration::from_secs(300),
+            minimization_budget: GeneratedScenarioMinimizationBudget {
+                wall_clock: Duration::from_secs(300),
+                max_trials: 10_000,
+                per_trial_timeout: Duration::from_secs(60),
+            },
+            input: Some(input),
+            capture_sensitive_replay: false,
+            worker: true,
+        })
+        .await;
+        panic!("worker fixture completed before being interrupted: {result:?}");
+    }
+
+    fn replacement_temporary_path(target: &Path, worker_pid: u32, id: u64) -> PathBuf {
+        let mut name = target
+            .file_name()
+            .expect("artifact target names a file")
+            .to_os_string();
+        name.push(format!(".tmp-{worker_pid}-{id}"));
+        target
+            .parent()
+            .expect("artifact target has a parent")
+            .join(name)
+    }
+
+    fn interrupted_minimization_case() -> GeneratedScenarioCase {
+        let mut scenario = cgka_conformance_simulator::ScenarioSpec {
+            name: "interrupted-minimization/v1/case-0".into(),
+            spec_version: "2".into(),
+            topology: Default::default(),
+            clients: vec!["alice".into(), "bob".into()],
+            steps: vec![
+                cgka_conformance_simulator::ScenarioStep::CreateGroup {
+                    creator: "alice".into(),
+                    name: "interrupted".into(),
+                    invitees: vec!["bob".into()],
+                    required_features: Vec::new(),
+                    initial_admins: None,
+                    pending: "create".into(),
+                },
+                cgka_conformance_simulator::ScenarioStep::accept_publication("alice", "create"),
+                cgka_conformance_simulator::ScenarioStep::DeliverAll,
+                cgka_conformance_simulator::ScenarioStep::Tick {
+                    clients: vec!["bob".into()],
+                },
+                cgka_conformance_simulator::ScenarioStep::ClearEvents {
+                    clients: vec!["alice".into(), "bob".into()],
+                },
+            ],
+        };
+        for index in 0..24 {
+            scenario
+                .steps
+                .push(cgka_conformance_simulator::ScenarioStep::SendAppMessage {
+                    sender: "bob".into(),
+                    payload: format!("interruption noise {index}"),
+                });
+        }
+        scenario.steps.extend([
+            cgka_conformance_simulator::ScenarioStep::DeliverAll,
+            cgka_conformance_simulator::ScenarioStep::Tick {
+                clients: vec!["alice".into()],
+            },
+            cgka_conformance_simulator::ScenarioStep::Observe {
+                clients: vec!["alice".into()],
+            },
+        ]);
+        GeneratedScenarioCase {
+            family_name: "interrupted-minimization/v1".into(),
+            generator_version: "1".into(),
+            seed: 17,
+            case_index: 0,
+            workload_profile: None,
+            subject: cgka_conformance_simulator::GeneratedSubjectKind::Engine,
+            scenario,
+            expected_outcomes: vec![cgka_conformance_simulator::TraceExpectation::ClientState {
+                client: "alice".into(),
+                epoch: 1,
+                member_count: 99,
+                received_payloads: None,
+                added_members: None,
+                removed_members: None,
+            }],
+        }
     }
 
     #[cfg(unix)]

--- a/crates/cgka-conformance-simulator/src/bin/cgka-conformance-campaign.rs
+++ b/crates/cgka-conformance-simulator/src/bin/cgka-conformance-campaign.rs
@@ -1,5 +1,6 @@
 use cgka_conformance_simulator::{
-    GeneratedScenarioCase, GeneratedScenarioInputV1, HarnessStorageMode, ReportArgs, ReportInput,
+    GeneratedScenarioCase, GeneratedScenarioInputV1, GeneratedScenarioMinimizationBudget,
+    GeneratedScenarioMinimizationStatus, HarnessStorageMode, ReportArgs, ReportInput,
     ScenarioReport, generate_family_case, resolve_scenario_input_bytes, run_report,
 };
 use serde::{Deserialize, Serialize};
@@ -16,6 +17,7 @@ struct Args {
     out: PathBuf,
     storage: HarnessStorageMode,
     case_timeout: Duration,
+    minimization_budget: GeneratedScenarioMinimizationBudget,
     input: Option<PathBuf>,
     capture_sensitive_replay: bool,
     worker: bool,
@@ -29,6 +31,9 @@ struct ProcessCampaignReportV1 {
     storage: String,
     case_timeout_ms: u64,
     capture_sensitive_replay: bool,
+    minimization_wall_time_ms: u64,
+    minimization_max_trials: usize,
+    minimization_trial_timeout_ms: u64,
     cases: Vec<ProcessCaseMeasurementV1>,
 }
 
@@ -46,6 +51,10 @@ struct ProcessCaseMeasurementV1 {
     exit_code: Option<i32>,
     signal: Option<i32>,
     timed_out: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    timeout_phase: Option<ProcessCaseTimeoutPhaseV1>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    minimization_status: Option<GeneratedScenarioMinimizationStatus>,
     wall_us: u64,
     user_cpu_us: Option<u64>,
     system_cpu_us: Option<u64>,
@@ -75,6 +84,16 @@ struct PlannedCase {
 struct CaseArtifactInspection {
     integrity_errors: Vec<String>,
     database_bytes: Option<u64>,
+    timeout_phase: Option<ProcessCaseTimeoutPhaseV1>,
+    minimization_status: Option<GeneratedScenarioMinimizationStatus>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ProcessCaseTimeoutPhaseV1 {
+    ScenarioExecution,
+    Minimization,
+    PostProcessing,
 }
 
 #[tokio::main]
@@ -119,7 +138,18 @@ async fn run() -> Result<ExitCode, Box<dyn Error>> {
             .arg("--out")
             .arg(&args.out)
             .arg("--storage")
-            .arg(storage_label(args.storage));
+            .arg(storage_label(args.storage))
+            .arg("--minimization-wall-time-secs")
+            .arg(args.minimization_budget.wall_clock.as_secs().to_string())
+            .arg("--minimization-max-trials")
+            .arg(args.minimization_budget.max_trials.to_string())
+            .arg("--minimization-trial-timeout-secs")
+            .arg(
+                args.minimization_budget
+                    .per_trial_timeout
+                    .as_secs()
+                    .to_string(),
+            );
         if args.capture_sensitive_replay {
             command.arg("--capture-sensitive-replay");
         }
@@ -146,6 +176,8 @@ async fn run() -> Result<ExitCode, Box<dyn Error>> {
             exit_code: usage.exit_code,
             signal: usage.signal,
             timed_out: usage.timed_out,
+            timeout_phase: inspection.timeout_phase,
+            minimization_status: inspection.minimization_status,
             wall_us: elapsed_us(started.elapsed()),
             user_cpu_us: usage.user_cpu_us,
             system_cpu_us: usage.system_cpu_us,
@@ -170,6 +202,9 @@ async fn run() -> Result<ExitCode, Box<dyn Error>> {
         storage: storage_label(args.storage).into(),
         case_timeout_ms: elapsed_ms(args.case_timeout),
         capture_sensitive_replay: args.capture_sensitive_replay,
+        minimization_wall_time_ms: elapsed_ms(args.minimization_budget.wall_clock),
+        minimization_max_trials: args.minimization_budget.max_trials,
+        minimization_trial_timeout_ms: elapsed_ms(args.minimization_budget.per_trial_timeout),
         cases: observations,
     };
     fs_private::write_private(&summary_path, &serde_json::to_vec_pretty(&summary)?)?;
@@ -192,6 +227,7 @@ async fn run_worker(args: &Args) -> Result<ExitCode, Box<dyn Error>> {
         strict_oracle: true,
         storage_mode: args.storage,
         capture_sensitive_replay: args.capture_sensitive_replay,
+        minimization_budget: args.minimization_budget,
     })
     .await?;
     println!("{}", summary.to_human_text());
@@ -254,6 +290,11 @@ fn inspect_case_artifacts(
     let database_bytes = report
         .as_ref()
         .and_then(|report| report.campaign_measurements.database_bytes);
+    let minimization_status = report
+        .as_ref()
+        .and_then(|report| report.metadata.generated.as_ref())
+        .map(|generated| generated.minimization.status);
+    let timeout_phase = classify_timeout_phase(usage.timed_out, minimization_status);
 
     // A timeout or signal may interrupt the worker before it can publish a
     // report. A normally exiting worker, including a strict-oracle failure,
@@ -297,7 +338,22 @@ fn inspect_case_artifacts(
     CaseArtifactInspection {
         integrity_errors: errors,
         database_bytes,
+        timeout_phase,
+        minimization_status,
     }
+}
+
+fn classify_timeout_phase(
+    timed_out: bool,
+    minimization_status: Option<GeneratedScenarioMinimizationStatus>,
+) -> Option<ProcessCaseTimeoutPhaseV1> {
+    timed_out.then_some(match minimization_status {
+        Some(GeneratedScenarioMinimizationStatus::Pending) => {
+            ProcessCaseTimeoutPhaseV1::Minimization
+        }
+        Some(_) => ProcessCaseTimeoutPhaseV1::PostProcessing,
+        None => ProcessCaseTimeoutPhaseV1::ScenarioExecution,
+    })
 }
 
 fn parse_args(args: impl Iterator<Item = String>) -> Result<Args, Box<dyn Error>> {
@@ -307,6 +363,7 @@ fn parse_args(args: impl Iterator<Item = String>) -> Result<Args, Box<dyn Error>
     let mut out = PathBuf::from("target/cgka-adversarial-reliability-process-campaign");
     let mut storage = HarnessStorageMode::TempFileBackedSqlite;
     let mut case_timeout = Duration::from_secs(300);
+    let mut minimization_budget = GeneratedScenarioMinimizationBudget::default();
     let mut input = None;
     let mut capture_sensitive_replay = false;
     let mut worker = false;
@@ -334,6 +391,26 @@ fn parse_args(args: impl Iterator<Item = String>) -> Result<Args, Box<dyn Error>
                         .parse()?,
                 )
             }
+            "--minimization-wall-time-secs" => {
+                minimization_budget.wall_clock = Duration::from_secs(
+                    args.next()
+                        .ok_or("missing --minimization-wall-time-secs value")?
+                        .parse()?,
+                )
+            }
+            "--minimization-max-trials" => {
+                minimization_budget.max_trials = args
+                    .next()
+                    .ok_or("missing --minimization-max-trials value")?
+                    .parse()?
+            }
+            "--minimization-trial-timeout-secs" => {
+                minimization_budget.per_trial_timeout = Duration::from_secs(
+                    args.next()
+                        .ok_or("missing --minimization-trial-timeout-secs value")?
+                        .parse()?,
+                )
+            }
             other => return Err(format!("unknown argument {other}").into()),
         }
     }
@@ -349,6 +426,7 @@ fn parse_args(args: impl Iterator<Item = String>) -> Result<Args, Box<dyn Error>
     if !worker && case_timeout.is_zero() {
         return Err("--case-timeout-secs must be greater than zero".into());
     }
+    minimization_budget = minimization_budget.validate()?;
     Ok(Args {
         family,
         seed,
@@ -356,6 +434,7 @@ fn parse_args(args: impl Iterator<Item = String>) -> Result<Args, Box<dyn Error>
         out,
         storage,
         case_timeout,
+        minimization_budget,
         input,
         capture_sensitive_replay,
         worker,
@@ -600,6 +679,57 @@ mod tests {
     }
 
     #[test]
+    fn parses_minimization_budgets() {
+        let args = parse_args(
+            [
+                "--minimization-wall-time-secs",
+                "19",
+                "--minimization-max-trials",
+                "31",
+                "--minimization-trial-timeout-secs",
+                "4",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .expect("arguments parse");
+        assert_eq!(
+            args.minimization_budget,
+            GeneratedScenarioMinimizationBudget {
+                wall_clock: Duration::from_secs(19),
+                max_trials: 31,
+                per_trial_timeout: Duration::from_secs(4),
+            }
+        );
+    }
+
+    #[test]
+    fn timeout_phase_distinguishes_scenario_execution_from_minimization() {
+        assert_eq!(
+            classify_timeout_phase(true, None),
+            Some(ProcessCaseTimeoutPhaseV1::ScenarioExecution)
+        );
+        assert_eq!(
+            classify_timeout_phase(true, Some(GeneratedScenarioMinimizationStatus::Pending)),
+            Some(ProcessCaseTimeoutPhaseV1::Minimization)
+        );
+        assert_eq!(
+            classify_timeout_phase(
+                true,
+                Some(GeneratedScenarioMinimizationStatus::BudgetExhausted)
+            ),
+            Some(ProcessCaseTimeoutPhaseV1::PostProcessing)
+        );
+        assert_eq!(
+            classify_timeout_phase(
+                false,
+                Some(GeneratedScenarioMinimizationStatus::BudgetExhausted)
+            ),
+            None
+        );
+    }
+
+    #[test]
     fn parses_family_and_sensitive_capture() {
         let args = parse_args(
             ["--family", "chat-journey/v1", "--capture-sensitive-replay"]
@@ -676,6 +806,9 @@ mod tests {
         for args in [
             vec!["--cases", "0"],
             vec!["--case-timeout-secs", "0"],
+            vec!["--minimization-wall-time-secs", "0"],
+            vec!["--minimization-max-trials", "0"],
+            vec!["--minimization-trial-timeout-secs", "0"],
             vec!["--input", "case.json"],
             vec!["--worker"],
         ] {

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -19,8 +19,52 @@ use rand::{Rng, SeedableRng};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::fmt;
+use std::time::{Duration, Instant};
 
 pub const GENERATED_SCENARIO_INPUT_SCHEMA_VERSION: &str = "1";
+
+/// Bounds optional semantic reduction after the original generated report has
+/// been produced. The defaults keep expensive failures from consuming the
+/// enclosing process deadline while still allowing small deterministic cases
+/// to reduce completely.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GeneratedScenarioMinimizationBudget {
+    pub wall_clock: Duration,
+    pub max_trials: usize,
+    pub per_trial_timeout: Duration,
+}
+
+impl Default for GeneratedScenarioMinimizationBudget {
+    fn default() -> Self {
+        Self {
+            wall_clock: Duration::from_secs(30),
+            max_trials: 256,
+            per_trial_timeout: Duration::from_secs(5),
+        }
+    }
+}
+
+impl GeneratedScenarioMinimizationBudget {
+    pub fn validate(self) -> Result<Self, &'static str> {
+        if self.wall_clock.is_zero() {
+            return Err("minimization wall-clock budget must be greater than zero");
+        }
+        if self.max_trials == 0 {
+            return Err("minimization trial budget must be greater than zero");
+        }
+        if self.per_trial_timeout.is_zero() {
+            return Err("minimization per-trial timeout must be greater than zero");
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct GeneratedScenarioMinimizationOutcome {
+    status: crate::GeneratedScenarioMinimizationStatus,
+    trials: usize,
+    minimized_case: Option<ScenarioSpec>,
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GeneratedScenarioCase {
@@ -635,12 +679,15 @@ pub async fn run_generated_case_report_with_storage_mode(
         storage_mode,
     )
     .await?;
-    add_generated_metadata(
+    let budget = GeneratedScenarioMinimizationBudget::default();
+    prepare_generated_metadata(case, &mut report, budget);
+    complete_generated_minimization(
         case,
         case.subject,
         expected_trace.as_ref(),
         &mut report,
         storage_mode,
+        budget,
     )
     .await;
     Ok(report)
@@ -670,6 +717,37 @@ pub async fn run_generated_case_report_with_capture_on_subject(
     expected_trace: Option<ScenarioTrace>,
     storage_mode: HarnessStorageMode,
     capture_sensitive_replay: bool,
+) -> Result<(ScenarioReport, crate::ScenarioFailureCaptureV1), ScenarioRunError> {
+    let budget = GeneratedScenarioMinimizationBudget::default();
+    let (mut report, failure_capture) =
+        run_generated_case_report_with_capture_on_subject_before_minimization(
+            case,
+            execution_subject,
+            expected_trace.clone(),
+            storage_mode,
+            capture_sensitive_replay,
+            budget,
+        )
+        .await?;
+    complete_generated_minimization(
+        case,
+        execution_subject,
+        expected_trace.as_ref(),
+        &mut report,
+        storage_mode,
+        budget,
+    )
+    .await;
+    Ok((report, failure_capture))
+}
+
+pub(crate) async fn run_generated_case_report_with_capture_on_subject_before_minimization(
+    case: &GeneratedScenarioCase,
+    execution_subject: GeneratedSubjectKind,
+    expected_trace: Option<ScenarioTrace>,
+    storage_mode: HarnessStorageMode,
+    capture_sensitive_replay: bool,
+    budget: GeneratedScenarioMinimizationBudget,
 ) -> Result<(ScenarioReport, crate::ScenarioFailureCaptureV1), ScenarioRunError> {
     let (mut report, failure_capture) = match execution_subject {
         GeneratedSubjectKind::Engine => {
@@ -744,35 +822,19 @@ pub async fn run_generated_case_report_with_capture_on_subject(
             )
         }
     };
-    add_generated_metadata(
-        case,
-        execution_subject,
-        expected_trace.as_ref(),
-        &mut report,
-        storage_mode,
-    )
-    .await;
+    prepare_generated_metadata(case, &mut report, budget);
     Ok((report, failure_capture))
 }
 
-async fn add_generated_metadata(
+fn prepare_generated_metadata(
     case: &GeneratedScenarioCase,
-    execution_subject: GeneratedSubjectKind,
-    expected_trace: Option<&ScenarioTrace>,
     report: &mut ScenarioReport,
-    storage_mode: HarnessStorageMode,
+    budget: GeneratedScenarioMinimizationBudget,
 ) {
-    let minimized_case = if fingerprint_report_failure(report).is_ok() {
-        minimize_failing_case(
-            case,
-            execution_subject,
-            expected_trace,
-            report,
-            storage_mode,
-        )
-        .await
+    let status = if fingerprint_report_failure(report).is_ok() {
+        crate::GeneratedScenarioMinimizationStatus::Pending
     } else {
-        None
+        crate::GeneratedScenarioMinimizationStatus::Skipped
     };
     report.metadata.generated = Some(GeneratedScenarioMetadata {
         family_name: case.family_name.clone(),
@@ -780,8 +842,45 @@ async fn add_generated_metadata(
         seed: case.seed,
         case_index: case.case_index,
         workload_profile: case.workload_profile.clone(),
-        minimized_case,
+        minimization: crate::GeneratedScenarioMinimizationV1 {
+            status,
+            trials: 0,
+            wall_clock_budget_ms: duration_ms(budget.wall_clock),
+            max_trials: budget.max_trials,
+            per_trial_timeout_ms: duration_ms(budget.per_trial_timeout),
+        },
+        minimized_case: None,
     });
+}
+
+pub(crate) async fn complete_generated_minimization(
+    case: &GeneratedScenarioCase,
+    execution_subject: GeneratedSubjectKind,
+    expected_trace: Option<&ScenarioTrace>,
+    report: &mut ScenarioReport,
+    storage_mode: HarnessStorageMode,
+    budget: GeneratedScenarioMinimizationBudget,
+) {
+    let is_pending = report.metadata.generated.as_ref().is_some_and(|metadata| {
+        metadata.minimization.status == crate::GeneratedScenarioMinimizationStatus::Pending
+    });
+    if !is_pending {
+        return;
+    }
+    let outcome = minimize_failing_case(
+        case,
+        execution_subject,
+        expected_trace,
+        report,
+        storage_mode,
+        budget,
+    )
+    .await;
+    if let Some(metadata) = report.metadata.generated.as_mut() {
+        metadata.minimization.status = outcome.status;
+        metadata.minimization.trials = outcome.trials;
+        metadata.minimized_case = outcome.minimized_case;
+    }
 }
 
 async fn minimize_failing_case(
@@ -790,11 +889,17 @@ async fn minimize_failing_case(
     expected_trace: Option<&ScenarioTrace>,
     failing_report: &ScenarioReport,
     storage_mode: HarnessStorageMode,
-) -> Option<ScenarioSpec> {
-    let target_identity = fingerprint_report_failure(failing_report)
-        .ok()?
-        .semantic_identity();
-    minimize_scenario_with(case.scenario.clone(), |trial| {
+    budget: GeneratedScenarioMinimizationBudget,
+) -> GeneratedScenarioMinimizationOutcome {
+    let Ok(fingerprint) = fingerprint_report_failure(failing_report) else {
+        return GeneratedScenarioMinimizationOutcome {
+            status: crate::GeneratedScenarioMinimizationStatus::Skipped,
+            trials: 0,
+            minimized_case: None,
+        };
+    };
+    let target_identity = fingerprint.semantic_identity();
+    minimize_scenario_with(case.scenario.clone(), budget, |trial| {
         let expected_trace = expected_trace.cloned();
         let expected_outcomes = case.expected_outcomes.clone();
         let target_identity = target_identity.clone();
@@ -815,30 +920,119 @@ async fn minimize_failing_case(
 
 async fn minimize_scenario_with<F, Fut>(
     mut candidate: ScenarioSpec,
+    budget: GeneratedScenarioMinimizationBudget,
     mut reproduces: F,
-) -> Option<ScenarioSpec>
+) -> GeneratedScenarioMinimizationOutcome
 where
     F: FnMut(ScenarioSpec) -> Fut,
     Fut: std::future::Future<Output = bool>,
 {
+    let started = Instant::now();
+    let mut trials = 0;
     let mut changed = false;
+    match run_minimization_trial(
+        &mut reproduces,
+        candidate.clone(),
+        budget,
+        started,
+        &mut trials,
+    )
+    .await
+    {
+        MinimizationTrial::Reproduced => {}
+        MinimizationTrial::DidNotReproduce => {
+            return GeneratedScenarioMinimizationOutcome {
+                status: crate::GeneratedScenarioMinimizationStatus::NotReproducible,
+                trials,
+                minimized_case: None,
+            };
+        }
+        MinimizationTrial::BudgetExhausted => {
+            return GeneratedScenarioMinimizationOutcome {
+                status: crate::GeneratedScenarioMinimizationStatus::BudgetExhausted,
+                trials,
+                minimized_case: None,
+            };
+        }
+    }
     loop {
         let mut reduced = false;
         for unit in semantic_minimization_units(&candidate.steps) {
             let mut trial = candidate.clone();
             remove_step_indices(&mut trial.steps, &unit);
-            if reproduces(trial.clone()).await {
-                candidate = trial;
-                changed = true;
-                reduced = true;
-                break;
+            match run_minimization_trial(
+                &mut reproduces,
+                trial.clone(),
+                budget,
+                started,
+                &mut trials,
+            )
+            .await
+            {
+                MinimizationTrial::Reproduced => {
+                    candidate = trial;
+                    changed = true;
+                    reduced = true;
+                    break;
+                }
+                MinimizationTrial::DidNotReproduce => {}
+                MinimizationTrial::BudgetExhausted => {
+                    return GeneratedScenarioMinimizationOutcome {
+                        status: crate::GeneratedScenarioMinimizationStatus::BudgetExhausted,
+                        trials,
+                        minimized_case: changed.then_some(candidate),
+                    };
+                }
             }
         }
         if !reduced {
             break;
         }
     }
-    changed.then_some(candidate)
+    GeneratedScenarioMinimizationOutcome {
+        status: crate::GeneratedScenarioMinimizationStatus::Complete,
+        trials,
+        minimized_case: changed.then_some(candidate),
+    }
+}
+
+enum MinimizationTrial {
+    Reproduced,
+    DidNotReproduce,
+    BudgetExhausted,
+}
+
+async fn run_minimization_trial<F, Fut>(
+    reproduces: &mut F,
+    trial: ScenarioSpec,
+    budget: GeneratedScenarioMinimizationBudget,
+    started: Instant,
+    trials: &mut usize,
+) -> MinimizationTrial
+where
+    F: FnMut(ScenarioSpec) -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    if *trials >= budget.max_trials {
+        return MinimizationTrial::BudgetExhausted;
+    }
+    let Some(remaining) = budget.wall_clock.checked_sub(started.elapsed()) else {
+        return MinimizationTrial::BudgetExhausted;
+    };
+    let trial_timeout = remaining.min(budget.per_trial_timeout);
+    if trial_timeout.is_zero() {
+        return MinimizationTrial::BudgetExhausted;
+    }
+    *trials += 1;
+    match tokio::time::timeout(trial_timeout, reproduces(trial)).await {
+        Ok(true) => MinimizationTrial::Reproduced,
+        Ok(false) => MinimizationTrial::DidNotReproduce,
+        Err(_) => MinimizationTrial::BudgetExhausted,
+    }
+}
+
+fn duration_ms(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
 
 /// Dependency-aware reduction units. Removing a fault arm without its release
@@ -4231,19 +4425,29 @@ mod tests {
             ],
         };
 
-        let minimized = minimize_scenario_with(scenario, |trial| async move {
-            let has_partition = trial
-                .steps
-                .iter()
-                .any(|step| matches!(step, ScenarioStep::SetPartition { .. }));
-            let has_clear = trial
-                .steps
-                .iter()
-                .any(|step| matches!(step, ScenarioStep::ClearPartition));
-            has_partition || has_clear
-        })
-        .await
-        .expect("independent noise should be removable");
+        let outcome = minimize_scenario_with(
+            scenario,
+            GeneratedScenarioMinimizationBudget::default(),
+            |trial| async move {
+                let has_partition = trial
+                    .steps
+                    .iter()
+                    .any(|step| matches!(step, ScenarioStep::SetPartition { .. }));
+                let has_clear = trial
+                    .steps
+                    .iter()
+                    .any(|step| matches!(step, ScenarioStep::ClearPartition));
+                has_partition || has_clear
+            },
+        )
+        .await;
+        assert_eq!(
+            outcome.status,
+            crate::GeneratedScenarioMinimizationStatus::Complete
+        );
+        let minimized = outcome
+            .minimized_case
+            .expect("independent noise should be removable");
 
         assert_eq!(minimized.steps.len(), 2);
         assert!(matches!(
@@ -4251,6 +4455,86 @@ mod tests {
             ScenarioStep::SetPartition { .. }
         ));
         assert!(matches!(minimized.steps[1], ScenarioStep::ClearPartition));
+    }
+
+    #[tokio::test]
+    async fn expensive_reproducer_exhausts_the_minimization_budget_after_the_original_run() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::time::{Duration, Instant};
+
+        let scenario = ScenarioSpec {
+            name: "budgeted-reduction".into(),
+            spec_version: "2".into(),
+            topology: Default::default(),
+            clients: vec!["alice".into()],
+            steps: vec![ScenarioStep::ClearEvents {
+                clients: vec!["alice".into()],
+            }],
+        };
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_for_reproducer = Arc::clone(&attempts);
+        let started = Instant::now();
+
+        let outcome = minimize_scenario_with(
+            scenario,
+            GeneratedScenarioMinimizationBudget {
+                wall_clock: Duration::from_millis(50),
+                max_trials: 8,
+                per_trial_timeout: Duration::from_millis(10),
+            },
+            move |_trial| {
+                let attempt = attempts_for_reproducer.fetch_add(1, Ordering::SeqCst);
+                async move {
+                    if attempt == 0 {
+                        true
+                    } else {
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                        true
+                    }
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(
+            outcome.status,
+            crate::GeneratedScenarioMinimizationStatus::BudgetExhausted
+        );
+        assert_eq!(outcome.trials, 2, "one complete run plus one timed trial");
+        assert!(outcome.minimized_case.is_none());
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        assert!(
+            started.elapsed() < Duration::from_millis(500),
+            "the per-trial timeout must bound an expensive reproduction"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_reproducing_original_case_is_reported() {
+        let scenario = ScenarioSpec {
+            name: "non-reproducing-reduction".into(),
+            spec_version: "2".into(),
+            topology: Default::default(),
+            clients: vec!["alice".into()],
+            steps: vec![ScenarioStep::ClearEvents {
+                clients: vec!["alice".into()],
+            }],
+        };
+
+        let outcome = minimize_scenario_with(
+            scenario,
+            GeneratedScenarioMinimizationBudget::default(),
+            |_trial| async { false },
+        )
+        .await;
+
+        assert_eq!(
+            outcome.status,
+            crate::GeneratedScenarioMinimizationStatus::NotReproducible
+        );
+        assert_eq!(outcome.trials, 1);
+        assert!(outcome.minimized_case.is_none());
     }
 
     #[test]

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -4461,7 +4461,7 @@ mod tests {
     async fn expensive_reproducer_exhausts_the_minimization_budget_after_the_original_run() {
         use std::sync::Arc;
         use std::sync::atomic::{AtomicUsize, Ordering};
-        use std::time::{Duration, Instant};
+        use std::time::Duration;
 
         let scenario = ScenarioSpec {
             name: "budgeted-reduction".into(),
@@ -4474,12 +4474,10 @@ mod tests {
         };
         let attempts = Arc::new(AtomicUsize::new(0));
         let attempts_for_reproducer = Arc::clone(&attempts);
-        let started = Instant::now();
-
         let outcome = minimize_scenario_with(
             scenario,
             GeneratedScenarioMinimizationBudget {
-                wall_clock: Duration::from_millis(50),
+                wall_clock: Duration::from_secs(5),
                 max_trials: 8,
                 per_trial_timeout: Duration::from_millis(10),
             },
@@ -4504,10 +4502,6 @@ mod tests {
         assert_eq!(outcome.trials, 2, "one complete run plus one timed trial");
         assert!(outcome.minimized_case.is_none());
         assert_eq!(attempts.load(Ordering::SeqCst), 2);
-        assert!(
-            started.elapsed() < Duration::from_millis(500),
-            "the per-trial timeout must bound an expensive reproduction"
-        );
     }
 
     #[tokio::test]

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -4458,6 +4458,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn completed_minimizer_removes_irrelevant_message_storm_and_reproduces() {
+        fn reproduces_synthetic_failure(scenario: &ScenarioSpec) -> bool {
+            scenario
+                .steps
+                .iter()
+                .any(|step| matches!(step, ScenarioStep::CreateGroup { .. }))
+        }
+
+        let mut scenario = ScenarioSpec {
+            name: "completed-reduction".into(),
+            spec_version: "2".into(),
+            topology: Default::default(),
+            clients: vec!["alice".into()],
+            steps: vec![ScenarioStep::CreateGroup {
+                creator: "alice".into(),
+                name: "retained-failure-trigger".into(),
+                invitees: Vec::new(),
+                required_features: Vec::new(),
+                initial_admins: None,
+                pending: "create".into(),
+            }],
+        };
+        for index in 0..24 {
+            scenario.steps.push(ScenarioStep::SendAppMessage {
+                sender: "alice".into(),
+                payload: format!("irrelevant storm message {index}"),
+            });
+        }
+
+        let outcome = minimize_scenario_with(
+            scenario,
+            GeneratedScenarioMinimizationBudget::default(),
+            |trial| async move { reproduces_synthetic_failure(&trial) },
+        )
+        .await;
+
+        assert_eq!(
+            outcome.status,
+            crate::GeneratedScenarioMinimizationStatus::Complete
+        );
+        let minimized = outcome
+            .minimized_case
+            .expect("completed reduction records the smaller reproducer");
+        assert!(
+            minimized
+                .steps
+                .iter()
+                .all(|step| !matches!(step, ScenarioStep::SendAppMessage { .. }))
+        );
+        assert!(reproduces_synthetic_failure(&minimized));
+    }
+
+    #[tokio::test]
     async fn expensive_reproducer_exhausts_the_minimization_budget_after_the_original_run() {
         use std::sync::Arc;
         use std::sync::atomic::{AtomicUsize, Ordering};

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -102,9 +102,10 @@ pub use failure_capsule::{
 };
 pub use family::{
     GENERATED_SCENARIO_INPUT_SCHEMA_VERSION, GeneratedScenarioCase, GeneratedScenarioInputV1,
-    GeneratedSubjectKind, GeneratedWorkloadProfileV1, UnsupportedGeneratedFamily,
-    generate_admin_churn_case, generate_admin_churn_family, generate_adversarial_reliability_case,
-    generate_adversarial_reliability_family, generate_adversarial_reliability_offline_regression,
+    GeneratedScenarioMinimizationBudget, GeneratedSubjectKind, GeneratedWorkloadProfileV1,
+    UnsupportedGeneratedFamily, generate_admin_churn_case, generate_admin_churn_family,
+    generate_adversarial_reliability_case, generate_adversarial_reliability_family,
+    generate_adversarial_reliability_offline_regression,
     generate_adversarial_reliability_self_update_regression,
     generate_adversarial_reliability_sustained_regression,
     generate_bounded_convergence_pressure_case, generate_bounded_convergence_pressure_family,
@@ -157,9 +158,10 @@ pub use retained_relay::{
 };
 pub use scenario::{
     AppInvalidationReportObservation, EpochChangeReportObservation, GeneratedScenarioMetadata,
-    InvariantFailure, ScenarioOutboundSelection, ScenarioReport, ScenarioReportMetadata,
-    ScenarioRunError, ScenarioSpec, ScenarioStep, ScenarioStepLogEntry, ScenarioStepStatus,
-    VectorFixtureMetadata, run_scenario_report, run_scenario_report_with_outcomes,
+    GeneratedScenarioMinimizationStatus, GeneratedScenarioMinimizationV1, InvariantFailure,
+    ScenarioOutboundSelection, ScenarioReport, ScenarioReportMetadata, ScenarioRunError,
+    ScenarioSpec, ScenarioStep, ScenarioStepLogEntry, ScenarioStepStatus, VectorFixtureMetadata,
+    run_scenario_report, run_scenario_report_with_outcomes,
     run_scenario_report_with_outcomes_and_capture,
     run_scenario_report_with_outcomes_and_storage_mode, run_scenario_report_with_storage_mode,
     run_scenario_report_with_subject, run_scenario_spec, run_scenario_spec_with_subject,

--- a/crates/cgka-conformance-simulator/src/report.rs
+++ b/crates/cgka-conformance-simulator/src/report.rs
@@ -1,12 +1,15 @@
 use std::error::Error;
+use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use crate::scenario_input::generated_scenario_input_provenance;
 use crate::{
     CoverageMatrixEntry, FailureCapsuleSensitivity, FailureCapsuleV1, GeneratedScenarioCase,
-    GeneratedScenarioInputV1, HarnessStorageMode, ScenarioInputProvenanceV1, ScenarioReport,
-    VectorFixture, coverage_matrix_entry, generate_family_case, resolve_scenario_input_bytes,
-    run_vector_fixture_report_with_capture, write_failure_capsule,
+    GeneratedScenarioInputV1, GeneratedScenarioMinimizationBudget, HarnessStorageMode,
+    ScenarioInputProvenanceV1, ScenarioReport, VectorFixture, coverage_matrix_entry,
+    generate_family_case, resolve_scenario_input_bytes, run_vector_fixture_report_with_capture,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -17,6 +20,7 @@ pub struct ReportArgs {
     pub storage_mode: HarnessStorageMode,
     /// Explicit opt-in because replay checkpoints contain MLS key material.
     pub capture_sensitive_replay: bool,
+    pub minimization_budget: GeneratedScenarioMinimizationBudget,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -180,6 +184,7 @@ fn scenario_report_failures(
 }
 
 pub async fn run_report(args: &ReportArgs) -> Result<ReportRunSummary, Box<dyn Error>> {
+    args.minimization_budget.validate()?;
     #[cfg(unix)]
     let _output_dir_guard = fs_private::prepare_directory_path(
         &args.out,
@@ -194,18 +199,7 @@ pub async fn run_report(args: &ReportArgs) -> Result<ReportRunSummary, Box<dyn E
             family,
             seed,
             cases,
-        } => {
-            run_generated_family_reports(
-                family,
-                *seed,
-                *cases,
-                &args.out,
-                args.strict_oracle,
-                args.storage_mode,
-                args.capture_sensitive_replay,
-            )
-            .await?
-        }
+        } => run_generated_family_reports(family, *seed, *cases, args).await?,
         ReportInput::VectorFixtures { paths } => {
             run_vector_fixture_reports(
                 paths,
@@ -217,15 +211,7 @@ pub async fn run_report(args: &ReportArgs) -> Result<ReportRunSummary, Box<dyn E
             .await?
         }
         ReportInput::GeneratedInputs { paths, adapter } => {
-            run_generated_input_reports(
-                paths,
-                *adapter,
-                &args.out,
-                args.strict_oracle,
-                args.storage_mode,
-                args.capture_sensitive_replay,
-            )
-            .await?
+            run_generated_input_reports(paths, *adapter, args).await?
         }
     };
 
@@ -245,15 +231,12 @@ async fn run_generated_family_reports(
     family: &str,
     seed: u64,
     cases: usize,
-    out: &Path,
-    strict_oracle: bool,
-    storage_mode: HarnessStorageMode,
-    capture_sensitive_replay: bool,
+    args: &ReportArgs,
 ) -> Result<Vec<ScenarioReportSummary>, Box<dyn Error>> {
     let mut summaries = Vec::with_capacity(cases);
     for case_index in 0..cases {
         let case = generate_family_case(family, seed, u64::try_from(case_index)?)?;
-        let input_output = out.join(format!(
+        let input_output = args.out.join(format!(
             "{}-seed-{}-case-{}-generated-input.json",
             case.family_name.replace('/', "-"),
             case.seed,
@@ -272,10 +255,11 @@ async fn run_generated_family_reports(
                     provenance,
                     label: source,
                 },
-                out,
-                strict_oracle,
-                storage_mode,
-                capture_sensitive_replay,
+                &args.out,
+                args.strict_oracle,
+                args.storage_mode,
+                args.capture_sensitive_replay,
+                args.minimization_budget,
             )
             .await?,
         );
@@ -287,10 +271,7 @@ async fn run_generated_family_reports(
 async fn run_generated_input_reports(
     paths: &[PathBuf],
     adapter: Option<crate::GeneratedSubjectKind>,
-    out: &Path,
-    strict_oracle: bool,
-    storage_mode: HarnessStorageMode,
-    capture_sensitive_replay: bool,
+    args: &ReportArgs,
 ) -> Result<Vec<ScenarioReportSummary>, Box<dyn Error>> {
     if paths.is_empty() {
         return Err("no generated input paths supplied".into());
@@ -310,10 +291,11 @@ async fn run_generated_input_reports(
                     provenance: resolved.provenance,
                     label: path.display().to_string(),
                 },
-                out,
-                strict_oracle,
-                storage_mode,
-                capture_sensitive_replay,
+                &args.out,
+                args.strict_oracle,
+                args.storage_mode,
+                args.capture_sensitive_replay,
+                args.minimization_budget,
             )
             .await?,
         );
@@ -334,17 +316,20 @@ async fn run_generated_case_artifacts(
     strict_oracle: bool,
     storage_mode: HarnessStorageMode,
     capture_sensitive_replay: bool,
+    minimization_budget: GeneratedScenarioMinimizationBudget,
 ) -> Result<ScenarioReportSummary, Box<dyn Error>> {
     let execution_subject = source.adapter.unwrap_or(case.subject);
     let adapter_overridden = execution_subject != case.subject;
-    let (mut report, failure_capture) = crate::run_generated_case_report_with_capture_on_subject(
-        case,
-        execution_subject,
-        None,
-        storage_mode,
-        capture_sensitive_replay,
-    )
-    .await?;
+    let (mut report, failure_capture) =
+        crate::family::run_generated_case_report_with_capture_on_subject_before_minimization(
+            case,
+            execution_subject,
+            None,
+            storage_mode,
+            capture_sensitive_replay,
+            minimization_budget,
+        )
+        .await?;
     report.metadata.input_provenance = Some(source.provenance);
     let artifact_stem = generated_artifact_stem(case, execution_subject);
     let output = out.join(format!("{artifact_stem}.json"));
@@ -357,6 +342,7 @@ async fn run_generated_case_artifacts(
     let coverage = coverage_matrix_entry(source.label.clone(), &report);
     let failures = scenario_report_failures(&report, strict_oracle);
     let failure_count = failures.len();
+    let capsule_capture = failure_capture_for(&failures, failure_capture);
     let failure_capsules = if failures.is_empty() {
         WrittenFailureCapsules::default()
     } else {
@@ -364,11 +350,38 @@ async fn run_generated_case_artifacts(
         let replay_path = out.join(format!("{artifact_stem}-sensitive-replay-capsule.v1.json"));
         write_report_failure_capsules(
             &report,
-            failure_capture_for(&failures, failure_capture),
+            capsule_capture.clone(),
             portable_path,
             replay_path,
+            ArtifactWriteMode::Create,
         )?
     };
+
+    // The original report, fixture candidate, and failure capsules are now
+    // durable. Optional semantic reduction may consume its own bounded budget
+    // without being able to erase the primary failure evidence.
+    crate::family::complete_generated_minimization(
+        case,
+        execution_subject,
+        None,
+        &mut report,
+        storage_mode,
+        minimization_budget,
+    )
+    .await;
+    replace_private_json(&output, &report)?;
+    if !failures.is_empty() {
+        write_report_failure_capsules(
+            &report,
+            capsule_capture,
+            failure_capsules
+                .portable
+                .clone()
+                .expect("failing generated reports always write a portable capsule"),
+            out.join(format!("{artifact_stem}-sensitive-replay-capsule.v1.json")),
+            ArtifactWriteMode::Replace,
+        )?;
+    }
     Ok(ScenarioReportSummary {
         scenario_name: report.metadata.scenario_name.clone(),
         source: source.label,
@@ -458,6 +471,7 @@ async fn run_vector_fixture_reports(
                 failure_capture_for(&failures, failure_capture),
                 portable_path,
                 replay_path,
+                ArtifactWriteMode::Create,
             )?
         };
         summaries.push(ScenarioReportSummary {
@@ -496,11 +510,18 @@ struct WrittenFailureCapsules {
     replay: Option<PathBuf>,
 }
 
+#[derive(Clone, Copy)]
+enum ArtifactWriteMode {
+    Create,
+    Replace,
+}
+
 fn write_report_failure_capsules(
     report: &ScenarioReport,
     capture: crate::ScenarioFailureCaptureV1,
     portable_path: PathBuf,
     replay_path: PathBuf,
+    mode: ArtifactWriteMode,
 ) -> Result<WrittenFailureCapsules, Box<dyn Error>> {
     let portable_capsule = FailureCapsuleV1::from_report_capture(
         report.clone(),
@@ -508,7 +529,7 @@ fn write_report_failure_capsules(
         capture.transport,
         None,
     )?;
-    write_failure_capsule(&portable_path, &portable_capsule)?;
+    write_private_json(&portable_path, &portable_capsule, mode)?;
 
     let replay = if let Some(byte_replay) = capture.byte_replay {
         let replay_capsule = FailureCapsuleV1::from_report(
@@ -517,7 +538,7 @@ fn write_report_failure_capsules(
             Vec::new(),
             Some(byte_replay),
         )?;
-        write_failure_capsule(&replay_path, &replay_capsule)?;
+        write_private_json(&replay_path, &replay_capsule, mode)?;
         Some(replay_path)
     } else {
         None
@@ -527,6 +548,66 @@ fn write_report_failure_capsules(
         portable: Some(portable_path),
         replay,
     })
+}
+
+fn write_private_json<T: serde::Serialize>(
+    path: &Path,
+    value: &T,
+    mode: ArtifactWriteMode,
+) -> Result<(), Box<dyn Error>> {
+    let bytes = serde_json::to_vec_pretty(value)?;
+    match mode {
+        ArtifactWriteMode::Create => fs_private::write_private(path, &bytes)?,
+        ArtifactWriteMode::Replace => replace_private(path, &bytes)?,
+    }
+    Ok(())
+}
+
+fn replace_private_json<T: serde::Serialize>(path: &Path, value: &T) -> Result<(), Box<dyn Error>> {
+    write_private_json(path, value, ArtifactWriteMode::Replace)
+}
+
+/// Durably replace a private artifact without exposing a truncated live path.
+/// A process killed during the write leaves either the original file or the
+/// complete replacement.
+fn replace_private(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(0);
+
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let file_name = path.file_name().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "private replacement path must name a file",
+        )
+    })?;
+    let (mut file, temporary) = loop {
+        let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
+        let mut temporary_name = file_name.to_os_string();
+        temporary_name.push(format!(".tmp-{}-{id}", std::process::id()));
+        let temporary = parent.join(temporary_name);
+        match fs_private::create_new_private(&temporary) {
+            Ok(file) => break (file, temporary),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        }
+    };
+
+    let result = (|| -> std::io::Result<()> {
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        drop(file);
+        std::fs::rename(&temporary, path)?;
+        #[cfg(unix)]
+        std::fs::File::open(parent)?.sync_all()?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temporary);
+    }
+    result
 }
 
 fn collect_vector_fixture_paths(paths: &[PathBuf]) -> Result<Vec<PathBuf>, Box<dyn Error>> {
@@ -601,6 +682,7 @@ pub fn parse_report_command(
     let mut storage_mode = None;
     let mut replay_capsule = None;
     let mut capture_sensitive_replay = false;
+    let mut minimization_budget = GeneratedScenarioMinimizationBudget::default();
     let mut scenario_input_selected = false;
     let mut generated_family_selected = false;
 
@@ -641,6 +723,23 @@ pub fn parse_report_command(
                 replay_capsule = Some(PathBuf::from(next_value(&mut args, "--replay-capsule")?));
             }
             "--capture-sensitive-replay" => capture_sensitive_replay = true,
+            "--minimization-wall-time-secs" => {
+                scenario_input_selected = true;
+                minimization_budget.wall_clock = Duration::from_secs(
+                    next_value(&mut args, "--minimization-wall-time-secs")?.parse()?,
+                );
+            }
+            "--minimization-max-trials" => {
+                scenario_input_selected = true;
+                minimization_budget.max_trials =
+                    next_value(&mut args, "--minimization-max-trials")?.parse()?;
+            }
+            "--minimization-trial-timeout-secs" => {
+                scenario_input_selected = true;
+                minimization_budget.per_trial_timeout = Duration::from_secs(
+                    next_value(&mut args, "--minimization-trial-timeout-secs")?.parse()?,
+                );
+            }
             "--out" => out = PathBuf::from(next_value(&mut args, "--out")?),
             "--storage" => {
                 storage_mode = Some(HarnessStorageMode::parse(&next_value(
@@ -673,6 +772,7 @@ pub fn parse_report_command(
     if generated_input_adapter.is_some() && generated_inputs.is_empty() {
         return Err("--adapter requires at least one --generated-input".into());
     }
+    minimization_budget = minimization_budget.validate()?;
 
     let input = if !generated_inputs.is_empty() {
         ReportInput::GeneratedInputs {
@@ -695,6 +795,7 @@ pub fn parse_report_command(
         strict_oracle,
         storage_mode: storage_mode.unwrap_or_else(HarnessStorageMode::from_env),
         capture_sensitive_replay,
+        minimization_budget,
     }))
 }
 
@@ -707,7 +808,7 @@ fn next_value(
 }
 
 pub fn report_usage() -> &'static str {
-    "Usage: cgka-conformance-simulator-report [--replay-capsule FILE | --generated-input FILE ... [--adapter engine|retained-relay|app-runtime] | --vectors FILE_OR_DIR ... | --family send-leave/v1|convergence-e2e-delivery/v1|convergence-chaos/v1|admin-churn/v1|adversarial-reliability/v1|bounded-convergence-pressure/v1|large-group-pressure/v1|offline-catchup-pressure/v1|cross-route-restart-permutations/v1|cross-route-exact-restart-permutations/v1|chat-journey/v1 --seed N --cases N] [--out DIR] [--storage memory|file] [--strict-oracle|--allow-weak-oracle] [--capture-sensitive-replay]"
+    "Usage: cgka-conformance-simulator-report [--replay-capsule FILE | --generated-input FILE ... [--adapter engine|retained-relay|app-runtime] | --vectors FILE_OR_DIR ... | --family send-leave/v1|convergence-e2e-delivery/v1|convergence-chaos/v1|admin-churn/v1|adversarial-reliability/v1|bounded-convergence-pressure/v1|large-group-pressure/v1|offline-catchup-pressure/v1|cross-route-restart-permutations/v1|cross-route-exact-restart-permutations/v1|chat-journey/v1 --seed N --cases N] [--out DIR] [--storage memory|file] [--strict-oracle|--allow-weak-oracle] [--capture-sensitive-replay] [--minimization-wall-time-secs N] [--minimization-max-trials N] [--minimization-trial-timeout-secs N]"
 }
 
 #[cfg(test)]
@@ -882,6 +983,7 @@ mod tests {
             seed: case.seed,
             case_index: case.case_index,
             workload_profile: case.workload_profile.clone(),
+            minimization: Default::default(),
             minimized_case: Some(minimized.clone()),
         });
 
@@ -889,5 +991,32 @@ mod tests {
 
         assert_eq!(fixture.scenario, original);
         assert_ne!(fixture.scenario, minimized);
+    }
+
+    #[test]
+    fn private_artifact_replacement_is_complete_and_owner_only() {
+        let root = tempfile::tempdir().expect("temporary artifact root");
+        let path = root.path().join("report.json");
+        fs_private::write_private(&path, br#"{"status":"original"}"#)
+            .expect("original artifact writes");
+
+        replace_private(&path, br#"{"status":"complete"}"#).expect("replacement artifact writes");
+
+        assert_eq!(
+            std::fs::read(&path).expect("replacement reads"),
+            br#"{"status":"complete"}"#
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&path)
+                    .expect("replacement metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                fs_private::PRIVATE_FILE_MODE
+            );
+        }
     }
 }

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -424,7 +424,34 @@ pub struct GeneratedScenarioMetadata {
     pub case_index: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workload_profile: Option<crate::GeneratedWorkloadProfileV1>,
+    #[serde(default)]
+    pub minimization: GeneratedScenarioMinimizationV1,
     pub minimized_case: Option<ScenarioSpec>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GeneratedScenarioMinimizationStatus {
+    /// The report has no fingerprinted failure, so reduction is unnecessary.
+    #[default]
+    Skipped,
+    /// The original report is durable and optional reduction is in progress.
+    Pending,
+    /// Reduction exhausted every eligible candidate inside the configured budget.
+    Complete,
+    /// The wall-clock, trial-count, or per-trial budget stopped reduction.
+    BudgetExhausted,
+    /// A fresh execution of the original scenario did not reproduce the failure.
+    NotReproducible,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GeneratedScenarioMinimizationV1 {
+    pub status: GeneratedScenarioMinimizationStatus,
+    pub trials: usize,
+    pub wall_clock_budget_ms: u64,
+    pub max_trials: usize,
+    pub per_trial_timeout_ms: u64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -2343,7 +2343,7 @@ async fn strict_chaos_boundary_retires_pre_join_opaque_resource_work() {
 }
 
 #[tokio::test]
-async fn failing_generated_case_records_a_minimized_reproducer() {
+async fn failing_generated_case_records_bounded_minimization_outcome() {
     let mut scenario = ScenarioSpec {
         name: "convergence-chaos/minimizer-smoke/v1".into(),
         spec_version: "2".into(),
@@ -2442,7 +2442,7 @@ async fn failing_generated_case_records_a_minimized_reproducer() {
                 .steps
                 .iter()
                 .all(|step| !matches!(step, ScenarioStep::SendAppMessage { .. })),
-            "a completed semantic reduction should remove the entire application-message storm"
+            "a completed semantic reduction should remove all irrelevant application-message noise"
         );
     }
     let minimized_report =

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -2406,23 +2406,36 @@ async fn failing_generated_case_records_a_minimized_reproducer() {
         .expect("failing generated case still reports");
 
     assert_eq!(report.expectation_failures.len(), 1);
-    let minimized = report
+    let generated = report
         .metadata
         .generated
         .as_ref()
-        .and_then(|generated| generated.minimized_case.as_ref())
+        .expect("failing generated case should record generated metadata");
+    assert!(matches!(
+        generated.minimization.status,
+        cgka_conformance_simulator::GeneratedScenarioMinimizationStatus::Complete
+            | cgka_conformance_simulator::GeneratedScenarioMinimizationStatus::BudgetExhausted
+    ));
+    assert!(generated.minimization.trials > 1);
+    let minimized = generated
+        .minimized_case
+        .as_ref()
         .expect("failing generated case should record a minimized case");
     assert!(
         minimized.steps.len() < case.scenario.steps.len(),
         "minimized case should remove irrelevant delivery noise"
     );
-    assert!(
-        minimized
-            .steps
-            .iter()
-            .all(|step| !matches!(step, ScenarioStep::SendAppMessage { .. })),
-        "semantic failure identity should let the reducer remove the entire application-message storm"
-    );
+    if generated.minimization.status
+        == cgka_conformance_simulator::GeneratedScenarioMinimizationStatus::Complete
+    {
+        assert!(
+            minimized
+                .steps
+                .iter()
+                .all(|step| !matches!(step, ScenarioStep::SendAppMessage { .. })),
+            "a completed semantic reduction should remove the entire application-message storm"
+        );
+    }
     let minimized_report =
         run_scenario_report_with_outcomes(minimized, None, case.expected_outcomes.clone())
             .await

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -2416,11 +2416,20 @@ async fn failing_generated_case_records_a_minimized_reproducer() {
         cgka_conformance_simulator::GeneratedScenarioMinimizationStatus::Complete
             | cgka_conformance_simulator::GeneratedScenarioMinimizationStatus::BudgetExhausted
     ));
-    assert!(generated.minimization.trials > 1);
-    let minimized = generated
-        .minimized_case
-        .as_ref()
-        .expect("failing generated case should record a minimized case");
+    assert!(generated.minimization.trials >= 1);
+    if generated.minimization.status
+        == cgka_conformance_simulator::GeneratedScenarioMinimizationStatus::Complete
+    {
+        assert!(generated.minimization.trials > 1);
+    }
+    let Some(minimized) = generated.minimized_case.as_ref() else {
+        assert_eq!(
+            generated.minimization.status,
+            cgka_conformance_simulator::GeneratedScenarioMinimizationStatus::BudgetExhausted,
+            "only budget exhaustion may omit a reduced case"
+        );
+        return;
+    };
     assert!(
         minimized.steps.len() < case.scenario.steps.len(),
         "minimized case should remove irrelevant delivery noise"

--- a/crates/cgka-conformance-simulator/tests/process_campaign_runner.rs
+++ b/crates/cgka-conformance-simulator/tests/process_campaign_runner.rs
@@ -59,6 +59,11 @@ fn isolated_campaign_preserves_input_provenance_and_refuses_overwrite() {
     assert_eq!(summary["family"], "send-leave/v1");
     assert_eq!(summary["storage"], "memory");
     assert_eq!(summary["case_timeout_ms"], 60_000);
+    assert_eq!(summary["minimization_wall_time_ms"], 30_000);
+    assert_eq!(summary["minimization_max_trials"], 256);
+    assert_eq!(summary["minimization_trial_timeout_ms"], 5_000);
+    assert_eq!(summary["cases"][0]["minimization_status"], "skipped");
+    assert!(summary["cases"][0].get("timeout_phase").is_none());
     assert_eq!(
         summary["cases"][0]["artifact_integrity_errors"],
         serde_json::json!([])

--- a/crates/cgka-conformance-simulator/tests/report_runner.rs
+++ b/crates/cgka-conformance-simulator/tests/report_runner.rs
@@ -3,8 +3,9 @@ use std::path::PathBuf;
 
 use cgka_conformance_simulator::{
     FailureCapsuleSensitivity, GeneratedScenarioCase, GeneratedScenarioInputV1,
-    GeneratedSubjectKind, HarnessStorageMode, OracleBehavior, ReportArgs, ReportCommand,
-    ReportInput, ScenarioSpec, ScenarioStep, ScenarioStimulus, parse_report_command,
+    GeneratedScenarioMinimizationBudget, GeneratedScenarioMinimizationStatus, GeneratedSubjectKind,
+    HarnessStorageMode, OracleBehavior, ReportArgs, ReportCommand, ReportInput, ScenarioReport,
+    ScenarioSpec, ScenarioStep, ScenarioStimulus, TraceExpectation, parse_report_command,
     promote_failure_capsule_to_vector, property_test_coverage_entries, read_failure_capsule,
     replay_engine_bytes, run_report,
 };
@@ -24,6 +25,7 @@ fn parse_defaults_to_send_leave_family() {
             strict_oracle: true,
             storage_mode: HarnessStorageMode::InMemorySqlite,
             capture_sensitive_replay: false,
+            minimization_budget: Default::default(),
         })
     );
 }
@@ -54,6 +56,7 @@ fn parse_custom_report_args() {
             strict_oracle: true,
             storage_mode: HarnessStorageMode::InMemorySqlite,
             capture_sensitive_replay: false,
+            minimization_budget: Default::default(),
         })
     );
 }
@@ -66,6 +69,42 @@ fn explicit_storage_flag_overrides_environment_default() {
         panic!("expected run command");
     };
     assert_eq!(args.storage_mode, HarnessStorageMode::TempFileBackedSqlite);
+}
+
+#[test]
+fn generated_report_minimization_budgets_are_configurable() {
+    let ReportCommand::Run(args) = parse_report_command([
+        "--minimization-wall-time-secs".into(),
+        "17".into(),
+        "--minimization-max-trials".into(),
+        "23".into(),
+        "--minimization-trial-timeout-secs".into(),
+        "3".into(),
+    ])
+    .expect("minimization budgets parse") else {
+        panic!("expected run command");
+    };
+    assert_eq!(
+        args.minimization_budget,
+        GeneratedScenarioMinimizationBudget {
+            wall_clock: std::time::Duration::from_secs(17),
+            max_trials: 23,
+            per_trial_timeout: std::time::Duration::from_secs(3),
+        }
+    );
+}
+
+#[test]
+fn generated_report_rejects_zero_minimization_budgets() {
+    for flag in [
+        "--minimization-wall-time-secs",
+        "--minimization-max-trials",
+        "--minimization-trial-timeout-secs",
+    ] {
+        let error = parse_report_command([flag.into(), "0".into()])
+            .expect_err("zero minimization budgets must fail");
+        assert!(error.to_string().contains("must be greater than zero"));
+    }
 }
 
 #[test]
@@ -98,6 +137,7 @@ fn parse_vector_fixture_report_args() {
             strict_oracle: true,
             storage_mode: HarnessStorageMode::InMemorySqlite,
             capture_sensitive_replay: false,
+            minimization_budget: Default::default(),
         })
     );
 }
@@ -130,6 +170,7 @@ fn parse_generated_input_report_args() {
             strict_oracle: true,
             storage_mode: HarnessStorageMode::InMemorySqlite,
             capture_sensitive_replay: false,
+            minimization_budget: Default::default(),
         })
     );
 }
@@ -205,6 +246,7 @@ async fn adapter_override_uses_distinct_artifacts_without_minting_a_fixture() {
             strict_oracle: false,
             storage_mode: HarnessStorageMode::InMemorySqlite,
             capture_sensitive_replay: false,
+            minimization_budget: Default::default(),
         })
         .await
         .unwrap();
@@ -241,6 +283,7 @@ fn parse_strict_oracle_report_args() {
             strict_oracle: true,
             storage_mode: HarnessStorageMode::InMemorySqlite,
             capture_sensitive_replay: false,
+            minimization_budget: Default::default(),
         })
     );
 }
@@ -358,6 +401,7 @@ async fn report_runner_writes_send_leave_json_reports() {
         strict_oracle: false,
         storage_mode: HarnessStorageMode::InMemorySqlite,
         capture_sensitive_replay: false,
+        minimization_budget: Default::default(),
     })
     .await
     .expect("runner writes reports");
@@ -408,6 +452,134 @@ async fn report_runner_writes_send_leave_json_reports() {
 }
 
 #[tokio::test]
+async fn minimization_budget_exhaustion_preserves_the_original_failure_artifacts() {
+    let root = tempfile::tempdir().expect("temporary report root");
+    let input_path = root.path().join("generated-input.json");
+    let out = root.path().join("reports");
+    let case = GeneratedScenarioCase {
+        family_name: "minimization-budget/v1".into(),
+        generator_version: "1".into(),
+        seed: 17,
+        case_index: 0,
+        workload_profile: None,
+        subject: GeneratedSubjectKind::Engine,
+        scenario: ScenarioSpec {
+            name: "minimization-budget/v1/case-0".into(),
+            spec_version: "2".into(),
+            topology: Default::default(),
+            clients: vec!["alice".into()],
+            steps: vec![
+                ScenarioStep::CreateGroup {
+                    creator: "alice".into(),
+                    name: "budgeted".into(),
+                    invitees: Vec::new(),
+                    required_features: Vec::new(),
+                    initial_admins: None,
+                    pending: "create".into(),
+                },
+                ScenarioStep::SetPartition {
+                    allow: vec!["alice".into()],
+                },
+                ScenarioStep::ClearPartition,
+                ScenarioStep::Observe {
+                    clients: vec!["alice".into()],
+                },
+            ],
+        },
+        expected_outcomes: vec![TraceExpectation::ClientState {
+            client: "alice".into(),
+            epoch: 1,
+            member_count: 99,
+            received_payloads: None,
+            added_members: None,
+            removed_members: None,
+        }],
+    };
+    fs_private::write_private(
+        &input_path,
+        &serde_json::to_vec_pretty(&GeneratedScenarioInputV1::new(case))
+            .expect("generated input serializes"),
+    )
+    .expect("generated input writes");
+
+    let summary = run_report(&ReportArgs {
+        input: ReportInput::GeneratedInputs {
+            paths: vec![input_path],
+            adapter: None,
+        },
+        out: out.clone(),
+        strict_oracle: true,
+        storage_mode: HarnessStorageMode::InMemorySqlite,
+        capture_sensitive_replay: false,
+        minimization_budget: GeneratedScenarioMinimizationBudget {
+            wall_clock: std::time::Duration::from_secs(1),
+            max_trials: 1,
+            per_trial_timeout: std::time::Duration::from_secs(1),
+        },
+    })
+    .await
+    .expect("budget exhaustion remains a reportable failure");
+
+    assert_eq!(summary.failed(), 1);
+    let stem = "minimization-budget-v1-seed-17-case-0";
+    let report_path = out.join(format!("{stem}.json"));
+    let fixture_path = out.join(format!("{stem}-fixture.v1.json"));
+    let capsule_path = out.join(format!("{stem}-failure-capsule.v1.json"));
+    assert!(
+        fixture_path.is_file(),
+        "the original fixture remains durable"
+    );
+    let report: ScenarioReport = serde_json::from_slice(
+        &fs::read(&report_path).expect("the original report remains durable"),
+    )
+    .expect("the report remains parseable");
+    let generated = report
+        .metadata
+        .generated
+        .as_ref()
+        .expect("generated metadata exists");
+    assert_eq!(
+        generated.minimization.status,
+        GeneratedScenarioMinimizationStatus::BudgetExhausted
+    );
+    assert_eq!(generated.minimization.trials, 1);
+    assert!(generated.minimized_case.is_none());
+    assert!(
+        report
+            .expectation_failures
+            .iter()
+            .any(|failure| failure.kind == "client_state_mismatch"),
+        "unexpected original failures: {:?}; steps: {:?}",
+        report.expectation_failures,
+        report.step_log
+    );
+
+    let capsule = read_failure_capsule(&capsule_path).expect("portable capsule remains readable");
+    assert_eq!(
+        capsule.sensitivity,
+        FailureCapsuleSensitivity::SyntheticShareable
+    );
+    assert!(
+        capsule
+            .report
+            .expectation_failures
+            .iter()
+            .any(|failure| failure.kind == "client_state_mismatch")
+    );
+    assert_eq!(
+        capsule
+            .report
+            .metadata
+            .generated
+            .as_ref()
+            .expect("capsule generated metadata")
+            .minimization
+            .status,
+        GeneratedScenarioMinimizationStatus::BudgetExhausted
+    );
+}
+
+#[tokio::test]
 async fn report_runner_strict_oracle_counts_weak_warnings_as_failures() {
     let out_dir = std::env::temp_dir().join(format!(
         "mdk-cgka-strict-oracle-report-test-{}",
@@ -441,6 +613,7 @@ async fn report_runner_strict_oracle_counts_weak_warnings_as_failures() {
         strict_oracle: true,
         storage_mode: HarnessStorageMode::InMemorySqlite,
         capture_sensitive_replay: false,
+        minimization_budget: Default::default(),
     })
     .await
     .expect("strict runner writes reports");
@@ -490,6 +663,7 @@ async fn report_runner_writes_convergence_delivery_json_reports() {
         strict_oracle: false,
         storage_mode: HarnessStorageMode::InMemorySqlite,
         capture_sensitive_replay: false,
+        minimization_budget: Default::default(),
     })
     .await
     .expect("runner writes convergence delivery reports");
@@ -544,6 +718,7 @@ async fn report_runner_writes_convergence_chaos_reports_and_fixture_candidates()
         strict_oracle: false,
         storage_mode: HarnessStorageMode::InMemorySqlite,
         capture_sensitive_replay: false,
+        minimization_budget: Default::default(),
     })
     .await
     .expect("runner writes convergence chaos reports");
@@ -636,6 +811,7 @@ async fn report_runner_writes_vector_fixture_reports_and_summary() {
         strict_oracle: false,
         storage_mode: HarnessStorageMode::InMemorySqlite,
         capture_sensitive_replay: false,
+        minimization_budget: Default::default(),
     })
     .await
     .expect("runner writes vector reports");
@@ -698,6 +874,7 @@ async fn failed_campaign_capsule_contains_a_replayable_tick_witness() {
         strict_oracle: false,
         storage_mode: HarnessStorageMode::InMemorySqlite,
         capture_sensitive_replay: true,
+        minimization_budget: Default::default(),
     })
     .await
     .expect("failing campaign reports");
@@ -841,6 +1018,7 @@ async fn refused_application_send_fails_step_without_aborting_the_run() {
         strict_oracle: false,
         storage_mode: HarnessStorageMode::InMemorySqlite,
         capture_sensitive_replay: false,
+        minimization_budget: Default::default(),
     })
     .await
     .expect("runner completes despite the refused send");

--- a/crates/cgka-conformance-simulator/tests/stateful_generator.rs
+++ b/crates/cgka-conformance-simulator/tests/stateful_generator.rs
@@ -85,6 +85,7 @@ async fn report_runner_executes_and_preserves_both_journey_profiles() {
         strict_oracle: true,
         storage_mode: HarnessStorageMode::InMemorySqlite,
         capture_sensitive_replay: false,
+        minimization_budget: Default::default(),
     })
     .await
     .expect("representative journeys execute");
@@ -143,6 +144,7 @@ async fn report_runner_executes_and_preserves_both_journey_profiles() {
         strict_oracle: true,
         storage_mode: HarnessStorageMode::InMemorySqlite,
         capture_sensitive_replay: false,
+        minimization_budget: Default::default(),
     })
     .await
     .expect("saved retained-relay input replays");


### PR DESCRIPTION
## Summary

- persist the original generated-case report, fixture candidate, and failure capsules before semantic minimization starts
- bound minimization by configurable wall-clock, trial-count, and per-trial limits, with explicit completion statuses
- distinguish scenario execution, minimization, and post-processing timeouts in process campaign summaries

## Test plan

- [x] cargo test -p cgka-conformance-simulator --locked
- [x] cargo test -p cgka-conformance-simulator --test report_runner --locked
- [x] cargo test -p cgka-conformance-simulator --bin cgka-conformance-campaign --locked
- [x] just fast-ci

Fixes #1652

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bounded minimization for generated scenarios with configurable wall-clock, trial-count, and per-trial limits.
  * Reports now include minimization status, trial counts, budgets, and timeout phases.
  * Added command-line options for configuring and validating minimization budgets.

* **Reliability**
  * Original failure artifacts and classifications are preserved when minimization is interrupted, exhausted, or unsuccessful.
  * Improved safe artifact replacement and cleanup of temporary campaign files.

* **Documentation**
  * Updated guidance for minimization outcomes, timeouts, pending records, and campaign result aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->