### PR TITLE
Fix/session error diagnosability

### DIFF
--- a/crates/cgka-engine/src/audit_helpers.rs
+++ b/crates/cgka-engine/src/audit_helpers.rs
@@ -542,39 +542,13 @@ pub(crate) fn create_group_outcome_event(result: &SendResult) -> AuditEventKind 
     }
 }
 
+/// Audit-row name for an engine failure.
+///
+/// The vocabulary lives on [`EngineError::privacy_safe_kind`] so the engine's
+/// audit rows, the app runtime's tracing fields, and the daemon's status JSON
+/// cannot drift apart.
 pub(crate) fn engine_error_kind(err: &EngineError) -> &'static str {
-    match err {
-        EngineError::UnknownGroup(_) => "unknown_group",
-        EngineError::GroupNotHydrated(_) => "group_not_hydrated",
-        EngineError::UnknownPending => "unknown_pending",
-        EngineError::NotAMember { .. } => "not_a_member",
-        EngineError::NotGroupAdmin { .. } => "not_group_admin",
-        EngineError::UnknownMember { .. } => "unknown_member",
-        EngineError::InvalidCredentialIdentity(_) => "invalid_credential_identity",
-        EngineError::AdminCannotSelfRemove { .. } => "admin_cannot_self_remove",
-        EngineError::LeaveAlreadyRequested { .. } => "leave_already_requested",
-        EngineError::AdminDepletion { .. } => "admin_depletion",
-        EngineError::MissingRequiredCapabilities { .. } => "missing_required_capabilities",
-        EngineError::DisbandingUnsupportedMembers { .. } => "disbanding_unsupported_members",
-        EngineError::DisbandingNotEnabled { .. } => "disbanding_not_enabled",
-        EngineError::UnsupportedCiphersuite { .. } => "unsupported_ciphersuite",
-        EngineError::InvalidAppMessagePayload(_) => "invalid_app_message_payload",
-        EngineError::InvalidAccountIdentityProof(_) => "invalid_account_identity_proof",
-        EngineError::InvalidKeyPackageLifetime { .. } => "invalid_key_package_lifetime",
-        EngineError::ForkedEpoch { .. } => "forked_epoch",
-        EngineError::QueuedOutboundAtCapacity { .. } => "queued_outbound_at_capacity",
-        EngineError::GroupUnrecoverableRepairRequired { .. } => {
-            "group_unrecoverable_repair_required"
-        }
-        EngineError::InvalidTransition(_) => "invalid_transition",
-        EngineError::Storage(_) => "storage",
-        EngineError::Peeler(_) => "peeler",
-        EngineError::Serialize(_) => "serialize",
-        EngineError::InvalidWelcome => "invalid_welcome",
-        EngineError::WelcomeAlreadyProcessed => "welcome_already_processed",
-        EngineError::Backend(_) => "backend",
-        EngineError::Other(_) => "other",
-    }
+    err.privacy_safe_kind()
 }
 
 pub(crate) fn engine_error_detail(err: &EngineError) -> Option<String> {

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -2046,6 +2046,20 @@ impl<S: StorageProvider> Engine<S> {
             {
                 continue;
             }
+            // Deliberately NOT gated on the commit having been applied locally.
+            // `pre_apply` reads `Created` for a rival this device buffered, the
+            // pass materialized, and branch selection put on the losing side —
+            // and that announces too. Narrowing to `Processed` would be the
+            // wrong trade in both directions. The wide signal is inert where it
+            // has nothing to retract: `origin_commit_id` is stamped only on rows
+            // synthesized from an applied commit's `GroupStateChanged`, so every
+            // consumer keyed on that id (the timeline withdrawal, the
+            // last-verdict filter in the app's `project_group_system_rows`,
+            // `mark_evolution_superseded`) matches nothing for a commit that was
+            // never applied. And the pair is the only portable statement that a
+            // NAMED commit lost selection, which is what a peer holding no branch
+            // of its own records as its share of the fleet's agreement about a
+            // fork's outcome.
             let invalidated_commit_id = message_id_from_hex(&deferred.message_id)?;
             // The stored record's epoch is the commit's source epoch (the fork
             // it lost). A missing record falls back to the selected branch's

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -2108,6 +2108,16 @@ impl<S: StorageProvider> Engine<S> {
             .ingest_group_message_from_sweep(&msg, group_id.as_slice().to_vec(), sweep)
             .await
         {
+            // Still unreadable: the row keeps its place in the retry lifecycle
+            // and the caller charges its budget. The verdict's `lineage` is
+            // dropped on purpose. There is exactly one lineage site
+            // (`Self::deferral_lineage`, reached from the single deferral return
+            // in `ingest_group_message_from_sweep`), and it answers about the
+            // GROUP's stored commit graph rather than about this row — so a
+            // sweep can only ever restate what live ingest already reported for
+            // this group, over rows the app's stall detector counted when they
+            // first arrived. Routing it out would re-count that evidence, not
+            // sharpen it.
             Ok(IngestOutcome::TransportDeferred { .. }) => Ok(false),
             Ok(IngestOutcome::ResourceRefused {
                 resource: InboundResourceLimit::TransportDeferredCapacity,

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -3656,6 +3656,17 @@ async fn convergence_pass_that_keeps_the_own_commit_emits_no_own_withdrawal() {
         local.drain_events().is_empty(),
         "buffering the rival must not be application-visible"
     );
+    // The withdrawal below names a commit this device never applied. Pinning the
+    // pre-pass state makes that deliberate: `emit_rolled_back_commits` reads the
+    // pre-apply state only to suppress a repeat announcement, never to require
+    // prior local application, so narrowing it to `Processed` would silence the
+    // pair a non-adopting peer records as its share of the fleet's agreement
+    // about which commit lost.
+    assert_eq!(
+        f.local_storage.get_message(&competing_id).unwrap().state,
+        MessageState::Created,
+        "the rival must reach the settling pass never having been applied"
+    );
 
     drive_convergence(&mut local, &f, &competing_id).await;
     assert_eq!(settled_branch(&local, &f), Branch::Own);

--- a/crates/marmot-app/src/client/audit.rs
+++ b/crates/marmot-app/src/client/audit.rs
@@ -34,6 +34,57 @@ pub(crate) struct EpochBackfillTerminalAudit {
     pub local_epoch_after: Option<u64>,
 }
 
+/// The audit row one terminal backfill outcome serializes to.
+///
+/// Free-standing so the `Option<u64>` -> row derivation is testable without a
+/// live client. Carrying the after-epoch as an `Option` only buys anything
+/// because of what this function does with `None`, and a derivation reachable
+/// only through a recorder is a derivation nothing pins.
+fn epoch_backfill_terminal_event_kind(
+    succeeded: bool,
+    terminal: EpochBackfillTerminalAudit,
+) -> AuditEventKind {
+    let observed = terminal.local_epoch_after.is_some();
+    // An unread after-epoch has no number to report, so the row repeats the
+    // before-epoch to keep the field's shape. `group_advanced_observed` beside
+    // it is what tells a reader the pair is a placeholder rather than a
+    // measurement.
+    let local_epoch_after = terminal
+        .local_epoch_after
+        .unwrap_or(terminal.local_epoch_before);
+    let group_advanced = local_epoch_after > terminal.local_epoch_before;
+    if succeeded {
+        // A run only succeeds once every armed group's after-epoch was read,
+        // so the completed row is always an observation and needs no flag.
+        AuditEventKind::EpochStallBackfillCompleted {
+            retry_ordinal: terminal.retry_ordinal,
+            duration_ms: terminal.duration_ms,
+            activation_outcome: terminal.activation_outcome,
+            completion_kind: terminal.completion_kind,
+            deliveries: terminal.deliveries,
+            skipped: Some(terminal.skipped),
+            refused: Some(terminal.refused),
+            local_epoch_before: terminal.local_epoch_before,
+            local_epoch_after,
+            group_advanced,
+        }
+    } else {
+        AuditEventKind::EpochStallBackfillFailed {
+            retry_ordinal: terminal.retry_ordinal,
+            duration_ms: terminal.duration_ms,
+            activation_outcome: terminal.activation_outcome,
+            error_kind: terminal.error_kind,
+            deliveries: terminal.deliveries,
+            skipped: Some(terminal.skipped),
+            refused: Some(terminal.refused),
+            local_epoch_before: terminal.local_epoch_before,
+            local_epoch_after,
+            group_advanced,
+            group_advanced_observed: Some(observed),
+        }
+    }
+}
+
 impl AppClient {
     pub(crate) fn local_human_action_context(
         action: impl Into<String>,
@@ -276,45 +327,7 @@ impl AppClient {
         terminal: EpochBackfillTerminalAudit,
         context: &AuditEventContext,
     ) {
-        let observed = terminal.local_epoch_after.is_some();
-        // An unread after-epoch has no number to report, so the row repeats the
-        // before-epoch to keep the field's shape. `group_advanced_observed`
-        // beside it is what tells a reader the pair is a placeholder rather than
-        // a measurement.
-        let local_epoch_after = terminal
-            .local_epoch_after
-            .unwrap_or(terminal.local_epoch_before);
-        let group_advanced = local_epoch_after > terminal.local_epoch_before;
-        let kind = if succeeded {
-            // A run only succeeds once every armed group's after-epoch was read,
-            // so the completed row is always an observation and needs no flag.
-            AuditEventKind::EpochStallBackfillCompleted {
-                retry_ordinal: terminal.retry_ordinal,
-                duration_ms: terminal.duration_ms,
-                activation_outcome: terminal.activation_outcome,
-                completion_kind: terminal.completion_kind,
-                deliveries: terminal.deliveries,
-                skipped: Some(terminal.skipped),
-                refused: Some(terminal.refused),
-                local_epoch_before: terminal.local_epoch_before,
-                local_epoch_after,
-                group_advanced,
-            }
-        } else {
-            AuditEventKind::EpochStallBackfillFailed {
-                retry_ordinal: terminal.retry_ordinal,
-                duration_ms: terminal.duration_ms,
-                activation_outcome: terminal.activation_outcome,
-                error_kind: terminal.error_kind,
-                deliveries: terminal.deliveries,
-                skipped: Some(terminal.skipped),
-                refused: Some(terminal.refused),
-                local_epoch_before: terminal.local_epoch_before,
-                local_epoch_after,
-                group_advanced,
-                group_advanced_observed: Some(observed),
-            }
-        };
+        let kind = epoch_backfill_terminal_event_kind(succeeded, terminal);
         self.runtime
             .session()
             .record_audit_event(Some(group_id), Some(context.clone()), kind);
@@ -648,9 +661,82 @@ fn schema_valid_message_ids(message_ids: Vec<String>) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::schema_valid_message_ids;
+    use super::{
+        EpochBackfillTerminalAudit, epoch_backfill_terminal_event_kind, schema_valid_message_ids,
+    };
+    use marmot_forensics::EpochBackfillActivationOutcome;
 
     const VALID: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    fn terminal_at(local_epoch_after: Option<u64>) -> EpochBackfillTerminalAudit {
+        EpochBackfillTerminalAudit {
+            retry_ordinal: 0,
+            duration_ms: 1,
+            activation_outcome: EpochBackfillActivationOutcome::Failed,
+            completion_kind: None,
+            error_kind: Some("backfill_drain_eose_timeout".to_string()),
+            deliveries: 0,
+            skipped: 0,
+            refused: 0,
+            local_epoch_before: 4,
+            local_epoch_after,
+        }
+    }
+
+    /// The row as an external reader sees it: what `JsonlRecorder` writes under
+    /// `kind`. Asserting the serialized object rather than the enum is what
+    /// makes these tests speak the analyzer's language.
+    fn row(succeeded: bool, local_epoch_after: Option<u64>) -> serde_json::Value {
+        serde_json::to_value(epoch_backfill_terminal_event_kind(
+            succeeded,
+            terminal_at(local_epoch_after),
+        ))
+        .expect("terminal audit kind serializes")
+    }
+
+    // The whole point of carrying the after-epoch as an `Option`. A failed
+    // after-read leaves the row's epoch pair a placeholder — `local_epoch_after`
+    // repeats `local_epoch_before` and `group_advanced` is that placeholder's
+    // arithmetic — so the row must say so in the one field that can, or it
+    // reads as "we looked and nothing moved" for a run that never looked.
+    #[test]
+    fn a_failed_after_read_marks_the_failed_row_unobserved() {
+        let row = row(false, None);
+        assert_eq!(row["type"], "epoch_stall_backfill_failed");
+        assert_eq!(row["group_advanced_observed"], false);
+        assert_eq!(row["local_epoch_after"], 4);
+        assert_eq!(row["group_advanced"], false);
+        // The observation state must not cost the row its real failure kind:
+        // separate fields exist so the two coexist.
+        assert_eq!(row["error_kind"], "backfill_drain_eose_timeout");
+    }
+
+    // The other branch of the same derivation. A failed run whose after-read
+    // did land reports a measurement, and `group_advanced: false` on it means
+    // what it says.
+    #[test]
+    fn an_observed_after_read_marks_the_failed_row_observed() {
+        let unmoved = row(false, Some(4));
+        assert_eq!(unmoved["group_advanced_observed"], true);
+        assert_eq!(unmoved["local_epoch_after"], 4);
+        assert_eq!(unmoved["group_advanced"], false);
+
+        let advanced = row(false, Some(9));
+        assert_eq!(advanced["group_advanced_observed"], true);
+        assert_eq!(advanced["local_epoch_after"], 9);
+        assert_eq!(advanced["group_advanced"], true);
+    }
+
+    // A completed run has read every armed group's epoch by definition, so the
+    // flag is failed-row-only. Pin its absence: a completed row that grew one
+    // would be a field no schema branch allows.
+    #[test]
+    fn a_completed_row_carries_no_observation_flag() {
+        let row = row(true, Some(9));
+        assert_eq!(row["type"], "epoch_stall_backfill_completed");
+        assert!(row.get("group_advanced_observed").is_none());
+        assert_eq!(row["group_advanced"], true);
+    }
 
     #[test]
     fn drops_empty_synthetic_source_id() {

--- a/crates/marmot-app/src/client/audit.rs
+++ b/crates/marmot-app/src/client/audit.rs
@@ -28,8 +28,10 @@ pub(crate) struct EpochBackfillTerminalAudit {
     pub skipped: u64,
     pub refused: u64,
     pub local_epoch_before: u64,
-    pub local_epoch_after: u64,
-    pub group_advanced: bool,
+    /// The group's post-replay local epoch, or `None` when the read failed.
+    /// `None` means "we could not look", which is a different finding from
+    /// "we looked and nothing moved".
+    pub local_epoch_after: Option<u64>,
 }
 
 impl AppClient {
@@ -274,7 +276,18 @@ impl AppClient {
         terminal: EpochBackfillTerminalAudit,
         context: &AuditEventContext,
     ) {
+        let observed = terminal.local_epoch_after.is_some();
+        // An unread after-epoch has no number to report, so the row repeats the
+        // before-epoch to keep the field's shape. `group_advanced_observed`
+        // beside it is what tells a reader the pair is a placeholder rather than
+        // a measurement.
+        let local_epoch_after = terminal
+            .local_epoch_after
+            .unwrap_or(terminal.local_epoch_before);
+        let group_advanced = local_epoch_after > terminal.local_epoch_before;
         let kind = if succeeded {
+            // A run only succeeds once every armed group's after-epoch was read,
+            // so the completed row is always an observation and needs no flag.
             AuditEventKind::EpochStallBackfillCompleted {
                 retry_ordinal: terminal.retry_ordinal,
                 duration_ms: terminal.duration_ms,
@@ -284,8 +297,8 @@ impl AppClient {
                 skipped: Some(terminal.skipped),
                 refused: Some(terminal.refused),
                 local_epoch_before: terminal.local_epoch_before,
-                local_epoch_after: terminal.local_epoch_after,
-                group_advanced: terminal.group_advanced,
+                local_epoch_after,
+                group_advanced,
             }
         } else {
             AuditEventKind::EpochStallBackfillFailed {
@@ -297,8 +310,9 @@ impl AppClient {
                 skipped: Some(terminal.skipped),
                 refused: Some(terminal.refused),
                 local_epoch_before: terminal.local_epoch_before,
-                local_epoch_after: terminal.local_epoch_after,
-                group_advanced: terminal.group_advanced,
+                local_epoch_after,
+                group_advanced,
+                group_advanced_observed: Some(observed),
             }
         };
         self.runtime

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -285,6 +285,54 @@ fn incomplete_full_history_repair(
     )
 }
 
+/// Build the per-group terminal audit rows for one backfill execution.
+///
+/// `epochs_after` is a *reading*, not a fact about the group: a group whose
+/// record could not be read is simply absent from the map, exactly like a group
+/// that was never armed. Carrying the after-epoch as an `Option` all the way to
+/// the row is what keeps the two apart — the alternative, defaulting it to the
+/// before-epoch, makes a failed read indistinguishable from a replay that
+/// recovered nothing and lets the row assert an observation nobody took.
+///
+/// Free-standing so the row content is testable without a live client; the
+/// caller owns the recorder.
+fn epoch_backfill_terminal_rows(
+    pending: &PendingEpochBackfill,
+    retry_ordinal: u64,
+    epochs_before: &HashMap<cgka_traits::GroupId, u64>,
+    epochs_after: &HashMap<cgka_traits::GroupId, u64>,
+    outcome: &EpochBackfillReplayOutcome,
+) -> Vec<(cgka_traits::GroupId, EpochBackfillTerminalAudit)> {
+    pending
+        .groups
+        .iter()
+        .map(|(group_id, group)| {
+            // The before-read has its own bail-out in
+            // `begin_epoch_backfill_execution`, so an absent entry here can only
+            // be the armed stalled epoch this intent was created from.
+            let local_epoch_before = epochs_before
+                .get(group_id)
+                .copied()
+                .unwrap_or(group.stalled_epoch);
+            (
+                group_id.clone(),
+                EpochBackfillTerminalAudit {
+                    retry_ordinal,
+                    duration_ms: outcome.duration_ms,
+                    activation_outcome: outcome.activation_outcome,
+                    error_kind: outcome.error_kind.clone(),
+                    completion_kind: outcome.completion_kind,
+                    deliveries: outcome.counts.deliveries,
+                    skipped: outcome.counts.skipped,
+                    refused: outcome.counts.refused,
+                    local_epoch_before,
+                    local_epoch_after: epochs_after.get(group_id).copied(),
+                },
+            )
+        })
+        .collect()
+}
+
 /// What one delivery's ingest settled, for the two seams that decide whether the
 /// delivery may be dropped from the fetch path.
 struct DeliveryIngest {
@@ -2924,11 +2972,27 @@ impl AppClient {
         );
     }
 
+    /// Read a group's current local epoch, or `None` when it cannot be read.
+    ///
+    /// `None` is deliberately not a claim about the group: it covers a group
+    /// that is gone as well as a storage backend that was busy or closed.
+    /// Callers must treat it as "unobserved", never as "unchanged". The read
+    /// error itself has no audit field to land in, so name its privacy-safe
+    /// kind here — that is the difference between chasing a deleted group and
+    /// chasing lock contention.
     fn local_epoch_for_group(&self, group_id: &cgka_traits::GroupId) -> Option<u64> {
-        self.runtime
-            .group_record(group_id)
-            .ok()
-            .map(|record| record.epoch.0)
+        match self.runtime.group_record(group_id) {
+            Ok(record) => Some(record.epoch.0),
+            Err(error) => {
+                tracing::warn!(
+                    target: "marmot_app::epoch_stall",
+                    method = "local_epoch_for_group",
+                    error_kind = AppError::from(error).privacy_safe_kind(),
+                    "local group epoch could not be read; treating it as unobserved"
+                );
+                None
+            }
+        }
     }
 
     fn capture_pending_group_epochs(
@@ -3006,6 +3070,11 @@ impl AppClient {
         let epochs_after = self.capture_pending_group_epochs(&execution.pending);
         let observed_all_groups = epochs_after.len() == execution.pending.groups.len();
         let succeeded = succeeded && observed_all_groups;
+        // The marker only fills in for a run that failed *because* an epoch was
+        // unreadable and had no other failure to report; a real failure kind
+        // keeps priority. That no longer costs anything, because the per-group
+        // row now carries `group_advanced_observed` — the failure kind and the
+        // observation state live in separate fields and coexist.
         let error_kind = if !observed_all_groups && error_kind.is_none() {
             Some("group_epoch_unavailable".to_string())
         } else {
@@ -3146,32 +3215,17 @@ impl AppClient {
         outcome: EpochBackfillReplayOutcome,
     ) {
         let context = Self::epoch_backfill_audit_context(pending);
-        for group_id in pending.groups.keys() {
-            let local_epoch_before = epochs_before
-                .get(group_id)
-                .copied()
-                .unwrap_or(pending.groups[group_id].stalled_epoch);
-            let local_epoch_after = epochs_after
-                .get(group_id)
-                .copied()
-                .unwrap_or(local_epoch_before);
-            let group_advanced = local_epoch_after > local_epoch_before;
+        for (group_id, terminal) in epoch_backfill_terminal_rows(
+            pending,
+            retry_ordinal,
+            epochs_before,
+            epochs_after,
+            &outcome,
+        ) {
             self.record_epoch_stall_backfill_terminal(
-                group_id,
+                &group_id,
                 outcome.succeeded,
-                EpochBackfillTerminalAudit {
-                    retry_ordinal,
-                    duration_ms: outcome.duration_ms,
-                    activation_outcome: outcome.activation_outcome,
-                    error_kind: outcome.error_kind.clone(),
-                    completion_kind: outcome.completion_kind,
-                    deliveries: outcome.counts.deliveries,
-                    skipped: outcome.counts.skipped,
-                    refused: outcome.counts.refused,
-                    local_epoch_before,
-                    local_epoch_after,
-                    group_advanced,
-                },
+                terminal,
                 &context,
             );
         }
@@ -4690,11 +4744,14 @@ pub(crate) fn epoch_stall_now_ms() -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use super::DrainCounts;
     use super::{
-        DrainVerdict, backfill_drain_verdict, incomplete_full_history_repair,
+        DrainVerdict, EpochBackfillReplayOutcome, backfill_drain_verdict,
+        epoch_backfill_terminal_rows, incomplete_full_history_repair,
         reconciliation_start_after_cursor, retry_backoff_for_ordinal,
         transport_reconciliation_record,
     };
+    use crate::client::epoch_stall::PendingEpochBackfill;
     use crate::tests::{
         ScriptedPushRelayClient, bounded_epoch_backfill_config, client_on_app_relay_plane,
     };
@@ -4703,9 +4760,75 @@ mod tests {
         SyncFailureStage, SyncSummary,
     };
     use marmot_account::AccountHome;
+    use marmot_forensics::EpochBackfillActivationOutcome;
+    use std::collections::HashMap;
     use std::sync::Arc;
     use std::time::Duration;
     use transport_nostr_adapter::AccountSubscriptionEose;
+
+    fn armed_backfill(group_id: &cgka_traits::GroupId, stalled_epoch: u64) -> PendingEpochBackfill {
+        let mut pending = PendingEpochBackfill::new();
+        pending.groups.insert(
+            group_id.clone(),
+            crate::client::epoch_stall::PendingEpochBackfillGroup { stalled_epoch },
+        );
+        pending
+    }
+
+    fn failed_replay_outcome() -> EpochBackfillReplayOutcome {
+        EpochBackfillReplayOutcome {
+            duration_ms: 1,
+            activation_outcome: EpochBackfillActivationOutcome::Succeeded,
+            error_kind: Some("backfill_drain_eose_timeout".to_string()),
+            completion_kind: None,
+            counts: DrainCounts::default(),
+            succeeded: false,
+        }
+    }
+
+    // "We looked and the group did not move" and "we could not look" are
+    // different facts and lead to different investigations. The after-read can
+    // fail on its own, so a row that reports `group_advanced: false` for an
+    // unread epoch asserts knowledge nobody has — which is what made the
+    // failed backfill rows untrustworthy in the field.
+    #[test]
+    fn an_unread_post_replay_epoch_is_reported_as_unobserved_not_as_no_advance() {
+        let group_id = cgka_traits::GroupId::new(vec![7u8; 16]);
+        let pending = armed_backfill(&group_id, 4);
+        let epochs_before = HashMap::from([(group_id.clone(), 4u64)]);
+        let epochs_after = HashMap::new();
+
+        let rows = epoch_backfill_terminal_rows(
+            &pending,
+            0,
+            &epochs_before,
+            &epochs_after,
+            &failed_replay_outcome(),
+        );
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].1.local_epoch_before, 4);
+        assert_eq!(rows[0].1.local_epoch_after, None);
+    }
+
+    // The observed case must keep saying exactly what it always said.
+    #[test]
+    fn an_observed_post_replay_epoch_still_reports_the_reading_it_took() {
+        let group_id = cgka_traits::GroupId::new(vec![7u8; 16]);
+        let pending = armed_backfill(&group_id, 4);
+        let epochs_before = HashMap::from([(group_id.clone(), 4u64)]);
+        let epochs_after = HashMap::from([(group_id.clone(), 4u64)]);
+
+        let rows = epoch_backfill_terminal_rows(
+            &pending,
+            0,
+            &epochs_before,
+            &epochs_after,
+            &failed_replay_outcome(),
+        );
+
+        assert_eq!(rows[0].1.local_epoch_after, Some(4));
+    }
 
     #[test]
     fn reconciliation_cursor_rotates_past_a_slow_route_and_wraps() {

--- a/crates/marmot-app/src/error.rs
+++ b/crates/marmot-app/src/error.rs
@@ -234,7 +234,7 @@ impl AppError {
         match self {
             Self::Account(error) => account_error_kind(error),
             Self::AccountHome(error) => account_home_error_kind(error),
-            Self::Session(_) => "session",
+            Self::Session(error) => session_error_kind(error),
             Self::Storage(error) => storage_error_kind(error),
             Self::Transport(_) => "transport",
             Self::Io(_) => "io",
@@ -392,8 +392,14 @@ fn engine_error_class(error: &cgka_traits::error::EngineError) -> SyncErrorClass
 
 fn account_error_kind(error: &AccountError) -> &'static str {
     match error {
-        AccountError::Session(_) => "account_session",
-        AccountError::Engine(_) => "account_engine",
+        // The wrapping depth is not the diagnosis. `as_engine_error` already
+        // treats these three shapes as one engine failure; the kind follows,
+        // so an operator greps one name instead of three.
+        AccountError::Session(error) => session_error_kind(error),
+        AccountError::Engine(cgka_traits::error::EngineError::Storage(error)) => {
+            storage_error_kind(error)
+        }
+        AccountError::Engine(error) => error.privacy_safe_kind(),
         AccountError::Transport(_) => "account_transport",
         AccountError::TransportRouting(_) => "account_transport_routing",
         AccountError::KeyPackage(_) => "account_key_package",
@@ -430,6 +436,29 @@ fn account_home_error_kind(error: &AccountHomeError) -> &'static str {
     }
 }
 
+/// Privacy-safe kind for a session failure.
+///
+/// `SessionError` is a two-variant passthrough, so the diagnostically useful
+/// name always lives one layer down. Collapsing it to a single `"session"`
+/// kind is what made the D5 field investigations blind.
+fn session_error_kind(error: &cgka_session::SessionError) -> &'static str {
+    match error {
+        // A storage failure is the same failure whichever layer wrapped it, so
+        // reuse the nine storage kinds at both depths. That keeps the one
+        // transient kind (`storage_busy`, the sole case
+        // `SessionError::is_transient` reports) distinguishable from the eight
+        // durable ones without a second transient/permanent axis to keep in
+        // sync.
+        cgka_session::SessionError::Storage(error)
+        | cgka_session::SessionError::Engine(cgka_traits::error::EngineError::Storage(error)) => {
+            storage_error_kind(error)
+        }
+        // Engine names come from the engine so an app tracing field and an
+        // engine forensic audit row say the same word for the same failure.
+        cgka_session::SessionError::Engine(error) => error.privacy_safe_kind(),
+    }
+}
+
 fn storage_error_kind(error: &StorageError) -> &'static str {
     match error {
         StorageError::NotFound => "storage_not_found",
@@ -446,8 +475,10 @@ fn storage_error_kind(error: &StorageError) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::{AccountCatchUpFailure, AppError};
+    use super::{AccountCatchUpFailure, AccountError, AppError, StorageError};
     use crate::SyncFailureClassification;
+    use cgka_traits::error::EngineError;
+    use cgka_traits::types::{EpochId, GroupId};
 
     // Kind strings leave the runtime: `account_error_message` interpolates
     // them into messages the CLI daemon persists and host apps log. Pin the
@@ -464,5 +495,83 @@ mod tests {
             err.to_string(),
             "account catch-up failed: runtime catch-up failed: account_session"
         );
+    }
+
+    // A session failure that is really a transient lock blip must not read the
+    // same as a durable one. `SessionError::is_transient` is true for exactly
+    // this case, so the kind has to carry the same split.
+    #[test]
+    fn transient_session_storage_failure_reports_the_busy_storage_kind() {
+        let err = AppError::Session(cgka_session::SessionError::Storage(StorageError::Busy(
+            "locked".into(),
+        )));
+        assert_eq!(err.privacy_safe_kind(), "storage_busy");
+    }
+
+    // A fork is the single most consequential engine failure a session can
+    // wrap, and `forked_epoch` is the name the engine's own audit rows already
+    // use for it. Reusing that vocabulary is what lets an operator join an app
+    // tracing field to an engine audit row.
+    #[test]
+    fn session_engine_failure_reports_the_engine_kind() {
+        let err = AppError::Session(cgka_session::SessionError::Engine(
+            EngineError::ForkedEpoch {
+                group_id: GroupId::new(vec![1u8; 16]),
+                last_stable: EpochId(7),
+                conflicting_epoch: EpochId(8),
+            },
+        ));
+        assert_eq!(err.privacy_safe_kind(), "forked_epoch");
+    }
+
+    // The engine wraps storage too, so a lock blip can arrive one layer deeper.
+    // It is the same blip and must get the same name — otherwise the transient
+    // case hides behind the engine's coarse `storage` bucket at one depth and
+    // is visible at the other.
+    #[test]
+    fn transient_storage_failure_wrapped_by_the_engine_reports_the_same_kind() {
+        let err = AppError::Session(cgka_session::SessionError::Engine(EngineError::Storage(
+            StorageError::Busy("locked".into()),
+        )));
+        assert_eq!(err.privacy_safe_kind(), "storage_busy");
+    }
+
+    // Most session failures reach the app wrapped in `AccountError`, and
+    // `as_engine_error` already treats all three wrappings as the same engine
+    // failure. The kind has to agree: one engine failure must not get three
+    // names depending on how deep it was wrapped.
+    #[test]
+    fn account_wrapped_session_failures_report_the_same_kind_as_unwrapped_ones() {
+        let direct = AppError::Session(cgka_session::SessionError::Engine(
+            EngineError::InvalidWelcome,
+        ));
+        let via_account_session = AppError::Account(AccountError::Session(
+            cgka_session::SessionError::Engine(EngineError::InvalidWelcome),
+        ));
+        let via_account_engine =
+            AppError::Account(AccountError::Engine(EngineError::InvalidWelcome));
+
+        assert_eq!(direct.privacy_safe_kind(), "invalid_welcome");
+        assert_eq!(via_account_session.privacy_safe_kind(), "invalid_welcome");
+        assert_eq!(via_account_engine.privacy_safe_kind(), "invalid_welcome");
+    }
+
+    // `is_transient` and the kind are two views of one fact. Pin them together
+    // so a future kind edit cannot silently make a retryable failure read as
+    // durable (or the reverse).
+    #[test]
+    fn session_kind_agrees_with_is_transient() {
+        for error in [
+            cgka_session::SessionError::Storage(StorageError::Busy("locked".into())),
+            cgka_session::SessionError::Engine(EngineError::Storage(StorageError::Busy(
+                "locked".into(),
+            ))),
+            cgka_session::SessionError::Storage(StorageError::Closed("shut".into())),
+            cgka_session::SessionError::Engine(EngineError::InvalidWelcome),
+        ] {
+            let transient = error.is_transient();
+            let kind = AppError::Session(error).privacy_safe_kind();
+            assert_eq!(transient, kind == "storage_busy", "kind {kind}");
+        }
     }
 }

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -1213,6 +1213,11 @@ fn failed_epoch_backfill_activation_retains_one_correlated_retry() {
         );
         assert_eq!(failed[0]["kind"]["deliveries"], 0);
         assert_eq!(failed[0]["kind"]["group_advanced"], false);
+        // This run did read the group's post-replay epoch, so `group_advanced:
+        // false` here is a measurement and the row says so. Without the
+        // companion flag a reader cannot separate this row from one whose
+        // after-read failed and defaulted to the before-epoch.
+        assert_eq!(failed[0]["kind"]["group_advanced_observed"], true);
     });
 }
 

--- a/crates/marmot-forensics/AGENTS.md
+++ b/crates/marmot-forensics/AGENTS.md
@@ -23,9 +23,15 @@ Shared JSONL forensic audit schema for Marmot incident capture.
 - Keep audit logging opt-in and explicit. The sole supported event model is privacy-safe: hashed/truncated identifiers,
   digests, lengths, counts, and typed outcomes only. Never add decrypted content, cleartext group values, full account
   or member identities, bearer/upload tokens, auth headers, private keys, ciphertext, or raw MLS bytes.
-- Keep the schema (`schema/audit-log-event.v3.schema.json`) and the Rust kind catalog in lockstep; the
-  `audit_log_event_schema_tracks_kind_catalog` test enforces it. Bump `AUDIT_LOG_SCHEMA_VERSION` and add a new versioned
-  schema file when changing required fields; analyzers reject unknown versions.
+- Keep the schema (`schema/audit-log-event.v3.schema.json`) and the Rust kind catalog in lockstep. Two tests enforce
+  two different halves of that, and both are load-bearing: `audit_log_event_schema_tracks_kind_catalog` compares the
+  set of `type` tags, so it catches an added or removed *event kind* — it does not look at properties and passes
+  cleanly with a property missing. `sample_events_serialize_within_schema_property_names` walks every sample kind's
+  serialized JSON against the schema's `additionalProperties: false` branches, so it is what catches an added *field*
+  the schema does not list. A new field therefore needs a `sample_audit_event_kinds` entry that populates it, or
+  nothing checks it. Bump `AUDIT_LOG_SCHEMA_VERSION` and add a new versioned schema file when changing required
+  fields; analyzers reject unknown versions. An additive optional field needs no bump, but note in its doc comment
+  that absence is then ambiguous between "old row" and "value known absent".
 
 ## Verification
 

--- a/crates/marmot-forensics/schema/audit-log-event.v3.schema.json
+++ b/crates/marmot-forensics/schema/audit-log-event.v3.schema.json
@@ -1541,6 +1541,9 @@
             },
             "group_advanced": {
               "type": "boolean"
+            },
+            "group_advanced_observed": {
+              "type": "boolean"
             }
           }
         },

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -1034,9 +1034,15 @@ pub enum AuditEventKind {
         /// `group_advanced` is that placeholder's arithmetic, not an
         /// observation: this replay's effect on the group is *unknown*, not
         /// absent. Only a failed row can carry it — a run that succeeds has
-        /// read every armed group's epoch by definition. Optional only so rows
-        /// written before this field existed stay readable; absent means the
-        /// reading was taken.
+        /// read every armed group's epoch by definition.
+        ///
+        /// Absent means the row predates this field *or* the reading was taken,
+        /// and an analyzer cannot tell which. The field is additive, so no
+        /// schema version separates old rows from new ones, and a pre-change
+        /// failed row whose after-read failed looks exactly like an observed
+        /// one — that indistinguishability is the very defect this field exists
+        /// to end going forward. Read absence as "unknown provenance", never as
+        /// proof the reading was taken.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         group_advanced_observed: Option<bool>,
     },

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -1027,6 +1027,18 @@ pub enum AuditEventKind {
         local_epoch_before: u64,
         local_epoch_after: u64,
         group_advanced: bool,
+        /// Whether `local_epoch_after` is a reading at all.
+        ///
+        /// `false` means the post-replay epoch read failed, so
+        /// `local_epoch_after` repeats `local_epoch_before` and
+        /// `group_advanced` is that placeholder's arithmetic, not an
+        /// observation: this replay's effect on the group is *unknown*, not
+        /// absent. Only a failed row can carry it — a run that succeeds has
+        /// read every armed group's epoch by definition. Optional only so rows
+        /// written before this field existed stay readable; absent means the
+        /// reading was taken.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        group_advanced_observed: Option<bool>,
     },
     /// A pending epoch-gap backfill replay was not executed on this pass.
     /// Account-scoped; does not clear pending recovery.

--- a/crates/marmot-forensics/src/audit/tests.rs
+++ b/crates/marmot-forensics/src/audit/tests.rs
@@ -892,6 +892,11 @@ fn sample_audit_event_kinds() -> Vec<AuditEventKind> {
             local_epoch_before: 19,
             local_epoch_after: 19,
             group_advanced: false,
+            // The unobserved case is the interesting one: the failure kind and
+            // the observation state have to coexist on one row, or a reader
+            // cannot tell a replay that recovered nothing from one whose effect
+            // was never read.
+            group_advanced_observed: Some(false),
         },
         AuditEventKind::EpochStallBackfillDeferred {
             reason: EpochBackfillDeferredReason::GroupEpochUnavailable,

--- a/crates/traits/src/error.rs
+++ b/crates/traits/src/error.rs
@@ -195,6 +195,49 @@ pub enum EngineError {
 }
 
 impl EngineError {
+    /// Stable, privacy-safe name for this failure.
+    ///
+    /// Names only the variant: no group ids, member ids, epochs, paths, or
+    /// `Display` text. It lives beside the enum rather than in any one consumer
+    /// so the engine's forensic audit rows, the app runtime's tracing fields,
+    /// and the daemon's status JSON all say the same word for the same failure
+    /// and an operator can join them.
+    #[must_use]
+    pub fn privacy_safe_kind(&self) -> &'static str {
+        match self {
+            EngineError::UnknownGroup(_) => "unknown_group",
+            EngineError::GroupNotHydrated(_) => "group_not_hydrated",
+            EngineError::UnknownPending => "unknown_pending",
+            EngineError::NotAMember { .. } => "not_a_member",
+            EngineError::NotGroupAdmin { .. } => "not_group_admin",
+            EngineError::UnknownMember { .. } => "unknown_member",
+            EngineError::InvalidCredentialIdentity(_) => "invalid_credential_identity",
+            EngineError::AdminCannotSelfRemove { .. } => "admin_cannot_self_remove",
+            EngineError::LeaveAlreadyRequested { .. } => "leave_already_requested",
+            EngineError::AdminDepletion { .. } => "admin_depletion",
+            EngineError::MissingRequiredCapabilities { .. } => "missing_required_capabilities",
+            EngineError::DisbandingUnsupportedMembers { .. } => "disbanding_unsupported_members",
+            EngineError::DisbandingNotEnabled { .. } => "disbanding_not_enabled",
+            EngineError::UnsupportedCiphersuite { .. } => "unsupported_ciphersuite",
+            EngineError::InvalidAppMessagePayload(_) => "invalid_app_message_payload",
+            EngineError::InvalidAccountIdentityProof(_) => "invalid_account_identity_proof",
+            EngineError::InvalidKeyPackageLifetime { .. } => "invalid_key_package_lifetime",
+            EngineError::ForkedEpoch { .. } => "forked_epoch",
+            EngineError::QueuedOutboundAtCapacity { .. } => "queued_outbound_at_capacity",
+            EngineError::GroupUnrecoverableRepairRequired { .. } => {
+                "group_unrecoverable_repair_required"
+            }
+            EngineError::InvalidTransition(_) => "invalid_transition",
+            EngineError::Storage(_) => "storage",
+            EngineError::Peeler(_) => "peeler",
+            EngineError::Serialize(_) => "serialize",
+            EngineError::InvalidWelcome => "invalid_welcome",
+            EngineError::WelcomeAlreadyProcessed => "welcome_already_processed",
+            EngineError::Backend(_) => "backend",
+            EngineError::Other(_) => "other",
+        }
+    }
+
     /// Whether this error reflects transient backend contention (a
     /// [`crate::storage::StorageError::Busy`] that survived the backend's own
     /// retries) rather than a durable failure. Callers driving the

--- a/crates/traits/src/error.rs
+++ b/crates/traits/src/error.rs
@@ -202,6 +202,17 @@ impl EngineError {
     /// so the engine's forensic audit rows, the app runtime's tracing fields,
     /// and the daemon's status JSON all say the same word for the same failure
     /// and an operator can join them.
+    ///
+    /// That join is byte-identical for every variant except [`Self::Storage`].
+    /// This method reports the coarse `"storage"` bucket, and engine audit rows
+    /// say `"storage"`; the app runtime deliberately unwraps one layer further
+    /// and reports the nine [`crate::storage::StorageError`] kinds instead
+    /// (`storage_busy`, `storage_not_found`, ...). The trade is intentional:
+    /// [`Self::is_transient`] is true for exactly `StorageError::Busy`, so
+    /// collapsing storage to one word app-side would hide the retryable failure
+    /// among eight durable ones. A consumer joining engine rows to app fields
+    /// must therefore treat `"storage"` as the prefix of the nine, not as a
+    /// tenth peer.
     #[must_use]
     pub fn privacy_safe_kind(&self) -> &'static str {
         match self {


### PR DESCRIPTION
Two diagnosability fixes for the account_session blind spot that made recent field investigations slow, plus a small docs commit pinning two adjudicated non-defects.

1. Session failures resolve to their underlying kind. Every AccountError::Session collapsed to one opaque "session"/"account_session" on the privacy_safe_kind axis (tracing error_kind fields, daemon status JSON, audit rows), while the sibling storage path already resolved nine kinds. Now: SessionError::Storage and engine-wrapped storage failures both resolve through the existing nine storage kinds (same blip, same name at both wrapping depths), and other engine errors resolve through the engine's existing 28-kind vocabulary, promoted from a pub(crate) audit helper onto EngineError itself (strings verified byte-identical, so historical JSONL grouping is unaffected, and an app tracing field and an engine forensic row now say the same word for the same failure — one documented exception: engine rows say "storage" where the app drills to the nine). Zero new strings invented. A new EngineError variant is a compile error, not a silent opaque bucket. is_transient deliberately not consulted: it is true exactly for storage_busy, which the mapping already names (pinned by a test).
2. Failed backfill rows stop claiming an epoch nobody read. A failed after-read used to default to the before-epoch, making group_advanced: false indistinguishable from "we could not look", and the disambiguating marker was suppressed whenever a failure kind was present. Now the after-read is carried as an Option end to end, EpochStallBackfillFailed rows carry an additive optional group_advanced_observed flag (failed rows only; completed rows imply observation by construction), and the failure kind coexists with the observation state in separate fields. No schema version bump (additive optional per the forensics contract); the schema JSON is updated in lockstep and the property-level guard test catches drift. The swallowed read error now logs its (1)-resolved kind, separating a deleted group from lock contention.

Docs commit: pins with comments and an executable test why a never-applied losing rival is still withdrawn (inert where no rows exist; the only portable "this commit lost" statement, consumed by the conformance ledger and Goggles) and why the sweep deliberately drops its deferral lineage (single shared lineage computation post-#1630; re-feeding would re-count spent detector evidence).

Tests: red-first throughout — kind-mapping tests per variant family, the Option threading, the wire-level derivation of the observation flag (mutation-verified: hard-coding it back to true fails), coexistence of failure kind and observation state, and the completed-row absence of the flag. Review round: mutation testing on all guards, byte-level string-stability diff across the vocabulary promotion, schema lockstep mutation, and a compile-probe of the no-fallback claim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Epoch backfill audit records now distinguish between an unreadable post-replay epoch, an observed unchanged epoch, and an observed advancement.
  - Failure records indicate whether the group’s epoch status was successfully verified, helping clarify recovery impact.
  - Error reporting now provides more consistent, privacy-safe diagnostic categories, including clearer storage and session-related classifications.

- **Documentation**
  - Clarified rollback, deferred-message retry, and audit schema behavior.

- **Tests**
  - Expanded coverage for epoch verification, rollback handling, deferred processing, and privacy-safe error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->