### PR TITLE
Make unread chat-list projection incremental

### DIFF
--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -2651,6 +2651,26 @@ impl MarmotApp {
         Ok(row)
     }
 
+    fn refresh_chat_list_row_for_messages(
+        &self,
+        label: &str,
+        group_id_hex: &str,
+        message_ids_hex: &[String],
+    ) -> Result<Option<ChatListRow>, AppError> {
+        let account = self.account_home().account(label)?;
+        let classifier = Self::chat_list_mention_classifier(&account.account_id_hex);
+        let mut row = self
+            .account_storage(&account.label)?
+            .refresh_chat_list_row_for_messages(
+                &account.account_id_hex,
+                group_id_hex,
+                message_ids_hex,
+                &classifier,
+            )?;
+        self.hydrate_chat_list_row(row.as_mut())?;
+        Ok(row)
+    }
+
     pub fn initialize_chat_read_state(
         &self,
         label: &str,
@@ -5459,7 +5479,19 @@ impl MarmotApp {
         label: &str,
         storage_update: TimelineProjectionUpdate,
     ) -> Result<AppProjectionUpdate, AppError> {
-        let chat_list_row = self.refresh_chat_list_row(label, &storage_update.group_id_hex)?;
+        let changed_message_ids = storage_update
+            .changes
+            .iter()
+            .map(|change| match change {
+                TimelineMessageChange::Upsert { message, .. } => message.message_id_hex.clone(),
+                TimelineMessageChange::Remove { message_id_hex, .. } => message_id_hex.clone(),
+            })
+            .collect::<Vec<_>>();
+        let chat_list_row = self.refresh_chat_list_row_for_messages(
+            label,
+            &storage_update.group_id_hex,
+            &changed_message_ids,
+        )?;
         let projects_group_system_activity = chat_list_row
             .as_ref()
             .is_some_and(|row| row.conversation_kind == ChatConversationKind::Group);

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -1005,6 +1005,7 @@ fn refresh_chat_list_row_for_messages_tx(
         return Ok(None);
     };
     if message_ids_hex.is_empty()
+        || !dirty_unread_messages_are_covered_tx(tx, group_id_hex, message_ids_hex)?
         || !projection_has_rows_tx(
             tx,
             "SELECT EXISTS(
@@ -1030,6 +1031,33 @@ fn refresh_chat_list_row_for_messages_tx(
         write_chat_list_row_for_group_tx(tx, &group, unread)?;
     }
     chat_list_row_tx(tx, group_id_hex)
+}
+
+fn dirty_unread_messages_are_covered_tx(
+    tx: &Connection,
+    group_id_hex: &str,
+    message_ids_hex: &[String],
+) -> StorageResult<bool> {
+    let supplied_message_ids = message_ids_hex
+        .iter()
+        .map(String::as_str)
+        .collect::<HashSet<_>>();
+    let mut statement = tx
+        .prepare_cached(
+            "SELECT message_id_hex FROM chat_list_unread_dirty_messages
+             WHERE group_id_hex = ?1",
+        )
+        .storage()?;
+    let dirty_message_ids = statement
+        .query_map(params![group_id_hex], |row| row.get::<_, String>(0))
+        .storage()?;
+    for dirty_message_id in dirty_message_ids {
+        let dirty_message_id = dirty_message_id.storage()?;
+        if !supplied_message_ids.contains(dirty_message_id.as_str()) {
+            return Ok(false);
+        }
+    }
+    Ok(true)
 }
 
 /// Current chat-list projection reconciliation version.
@@ -1826,7 +1854,11 @@ fn rebuild_unread_membership_tx(
                     rusqlite::types::Value::Integer(u64_to_i64(last_read_at)?),
                     rusqlite::types::Value::Text(marker_id.to_owned()),
                 ],
-                "timeline_at ASC, message_id_hex ASC",
+                "timeline_order_class ASC,
+              timeline_order_primary ASC,
+              timeline_order_phase ASC,
+              timeline_order_at ASC,
+              message_id_hex ASC",
             )
         } else {
             (
@@ -1835,13 +1867,19 @@ fn rebuild_unread_membership_tx(
                     rusqlite::types::Value::Integer(u64_to_i64(read_state.initialized_at)?),
                     rusqlite::types::Value::Text(String::new()),
                 ],
-                "timeline_at ASC, message_id_hex ASC",
+                "timeline_order_class ASC,
+              timeline_order_primary ASC,
+              timeline_order_phase ASC,
+              timeline_order_at ASC,
+              message_id_hex ASC",
             )
         };
     // Derive count + first-unread id + mention_count from one ordered scan over
     // the unread window. Persisted canonical anchors use the same accepted-history
     // key as timeline pagination even after retention prunes the marker row.
