### PR TITLE
ci: add stable required CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -620,3 +620,32 @@ jobs:
           # test_installer_env.sh against its real GatewayRunner, then runs the
           # adapter E2E. A missing Hermes venv is a hard failure, not a skip.
           ./scripts/hermes_marmot_deterministic_e2e.sh --root "$RUNNER_TEMP/hermes-installer-auth"
+
+  required-ci:
+    name: Required CI
+    if: always()
+    needs:
+      - rust-format
+      - rust-audit
+      - terminal-harness-installers
+      - rust-check
+      - rust-clippy
+      - c-smoke
+      - ios-account-clippy
+      - convergence-policy-pin
+      - rust-test
+      - cli-e2e
+      - relay-runtime
+      - relay-e2e
+      - conformance
+      - formal
+      - hermes-installer-auth
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Require every core CI job to succeed
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          jq --exit-status 'all(.[]; .result == "success")' <<<"$NEEDS"


### PR DESCRIPTION
## Summary

- add an always-running `Required CI` aggregation job to the main CI workflow
- make it depend on every core PR job, including the complete Rust test matrix
- fail the aggregate check unless every dependency succeeds

`Safe Master` is configured to require the `Required CI` context specifically from the GitHub Actions integration. This keeps the ruleset stable as matrix partitions and individual CI job names evolve.

## Validation

- `actionlint .github/workflows/ci.yml`
- `python3 scripts/test_check_cargo_audit_ci.py`
- `git diff --check`
- verified the dependency list exactly matches all 15 upstream jobs
- verified the reducer passes all-success input and fails failure, cancelled, and skipped input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release validation to ensure all required quality checks complete successfully before a build is accepted.
  * No changes to user-facing features, functionality, or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->