### PR TITLE
Fix/anchorless rewind base

### DIFF
--- a/crates/cgka-engine/AGENTS.md
+++ b/crates/cgka-engine/AGENTS.md
@@ -333,8 +333,11 @@ restarted committer alike. The durable retained anchor (`openmls-retained-anchor
 into the pass. Anchors mark the epochs a device *stopped* at, not every epoch it passed through — a multi-commit
 convergence apply retains one at its start epoch and one at its final tip, because snapshots cannot nest inside the
 apply transaction — so the rewind base is `retained_anchor_rewind_base`: the **greatest** anchor at or below the fork
-epoch, within the horizon, with the already-applied commits between it and the fork replayed instead of skipped. Own
-commits materialize from their commit-addressed checkpoints (#1285); no anchor at or below an in-horizon fork fails
+epoch, within the horizon, with the already-applied commits between it and the fork replayed instead of skipped. That
+replay bounds the descent (`lowest_replayable_epoch`, read identically by the pass seeder and the apply so the pass
+never selects what the apply cannot realize): it stops above an own commit, above a commit whose by-reference proposal
+has been consumed, and above any gap in the stored chain. Own commits otherwise materialize from their
+commit-addressed checkpoints (#1285); no usable anchor at or below an in-horizon fork fails
 closed loudly, with ingest retaining and scheduling the
 unadjudicable rival and the convergence coordinator issuing the durable `Unrecoverable` +
 `GroupEvent::GroupUnrecoverable` from the authenticated pass. The former pairwise fast-path (`ForkRecoveryManager`, `committed_from` routing,

--- a/crates/cgka-engine/AGENTS.md
+++ b/crates/cgka-engine/AGENTS.md
@@ -329,9 +329,13 @@ OpenMLS 0.8.1 surface used: `MlsGroup::pending_commit() -> Option<&StagedCommit>
 ### Done — fork-resolution route unification (2026-08-06, supersedes ForkRecoveryManager 2026-05-04)
 
 Same-epoch rival commits are adjudicated by distributed convergence for every member — committer, observer, or
-restarted committer alike. The durable source-epoch anchor (`openmls-retained-anchor-{epoch}`, retained on every
-canonical advance) admits an in-horizon rival into the pass; own commits materialize from their commit-addressed
-checkpoints (#1285); a missing in-horizon anchor fails closed loudly, with ingest retaining and scheduling the
+restarted committer alike. The durable retained anchor (`openmls-retained-anchor-{epoch}`) admits an in-horizon rival
+into the pass. Anchors mark the epochs a device *stopped* at, not every epoch it passed through — a multi-commit
+convergence apply retains one at its start epoch and one at its final tip, because snapshots cannot nest inside the
+apply transaction — so the rewind base is `retained_anchor_rewind_base`: the **greatest** anchor at or below the fork
+epoch, within the horizon, with the already-applied commits between it and the fork replayed instead of skipped. Own
+commits materialize from their commit-addressed checkpoints (#1285); no anchor at or below an in-horizon fork fails
+closed loudly, with ingest retaining and scheduling the
 unadjudicable rival and the convergence coordinator issuing the durable `Unrecoverable` +
 `GroupEvent::GroupUnrecoverable` from the authenticated pass. The former pairwise fast-path (`ForkRecoveryManager`, `committed_from` routing,
 send/apply-time `fork-` snapshots, `GroupEvent::ForkRecovered`) is deleted. The deterministic ordering key

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -1290,7 +1290,12 @@ fn seed_stored_openmls_graph_inputs<S: StorageProvider>(
     }
 
     let historical_start_epoch = historical_replay_start_epoch(&commit_messages, current_epoch);
-    let replay_start_epoch = historical_start_epoch.unwrap_or(current_epoch);
+    let replay_start_epoch = match historical_start_epoch {
+        Some(fork_epoch) => {
+            retained_anchor_rewind_base(storage, group_id, fork_epoch, retained_anchor_epoch)?
+        }
+        None => current_epoch,
+    };
     let commit_messages: Vec<_> = if historical_start_epoch.is_some() {
         commit_messages
     } else {
@@ -1549,6 +1554,39 @@ fn canonicalize_stored_openmls_messages_from_current<S: StorageProvider>(
     append_dropped_messages(&mut result, path_result.invalid_commit_drops);
     append_missing_parent_deferred_commits(&mut result, path_result.unmaterialized_commit_ids);
     Ok(result)
+}
+
+/// The epoch a retained-anchor rewind can actually land on when replaying a fork
+/// at `fork_epoch`: the greatest retained anchor in `floor_epoch..=fork_epoch`.
+///
+/// Anchors exist only at the epochs a device *stopped* at. A convergence apply
+/// that traverses several commits retains one at its start epoch and one at its
+/// final tip — snapshots cannot nest inside the apply transaction — so every
+/// epoch it passed through is anchorless by construction. Demanding an anchor at
+/// exactly the fork epoch therefore halted an ordinary catch-up shape, and the
+/// halt froze the tip so the drop horizon never aged the rival out. Rewinding to
+/// the anchor below the fork and replaying the already-applied commits back up
+/// to it adjudicates the rival instead.
+///
+/// `floor_epoch` keeps the base inside the window whose commits are still
+/// available to replay. With no anchor in range this returns `fork_epoch`
+/// unchanged, so the caller's rollback still fails closed on
+/// `MissingRetainedAnchor` — the residual case of genuinely lost recovery
+/// material.
+fn retained_anchor_rewind_base<S: StorageProvider>(
+    storage: &S,
+    group_id: &GroupId,
+    fork_epoch: u64,
+    floor_epoch: u64,
+) -> Result<u64, OpenMlsProjectionError> {
+    Ok(storage
+        .list_group_snapshots(group_id)
+        .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?
+        .iter()
+        .filter_map(|name| retained_anchor_epoch_from_snapshot_name(name))
+        .filter(|epoch| (floor_epoch..=fork_epoch).contains(epoch))
+        .max()
+        .unwrap_or(fork_epoch))
 }
 
 fn historical_replay_start_epoch(
@@ -2363,11 +2401,21 @@ pub(crate) fn apply_openmls_canonicalization_result_with_profile_policy<S: Stora
         checkpoint_realizable_own_commit_prefix(storage, result, &applied_prefix)?;
     let mut skipped_prefix = applied_prefix;
     skipped_prefix.extend(own_checkpoint_prefix.commit_ids.iter().cloned());
-    let apply_start_epoch = match own_checkpoint_prefix.realized.as_ref() {
+    let mut apply_start_epoch = match own_checkpoint_prefix.realized.as_ref() {
         Some(realized) => realized.resulting_epoch,
         None => apply_start_epoch_for_canonicalization_result(storage, result, &skipped_prefix)?
             .unwrap_or(current_epoch),
     };
+    // A checkpoint restore is addressed by commit, not by epoch, so only the
+    // anchor rewind needs a base that actually exists.
+    if own_checkpoint_prefix.realized.is_none() && apply_start_epoch < current_epoch {
+        (apply_start_epoch, skipped_prefix) = rebase_apply_onto_retained_anchor(
+            storage,
+            group_id,
+            skipped_prefix,
+            apply_start_epoch,
+        )?;
+    }
     // The own-checkpoint case must restore even when its epoch equals the live
     // tip: the live tip may be a different branch's state at that epoch.
     let rewind_to_retained_anchor = apply_start_epoch < current_epoch;
@@ -2611,6 +2659,41 @@ fn already_applied_commit_prefix<S: StorageProvider>(
         prefix.insert(commit_id.clone());
     }
     Ok(prefix)
+}
+
+/// Rebase a historical apply onto the retained anchor a rewind can restore.
+///
+/// The apply skips the selected branch's already-applied prefix and rewinds to
+/// the first new commit's source epoch, but that epoch may have been merely
+/// traversed by an earlier multi-commit apply and so carry no anchor (see
+/// [`retained_anchor_rewind_base`]). Un-skipping the prefix commits at or above
+/// the anchor below it restores a contiguous replay from a base that exists.
+///
+/// The prefix's own source epochs are the only eligible bases: rewinding below
+/// the branch root would leave the replay with no commit to apply against the
+/// restored state. With no anchor among them the fork epoch is returned
+/// unchanged and the rollback fails closed.
+fn rebase_apply_onto_retained_anchor<S: StorageProvider>(
+    storage: &S,
+    group_id: &GroupId,
+    mut skipped_prefix: BTreeSet<String>,
+    fork_epoch: u64,
+) -> Result<(u64, BTreeSet<String>), OpenMlsProjectionError> {
+    let mut source_epochs = BTreeMap::new();
+    for commit_id in &skipped_prefix {
+        let record = storage
+            .get_message(&message_id_from_hex(commit_id)?)
+            .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
+        source_epochs.insert(commit_id.clone(), record.epoch.0);
+    }
+    let Some(&branch_root_epoch) = source_epochs.values().min() else {
+        return Ok((fork_epoch, skipped_prefix));
+    };
+    let base = retained_anchor_rewind_base(storage, group_id, fork_epoch, branch_root_epoch)?;
+    if base < fork_epoch {
+        skipped_prefix.retain(|commit_id| source_epochs[commit_id] < base);
+    }
+    Ok((base, skipped_prefix))
 }
 
 fn apply_start_epoch_for_canonicalization_result<S: StorageProvider>(

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -1202,6 +1202,11 @@ fn seed_stored_openmls_graph_inputs<S: StorageProvider>(
     let mut already_delivered_app_ids = BTreeSet::new();
     let mut stale_commit_drops = Vec::new();
     let mut own_commits = PrevalidatedOwnCommits::default();
+    // Epochs a rewind below the fork may descend past: an already-applied
+    // (`Processed`) commit is there to replay, and this device did not author
+    // it. See `lowest_replayable_epoch`; the apply applies the same rule to the
+    // branch it realizes, so a pass must not select what the apply cannot.
+    let mut replayable_epochs = BTreeSet::new();
 
     for record in records {
         if admitted_message_ids.is_some_and(|admitted| !admitted.contains(&record.id)) {
@@ -1240,6 +1245,9 @@ fn seed_stored_openmls_graph_inputs<S: StorageProvider>(
                 }
                 if record.state == MessageState::Processed {
                     own_commits.insert_canonical(projection.message_digest);
+                    if own_commit_stamp.is_none() {
+                        replayable_epochs.insert(source_epoch);
+                    }
                 }
                 // Confirmed own commits remain prevalidated while canonical or
                 // parked for convergence. Terminal states must not regain
@@ -1292,7 +1300,14 @@ fn seed_stored_openmls_graph_inputs<S: StorageProvider>(
     let historical_start_epoch = historical_replay_start_epoch(&commit_messages, current_epoch);
     let replay_start_epoch = match historical_start_epoch {
         Some(fork_epoch) => {
-            retained_anchor_rewind_base(storage, group_id, fork_epoch, retained_anchor_epoch)?
+            for epoch in
+                epochs_with_unreplayable_proposals(storage, group_id, retained_anchor_epoch)?
+            {
+                replayable_epochs.remove(&epoch);
+            }
+            let floor =
+                lowest_replayable_epoch(fork_epoch, &replayable_epochs).max(retained_anchor_epoch);
+            retained_anchor_rewind_base(storage, group_id, fork_epoch, floor)?
         }
         None => current_epoch,
     };
@@ -1568,8 +1583,9 @@ fn canonicalize_stored_openmls_messages_from_current<S: StorageProvider>(
 /// the anchor below the fork and replaying the already-applied commits back up
 /// to it adjudicates the rival instead.
 ///
-/// `floor_epoch` keeps the base inside the window whose commits are still
-/// available to replay. With no anchor in range this returns `fork_epoch`
+/// `floor_epoch` is the lowest base the replay from it can actually start at —
+/// see [`lowest_replayable_epoch`]; being inside the retention window is
+/// necessary but not sufficient. With no anchor in range this returns `fork_epoch`
 /// unchanged, so the caller's rollback still fails closed on
 /// `MissingRetainedAnchor` — the residual case of genuinely lost recovery
 /// material.
@@ -1587,6 +1603,73 @@ fn retained_anchor_rewind_base<S: StorageProvider>(
         .filter(|epoch| (floor_epoch..=fork_epoch).contains(epoch))
         .max()
         .unwrap_or(fork_epoch))
+}
+
+/// Epochs whose commit cannot be replayed because a proposal it may have
+/// referenced is no longer an input.
+///
+/// MLS proposals are epoch-scoped: a proposal from epoch `E` is only
+/// committable by a commit whose source epoch is `E`, so a proposal's own epoch
+/// IS the source epoch of the commit that could have consumed it. Accepting
+/// that proposal marks it `Processed`, which
+/// [`record_state_is_canonicalization_input`] excludes, and a retained anchor
+/// predates the proposal's arrival — so neither the seeded pass inputs nor a
+/// rolled-back proposal store can offer it to a replay again.
+///
+/// A safe over-approximation: every `Processed` proposal's epoch is reported,
+/// including one no commit on the selected branch actually referenced. That
+/// only floors the rewind higher, which fails closed; missing an epoch here
+/// would let the descent pass a commit it cannot replay.
+///
+/// Read through one shared query so the pass and the apply floor the rewind
+/// identically; a disagreement there selects branches the apply cannot realize.
+fn epochs_with_unreplayable_proposals<S: StorageProvider>(
+    storage: &S,
+    group_id: &GroupId,
+    at_or_after_epoch: u64,
+) -> Result<BTreeSet<u64>, OpenMlsProjectionError> {
+    let mut epochs = BTreeSet::new();
+    for record in storage
+        .list_messages_in_states(
+            group_id,
+            &[MessageState::Processed],
+            EpochId(at_or_after_epoch),
+        )
+        .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?
+    {
+        let Some(message) = openmls_wire_message_from_record(&record)? else {
+            continue;
+        };
+        // Authenticated wire epoch, never the mutable row metadata: a lagging
+        // row would silently drop an epoch from the exclusion set.
+        let projection = project_mls_message(&message.payload)?;
+        if projection.kind == OpenMlsContentKind::Proposal
+            && let Some(source_epoch) = projection.source_epoch
+        {
+            epochs.insert(source_epoch);
+        }
+    }
+    Ok(epochs)
+}
+
+/// The lowest epoch a rewind base may descend to: rewinding below the fork
+/// re-replays the already-applied commits in between, so the base may only pass
+/// epochs whose commit this device can replay again.
+///
+/// `replayable_epochs` holds those epochs — epoch `e` is present when the commit
+/// that took this device from `e` to `e + 1` is still a usable replay input:
+/// it is stored and already applied, this device did not author it (OpenMLS
+/// refuses to re-process own commits), and it referenced no proposal that has
+/// since been consumed ([`epochs_with_unreplayable_proposals`]). Walking down from
+/// `fork_epoch` and stopping at the first epoch missing from the set keeps the
+/// replay contiguous; below that the rewind fails closed on
+/// `MissingRetainedAnchor` rather than stalling on a branch it cannot rebuild.
+fn lowest_replayable_epoch(fork_epoch: u64, replayable_epochs: &BTreeSet<u64>) -> u64 {
+    let mut floor = fork_epoch;
+    while floor > 0 && replayable_epochs.contains(&(floor - 1)) {
+        floor -= 1;
+    }
+    floor
 }
 
 fn historical_replay_start_epoch(
@@ -2399,7 +2482,7 @@ pub(crate) fn apply_openmls_canonicalization_result_with_profile_policy<S: Stora
     // for the run's final own commit — the exact post-merge state it produced.
     let own_checkpoint_prefix =
         checkpoint_realizable_own_commit_prefix(storage, result, &applied_prefix)?;
-    let mut skipped_prefix = applied_prefix;
+    let mut skipped_prefix: BTreeSet<String> = applied_prefix.keys().cloned().collect();
     skipped_prefix.extend(own_checkpoint_prefix.commit_ids.iter().cloned());
     let mut apply_start_epoch = match own_checkpoint_prefix.realized.as_ref() {
         Some(realized) => realized.resulting_epoch,
@@ -2412,6 +2495,7 @@ pub(crate) fn apply_openmls_canonicalization_result_with_profile_policy<S: Stora
         (apply_start_epoch, skipped_prefix) = rebase_apply_onto_retained_anchor(
             storage,
             group_id,
+            &applied_prefix,
             skipped_prefix,
             apply_start_epoch,
         )?;
@@ -2634,18 +2718,29 @@ pub(crate) fn openmls_canonicalization_dispositions(
         .collect()
 }
 
+/// A commit of the already-applied prefix, with what
+/// [`rebase_apply_onto_retained_anchor`] needs to decide whether the rewind may
+/// descend past it.
+struct AppliedPrefixCommit {
+    /// Epoch this commit consumed; it produced `source_epoch + 1`.
+    source_epoch: u64,
+    /// Authored and confirmed by this device.
+    is_own: bool,
+}
+
 /// The longest leading run of accepted commits already applied on the live
 /// canonical state: `Processed` records whose source epoch sits below the live
 /// tip. `Processed` means "applied on this device's canonical chain" (there is
-/// at most one per epoch), so the prefix needs no re-replay — and an OWN
-/// confirmed commit in it CANNOT be re-replayed (`process_message` refuses own
-/// commits).
+/// at most one per epoch), so the prefix needs no re-replay — it is skipped, and
+/// only a rewind to an anchor *below* the fork puts any of it back into the
+/// replay (see [`rebase_apply_onto_retained_anchor`], which is what keeps an OWN
+/// confirmed commit out: `process_message` refuses own commits).
 fn already_applied_commit_prefix<S: StorageProvider>(
     storage: &S,
     result: &CanonicalizationResult,
     current_epoch: u64,
-) -> Result<BTreeSet<String>, OpenMlsProjectionError> {
-    let mut prefix = BTreeSet::new();
+) -> Result<BTreeMap<String, AppliedPrefixCommit>, OpenMlsProjectionError> {
+    let mut prefix = BTreeMap::new();
     for commit_id in &result.accepted_commits {
         let message_id = message_id_from_hex(commit_id)?;
         let record = match storage.get_message(&message_id) {
@@ -2656,7 +2751,15 @@ fn already_applied_commit_prefix<S: StorageProvider>(
         if record.state != MessageState::Processed || record.epoch.0 >= current_epoch {
             break;
         }
-        prefix.insert(commit_id.clone());
+        let is_own = StoredMessagePayload::decode(&record.payload)
+            .is_ok_and(|payload| payload.own_commit_stamp().is_some());
+        prefix.insert(
+            commit_id.clone(),
+            AppliedPrefixCommit {
+                source_epoch: record.epoch.0,
+                is_own,
+            },
+        );
     }
     Ok(prefix)
 }
@@ -2666,32 +2769,45 @@ fn already_applied_commit_prefix<S: StorageProvider>(
 /// The apply skips the selected branch's already-applied prefix and rewinds to
 /// the first new commit's source epoch, but that epoch may have been merely
 /// traversed by an earlier multi-commit apply and so carry no anchor (see
-/// [`retained_anchor_rewind_base`]). Un-skipping the prefix commits at or above
-/// the anchor below it restores a contiguous replay from a base that exists.
+/// [`retained_anchor_rewind_base`]). Descending to the anchor below it un-skips
+/// the prefix commits at or above that anchor so they are replayed instead.
 ///
-/// The prefix's own source epochs are the only eligible bases: rewinding below
-/// the branch root would leave the replay with no commit to apply against the
-/// restored state. With no anchor among them the fork epoch is returned
-/// unchanged and the rollback fails closed.
+/// [`lowest_replayable_epoch`] bounds the descent — an own commit or a commit
+/// whose by-reference proposal is gone ends it — and the bound is read the same
+/// way the pass reads it, so the apply never faces a branch the pass selected
+/// from lower down. Where the bound leaves no anchor, the rollback fails closed
+/// instead of erroring the pass.
+///
+/// The two sets are not identical, benignly: the pass seeds through its frozen
+/// batch (`admitted_message_ids`) while this reads the accepted branch, so on a
+/// frozen-batch pass the apply may descend deeper than the pass validated. The
+/// extra commits satisfy the same predicate, so they replay cleanly.
 fn rebase_apply_onto_retained_anchor<S: StorageProvider>(
     storage: &S,
     group_id: &GroupId,
+    applied_prefix: &BTreeMap<String, AppliedPrefixCommit>,
     mut skipped_prefix: BTreeSet<String>,
     fork_epoch: u64,
 ) -> Result<(u64, BTreeSet<String>), OpenMlsProjectionError> {
-    let mut source_epochs = BTreeMap::new();
-    for commit_id in &skipped_prefix {
-        let record = storage
-            .get_message(&message_id_from_hex(commit_id)?)
-            .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
-        source_epochs.insert(commit_id.clone(), record.epoch.0);
-    }
-    let Some(&branch_root_epoch) = source_epochs.values().min() else {
+    let mut replayable_epochs: BTreeSet<u64> = applied_prefix
+        .values()
+        .filter(|commit| !commit.is_own)
+        .map(|commit| commit.source_epoch)
+        .collect();
+    let Some(&branch_root_epoch) = replayable_epochs.first() else {
         return Ok((fork_epoch, skipped_prefix));
     };
-    let base = retained_anchor_rewind_base(storage, group_id, fork_epoch, branch_root_epoch)?;
+    for epoch in epochs_with_unreplayable_proposals(storage, group_id, branch_root_epoch)? {
+        replayable_epochs.remove(&epoch);
+    }
+    let floor = lowest_replayable_epoch(fork_epoch, &replayable_epochs);
+    let base = retained_anchor_rewind_base(storage, group_id, fork_epoch, floor)?;
     if base < fork_epoch {
-        skipped_prefix.retain(|commit_id| source_epochs[commit_id] < base);
+        skipped_prefix.retain(|commit_id| {
+            applied_prefix
+                .get(commit_id)
+                .is_none_or(|commit| commit.source_epoch < base)
+        });
     }
     Ok((base, skipped_prefix))
 }
@@ -2744,13 +2860,13 @@ struct RealizedCheckpoint {
 fn checkpoint_realizable_own_commit_prefix<S: StorageProvider>(
     storage: &S,
     result: &CanonicalizationResult,
-    applied_prefix: &BTreeSet<String>,
+    applied_prefix: &BTreeMap<String, AppliedPrefixCommit>,
 ) -> Result<CheckpointRealizableOwnPrefix, OpenMlsProjectionError> {
     let mut prefix = CheckpointRealizableOwnPrefix::default();
     for commit_id in result
         .accepted_commits
         .iter()
-        .filter(|commit_id| !applied_prefix.contains(*commit_id))
+        .filter(|commit_id| !applied_prefix.contains_key(*commit_id))
     {
         let message_id = message_id_from_hex(commit_id)?;
         let record = match storage.get_message(&message_id) {
@@ -2967,7 +3083,9 @@ fn apply_openmls_canonicalization_result_inner<S: StorageProvider>(
         // No pre-validated own messages here. Snapshot rollforward cannot nest
         // inside this transaction, and every own commit on the accepted
         // branch was excluded from `replay_messages` before this call —
-        // either as part of the already-applied prefix or as a
+        // either as part of the already-applied prefix (which a rewind to a
+        // lower anchor un-skips only down to the newest own commit, never
+        // past it: `rebase_apply_onto_retained_anchor`) or as a
         // checkpoint-realizable own-commit run whose exact restore the
         // caller performs itself (`checkpoint_realizable_own_commit_prefix`).
         // Leaving own-application stamps out is also load-bearing: those apps
@@ -4275,6 +4393,28 @@ mod reuse_scope_tests {
 }
 
 #[cfg(test)]
+mod rewind_descent_tests {
+    use super::lowest_replayable_epoch;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn rewind_descent_stops_at_the_first_epoch_it_cannot_replay() {
+        // A contiguous run of replayable epochs is walked in full.
+        assert_eq!(
+            lowest_replayable_epoch(27, &BTreeSet::from([24, 25, 26])),
+            24
+        );
+        // A gap — a retired commit, an own commit, a consumed proposal — ends
+        // the descent above it, so the replay never starts where it cannot
+        // reach the fork.
+        assert_eq!(lowest_replayable_epoch(27, &BTreeSet::from([24, 26])), 26);
+        // Nothing to descend over: the fork epoch is its own floor.
+        assert_eq!(lowest_replayable_epoch(27, &BTreeSet::new()), 27);
+        assert_eq!(lowest_replayable_epoch(0, &BTreeSet::from([0])), 0);
+    }
+}
+
+#[cfg(test)]
 mod unresolved_commit_state_tests {
     use super::unresolved_commit_state;
     use cgka_traits::message::MessageState;
@@ -4336,7 +4476,7 @@ mod checkpoint_prefix_tests {
     use cgka_traits::storage::{GroupStateCheckpointRef, GroupStorage, MessageStorage};
     use cgka_traits::transport::{Timestamp, TransportEnvelope, TransportMessage, TransportSource};
     use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
-    use std::collections::BTreeSet;
+    use std::collections::BTreeMap;
     use storage_sqlite::SqliteAccountStorage;
 
     fn group_id() -> GroupId {
@@ -4455,7 +4595,7 @@ mod checkpoint_prefix_tests {
         let prefix = checkpoint_realizable_own_commit_prefix(
             &storage,
             &result_accepting(&[b"commit-a"]),
-            &BTreeSet::new(),
+            &BTreeMap::new(),
         )
         .unwrap();
         let realized = prefix.realized.expect("checkpoint should be realizable");
@@ -4478,7 +4618,7 @@ mod checkpoint_prefix_tests {
         let prefix = checkpoint_realizable_own_commit_prefix(
             &storage,
             &result_accepting(&[b"commit-a"]),
-            &BTreeSet::new(),
+            &BTreeMap::new(),
         )
         .unwrap();
         assert!(
@@ -4516,7 +4656,7 @@ mod checkpoint_prefix_tests {
         let prefix = checkpoint_realizable_own_commit_prefix(
             &storage,
             &result_accepting(&[b"commit-a", b"commit-a-next"]),
-            &BTreeSet::new(),
+            &BTreeMap::new(),
         )
         .unwrap();
         assert_eq!(prefix.commit_ids.len(), 2);
@@ -4540,7 +4680,7 @@ mod checkpoint_prefix_tests {
         let prefix = checkpoint_realizable_own_commit_prefix(
             &storage,
             &result_accepting(&[b"commit-a2"]),
-            &BTreeSet::new(),
+            &BTreeMap::new(),
         )
         .unwrap();
         assert!(

--- a/crates/cgka-engine/tests/AGENTS.md
+++ b/crates/cgka-engine/tests/AGENTS.md
@@ -116,7 +116,8 @@ epoch-scoped readability; `MockPeeler` stays right for everything else.
 cargo test -p cgka-engine
 ```
 
-Note: the default build pins the v1 convergence policy; suites that install custom policies need
+Note: the default build pins the v1 convergence policy, so the bare command above FAILS the suites that install
+custom policies (~18 tests, `distributed_convergence.rs` and `deferred_peel_lifecycle.rs`) — they need
 `cargo test -p cgka-engine --features test-policy-overrides` (CI runs the workspace with
 `wn-cli/test-policy-overrides,cgka-engine/test-crash-hooks`, see `justfile`).
 

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -4537,6 +4537,17 @@ async fn convergence_rewinds_to_greatest_anchor_at_or_below_traversed_fork_epoch
         &alice_chain[2],
         MessageState::ConvergenceDeferred,
     );
+    let anchors = carol_storage.list_group_snapshots(&group_id).unwrap();
+    assert!(
+        anchors
+            .iter()
+            .all(|name| name.starts_with("openmls-retained-anchor-")),
+        "the rewind must leave no probe or apply snapshot behind, got {anchors:?}"
+    );
+    assert!(
+        anchors.contains(&"openmls-retained-anchor-4".to_string()),
+        "the new tip must be anchored for the next pass, got {anchors:?}"
+    );
     let members = carol.members(&group_id).unwrap();
     assert!(
         members.iter().any(|member| member.id == gina.self_id()),
@@ -10105,6 +10116,7 @@ async fn joiners_first_advance_anchors_the_join_epoch_so_a_rival_there_adjudicat
     );
 
     // So the rival forking from the join epoch is adjudicated, not halted.
+    let bob_rival_id = bob_rival.clone();
     carol
         .buffer_openmls_convergence_message_at(&group_id, bob_rival, 3_000)
         .unwrap();
@@ -10114,4 +10126,284 @@ async fn joiners_first_advance_anchors_the_join_epoch_so_a_rival_there_adjudicat
     assert_eq!(result.errors, Vec::new());
     assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
     assert!(!carol_storage.get_group(&group_id).unwrap().unrecoverable);
+
+    // Adjudicated, not merely error-free: Bob wins the epoch-2 tiebreak, so
+    // Carol rolls Alice's commit back and adopts the rival's branch.
+    assert!(committer_wins(&bob.self_id(), &alice.self_id()));
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(3));
+    assert_message_state(&carol_storage, &bob_rival_id, MessageState::Processed);
+    let members = carol.members(&group_id).unwrap();
+    assert!(members.iter().any(|member| member.id == eve.self_id()));
+    assert!(!members.iter().any(|member| member.id == david.self_id()));
+}
+
+/// The rewind base must not descend past this device's OWN applied commit.
+///
+/// Descending un-skips the already-applied prefix so it can be replayed, but
+/// OpenMLS refuses to re-process a commit this device authored. Confirming an
+/// own commit anchors both the epoch it started from and the epoch it produced,
+/// so the floor costs nothing in practice; it matters when the upper anchor is
+/// lost, which must fail closed rather than error the whole pass.
+#[tokio::test]
+async fn rewind_base_never_descends_past_an_own_applied_commit() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut bob, _bob_storage) = build_client(b"bob");
+    let (mut carol, carol_storage) = build_client(b"carol");
+    let (mut david, _david_storage) = build_client(b"david");
+    let (mut eve, _eve_storage) = build_client(b"eve");
+    let (mut frank, _frank_storage) = build_client(b"frank");
+
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "own-commit-floor".into(),
+            description: String::new(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![bob.self_id(), carol.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcome_for(&welcomes, b"bob"))
+        .await
+        .unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+    assert!(committer_wins(&bob.self_id(), &alice.self_id()));
+
+    // Carol's OWN commit carries epoch 1 -> 2 and lands `Processed`.
+    let david_kp = david.fresh_key_package().await.unwrap();
+    let (carol_commit, carol_pending) = evolution(
+        carol
+            .send(SendIntent::Invite {
+                group_id: group_id.clone(),
+                key_packages: vec![david_kp],
+                initial_admins: vec![],
+            })
+            .await
+            .unwrap(),
+    );
+    carol.confirm_published(carol_pending).await.unwrap();
+    let carol_commit = route(carol_commit, &group_id);
+    for follower in [&mut alice, &mut bob] {
+        follower
+            .buffer_openmls_convergence_message_at(&group_id, carol_commit.clone(), 1_000)
+            .unwrap();
+        follower
+            .converge_stored_openmls_messages_at(&group_id, 1_000_000)
+            .unwrap();
+    }
+
+    // Alice and Bob then fork at epoch 2.
+    let eve_kp = eve.fresh_key_package().await.unwrap();
+    let (alice_commit, alice_pending) = evolution(
+        alice
+            .send(SendIntent::Invite {
+                group_id: group_id.clone(),
+                key_packages: vec![eve_kp],
+                initial_admins: vec![],
+            })
+            .await
+            .unwrap(),
+    );
+    alice.confirm_published(alice_pending).await.unwrap();
+    let alice_commit = route(alice_commit, &group_id);
+    let frank_kp = frank.fresh_key_package().await.unwrap();
+    let (bob_rival, _bob_pending) = evolution(
+        bob.send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![frank_kp],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap(),
+    );
+    let bob_rival = route(bob_rival, &group_id);
+
+    carol
+        .buffer_openmls_convergence_message_at(&group_id, alice_commit, 2_000)
+        .unwrap();
+    carol
+        .converge_stored_openmls_messages_at(&group_id, 2_000_000)
+        .unwrap();
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(3));
+
+    // Storage loss takes the anchor at the fork epoch but leaves the one below
+    // it, which sits under Carol's own commit.
+    carol_storage
+        .release_group_snapshot(&group_id, "openmls-retained-anchor-2")
+        .expect("release the fork-epoch anchor");
+    assert!(
+        carol_storage
+            .list_group_snapshots(&group_id)
+            .unwrap()
+            .contains(&"openmls-retained-anchor-1".to_string()),
+        "the anchor below the own commit must survive for this shape"
+    );
+
+    carol
+        .buffer_openmls_convergence_message_at(&group_id, bob_rival, 3_000)
+        .unwrap();
+    let result = carol
+        .converge_stored_openmls_messages_at(&group_id, 3_000_000)
+        .expect("an unreplayable own commit must not error the pass");
+
+    assert_eq!(
+        result.errors,
+        vec![CanonicalizationError::MissingRetainedAnchor],
+        "with no anchor above the own commit the pass must fail closed"
+    );
+    assert_eq!(result.convergence_status, ConvergenceStatus::Blocked);
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(3));
+}
+
+/// The rewind base must not descend past a commit that consumed a proposal
+/// BY REFERENCE (the SelfRemove auto-commit shape).
+///
+/// Accepting a proposal marks it `Processed`, which is not a canonicalization
+/// input, and the anchor below it predates its arrival — so neither the seeded
+/// pass inputs nor the rolled-back proposal store can offer it again. Replaying
+/// the commit from there is impossible, so the descent must stop above it and
+/// the pass must fail closed instead of silently selecting nothing.
+#[tokio::test]
+async fn rewind_base_never_descends_past_a_commit_consuming_a_proposal_by_reference() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut bob, _bob_storage) = build_client(b"bob");
+    let (mut carol, carol_storage) = build_client(b"carol");
+    let (mut dave, _dave_storage) = build_client(b"dave");
+    let (mut eve, _eve_storage) = build_client(b"eve");
+    let (mut frank, _frank_storage) = build_client(b"frank");
+
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let dave_kp = dave.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "by-ref-proposal-floor".into(),
+            description: String::new(),
+            members: vec![bob_kp, carol_kp, dave_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![dave.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    for (member, name) in [
+        (&mut bob, &b"bob"[..]),
+        (&mut carol, &b"carol"[..]),
+        (&mut dave, &b"dave"[..]),
+    ] {
+        member
+            .join_welcome(welcome_for(&welcomes, name))
+            .await
+            .unwrap();
+    }
+
+    // Bob leaves: a SelfRemove proposal, auto-committed by reference.
+    let leave_proposal = route(
+        proposal(
+            bob.send(SendIntent::Leave {
+                group_id: group_id.clone(),
+            })
+            .await
+            .unwrap(),
+        ),
+        &group_id,
+    );
+    alice.ingest(leave_proposal.clone()).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(75)).await;
+    alice.advance_convergence(&group_id).await.unwrap();
+    let auto = alice
+        .drain_auto_publish()
+        .into_iter()
+        .next()
+        .expect("alice auto-commits bob's self-remove");
+    let selfremove_commit = route(auto.msg, &group_id);
+    alice.confirm_published(auto.pending).await.unwrap();
+    assert_eq!(alice.epoch(&group_id).unwrap(), EpochId(2));
+
+    // Alice carries the chain on to epoch 3; Dave forks at epoch 2.
+    let eve_kp = eve.fresh_key_package().await.unwrap();
+    let (alice_commit, alice_pending) = evolution(
+        alice
+            .send(SendIntent::Invite {
+                group_id: group_id.clone(),
+                key_packages: vec![eve_kp],
+                initial_admins: vec![],
+            })
+            .await
+            .unwrap(),
+    );
+    alice.confirm_published(alice_pending).await.unwrap();
+    let alice_commit = route(alice_commit, &group_id);
+
+    for message in [leave_proposal.clone(), selfremove_commit.clone()] {
+        dave.buffer_openmls_convergence_message_at(&group_id, message, 500)
+            .unwrap();
+    }
+    dave.converge_stored_openmls_messages_at(&group_id, 500_000)
+        .unwrap();
+    assert_eq!(dave.epoch(&group_id).unwrap(), EpochId(2));
+    let frank_kp = frank.fresh_key_package().await.unwrap();
+    let (dave_rival, _dave_pending) = evolution(
+        dave.send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![frank_kp],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap(),
+    );
+    let dave_rival = route(dave_rival, &group_id);
+
+    // Carol traverses epoch 2 in one pass, so she anchors 1 and 3 only, and the
+    // proposal the epoch-1 commit consumed lands `Processed`.
+    for (message, at) in [
+        (leave_proposal.clone(), 1_000),
+        (selfremove_commit.clone(), 1_000),
+        (alice_commit, 1_000),
+    ] {
+        carol
+            .buffer_openmls_convergence_message_at(&group_id, message, at)
+            .unwrap();
+    }
+    carol
+        .converge_stored_openmls_messages_at(&group_id, 1_000_000)
+        .expect("carol catches up in one pass");
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(3));
+    assert_message_state(&carol_storage, &leave_proposal, MessageState::Processed);
+    let anchors = carol_storage.list_group_snapshots(&group_id).unwrap();
+    assert!(
+        !anchors.contains(&"openmls-retained-anchor-2".to_string()),
+        "epoch 2 must be traversed, got {anchors:?}"
+    );
+
+    carol
+        .buffer_openmls_convergence_message_at(&group_id, dave_rival, 2_000)
+        .unwrap();
+    let result = carol
+        .converge_stored_openmls_messages_at(&group_id, 2_000_000)
+        .expect("a consumed by-reference proposal must not error the pass");
+
+    assert_eq!(
+        result.errors,
+        vec![CanonicalizationError::MissingRetainedAnchor],
+        "with no anchor above the proposal-consuming commit the pass fails closed"
+    );
+    assert_eq!(result.convergence_status, ConvergenceStatus::Blocked);
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(3));
 }

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -4387,6 +4387,167 @@ async fn engine_reports_missing_retained_anchor_without_mutating_late_commit() {
     assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(2));
 }
 
+/// A rival forking from an epoch this device only *traversed* must still be
+/// adjudicated: the rewind base is the greatest retained anchor at or below the
+/// fork, not an anchor demanded at exactly the fork epoch.
+///
+/// Anchors exist only at the epochs a device *stopped* at. A multi-commit
+/// convergence apply retains one at its start epoch and one at its final tip
+/// (snapshots cannot nest inside the apply transaction), so every epoch in
+/// between is anchorless by construction on a device that caught up in one
+/// pass. Demanding an exact-epoch anchor turned that ordinary shape into a
+/// permanent `MissingRetainedAnchor` halt: the halt freezes the tip, so the
+/// drop horizon never advances past the rival and every later pass re-halts.
+#[tokio::test]
+async fn convergence_rewinds_to_greatest_anchor_at_or_below_traversed_fork_epoch() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut bob, _bob_storage) = build_client(b"bob");
+    let (mut carol, carol_storage) = build_client(b"carol");
+    let (mut david, _david_storage) = build_client(b"david");
+    let (mut eve, _eve_storage) = build_client(b"eve");
+    let (mut frank, _frank_storage) = build_client(b"frank");
+    let (mut gina, _gina_storage) = build_client(b"gina");
+
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "traversed-epoch-fork".into(),
+            description: String::new(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![bob.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcome_for(&welcomes, b"bob"))
+        .await
+        .unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+
+    // Bob is the deterministic tiebreak winner against Alice, so the rival
+    // forking from the traversed epoch is the branch convergence must adopt.
+    assert!(committer_wins(&bob.self_id(), &alice.self_id()));
+
+    // Alice builds the canonical chain 1 -> 2 -> 3 -> 4.
+    let mut alice_chain = Vec::new();
+    for invitee in [&mut david, &mut eve, &mut frank] {
+        let kp = invitee.fresh_key_package().await.unwrap();
+        let (commit, pending) = evolution(
+            alice
+                .send(SendIntent::Invite {
+                    group_id: group_id.clone(),
+                    key_packages: vec![kp],
+                    initial_admins: vec![],
+                })
+                .await
+                .unwrap(),
+        );
+        alice.confirm_published(pending).await.unwrap();
+        alice_chain.push(route(commit, &group_id));
+    }
+
+    // Bob follows the chain to epoch 3, then forks there.
+    bob.buffer_openmls_convergence_message_at(&group_id, alice_chain[0].clone(), 1_000)
+        .unwrap();
+    bob.buffer_openmls_convergence_message_at(&group_id, alice_chain[1].clone(), 1_000)
+        .unwrap();
+    bob.converge_stored_openmls_messages_at(&group_id, 1_000_000)
+        .unwrap();
+    assert_eq!(bob.epoch(&group_id).unwrap(), EpochId(3));
+    let gina_kp = gina.fresh_key_package().await.unwrap();
+    let (bob_rival, _bob_pending) = evolution(
+        bob.send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![gina_kp],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap(),
+    );
+    let bob_rival = route(bob_rival, &group_id);
+
+    // Carol stops at epoch 2, so she anchors 1 and 2...
+    carol
+        .buffer_openmls_convergence_message_at(&group_id, alice_chain[0].clone(), 1_000)
+        .expect("first chain commit buffered");
+    carol
+        .converge_stored_openmls_messages_at(&group_id, 1_000_000)
+        .expect("first chain commit applies");
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(2));
+
+    // ...then catches up 2 -> 3 -> 4 inside ONE convergence apply, which
+    // anchors only its start (2) and its final tip (4). Epoch 3 is traversed.
+    carol
+        .buffer_openmls_convergence_message_at(&group_id, alice_chain[1].clone(), 2_000)
+        .expect("second chain commit buffered");
+    carol
+        .buffer_openmls_convergence_message_at(&group_id, alice_chain[2].clone(), 2_000)
+        .expect("third chain commit buffered");
+    carol
+        .converge_stored_openmls_messages_at(&group_id, 3_000_000)
+        .expect("both chain commits apply in one pass");
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(4));
+
+    let anchors = carol_storage.list_group_snapshots(&group_id).unwrap();
+    assert!(
+        anchors.contains(&"openmls-retained-anchor-2".to_string()),
+        "the multi-commit apply must anchor its start epoch, got {anchors:?}"
+    );
+    assert!(
+        !anchors.contains(&"openmls-retained-anchor-3".to_string()),
+        "the traversed epoch is anchorless by construction, got {anchors:?}"
+    );
+
+    // The rival forks from the traversed epoch 3, well inside the rewind
+    // horizon (tip 4, `max_rewind_commits` 5).
+    carol
+        .buffer_openmls_convergence_message_at(&group_id, bob_rival.clone(), 4_000)
+        .expect("rival buffered");
+    let result = carol
+        .converge_stored_openmls_messages_at(&group_id, 5_000_000)
+        .expect("the rival is adjudicated from the anchor below the fork");
+
+    assert_eq!(
+        result.errors,
+        Vec::new(),
+        "an anchor at or below the fork epoch is enough to adjudicate"
+    );
+    assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
+    assert!(
+        !carol_storage.get_group(&group_id).unwrap().unrecoverable,
+        "an adjudicable fork must never halt the group"
+    );
+
+    // Carol rewound to the epoch-2 anchor, replayed the already-applied commit
+    // that carried her to the fork, and adopted the winning branch.
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(4));
+    assert_message_state(&carol_storage, &bob_rival, MessageState::Processed);
+    assert_message_state(
+        &carol_storage,
+        &alice_chain[2],
+        MessageState::ConvergenceDeferred,
+    );
+    let members = carol.members(&group_id).unwrap();
+    assert!(
+        members.iter().any(|member| member.id == gina.self_id()),
+        "the winning branch's added member must be live"
+    );
+    assert!(
+        !members.iter().any(|member| member.id == frank.self_id()),
+        "the losing branch's added member must be rolled back"
+    );
+}
+
 #[tokio::test]
 async fn durable_unrecoverable_halt_blocks_queued_drain_without_rehydration() {
     let (mut alice, storage) = build_client(b"alice");

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -9988,3 +9988,130 @@ async fn a_deferral_with_only_one_retained_branch_reports_uncontested_lineage() 
         "one retained commit cannot fork with itself; an absent rival looks exactly like missing history, which is what a backfill is for"
     );
 }
+
+/// A joiner anchors its join epoch on its first advance, so a rival forking
+/// from that epoch is adjudicated rather than halting the group.
+///
+/// `do_join_welcome` retains no anchor of its own — the join epoch is anchored
+/// by whatever first carries the device past it, because every advance path
+/// (direct ingest, confirm-published, and the convergence apply that starts at
+/// the live tip) snapshots the pre-advance epoch. That is what keeps a late
+/// joiner out of the `MissingRetainedAnchor` residual, and it is the invariant
+/// [`convergence_rewinds_to_greatest_anchor_at_or_below_traversed_fork_epoch`]
+/// leans on: a rewind base exists at every epoch a device stopped at.
+#[tokio::test]
+async fn joiners_first_advance_anchors_the_join_epoch_so_a_rival_there_adjudicates() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut bob, _bob_storage) = build_client(b"bob");
+    let (mut carol, carol_storage) = build_client(b"carol");
+    let (mut david, _david_storage) = build_client(b"david");
+    let (mut eve, _eve_storage) = build_client(b"eve");
+
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "late-joiner-rival".into(),
+            description: String::new(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![bob.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcome_for(&welcomes, b"bob"))
+        .await
+        .unwrap();
+
+    // Carol joins late, at epoch 2.
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (carol_invite, carol_welcomes, carol_pending) = match alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![carol_kp],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::GroupEvolution {
+            msg,
+            welcomes,
+            pending,
+        } => (msg, welcomes, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(carol_pending).await.unwrap();
+    let carol_invite = route(carol_invite, &group_id);
+    carol
+        .join_welcome(welcome_for(&carol_welcomes, b"carol"))
+        .await
+        .unwrap();
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(2));
+    assert_eq!(
+        carol_storage.list_group_snapshots(&group_id).unwrap(),
+        Vec::<String>::new(),
+        "the join itself retains no anchor"
+    );
+
+    // Bob follows to epoch 2 and forks there.
+    bob.buffer_openmls_convergence_message_at(&group_id, carol_invite, 1_000)
+        .unwrap();
+    bob.converge_stored_openmls_messages_at(&group_id, 1_000_000)
+        .unwrap();
+    let eve_kp = eve.fresh_key_package().await.unwrap();
+    let (bob_rival, _bob_pending) = evolution(
+        bob.send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![eve_kp],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap(),
+    );
+    let bob_rival = route(bob_rival, &group_id);
+
+    // Carol's first advance past the join epoch anchors it.
+    let david_kp = david.fresh_key_package().await.unwrap();
+    let (alice_commit, alice_pending) = evolution(
+        alice
+            .send(SendIntent::Invite {
+                group_id: group_id.clone(),
+                key_packages: vec![david_kp],
+                initial_admins: vec![],
+            })
+            .await
+            .unwrap(),
+    );
+    alice.confirm_published(alice_pending).await.unwrap();
+    carol
+        .buffer_openmls_convergence_message_at(&group_id, route(alice_commit, &group_id), 2_000)
+        .unwrap();
+    carol
+        .converge_stored_openmls_messages_at(&group_id, 2_000_000)
+        .unwrap();
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(3));
+    assert!(
+        carol_storage
+            .list_group_snapshots(&group_id)
+            .unwrap()
+            .contains(&"openmls-retained-anchor-2".to_string()),
+        "the first advance must anchor the join epoch"
+    );
+
+    // So the rival forking from the join epoch is adjudicated, not halted.
+    carol
+        .buffer_openmls_convergence_message_at(&group_id, bob_rival, 3_000)
+        .unwrap();
+    let result = carol
+        .converge_stored_openmls_messages_at(&group_id, 3_000_000)
+        .expect("the join-epoch rival is adjudicated");
+    assert_eq!(result.errors, Vec::new());
+    assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
+    assert!(!carol_storage.get_group(&group_id).unwrap().unrecoverable);
+}

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -2609,11 +2609,14 @@ async fn restarted_committer_without_source_anchor_halts_through_convergence() {
     // is absent (pre-mechanism database, storage loss). The rival is then
     // unadjudicable: `has_retained_anchor_snapshot` refuses convergence
     // admission and no other resolution route exists.
-    // Within the rewind horizon that absence is abnormal by construction —
-    // every canonical advance retains a source-epoch anchor and pruning runs
-    // only beyond the horizon — so a durable, observable halt is the honest
-    // outcome: silently keeping our own (possibly losing) branch would be
-    // permanent divergence invisible to both the app and forensics.
+    // Within the rewind horizon that absence is abnormal: the device stopped
+    // at this epoch, so it anchored it, and pruning runs only beyond the
+    // horizon. A fork epoch the device merely *traversed* is a different
+    // shape, adjudicated from the anchor below it
+    // (`convergence_rewinds_to_greatest_anchor_at_or_below_traversed_fork_epoch`).
+    // With nothing at or below the fork, a durable, observable halt is the
+    // honest outcome: silently keeping our own (possibly losing) branch would
+    // be permanent divergence invisible to both the app and forensics.
     //
     // Ingest does not write that halt. It cannot honestly: it reaches this
     // decision through OpenMLS's `WrongEpoch` framing check, upstream of every

--- a/docs/marmot-architecture/cgka-engine-spec.md
+++ b/docs/marmot-architecture/cgka-engine-spec.md
@@ -273,7 +273,9 @@ Commit rules:
 - A commit creates a candidate edge only if it validates against exactly one parent state.
 - A child commit whose parent is unavailable is explicitly deferred until the parent appears or the child expires.
 - A commit at or after the retained anchor MAY be replayed from the greatest retained snapshot at or below its source
-  epoch; anchors exist only where a device stopped, so a traversed source epoch has none of its own.
+  epoch; anchors exist only where a device stopped, so a traversed source epoch has none of its own. Replay from that
+  snapshot re-applies the already-applied commits in between, so the snapshot MUST NOT sit below an own commit, a
+  commit that consumed a proposal by reference, or a gap in the stored chain.
 - A commit older than the retained anchor MUST be dropped with `BeyondAnchor`.
 - A commit that needs a retained snapshot inside the rewind window, when no snapshot at or below its source epoch
   survives there, MUST return `MissingRetainedAnchor` without mutating group state or message state.

--- a/docs/marmot-architecture/cgka-engine-spec.md
+++ b/docs/marmot-architecture/cgka-engine-spec.md
@@ -272,10 +272,11 @@ Commit rules:
 
 - A commit creates a candidate edge only if it validates against exactly one parent state.
 - A child commit whose parent is unavailable is explicitly deferred until the parent appears or the child expires.
-- A commit at or after the retained anchor MAY be replayed from the retained snapshot for its source epoch.
+- A commit at or after the retained anchor MAY be replayed from the greatest retained snapshot at or below its source
+  epoch; anchors exist only where a device stopped, so a traversed source epoch has none of its own.
 - A commit older than the retained anchor MUST be dropped with `BeyondAnchor`.
-- A commit that needs a retained snapshot inside the rewind window, when that snapshot is missing, MUST return
-  `MissingRetainedAnchor` without mutating group state or message state.
+- A commit that needs a retained snapshot inside the rewind window, when no snapshot at or below its source epoch
+  survives there, MUST return `MissingRetainedAnchor` without mutating group state or message state.
 - Candidate states outside the retention horizon MUST be dropped.
 
 Same-epoch commit recovery uses an authenticated ordering key:

--- a/docs/marmot-architecture/distributed-convergence.md
+++ b/docs/marmot-architecture/distributed-convergence.md
@@ -73,7 +73,10 @@ retained anchors as soon as stable canonicalization advances the current tip pas
 An anchor is not retained at *every* in-window epoch: a snapshot is taken where a device stops, so a device that
 crossed several epochs in one apply holds anchors at that apply's start and tip and none for the epochs it traversed.
 The rewind base is therefore the **greatest retained anchor at or below the fork epoch**, inside the window; the
-already-applied commits between that anchor and the fork are replayed rather than skipped.
+already-applied commits between that anchor and the fork are re-applied by replaying them, not skipped. That replay is
+what bounds how low the base may go: it may not descend past a commit this device authored (MLS refuses to re-process
+an own commit) or one that consumed a proposal by reference (the proposal is no longer an input), nor past a gap in
+the stored chain.
 
 Late commits are handled by their source epoch:
 

--- a/docs/marmot-architecture/distributed-convergence.md
+++ b/docs/marmot-architecture/distributed-convergence.md
@@ -67,15 +67,20 @@ Edges are discovered by replay. A v0.1 commit does not need an explicit parent p
 ## Retained Anchors
 
 The retained anchor is the oldest epoch from which the engine may rebuild a candidate branch. Implementations MUST
-retain epoch snapshots for the current tip and every epoch inside `max_rewind_commits`. They MUST prune older retained
-anchors as soon as stable canonicalization advances the current tip past the rewind window.
+retain an epoch snapshot for the current tip and MUST NOT prune one inside `max_rewind_commits`. They MUST prune older
+retained anchors as soon as stable canonicalization advances the current tip past the rewind window.
+
+An anchor is not retained at *every* in-window epoch: a snapshot is taken where a device stops, so a device that
+crossed several epochs in one apply holds anchors at that apply's start and tip and none for the epochs it traversed.
+The rewind base is therefore the **greatest retained anchor at or below the fork epoch**, inside the window; the
+already-applied commits between that anchor and the fork are replayed rather than skipped.
 
 Late commits are handled by their source epoch:
 
-- If the commit source epoch is at or after the retained anchor, the engine may roll back to that retained snapshot,
-  replay candidate paths, and select the canonical branch.
-- If the required retained snapshot is missing, canonicalization returns `MissingRetainedAnchor` and leaves group state
-  and message state unchanged.
+- If the commit source epoch is at or after the retained anchor, the engine may roll back to the rewind base for that
+  source epoch, replay candidate paths, and select the canonical branch.
+- If no retained snapshot at or below the source epoch survives inside the window, canonicalization returns
+  `MissingRetainedAnchor` and leaves group state and message state unchanged.
 - If the commit source epoch is older than the retained anchor, the commit is dropped with `BeyondAnchor` and persisted
   as invalidated.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved fork and branch convergence by selecting the safest available retained state during rewinds.
  - Prevented unrecoverable replay scenarios from applying inconsistent state.
  - Preserved locally authored changes and proposal-related history during replay.
  - Improved handling of missing historical state by halting safely and allowing later convergence.

- **Documentation**
  - Updated architecture and testing guidance to clarify rewind behavior, convergence safeguards, and required test-policy settings.

- **Tests**
  - Added regression coverage for fork resolution, rewind boundaries, joiner advances, missing state, and distributed convergence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->