-    // Legacy states without a canonical anchor use wall-clock predicate + order.
+    // Legacy states without a canonical anchor retain their wall-clock unread
+    // predicate, then use the canonical tuple to order that unread set just as
+    // incremental reconciliation does.
     let activity_filter = chat_list_activity_filter_sql("");
     let scan_sql = format!(
         "SELECT message_id_hex, plaintext, tags_json, kind,

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -665,7 +665,7 @@ impl SqliteAccountStorage {
     ) -> StorageResult<()> {
         self.connection.with_transaction(|| {
             let conn = self.lock()?;
-            if !chat_list_projection_complete_tx(&conn, local_account_id_hex, mention_classifier)? {
+            if !chat_list_projection_complete_tx(&conn)? {
                 rebuild_all_chat_list_rows_tx(&conn, local_account_id_hex, mention_classifier)?;
             }
             Ok(())
@@ -1203,11 +1203,10 @@ fn set_chat_list_projection_version_tx(tx: &Connection, version: i64) -> Storage
 /// `ChatListRow::leave_requested_at_ms` is derived at read time rather than
 /// materialized, so there is no stored value that can drift out of date — and
 /// comparing a read-time-only field here would mark every row stale forever.
-fn chat_list_projection_complete_tx(
-    tx: &Connection,
-    _local_account_id_hex: &str,
-    _mention_classifier: &MentionClassifier<'_>,
-) -> StorageResult<bool> {
+fn chat_list_projection_complete_tx(tx: &Connection) -> StorageResult<bool> {
+    if chat_list_projection_version_tx(tx)? < CHAT_LIST_PROJECTION_VERSION {
+        return Ok(false);
+    }
     let activity_filter = chat_list_activity_filter_sql("mt.");
     let preview_order = chat_list_preview_order_desc("mt.");
     let preview_eligibility = chat_list_preview_eligibility_sql("mt.");
@@ -1383,12 +1382,6 @@ fn chat_list_projection_complete_tx(
     )? {
         return Ok(false);
     }
-    if chat_list_projection_version_tx(tx)? >= CHAT_LIST_PROJECTION_VERSION {
-        return Ok(true);
-    }
-    // Every group has durable membership now, so an account-wide marker left
-    // behind by targeted post-migration rebuilds can be advanced safely.
-    set_chat_list_projection_version_tx(tx, CHAT_LIST_PROJECTION_VERSION)?;
     Ok(true)
 }
 

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -700,6 +700,28 @@ impl SqliteAccountStorage {
         })
     }
 
+    /// Refresh one chat-list row after a timeline projection changed only the
+    /// supplied message ids. Unread membership is reconciled incrementally;
+    /// older databases and incomplete projections fall back to a full rebuild.
+    pub fn refresh_chat_list_row_for_messages(
+        &self,
+        local_account_id_hex: &str,
+        group_id_hex: &str,
+        message_ids_hex: &[String],
+        mention_classifier: &MentionClassifier<'_>,
+    ) -> StorageResult<Option<ChatListRow>> {
+        self.connection.with_transaction(|| {
+            let conn = self.lock()?;
+            refresh_chat_list_row_for_messages_tx(
+                &conn,
+                local_account_id_hex,
+                group_id_hex,
+                message_ids_hex,
+                mention_classifier,
+            )
+        })
+    }
+
     /// Persist an exact account-projection delta and materialize one chat-list
     /// row in the same SQLCipher transaction, returning the committed row.
     ///
@@ -967,13 +989,57 @@ fn refresh_chat_list_row_tx(
     chat_list_row_tx(tx, group_id_hex)
 }
 
+fn refresh_chat_list_row_for_messages_tx(
+    tx: &Connection,
+    local_account_id_hex: &str,
+    group_id_hex: &str,
+    message_ids_hex: &[String],
+    mention_classifier: &MentionClassifier<'_>,
+) -> StorageResult<Option<ChatListRow>> {
+    let Some(group) = account_group_tx(tx, group_id_hex)? else {
+        tx.execute_cached(
+            "DELETE FROM chat_list_rows WHERE group_id_hex = ?1",
+            params![group_id_hex],
+        )
+        .storage()?;
+        return Ok(None);
+    };
+    if message_ids_hex.is_empty()
+        || chat_list_projection_version_tx(tx)? < CHAT_LIST_PROJECTION_VERSION
+        || !projection_has_rows_tx(
+            tx,
+            "SELECT EXISTS(SELECT 1 FROM chat_list_rows WHERE group_id_hex = ?1)",
+            params![group_id_hex],
+        )?
+    {
+        rebuild_chat_list_row_for_group_tx(tx, local_account_id_hex, group, mention_classifier)?;
+    } else {
+        let unread = reconcile_unread_messages_tx(
+            tx,
+            local_account_id_hex,
+            &group.group_id_hex,
+            message_ids_hex,
+            mention_classifier,
+        )?;
+        write_chat_list_row_for_group_tx(tx, &group, unread)?;
+    }
+    set_chat_list_projection_version_tx(tx, CHAT_LIST_PROJECTION_VERSION)?;
+    tx.execute_cached(
+        "DELETE FROM chat_list_unread_dirty_groups WHERE group_id_hex = ?1",
+        params![group_id_hex],
+    )
+    .storage()?;
+    chat_list_row_tx(tx, group_id_hex)
+}
+
 /// Current chat-list projection reconciliation version.
 ///
 /// Version 1 covered unread-mention counts (#750). Version 2 additionally
 /// projects kind-1210 group-system rows into preview, activity, and unread state
-/// (#822). The persisted column keeps its legacy `mention_counts_version` name
+/// (#822). Version 3 materializes per-message unread membership so incremental
+/// refreshes do not rescan the unread window. The persisted column keeps its legacy `mention_counts_version` name
 /// for schema compatibility, but now gates the complete derived-row contract.
-const CHAT_LIST_PROJECTION_VERSION: i64 = 2;
+const CHAT_LIST_PROJECTION_VERSION: i64 = 3;
 
 const CHAT_LIST_GROUP_ACTIVITY_TYPES: [&str; 5] = [
     GROUP_SYSTEM_TYPE_MEMBER_ADDED,
@@ -1161,6 +1227,13 @@ fn chat_list_projection_complete_tx(
     }
     if projection_has_rows_tx(
         tx,
+        "SELECT EXISTS(SELECT 1 FROM chat_list_unread_dirty_groups)",
+        [],
+    )? {
+        return Ok(false);
+    }
+    if projection_has_rows_tx(
+        tx,
         "SELECT EXISTS(
                 SELECT 1
                 FROM chat_list_rows AS row
@@ -1301,61 +1374,10 @@ fn chat_list_projection_complete_tx(
     if chat_list_projection_version_tx(tx)? >= CHAT_LIST_PROJECTION_VERSION {
         return Ok(true);
     }
-    // The version marker can lag behind rows that a targeted refresh already
-    // brought current. Re-derive the unread summary once and rebuild only when
-    // a row is actually stale; this preserves the cheap warm path after the
-    // marker advances without turning a metadata-only open into needless SQL.
-    for (group_id_hex, stored) in chat_list_stored_unread_summaries_tx(tx)? {
-        let read_state = read_state_tx(tx, &group_id_hex)?;
-        let derived = unread_summary_tx(
-            tx,
-            local_account_id_hex,
-            &group_id_hex,
-            read_state.as_ref(),
-            mention_classifier,
-        )?;
-        if derived.count != stored.count
-            || derived.mention_count != stored.mention_count
-            || derived.first_message_id != stored.first_message_id
-        {
-            return Ok(false);
-        }
-    }
-    set_chat_list_projection_version_tx(tx, CHAT_LIST_PROJECTION_VERSION)?;
-    Ok(true)
-}
-
-fn chat_list_stored_unread_summaries_tx(
-    tx: &Connection,
-) -> StorageResult<Vec<(String, UnreadSummary)>> {
-    let mut stmt = tx
-        .prepare_cached(
-            "SELECT group_id_hex, unread_count, unread_mention_count,
-                    first_unread_message_id_hex
-             FROM chat_list_rows",
-        )
-        .storage()?;
-    stmt.query_map([], |row| {
-        Ok((
-            row.get::<_, String>(0)?,
-            row.get::<_, i64>(1)?,
-            row.get::<_, i64>(2)?,
-            row.get::<_, Option<String>>(3)?,
-        ))
-    })
-    .storage()?
-    .map(|entry| {
-        let (group_id_hex, count, mention_count, first_message_id) = entry.storage()?;
-        Ok((
-            group_id_hex,
-            UnreadSummary {
-                count: i64_to_u64(count)?,
-                mention_count: i64_to_u64(mention_count)?,
-                first_message_id,
-            },
-        ))
-    })
-    .collect()
+    // Older projection versions have no durable unread membership to compare;
+    // seed it with one authoritative rebuild.
+    let _ = (local_account_id_hex, mention_classifier);
+    Ok(false)
 }
 
 fn projection_has_rows_tx<P: Params>(tx: &Connection, sql: &str, params: P) -> StorageResult<bool> {
@@ -1375,18 +1397,33 @@ fn rebuild_chat_list_row_for_group_tx(
     group: AccountGroupRow,
     mention_classifier: &MentionClassifier<'_>,
 ) -> StorageResult<()> {
-    let latest = latest_chat_list_activity_tx(tx, &group.group_id_hex)?;
-    let latest_message = latest.as_ref().map(|latest| &latest.preview);
-    let accepted_activity_insert_order =
-        latest_accepted_activity_insert_order_tx(tx, &group.group_id_hex)?.unwrap_or(0);
     let read_state = read_state_tx(tx, &group.group_id_hex)?;
-    let unread = unread_summary_tx(
+    let unread = rebuild_unread_membership_tx(
         tx,
         local_account_id_hex,
         &group.group_id_hex,
         read_state.as_ref(),
         mention_classifier,
     )?;
+    write_chat_list_row_for_group_tx(tx, &group, unread)?;
+    tx.execute_cached(
+        "DELETE FROM chat_list_unread_dirty_groups WHERE group_id_hex = ?1",
+        params![group.group_id_hex],
+    )
+    .storage()?;
+    set_chat_list_projection_version_tx(tx, CHAT_LIST_PROJECTION_VERSION)
+}
+
+fn write_chat_list_row_for_group_tx(
+    tx: &Connection,
+    group: &AccountGroupRow,
+    unread: UnreadSummary,
+) -> StorageResult<()> {
+    let latest = latest_chat_list_activity_tx(tx, &group.group_id_hex)?;
+    let latest_message = latest.as_ref().map(|latest| &latest.preview);
+    let accepted_activity_insert_order =
+        latest_accepted_activity_insert_order_tx(tx, &group.group_id_hex)?.unwrap_or(0);
+    let read_state = read_state_tx(tx, &group.group_id_hex)?;
     let activity_sort_at = latest_message
         .map(|message| message.timeline_at)
         .into_iter()
@@ -1458,7 +1495,7 @@ fn rebuild_chat_list_row_for_group_tx(
             &group.group_id_hex,
             bool_i64(group.archived),
             bool_i64(group.pending_confirmation),
-            chat_title(&group),
+            chat_title(group),
             &group.profile_name,
             group.avatar_url.as_deref(),
             group
@@ -1531,13 +1568,211 @@ struct UnreadSummary {
     first_message_id: Option<String>,
 }
 
-fn unread_summary_tx(
+struct UnreadMembership {
+    mentions_local: bool,
+    order_class: i64,
+    order_primary: i64,
+    order_phase: i64,
+    order_at: i64,
+}
+
+fn reconcile_unread_messages_tx(
+    tx: &Connection,
+    local_account_id_hex: &str,
+    group_id_hex: &str,
+    message_ids_hex: &[String],
+    mention_classifier: &MentionClassifier<'_>,
+) -> StorageResult<UnreadSummary> {
+    let (stored_count, stored_mention_count): (i64, i64) = tx
+        .query_row_cached(
+            "SELECT unread_count, unread_mention_count
+             FROM chat_list_rows WHERE group_id_hex = ?1",
+            params![group_id_hex],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .storage()?;
+    let read_state = read_state_tx(tx, group_id_hex)?;
+    let mut count_delta = 0i64;
+    let mut mention_delta = 0i64;
+    let mut seen = HashSet::with_capacity(message_ids_hex.len());
+    for message_id_hex in message_ids_hex {
+        if !seen.insert(message_id_hex) {
+            continue;
+        }
+        let old_mentions = tx
+            .query_row_cached(
+                "SELECT mentions_local FROM chat_list_unread_messages
+                 WHERE group_id_hex = ?1 AND message_id_hex = ?2",
+                params![group_id_hex, message_id_hex],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()
+            .storage()?;
+        let current = unread_membership_for_message_tx(
+            tx,
+            local_account_id_hex,
+            group_id_hex,
+            message_id_hex,
+            read_state.as_ref(),
+            mention_classifier,
+        )?;
+        match (old_mentions, current) {
+            (None, None) => {}
+            (Some(old), None) => {
+                tx.execute_cached(
+                    "DELETE FROM chat_list_unread_messages
+                     WHERE group_id_hex = ?1 AND message_id_hex = ?2",
+                    params![group_id_hex, message_id_hex],
+                )
+                .storage()?;
+                count_delta -= 1;
+                mention_delta -= old;
+            }
+            (old, Some(current)) => {
+                tx.execute_cached(
+                    "INSERT INTO chat_list_unread_messages (
+                        group_id_hex, message_id_hex, mentions_local,
+                        timeline_order_class, timeline_order_primary,
+                        timeline_order_phase, timeline_order_at
+                     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                     ON CONFLICT(group_id_hex, message_id_hex) DO UPDATE SET
+                        mentions_local = excluded.mentions_local,
+                        timeline_order_class = excluded.timeline_order_class,
+                        timeline_order_primary = excluded.timeline_order_primary,
+                        timeline_order_phase = excluded.timeline_order_phase,
+                        timeline_order_at = excluded.timeline_order_at",
+                    params![
+                        group_id_hex,
+                        message_id_hex,
+                        bool_i64(current.mentions_local),
+                        current.order_class,
+                        current.order_primary,
+                        current.order_phase,
+                        current.order_at,
+                    ],
+                )
+                .storage()?;
+                if let Some(old) = old {
+                    mention_delta += bool_i64(current.mentions_local) - old;
+                } else {
+                    count_delta += 1;
+                    mention_delta += bool_i64(current.mentions_local);
+                }
+            }
+        }
+    }
+    let first_message_id = tx
+        .query_row_cached(
+            "SELECT message_id_hex
+             FROM chat_list_unread_messages
+             WHERE group_id_hex = ?1
+             ORDER BY timeline_order_class, timeline_order_primary,
+                      timeline_order_phase, timeline_order_at, message_id_hex
+             LIMIT 1",
+            params![group_id_hex],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .storage()?;
+    Ok(UnreadSummary {
+        count: i64_to_u64(stored_count + count_delta)?,
+        mention_count: i64_to_u64(stored_mention_count + mention_delta)?,
+        first_message_id,
+    })
+}
+
+fn unread_membership_for_message_tx(
+    tx: &Connection,
+    local_account_id_hex: &str,
+    group_id_hex: &str,
+    message_id_hex: &str,
+    read_state: Option<&ConversationReadState>,
+    mention_classifier: &MentionClassifier<'_>,
+) -> StorageResult<Option<UnreadMembership>> {
+    let Some(read_state) = read_state else {
+        return Ok(None);
+    };
+    let (where_sql, marker_params) =
+        if let Some((class, primary, phase, at, id)) = read_state.canonical_order_key() {
+            (
+                "(timeline_order_class, timeline_order_primary,
+                  timeline_order_phase, timeline_order_at, message_id_hex)
+                    > (?4, ?5, ?6, ?7, ?8)",
+                vec![
+                    rusqlite::types::Value::Integer(i64::from(class)),
+                    rusqlite::types::Value::Integer(u64_to_i64(primary)?),
+                    rusqlite::types::Value::Integer(i64::from(phase)),
+                    rusqlite::types::Value::Integer(u64_to_i64(at)?),
+                    rusqlite::types::Value::Text(id.to_owned()),
+                ],
+            )
+        } else if let Some(last_read_at) = read_state.last_read_timeline_at {
+            (
+                "(timeline_at > ?4 OR (timeline_at = ?4 AND message_id_hex > ?5))",
+                vec![
+                    rusqlite::types::Value::Integer(u64_to_i64(last_read_at)?),
+                    rusqlite::types::Value::Text(
+                        read_state
+                            .last_read_message_id_hex
+                            .as_deref()
+                            .unwrap_or("")
+                            .to_owned(),
+                    ),
+                ],
+            )
+        } else {
+            (
+                "timeline_at > ?4",
+                vec![rusqlite::types::Value::Integer(u64_to_i64(
+                    read_state.initialized_at,
+                )?)],
+            )
+        };
+    let activity_filter = chat_list_activity_filter_sql("");
+    let sql = format!(
+        "SELECT plaintext, tags_json, kind, timeline_order_class,
+                timeline_order_primary, timeline_order_phase, timeline_order_at
+         FROM message_timeline
+         WHERE group_id_hex = ?1 AND sender != ?2 AND message_id_hex = ?3
+           AND {activity_filter} AND deleted = 0
+           AND invalidation_status IS NULL AND {where_sql}"
+    );
+    let mut query_params = vec![
+        rusqlite::types::Value::Text(group_id_hex.to_owned()),
+        rusqlite::types::Value::Text(local_account_id_hex.to_owned()),
+        rusqlite::types::Value::Text(message_id_hex.to_owned()),
+    ];
+    query_params.extend(marker_params);
+    tx.query_row_cached(&sql, rusqlite::params_from_iter(query_params), |row| {
+        let plaintext: String = row.get(0)?;
+        let tags_json: String = row.get(1)?;
+        let kind = row.get::<_, i64>(2)? as u64;
+        let tags = crate::tags_from_json(tags_json).unwrap_or_default();
+        Ok(UnreadMembership {
+            mentions_local: kind == MARMOT_APP_EVENT_KIND_CHAT
+                && mention_classifier(&plaintext, &tags),
+            order_class: row.get(3)?,
+            order_primary: row.get(4)?,
+            order_phase: row.get(5)?,
+            order_at: row.get(6)?,
+        })
+    })
+    .optional()
+    .storage()
+}
+
+fn rebuild_unread_membership_tx(
     tx: &Connection,
     local_account_id_hex: &str,
     group_id_hex: &str,
     read_state: Option<&ConversationReadState>,
     mention_classifier: &MentionClassifier<'_>,
 ) -> StorageResult<UnreadSummary> {
+    tx.execute_cached(
+        "DELETE FROM chat_list_unread_messages WHERE group_id_hex = ?1",
+        params![group_id_hex],
+    )
+    .storage()?;
     let Some(read_state) = read_state else {
         return Ok(UnreadSummary {
             count: 0,
@@ -1592,7 +1827,9 @@ fn unread_summary_tx(
     // Legacy states without a canonical anchor use wall-clock predicate + order.
     let activity_filter = chat_list_activity_filter_sql("");
     let scan_sql = format!(
-        "SELECT message_id_hex, plaintext, tags_json, kind
+        "SELECT message_id_hex, plaintext, tags_json, kind,
+                timeline_order_class, timeline_order_primary,
+                timeline_order_phase, timeline_order_at
          FROM message_timeline
          WHERE group_id_hex = ?1
            AND {activity_filter}
@@ -1619,14 +1856,37 @@ fn unread_summary_tx(
         let plaintext: String = row.get(1).storage()?;
         let tags_json: String = row.get(2).storage()?;
         let kind = i64_to_u64(row.get(3).storage()?)?;
+        let timeline_order_class: i64 = row.get(4).storage()?;
+        let timeline_order_primary: i64 = row.get(5).storage()?;
+        let timeline_order_phase: i64 = row.get(6).storage()?;
+        let timeline_order_at: i64 = row.get(7).storage()?;
         if first_message_id.is_none() {
-            first_message_id = Some(message_id_hex);
+            first_message_id = Some(message_id_hex.clone());
         }
         count += 1;
         let tags = crate::tags_from_json(tags_json).unwrap_or_default();
-        if kind == MARMOT_APP_EVENT_KIND_CHAT && mention_classifier(&plaintext, &tags) {
+        let mentions_local =
+            kind == MARMOT_APP_EVENT_KIND_CHAT && mention_classifier(&plaintext, &tags);
+        if mentions_local {
             mention_count += 1;
         }
+        tx.execute_cached(
+            "INSERT INTO chat_list_unread_messages (
+                group_id_hex, message_id_hex, mentions_local,
+                timeline_order_class, timeline_order_primary,
+                timeline_order_phase, timeline_order_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                group_id_hex,
+                &message_id_hex,
+                bool_i64(mentions_local),
+                timeline_order_class,
+                timeline_order_primary,
+                timeline_order_phase,
+                timeline_order_at,
+            ],
+        )
+        .storage()?;
     }
     Ok(UnreadSummary {
         count,
@@ -1642,7 +1902,7 @@ pub(crate) fn refresh_chat_list_unread_after_secure_prune_tx(
     mention_classifier: &MentionClassifier<'_>,
 ) -> StorageResult<()> {
     let read_state = read_state_tx(tx, group_id_hex)?;
-    let unread = unread_summary_tx(
+    let unread = rebuild_unread_membership_tx(
         tx,
         local_account_id_hex,
         group_id_hex,
@@ -1661,6 +1921,11 @@ pub(crate) fn refresh_chat_list_unread_after_secure_prune_tx(
             u64_to_i64(unread.mention_count)?,
             unread.first_message_id
         ],
+    )
+    .storage()?;
+    tx.execute_cached(
+        "DELETE FROM chat_list_unread_dirty_groups WHERE group_id_hex = ?1",
+        params![group_id_hex],
     )
     .storage()?;
     Ok(())

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -1005,7 +1005,13 @@ fn refresh_chat_list_row_for_messages_tx(
         return Ok(None);
     };
     if message_ids_hex.is_empty()
-        || chat_list_projection_version_tx(tx)? < CHAT_LIST_PROJECTION_VERSION
+        || !projection_has_rows_tx(
+            tx,
+            "SELECT EXISTS(
+                SELECT 1 FROM chat_list_unread_ready_groups WHERE group_id_hex = ?1
+             )",
+            params![group_id_hex],
+        )?
         || !projection_has_rows_tx(
             tx,
             "SELECT EXISTS(SELECT 1 FROM chat_list_rows WHERE group_id_hex = ?1)",
@@ -1023,12 +1029,6 @@ fn refresh_chat_list_row_for_messages_tx(
         )?;
         write_chat_list_row_for_group_tx(tx, &group, unread)?;
     }
-    set_chat_list_projection_version_tx(tx, CHAT_LIST_PROJECTION_VERSION)?;
-    tx.execute_cached(
-        "DELETE FROM chat_list_unread_dirty_groups WHERE group_id_hex = ?1",
-        params![group_id_hex],
-    )
-    .storage()?;
     chat_list_row_tx(tx, group_id_hex)
 }
 
@@ -1205,8 +1205,8 @@ fn set_chat_list_projection_version_tx(tx: &Connection, version: i64) -> Storage
 /// comparing a read-time-only field here would mark every row stale forever.
 fn chat_list_projection_complete_tx(
     tx: &Connection,
-    local_account_id_hex: &str,
-    mention_classifier: &MentionClassifier<'_>,
+    _local_account_id_hex: &str,
+    _mention_classifier: &MentionClassifier<'_>,
 ) -> StorageResult<bool> {
     let activity_filter = chat_list_activity_filter_sql("mt.");
     let preview_order = chat_list_preview_order_desc("mt.");
@@ -1227,7 +1227,19 @@ fn chat_list_projection_complete_tx(
     }
     if projection_has_rows_tx(
         tx,
-        "SELECT EXISTS(SELECT 1 FROM chat_list_unread_dirty_groups)",
+        "SELECT EXISTS(SELECT 1 FROM chat_list_unread_dirty_messages)",
+        [],
+    )? {
+        return Ok(false);
+    }
+    if projection_has_rows_tx(
+        tx,
+        "SELECT EXISTS(
+            SELECT 1 FROM account_groups AS ag
+            LEFT JOIN chat_list_unread_ready_groups AS ready
+                ON ready.group_id_hex = ag.group_id_hex
+            WHERE ready.group_id_hex IS NULL
+         )",
         [],
     )? {
         return Ok(false);
@@ -1374,10 +1386,10 @@ fn chat_list_projection_complete_tx(
     if chat_list_projection_version_tx(tx)? >= CHAT_LIST_PROJECTION_VERSION {
         return Ok(true);
     }
-    // Older projection versions have no durable unread membership to compare;
-    // seed it with one authoritative rebuild.
-    let _ = (local_account_id_hex, mention_classifier);
-    Ok(false)
+    // Every group has durable membership now, so an account-wide marker left
+    // behind by targeted post-migration rebuilds can be advanced safely.
+    set_chat_list_projection_version_tx(tx, CHAT_LIST_PROJECTION_VERSION)?;
+    Ok(true)
 }
 
 fn projection_has_rows_tx<P: Params>(tx: &Connection, sql: &str, params: P) -> StorageResult<bool> {
@@ -1407,11 +1419,17 @@ fn rebuild_chat_list_row_for_group_tx(
     )?;
     write_chat_list_row_for_group_tx(tx, &group, unread)?;
     tx.execute_cached(
-        "DELETE FROM chat_list_unread_dirty_groups WHERE group_id_hex = ?1",
+        "DELETE FROM chat_list_unread_dirty_messages WHERE group_id_hex = ?1",
         params![group.group_id_hex],
     )
     .storage()?;
-    set_chat_list_projection_version_tx(tx, CHAT_LIST_PROJECTION_VERSION)
+    tx.execute_cached(
+        "INSERT INTO chat_list_unread_ready_groups (group_id_hex) VALUES (?1)
+         ON CONFLICT(group_id_hex) DO NOTHING",
+        params![group.group_id_hex],
+    )
+    .storage()?;
+    Ok(())
 }
 
 fn write_chat_list_row_for_group_tx(
@@ -1660,6 +1678,12 @@ fn reconcile_unread_messages_tx(
                 }
             }
         }
+        tx.execute_cached(
+            "DELETE FROM chat_list_unread_dirty_messages
+             WHERE group_id_hex = ?1 AND message_id_hex = ?2",
+            params![group_id_hex, message_id_hex],
+        )
+        .storage()?;
     }
     let first_message_id = tx
         .query_row_cached(
@@ -1924,7 +1948,16 @@ pub(crate) fn refresh_chat_list_unread_after_secure_prune_tx(
     )
     .storage()?;
     tx.execute_cached(
-        "DELETE FROM chat_list_unread_dirty_groups WHERE group_id_hex = ?1",
+        "DELETE FROM chat_list_unread_dirty_messages WHERE group_id_hex = ?1",
+        params![group_id_hex],
+    )
+    .storage()?;
+    tx.execute_cached(
+        "INSERT INTO chat_list_unread_ready_groups (group_id_hex)
+         SELECT ?1 WHERE EXISTS (
+            SELECT 1 FROM account_groups WHERE group_id_hex = ?1
+         )
+         ON CONFLICT(group_id_hex) DO NOTHING",
         params![group_id_hex],
     )
     .storage()?;

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -1975,6 +1975,52 @@ fn replayed_older_authenticated_message_does_not_replace_newer_pending_preview()
 }
 
 #[test]
+fn legacy_read_state_uses_canonical_first_unread_order_across_refresh_paths() {
+    let store = setup_store();
+    {
+        let conn = store.lock().unwrap();
+        conn.execute(
+            "INSERT INTO conversation_read_state (
+                group_id_hex, last_read_message_id_hex, last_read_timeline_at,
+                initialized_at, updated_at
+             ) VALUES (?1, 'marker', 5, 0, 1)",
+            params![GROUP],
+        )
+        .unwrap();
+    }
+
+    let mut higher_epoch = chat("higher-epoch", REMOTE, 10, "earlier wall clock");
+    higher_epoch.source_epoch = Some(8);
+    store.record_app_event(&higher_epoch).unwrap();
+    let mut lower_epoch = chat("lower-epoch", REMOTE, 20, "later wall clock");
+    lower_epoch.source_epoch = Some(7);
+    store.record_app_event(&lower_epoch).unwrap();
+
+    let rebuilt = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(
+        rebuilt.first_unread_message_id_hex.as_deref(),
+        Some("lower-epoch")
+    );
+
+    let targeted = store
+        .refresh_chat_list_row_for_messages(
+            LOCAL,
+            GROUP,
+            &["higher-epoch".to_owned()],
+            &no_mentions,
+        )
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(
+        targeted.first_unread_message_id_hex,
+        rebuilt.first_unread_message_id_hex
+    );
+}
+
+#[test]
 fn ensure_repairs_a_stale_pending_preview_after_newer_authenticated_activity() {
     let store = setup_store();
     let mut pending = chat("pending", LOCAL, 100, "older pending send");
@@ -3067,13 +3113,17 @@ fn targeted_refresh_classifies_only_changed_unread_messages() {
         .refresh_chat_list_row_for_messages(LOCAL, GROUP, &["third".to_owned()], &classifier)
         .unwrap()
         .expect("chat row");
-    assert_eq!(classifier_calls.get(), 0);
+    assert_eq!(
+        classifier_calls.get(),
+        2,
+        "timeline invalidation dirties rewritten siblings, so uncovered work must force a rebuild"
+    );
     assert_eq!(row.unread_count, 2);
     assert_eq!(row.unread_mention_count, 0);
 }
 
 #[test]
-fn later_targeted_refresh_preserves_earlier_dirty_message_for_repair() {
+fn later_targeted_refresh_rebuilds_when_an_earlier_message_is_still_dirty() {
     let store = setup_store();
     store
         .initialize_chat_read_state(LOCAL, GROUP, &no_mentions)
@@ -3097,18 +3147,18 @@ fn later_targeted_refresh_preserves_earlier_dirty_message_for_repair() {
         .refresh_chat_list_row_for_messages(LOCAL, GROUP, &["third".to_owned()], &no_mentions)
         .unwrap()
         .expect("chat row");
-    assert_eq!(row.unread_count, 2);
+    assert_eq!(row.unread_count, 3);
     {
         let conn = store.lock().unwrap();
-        let dirty_message: String = conn
+        let dirty_messages: i64 = conn
             .query_row(
-                "SELECT message_id_hex FROM chat_list_unread_dirty_messages
+                "SELECT count(*) FROM chat_list_unread_dirty_messages
                  WHERE group_id_hex = ?1",
                 params![GROUP],
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(dirty_message, "second");
+        assert_eq!(dirty_messages, 0);
     }
 
     store.ensure_chat_list_rows(LOCAL, &no_mentions).unwrap();
@@ -3123,6 +3173,56 @@ fn later_targeted_refresh_preserves_earlier_dirty_message_for_repair() {
         )
         .unwrap();
     assert_eq!(dirty, 0);
+}
+
+#[test]
+fn targeted_refresh_leaves_other_groups_dirty_work_untouched() {
+    const OTHER_GROUP: &str = "22";
+    let mut other_group = group();
+    other_group.group_id_hex = OTHER_GROUP.to_owned();
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    store
+        .save_account_projection_state(
+            &StoredAccountState {
+                label: "alice".to_owned(),
+                groups: vec![group(), other_group],
+                ..StoredAccountState::default()
+            },
+            256,
+            MAX_FUTURE_SKEW_SECS,
+        )
+        .unwrap();
+    store
+        .initialize_chat_read_state(LOCAL, GROUP, &no_mentions)
+        .unwrap();
+    store
+        .initialize_chat_read_state(LOCAL, OTHER_GROUP, &no_mentions)
+        .unwrap();
+    store.refresh_chat_list_rows(LOCAL, &no_mentions).unwrap();
+
+    let mut missed = chat("missed", REMOTE, 10, "other group");
+    missed.group_id_hex = OTHER_GROUP.to_owned();
+    store.record_app_event(&missed).unwrap();
+    store
+        .record_app_event(&chat("current", REMOTE, 20, "current group"))
+        .unwrap();
+    let row = store
+        .refresh_chat_list_row_for_messages(LOCAL, GROUP, &["current".to_owned()], &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(row.unread_count, 1);
+
+    let other_group_dirty: i64 = store
+        .lock()
+        .unwrap()
+        .query_row(
+            "SELECT count(*) FROM chat_list_unread_dirty_messages
+             WHERE group_id_hex = ?1 AND message_id_hex = ?2",
+            params![OTHER_GROUP, "missed"],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(other_group_dirty, 1);
 }
 
 #[test]

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -1736,9 +1736,7 @@ fn ensure_chat_list_rows_treats_unknown_self_membership_as_normalized() {
     // CASE) — otherwise it sees 'member' != '<unknown>' forever and rebuilds the
     // whole projection on every open.
     let store = setup_store();
-    store
-        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
-        .unwrap();
+    store.refresh_chat_list_rows(LOCAL, &no_mentions).unwrap();
 
     {
         let conn = store.lock().unwrap();
@@ -2184,10 +2182,8 @@ fn failed_local_send_does_not_replace_delivered_preview_after_prune_or_ensure() 
     delivered.source_epoch = Some(8);
     store.record_app_event(&delivered).unwrap();
 
-    let row = store
-        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
-        .unwrap()
-        .expect("chat row");
+    store.refresh_chat_list_rows(LOCAL, &no_mentions).unwrap();
+    let row = store.chat_list_row(GROUP).unwrap().expect("chat row");
     assert_eq!(
         row.last_message
             .as_ref()
@@ -2210,7 +2206,7 @@ fn failed_local_send_does_not_replace_delivered_preview_after_prune_or_ensure() 
     {
         let conn = store.lock().unwrap();
         assert!(
-            chat_list_projection_complete_tx(&conn, LOCAL, &no_mentions).unwrap(),
+            chat_list_projection_complete_tx(&conn).unwrap(),
             "failed-send preview priority must match the completeness query"
         );
     }
@@ -3299,11 +3295,22 @@ fn ensure_chat_list_rows_corrects_stale_unread_mention_count() {
             [],
         )
         .unwrap();
-        conn.execute(
-            "DELETE FROM chat_list_unread_ready_groups WHERE group_id_hex = ?1",
-            params![GROUP],
-        )
-        .unwrap();
+        let ready_groups: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM chat_list_unread_ready_groups",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let dirty_messages: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM chat_list_unread_dirty_messages",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(ready_groups, 1);
+        assert_eq!(dirty_messages, 0);
     }
 
     store.ensure_chat_list_rows(LOCAL, &mentions_local).unwrap();
@@ -3957,7 +3964,7 @@ fn chat_list_rows_report_the_durable_leave_request_at_read_time() {
     {
         let conn = store.lock().unwrap();
         assert!(
-            chat_list_projection_complete_tx(&conn, LOCAL, &no_mentions).unwrap(),
+            chat_list_projection_complete_tx(&conn).unwrap(),
             "a pending leave request must not make the projection look stale"
         );
     }

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -3028,6 +3028,102 @@ fn unread_mention_of_other_account_does_not_count() {
 }
 
 #[test]
+fn targeted_refresh_classifies_only_changed_unread_messages() {
+    let store = setup_store();
+    store
+        .initialize_chat_read_state(LOCAL, GROUP, &no_mentions)
+        .unwrap();
+    store
+        .record_app_event(&chat("first", REMOTE, 10, "hello"))
+        .unwrap();
+    store
+        .record_app_event(&chat("second", REMOTE, 20, "hello again"))
+        .unwrap();
+
+    let classifier_calls = std::cell::Cell::new(0usize);
+    let classifier = |plaintext: &str, _tags: &[Vec<String>]| {
+        classifier_calls.set(classifier_calls.get() + 1);
+        plaintext.contains("@local")
+    };
+    store
+        .refresh_chat_list_row(LOCAL, GROUP, &classifier)
+        .unwrap();
+    assert_eq!(classifier_calls.get(), 2);
+
+    classifier_calls.set(0);
+    store
+        .record_app_event(&chat("third", REMOTE, 30, "hello @local"))
+        .unwrap();
+    let row = store
+        .refresh_chat_list_row_for_messages(LOCAL, GROUP, &["third".to_owned()], &classifier)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(classifier_calls.get(), 1);
+    assert_eq!(row.unread_count, 3);
+    assert_eq!(row.unread_mention_count, 1);
+    assert_eq!(row.first_unread_message_id_hex.as_deref(), Some("first"));
+
+    classifier_calls.set(0);
+    store
+        .invalidate_app_event_by_message_id(GROUP, "third", "LosingBranch")
+        .unwrap();
+    let row = store
+        .refresh_chat_list_row_for_messages(LOCAL, GROUP, &["third".to_owned()], &classifier)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(classifier_calls.get(), 0);
+    assert_eq!(row.unread_count, 2);
+    assert_eq!(row.unread_mention_count, 0);
+}
+
+#[test]
+fn ensure_repairs_timeline_change_left_dirty_before_chat_list_refresh() {
+    let store = setup_store();
+    store
+        .initialize_chat_read_state(LOCAL, GROUP, &no_mentions)
+        .unwrap();
+    store
+        .record_app_event(&chat("first", REMOTE, 10, "first"))
+        .unwrap();
+    store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap();
+
+    // Model a process stop between the timeline commit and the app's targeted
+    // chat-list refresh. The trigger-owned marker must make startup repair it.
+    store
+        .record_app_event(&chat("second", REMOTE, 20, "second"))
+        .unwrap();
+    {
+        let conn = store.lock().unwrap();
+        let dirty: i64 = conn
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM chat_list_unread_dirty_groups
+                    WHERE group_id_hex = ?1
+                 )",
+                params![GROUP],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(dirty, 1);
+    }
+
+    store.ensure_chat_list_rows(LOCAL, &no_mentions).unwrap();
+    let row = store.chat_list_row(GROUP).unwrap().expect("chat row");
+    assert_eq!(row.unread_count, 2);
+    let conn = store.lock().unwrap();
+    let dirty: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM chat_list_unread_dirty_groups",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(dirty, 0);
+}
+
+#[test]
 fn already_read_mention_does_not_count_as_unread_mention() {
     let store = setup_store();
     // A mention arrives, then the client reads it: it is before the read marker
@@ -3115,6 +3211,11 @@ fn ensure_chat_list_rows_corrects_stale_unread_mention_count() {
         conn.execute(
             "UPDATE chat_list_rows SET unread_mention_count = 0 WHERE group_id_hex = ?1",
             params![GROUP],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE chat_list_projection_meta SET mention_counts_version = 0 WHERE id = 1",
+            [],
         )
         .unwrap();
     }

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -3077,7 +3077,7 @@ fn targeted_refresh_classifies_only_changed_unread_messages() {
 }
 
 #[test]
-fn ensure_repairs_timeline_change_left_dirty_before_chat_list_refresh() {
+fn later_targeted_refresh_preserves_earlier_dirty_message_for_repair() {
     let store = setup_store();
     store
         .initialize_chat_read_state(LOCAL, GROUP, &no_mentions)
@@ -3089,38 +3089,119 @@ fn ensure_repairs_timeline_change_left_dirty_before_chat_list_refresh() {
         .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
         .unwrap();
 
-    // Model a process stop between the timeline commit and the app's targeted
-    // chat-list refresh. The trigger-owned marker must make startup repair it.
+    // Model a process stop between this timeline commit and its targeted
+    // chat-list refresh.
     store
         .record_app_event(&chat("second", REMOTE, 20, "second"))
         .unwrap();
+    store
+        .record_app_event(&chat("third", REMOTE, 30, "third"))
+        .unwrap();
+    let row = store
+        .refresh_chat_list_row_for_messages(LOCAL, GROUP, &["third".to_owned()], &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(row.unread_count, 2);
     {
         let conn = store.lock().unwrap();
-        let dirty: i64 = conn
+        let dirty_message: String = conn
             .query_row(
-                "SELECT EXISTS(
-                    SELECT 1 FROM chat_list_unread_dirty_groups
-                    WHERE group_id_hex = ?1
-                 )",
+                "SELECT message_id_hex FROM chat_list_unread_dirty_messages
+                 WHERE group_id_hex = ?1",
                 params![GROUP],
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(dirty, 1);
+        assert_eq!(dirty_message, "second");
     }
 
     store.ensure_chat_list_rows(LOCAL, &no_mentions).unwrap();
     let row = store.chat_list_row(GROUP).unwrap().expect("chat row");
-    assert_eq!(row.unread_count, 2);
+    assert_eq!(row.unread_count, 3);
     let conn = store.lock().unwrap();
     let dirty: i64 = conn
         .query_row(
-            "SELECT count(*) FROM chat_list_unread_dirty_groups",
+            "SELECT count(*) FROM chat_list_unread_dirty_messages",
             [],
             |row| row.get(0),
         )
         .unwrap();
     assert_eq!(dirty, 0);
+}
+
+#[test]
+fn targeted_refresh_requires_per_group_membership_readiness_after_upgrade() {
+    const SECOND_GROUP: &str = "22";
+    let mut other_group = group();
+    other_group.group_id_hex = SECOND_GROUP.to_owned();
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    store
+        .save_account_projection_state(
+            &StoredAccountState {
+                label: "alice".to_owned(),
+                groups: vec![group(), other_group],
+                ..StoredAccountState::default()
+            },
+            256,
+            MAX_FUTURE_SKEW_SECS,
+        )
+        .unwrap();
+    store
+        .initialize_chat_read_state(LOCAL, GROUP, &mentions_local)
+        .unwrap();
+    store
+        .initialize_chat_read_state(LOCAL, SECOND_GROUP, &mentions_local)
+        .unwrap();
+    let mut historical = chat_with_tags(
+        "h-old",
+        REMOTE,
+        10,
+        "historical mention",
+        vec![vec!["p".to_owned(), LOCAL.to_owned()]],
+    );
+    historical.group_id_hex = SECOND_GROUP.to_owned();
+    store.record_app_event(&historical).unwrap();
+    store
+        .refresh_chat_list_row(LOCAL, SECOND_GROUP, &mentions_local)
+        .unwrap();
+
+    // Reproduce the post-migration state: old chat-list rows exist, but no
+    // group has had its membership projection seeded yet.
+    {
+        let conn = store.lock().unwrap();
+        conn.execute("DELETE FROM chat_list_unread_messages", [])
+            .unwrap();
+        conn.execute("DELETE FROM chat_list_unread_ready_groups", [])
+            .unwrap();
+        conn.execute(
+            "UPDATE chat_list_projection_meta SET mention_counts_version = 0 WHERE id = 1",
+            [],
+        )
+        .unwrap();
+    }
+
+    store
+        .record_app_event(&chat("g-new", REMOTE, 20, "new in first group"))
+        .unwrap();
+    store
+        .refresh_chat_list_row_for_messages(LOCAL, GROUP, &["g-new".to_owned()], &mentions_local)
+        .unwrap();
+
+    let mut new_in_second = chat("h-new", REMOTE, 20, "new in second group");
+    new_in_second.group_id_hex = SECOND_GROUP.to_owned();
+    store.record_app_event(&new_in_second).unwrap();
+    let row = store
+        .refresh_chat_list_row_for_messages(
+            LOCAL,
+            SECOND_GROUP,
+            &["h-new".to_owned()],
+            &mentions_local,
+        )
+        .unwrap()
+        .expect("second chat row");
+    assert_eq!(row.unread_count, 2);
+    assert_eq!(row.unread_mention_count, 1);
+    assert_eq!(row.first_unread_message_id_hex.as_deref(), Some("h-old"));
 }
 
 #[test]
@@ -3216,6 +3297,11 @@ fn ensure_chat_list_rows_corrects_stale_unread_mention_count() {
         conn.execute(
             "UPDATE chat_list_projection_meta SET mention_counts_version = 0 WHERE id = 1",
             [],
+        )
+        .unwrap();
+        conn.execute(
+            "DELETE FROM chat_list_unread_ready_groups WHERE group_id_hex = ?1",
+            params![GROUP],
         )
         .unwrap();
     }

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -114,6 +114,8 @@ mod migration_0056_chat_list_accepted_activity_high_water;
 mod migration_0057_openmls_values_msgpack;
 #[path = "migrations/0058_processed_transport_ids.rs"]
 mod migration_0058_processed_transport_ids;
+#[path = "migrations/0059_chat_list_unread_membership.rs"]
+mod migration_0059_chat_list_unread_membership;
 #[cfg(test)]
 #[path = "migrations/test_support.rs"]
 mod test_support;
@@ -418,6 +420,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 58,
         name: "0058_processed_transport_ids",
         apply: migration_0058_processed_transport_ids::apply,
+    },
+    Migration {
+        version: 59,
+        name: "0059_chat_list_unread_membership",
+        apply: migration_0059_chat_list_unread_membership::apply,
     },
 ];
 
@@ -946,7 +953,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 58,
+                found: 59,
                 latest_supported: 46,
             }
         ));
@@ -1002,7 +1009,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 58,
+                found: 59,
                 latest_supported: 46,
             }
         ));
@@ -1306,7 +1313,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 58,
+                found: 59,
                 latest_supported: 46,
             }
         ));

--- a/crates/storage-sqlite/src/migrations/0059_chat_list_unread_membership.rs
+++ b/crates/storage-sqlite/src/migrations/0059_chat_list_unread_membership.rs
@@ -1,0 +1,76 @@
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+/// Materialize unread membership so projecting one new message does not scan
+/// and reclassify the entire unread window.
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE TABLE chat_list_unread_messages (
+    group_id_hex           TEXT NOT NULL
+                           REFERENCES account_groups(group_id_hex) ON DELETE CASCADE,
+    message_id_hex         TEXT NOT NULL,
+    mentions_local         INTEGER NOT NULL CHECK (mentions_local IN (0, 1)),
+    timeline_order_class   INTEGER NOT NULL,
+    timeline_order_primary INTEGER NOT NULL,
+    timeline_order_phase   INTEGER NOT NULL,
+    timeline_order_at      INTEGER NOT NULL,
+    PRIMARY KEY (group_id_hex, message_id_hex)
+);
+CREATE INDEX idx_chat_list_unread_messages_first
+    ON chat_list_unread_messages (
+        group_id_hex,
+        timeline_order_class,
+        timeline_order_primary,
+        timeline_order_phase,
+        timeline_order_at,
+        message_id_hex
+    );
+
+CREATE TABLE chat_list_unread_dirty_groups (
+    group_id_hex TEXT PRIMARY KEY
+                 REFERENCES account_groups(group_id_hex) ON DELETE CASCADE
+);
+INSERT INTO chat_list_unread_dirty_groups (group_id_hex)
+SELECT group_id_hex FROM account_groups;
+
+CREATE TRIGGER chat_list_unread_dirty_after_timeline_insert
+AFTER INSERT ON message_timeline
+BEGIN
+    INSERT INTO chat_list_unread_dirty_groups (group_id_hex)
+    SELECT NEW.group_id_hex
+    WHERE EXISTS (
+        SELECT 1 FROM account_groups WHERE group_id_hex = NEW.group_id_hex
+    )
+    ON CONFLICT(group_id_hex) DO NOTHING;
+END;
+CREATE TRIGGER chat_list_unread_dirty_after_timeline_update
+AFTER UPDATE ON message_timeline
+BEGIN
+    INSERT INTO chat_list_unread_dirty_groups (group_id_hex)
+    SELECT NEW.group_id_hex
+    WHERE EXISTS (
+        SELECT 1 FROM account_groups WHERE group_id_hex = NEW.group_id_hex
+    )
+    ON CONFLICT(group_id_hex) DO NOTHING;
+END;
+CREATE TRIGGER chat_list_unread_dirty_after_timeline_delete
+AFTER DELETE ON message_timeline
+BEGIN
+    INSERT INTO chat_list_unread_dirty_groups (group_id_hex)
+    SELECT OLD.group_id_hex
+    WHERE EXISTS (
+        SELECT 1 FROM account_groups WHERE group_id_hex = OLD.group_id_hex
+    )
+    ON CONFLICT(group_id_hex) DO NOTHING;
+END;
+
+-- Force one authoritative rebuild to seed the new derived projection.
+UPDATE chat_list_projection_meta
+SET mention_counts_version = 0
+WHERE id = 1;
+"#,
+    )
+    .storage()
+}

--- a/crates/storage-sqlite/src/migrations/0059_chat_list_unread_membership.rs
+++ b/crates/storage-sqlite/src/migrations/0059_chat_list_unread_membership.rs
@@ -28,42 +28,47 @@ CREATE INDEX idx_chat_list_unread_messages_first
         message_id_hex
     );
 
-CREATE TABLE chat_list_unread_dirty_groups (
+CREATE TABLE chat_list_unread_ready_groups (
     group_id_hex TEXT PRIMARY KEY
                  REFERENCES account_groups(group_id_hex) ON DELETE CASCADE
 );
-INSERT INTO chat_list_unread_dirty_groups (group_id_hex)
-SELECT group_id_hex FROM account_groups;
+
+CREATE TABLE chat_list_unread_dirty_messages (
+    group_id_hex   TEXT NOT NULL
+                   REFERENCES account_groups(group_id_hex) ON DELETE CASCADE,
+    message_id_hex TEXT NOT NULL,
+    PRIMARY KEY (group_id_hex, message_id_hex)
+);
 
 CREATE TRIGGER chat_list_unread_dirty_after_timeline_insert
 AFTER INSERT ON message_timeline
 BEGIN
-    INSERT INTO chat_list_unread_dirty_groups (group_id_hex)
-    SELECT NEW.group_id_hex
+    INSERT INTO chat_list_unread_dirty_messages (group_id_hex, message_id_hex)
+    SELECT NEW.group_id_hex, NEW.message_id_hex
     WHERE EXISTS (
         SELECT 1 FROM account_groups WHERE group_id_hex = NEW.group_id_hex
     )
-    ON CONFLICT(group_id_hex) DO NOTHING;
+    ON CONFLICT(group_id_hex, message_id_hex) DO NOTHING;
 END;
 CREATE TRIGGER chat_list_unread_dirty_after_timeline_update
 AFTER UPDATE ON message_timeline
 BEGIN
-    INSERT INTO chat_list_unread_dirty_groups (group_id_hex)
-    SELECT NEW.group_id_hex
+    INSERT INTO chat_list_unread_dirty_messages (group_id_hex, message_id_hex)
+    SELECT NEW.group_id_hex, NEW.message_id_hex
     WHERE EXISTS (
         SELECT 1 FROM account_groups WHERE group_id_hex = NEW.group_id_hex
     )
-    ON CONFLICT(group_id_hex) DO NOTHING;
+    ON CONFLICT(group_id_hex, message_id_hex) DO NOTHING;
 END;
 CREATE TRIGGER chat_list_unread_dirty_after_timeline_delete
 AFTER DELETE ON message_timeline
 BEGIN
-    INSERT INTO chat_list_unread_dirty_groups (group_id_hex)
-    SELECT OLD.group_id_hex
+    INSERT INTO chat_list_unread_dirty_messages (group_id_hex, message_id_hex)
+    SELECT OLD.group_id_hex, OLD.message_id_hex
     WHERE EXISTS (
         SELECT 1 FROM account_groups WHERE group_id_hex = OLD.group_id_hex
     )
-    ON CONFLICT(group_id_hex) DO NOTHING;
+    ON CONFLICT(group_id_hex, message_id_hex) DO NOTHING;
 END;
 
 -- Force one authoritative rebuild to seed the new derived projection.


### PR DESCRIPTION
## Summary

Eliminate the quadratic unread-message path in chat-list projection.

Previously, every timeline update rebuilt unread state by scanning and reclassifying the entire unread window. Processing N unread messages therefore performed roughly O(N²) classification work.

This change introduces a durable, indexed unread-membership projection. Ordinary timeline updates now reconcile only the affected message IDs and update unread and mention counters by delta.

## Changes

- Add migration 0059 with:
  - per-message unread membership
  - canonical ordering fields for indexed first-unread lookup
  - per-group dirty markers for interrupted projection updates
- Pass exact changed message IDs from the app timeline projector into chat-list refresh.
- Incrementally handle new messages, edits, deletes, invalidations, and reprojections.
- Preserve authoritative full rebuilds for schema migration, read-marker changes, secure pruning, and projection repair.
- Detect timeline commits not followed by chat-list refresh and repair them on startup.

## Performance

The ordinary incoming-message path no longer scans all existing unread messages.

Across N incoming unread messages, unread classification changes from approximately O(N²) to O(N), with indexed first-unread lookup making the overall projection path approximately O(N log N).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Chat-list updates now refresh only rows affected by changed messages, reducing unnecessary full-row refreshes.
  * Unread mentions and ordering are reconciled incrementally for faster updates.

* **Bug Fixes**
  * Added automatic repair and rebuilding for outdated or incomplete chat-list data.
  * Improved unread-state handling after message updates, deletions, and timeline changes.

* **Migration**
  * Added database support for reliable unread-message tracking and chat-list projection updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->