### PR TITLE
ci: shorten pull request feedback lanes

### DIFF
--- a/.github/workflows/c-smoke-nightly.yml
+++ b/.github/workflows/c-smoke-nightly.yml
@@ -1,0 +1,49 @@
+name: C Bindings Nightly
+
+on:
+  schedule:
+    - cron: "31 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: c-bindings-nightly-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  CARGO_PROFILE_RELEASE_DEBUG: "0"
+
+jobs:
+  c-smoke:
+    name: Release C bindings smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        run: |
+          set -euo pipefail
+          toolchain="$(sed -n 's/^channel = "\(.*\)"/\1/p' rust-toolchain.toml)"
+          rustup toolchain install "$toolchain" --profile minimal
+          rustup default "$toolchain"
+
+      - name: Cache Cargo artifacts
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Install C smoke dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y valgrind clang
+
+      - name: Compile and run release C smoke test
+        run: ./crates/marmot-c/c-smoke.sh gcc clang

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,43 @@ env:
   CARGO_PROFILE_TEST_DEBUG: "0"
 
 jobs:
+  changes:
+    name: Classify CI changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run_full: ${{ steps.classify.outputs.run_full }}
+      run_c: ${{ steps.classify.outputs.run_c }}
+      run_conformance: ${{ steps.classify.outputs.run_conformance }}
+      run_ios: ${{ steps.classify.outputs.run_ios }}
+      run_formal: ${{ steps.classify.outputs.run_formal }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Classify changed paths
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "workflow_dispatch" \
+            || -z "$BASE_SHA" \
+            || "$BASE_SHA" =~ ^0+$ ]] \
+            || ! git cat-file -e "${BASE_SHA}^{commit}"; then
+            python3 scripts/classify_ci_changes.py --all --github-output "$GITHUB_OUTPUT" </dev/null
+          else
+            # Disable rename detection so a code-to-Markdown rename exposes
+            # both the removed code path and the added documentation path.
+            git diff --no-renames --name-only -z "$BASE_SHA" "$GITHUB_SHA" \
+              | python3 scripts/classify_ci_changes.py --github-output "$GITHUB_OUTPUT"
+          fi
+
   rust-format:
     name: Rust format
     runs-on: ubuntu-latest
@@ -63,8 +100,11 @@ jobs:
       - name: Agent install documentation gate
         run: ./scripts/check_agent_install_docs.sh
 
-      - name: Cargo audit workflow policy gate
-        run: python3 scripts/test_check_cargo_audit_ci.py
+      - name: CI policy and path-classifier gates
+        run: |
+          ./scripts/check_convergence_constant_ledger.sh
+          python3 scripts/test_check_cargo_audit_ci.py
+          python3 scripts/test_classify_ci_changes.py
 
   rust-audit:
     name: Rust audit
@@ -98,6 +138,8 @@ jobs:
 
   terminal-harness-installers:
     name: Terminal harness installer tests
+    needs: changes
+    if: needs.changes.outputs.run_full == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -116,6 +158,8 @@ jobs:
 
   rust-check:
     name: Rust check
+    needs: changes
+    if: needs.changes.outputs.run_full == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -145,6 +189,8 @@ jobs:
 
   rust-clippy:
     name: Rust clippy
+    needs: changes
+    if: needs.changes.outputs.run_full == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -174,6 +220,8 @@ jobs:
 
   c-smoke:
     name: C bindings smoke
+    needs: changes
+    if: needs.changes.outputs.run_c == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -193,6 +241,11 @@ jobs:
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
+      - name: Install cbindgen
+        uses: taiki-e/install-action@b18fb392e1a1b90971f7c7572c92790fa54f23d5
+        with:
+          tool: cbindgen@0.29.4
+
       - name: Header diff gate
         run: |
           set -euo pipefail
@@ -200,7 +253,6 @@ jobs:
           # checked-in header and fail the diff gate on unrelated PRs.
           # RUSTC_BOOTSTRAP=1 lets cbindgen expand the mirror-generating
           # macros on stable; it only affects header generation.
-          cargo install cbindgen --version 0.29.4 --locked
           RUSTC_BOOTSTRAP=1 cbindgen --config crates/marmot-c/cbindgen.toml --crate marmot-c \
             --output crates/marmot-c/include/marmot.h crates/marmot-c
           git diff --exit-code crates/marmot-c/include/marmot.h
@@ -208,15 +260,13 @@ jobs:
       - name: Alloc-audit tests
         run: cargo test -p marmot-c --features alloc-audit --locked
 
-      - name: Compile and run C smoke test (gcc + clang, valgrind)
-        run: |
-          set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y valgrind clang
-          ./crates/marmot-c/c-smoke.sh gcc clang
+      - name: Compile and run debug C smoke test (gcc)
+        run: ./crates/marmot-c/c-smoke.sh --debug gcc
 
   ios-account-clippy:
     name: iOS account keychain clippy
+    needs: changes
+    if: needs.changes.outputs.run_ios == 'true'
     runs-on: macos-latest
     timeout-minutes: 30
 
@@ -248,6 +298,8 @@ jobs:
   # reject every non-v1 convergence policy (mdk#970).
   convergence-policy-pin:
     name: Convergence policy pin (release assertions)
+    needs: changes
+    if: needs.changes.outputs.run_full == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -275,6 +327,8 @@ jobs:
 
   rust-test:
     name: Rust tests (${{ matrix.partition }}/4)
+    needs: changes
+    if: needs.changes.outputs.run_full == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -315,6 +369,8 @@ jobs:
 
   cli-e2e:
     name: CLI e2e (mock relay)
+    needs: changes
+    if: needs.changes.outputs.run_full == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -348,6 +404,8 @@ jobs:
 
   relay-runtime:
     name: Relay runtime tests
+    needs: changes
+    if: needs.changes.outputs.run_full == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -377,6 +435,8 @@ jobs:
 
   relay-e2e:
     name: Relay CLI E2E
+    needs: changes
+    if: needs.changes.outputs.run_full == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -424,6 +484,8 @@ jobs:
 
   conformance:
     name: Simulator and vectors
+    needs: changes
+    if: needs.changes.outputs.run_conformance == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -474,26 +536,10 @@ jobs:
       - name: Verify convergence with independent models
         run: just convergence-verification-ci
 
-      - name: Run encrypted file-backed vector report
-        run: |
-          cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report --locked -- \
-            --vectors crates/cgka-conformance-simulator/vectors \
-            --out target/cgka-conformance-simulator-reports \
-            --storage file \
-            --strict-oracle
-          jq -s -e 'all(.[]; .metadata.storage_backend == "encrypted-file-sqlite")' \
-            target/cgka-conformance-simulator-reports/*-report.json >/dev/null
-
-      - name: Upload vector report
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: cgka-conformance-simulator-reports
-          path: target/cgka-conformance-simulator-reports
-          if-no-files-found: error
-          retention-days: 14
-
   formal:
     name: Tamarin proofs
+    needs: changes
+    if: needs.changes.outputs.run_formal == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -545,6 +591,8 @@ jobs:
 
   hermes-installer-auth:
     name: Hermes installer auth
+    needs: changes
+    if: needs.changes.outputs.run_full == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -625,6 +673,7 @@ jobs:
     name: Required CI
     if: always()
     needs:
+      - changes
       - rust-format
       - rust-audit
       - terminal-harness-installers
@@ -644,8 +693,8 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - name: Require every core CI job to succeed
+      - name: Require every selected core CI job to succeed
         env:
           NEEDS: ${{ toJSON(needs) }}
         run: |
-          jq --exit-status 'all(.[]; .result == "success")' <<<"$NEEDS"
+          jq --exit-status 'all(.[]; .result == "success" or .result == "skipped")' <<<"$NEEDS"

--- a/.github/workflows/quic-broker-image.yml
+++ b/.github/workflows/quic-broker-image.yml
@@ -14,6 +14,8 @@ on:
       - crates/transport-quic-stream/**
       - crates/transport-quic-broker/**
       - .github/workflows/quic-broker-image.yml
+      - '!*.md'
+      - '!**/*.md'
   push:
     branches:
       - master

--- a/.github/workflows/wn-agent-binaries.yml
+++ b/.github/workflows/wn-agent-binaries.yml
@@ -36,6 +36,8 @@ on:
       - crates/transport-nostr-peeler/**
       - crates/transport-quic-broker/**
       - crates/transport-quic-stream/**
+      - '!*.md'
+      - '!**/*.md'
   push:
     branches:
       - master

--- a/.github/workflows/wn-agent-binaries.yml
+++ b/.github/workflows/wn-agent-binaries.yml
@@ -38,6 +38,7 @@ on:
       - crates/transport-quic-stream/**
       - '!*.md'
       - '!**/*.md'
+      - integrations/openclaw/marmot/README.md
   push:
     branches:
       - master

--- a/Justfile
+++ b/Justfile
@@ -237,6 +237,9 @@ cargo-audit-policy-gate:
     python3 scripts/check_cargo_audit_ci.py
     python3 scripts/test_check_cargo_audit_ci.py
 
+ci-path-classifier-gate:
+    python3 scripts/test_classify_ci_changes.py
+
 openclaw-dev-smoke root="":
     #!/usr/bin/env bash
     set -euo pipefail
@@ -311,12 +314,12 @@ conformance-slow:
     cargo nextest run -p cgka-conformance-simulator --features conformance-slow
 
 # Fast PR feedback: ordinary simulator coverage without dedicated verification
-# binaries or the generated multi-minute reliability batches. Run the
-# subprocess-heavy process suite separately so relay tasks do not compete with
-# the parallel simulator tests.
+# binaries or the generated multi-minute reliability batches. Keep two
+# production-shaped process canaries in PR CI; the complete serialized process
+# suite runs in the nightly lane below.
 simulator-smoke:
     cargo nextest run -p cgka-conformance-simulator --locked --profile ci -E '{{simulator-smoke-filter}}'
-    cargo nextest run -p cgka-conformance-simulator --test process_orchestrator --locked --profile ci
+    cargo nextest run -p cgka-conformance-simulator --test process_orchestrator --locked --profile ci -E 'test(=engine_app_runtime_and_process_adapters_reach_equivalent_public_state) | test(=process_kill_disconnect_reconnect_and_restart_agree_with_uninterrupted_execution)'
 
 # Complete generic simulator coverage for the nightly lane. Dedicated
 # adversarial and independent-verification binaries run in later recipes.
@@ -583,6 +586,6 @@ test-convergence-policy-pin:
 
 # Fast local pre-push gate: mechanical/static checks plus the release pin proof.
 # GitHub CI invokes the static gates directly and runs the full test matrix.
-fast-ci: fmt-check naming-gate c-parity-gate convergence-ledger-gate campaign-toolchain-gate agent-install-docs-gate install-example-sha256-gate cargo-audit-policy-gate check clippy test-convergence-policy-pin
+fast-ci: fmt-check naming-gate c-parity-gate convergence-ledger-gate campaign-toolchain-gate agent-install-docs-gate install-example-sha256-gate cargo-audit-policy-gate ci-path-classifier-gate check clippy test-convergence-policy-pin
 
-ci: fmt-check naming-gate c-parity-gate convergence-ledger-gate campaign-toolchain-gate agent-install-docs-gate install-example-sha256-gate cargo-audit-policy-gate check clippy test-convergence-policy-pin test
+ci: fmt-check naming-gate c-parity-gate convergence-ledger-gate campaign-toolchain-gate agent-install-docs-gate install-example-sha256-gate cargo-audit-policy-gate ci-path-classifier-gate check clippy test-convergence-policy-pin test

--- a/crates/cgka-conformance-simulator/tests/report_runner.rs
+++ b/crates/cgka-conformance-simulator/tests/report_runner.rs
@@ -802,10 +802,14 @@ async fn report_runner_writes_vector_fixture_reports_and_summary() {
         fs::remove_dir_all(&out_dir).expect("remove stale output dir");
     }
 
-    let vectors_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("vectors");
+    // The canonical-scenarios gate executes every committed vector. This test
+    // only needs one semantic fixture to prove the report writer and summary
+    // path, rather than executing the complete vector directory a second time.
+    let vector =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("vectors/group-data-fork-recovery.v1.json");
     let summary = run_report(&ReportArgs {
         input: ReportInput::VectorFixtures {
-            paths: vec![vectors_dir],
+            paths: vec![vector],
         },
         out: out_dir.clone(),
         strict_oracle: false,
@@ -817,7 +821,7 @@ async fn report_runner_writes_vector_fixture_reports_and_summary() {
     .expect("runner writes vector reports");
 
     assert_eq!(summary.failed(), 0);
-    assert!(summary.total() >= 3);
+    assert_eq!(summary.total(), 1);
     let text = summary.to_human_text();
     assert!(text.contains("PASS"));
     assert!(text.contains("group-data-fork-recovery/v1"));

--- a/crates/convergence-campaign-runner/tests/lane_policy.rs
+++ b/crates/convergence-campaign-runner/tests/lane_policy.rs
@@ -43,13 +43,13 @@ fn workflow_artifact_retention_matches_lane_policy() {
     let nightly = include_str!("../../../.github/workflows/simulator-nightly.yml");
     let hardening = include_str!("../../../.github/workflows/convergence-hardening.yml");
 
-    assert_artifact_retention(
-        ci,
-        "name: cgka-conformance-simulator-reports",
-        &CampaignLaneConfigV1::builtin(CampaignLaneV1::PullRequest)
-            .budgets
-            .artifact_retention_days
-            .to_string(),
+    assert!(
+        !ci.contains("name: cgka-conformance-simulator-reports"),
+        "PR CI must not duplicate the full file-backed vector report"
+    );
+    assert!(
+        nightly.contains("--vectors crates/cgka-conformance-simulator/vectors"),
+        "nightly CI must retain the complete file-backed vector report"
     );
     assert_artifact_retention(
         nightly,

--- a/crates/marmot-c/README.md
+++ b/crates/marmot-c/README.md
@@ -57,7 +57,9 @@ int main(void) {
 `examples/smoke.c` is a worked example covering lifecycle, Markdown
 tagged-union walking, offline reads, the error taxonomy, and best-effort
 identity creation. `./crates/marmot-c/c-smoke.sh` builds and runs it
-against both linkage models (valgrind when available).
+against both linkage models (valgrind when available). Pass `--debug` first
+to reuse debug/test-profile dependencies for a faster local or PR smoke run;
+release and scheduled validation use the default release build.
 
 ## Rules of the road
 

--- a/crates/marmot-c/c-smoke.sh
+++ b/crates/marmot-c/c-smoke.sh
@@ -2,7 +2,10 @@
 # Build marmot-c and run the C smoke example against both linkage models:
 # the shared object and the static archive, for each compiler given as an
 # argument (default: cc). Runs the shared build under valgrind when
-# available. Usage: c-smoke.sh [cc...]
+# available. The default release build is the packaging/release gate; PR CI
+# uses --debug so it can reuse test-profile dependencies while still proving
+# the checked-in header compiles and both linkage models work.
+# Usage: c-smoke.sh [--debug] [cc...]
 
 set -euo pipefail
 
@@ -11,13 +14,25 @@ export PATH="$HOME/.cargo/bin:$PATH"
 CRATE_DIR="$(cd "$(dirname "$0")" && pwd)"
 WORKSPACE_DIR="$(cd "$CRATE_DIR/../.." && pwd)"
 TARGET_DIR="${CARGO_TARGET_DIR:-$WORKSPACE_DIR/target}"
+PROFILE=release
+PROFILE_DIR=release
+if [[ "${1:-}" == "--debug" ]]; then
+    PROFILE=dev
+    PROFILE_DIR=debug
+    shift
+fi
+
 COMPILERS=("$@")
 [ ${#COMPILERS[@]} -gt 0 ] || COMPILERS=(cc)
 
 cd "$WORKSPACE_DIR"
 
-echo "==> Building marmot-c (release)"
-cargo build --release -p marmot-c
+echo "==> Building marmot-c ($PROFILE)"
+if [[ "$PROFILE" == "release" ]]; then
+    cargo build --release -p marmot-c
+else
+    cargo build -p marmot-c
+fi
 
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
@@ -38,18 +53,18 @@ run() {
     local bin="$1"; shift
     local home
     home="$(mktemp -d "$WORK/home.XXXXXX")"
-    env "$LIB_PATH_VAR=$TARGET_DIR/release" "$@" "$bin" "$home"
+    env "$LIB_PATH_VAR=$TARGET_DIR/$PROFILE_DIR" "$@" "$bin" "$home"
     rm -rf "$home"
 }
 
 for cc in "${COMPILERS[@]}"; do
     echo "==> [$cc] Compiling smoke.c against the shared object"
     "$cc" "${CFLAGS[@]}" "$CRATE_DIR/examples/smoke.c" \
-        -L"$TARGET_DIR/release" -lmarmot_c -o "$WORK/smoke-shared-$cc"
+        -L"$TARGET_DIR/$PROFILE_DIR" -lmarmot_c -o "$WORK/smoke-shared-$cc"
 
     echo "==> [$cc] Compiling smoke.c against the static archive"
     "$cc" "${CFLAGS[@]}" "$CRATE_DIR/examples/smoke.c" \
-        "$TARGET_DIR/release/libmarmot_c.a" "${STATIC_LIBS[@]}" -o "$WORK/smoke-static-$cc"
+        "$TARGET_DIR/$PROFILE_DIR/libmarmot_c.a" "${STATIC_LIBS[@]}" -o "$WORK/smoke-static-$cc"
 
     echo "==> [$cc] Running smoke (shared)"
     run "$WORK/smoke-shared-$cc"

--- a/scripts/check_convergence_constant_ledger.sh
+++ b/scripts/check_convergence_constant_ledger.sh
@@ -66,7 +66,7 @@ while IFS='|' read -r ledger_id source_path symbol; do
         report "convergence inventory source does not exist: ${source_path}"
         continue
     fi
-    if ! rg -q "^(pub(\\([^)]*\\))? )?const ${symbol}:" "$source_path"; then
+    if ! grep -Eq -- "^(pub(\\([^)]*\\))? )?const ${symbol}:" "$source_path"; then
         report "convergence inventory declaration is missing: ${source_path}:${symbol}"
     fi
 done < "$inventory_path"
@@ -82,7 +82,7 @@ for expected_id in "${expected_ids[@]}"; do
     if [[ "$found" -eq 0 ]]; then
         report "convergence inventory is missing ledger id ${expected_id}"
     fi
-    if ! rg -q "^\\| ${expected_id} \\|" "$plan_path"; then
+    if ! grep -Eq -- "^\\| ${expected_id} \\|" "$plan_path"; then
         report "convergence plan is missing ledger row ${expected_id}"
     fi
 done
@@ -102,7 +102,7 @@ discover_constants() {
             report "unreviewed convergence constant ${source_path}:${symbol}"
         fi
     done < <(
-        rg --no-filename -o \
+        grep -Eo -- \
             "^(pub(\\([^)]*\\))? )?const (${name_pattern}):" \
             "$source_path" || true
     )

--- a/scripts/classify_ci_changes.py
+++ b/scripts/classify_ci_changes.py
@@ -72,6 +72,36 @@ IOS_WORKSPACE_CRATES = {
     "traits",
 }
 
+INDEPENDENT_WORKSPACE_CRATES = {
+    "agent-connector",
+    "agent-control",
+    "agent-stream-compose",
+    "cli",
+    "incident-replay",
+}
+
+CLASSIFIED_WORKSPACE_CRATES = (
+    C_WORKSPACE_CRATES
+    | CONFORMANCE_WORKSPACE_CRATES
+    | IOS_WORKSPACE_CRATES
+    | INDEPENDENT_WORKSPACE_CRATES
+)
+
+SPECIALIST_EXACT_PATHS = {
+    ".github/workflows/bindings.yaml",
+    ".github/workflows/c-smoke-nightly.yml",
+    ".github/workflows/convergence-hardening.yml",
+    ".github/workflows/simulator-nightly.yml",
+    "Dockerfile.convergence-campaign",
+    "crates/cgka-conformance-simulator/src/policy_cases.rs",
+    "crates/cgka-conformance-simulator/tests/generated_policy_cases.rs",
+    "crates/cgka-conformance-simulator/tests/policy_case_tamarin_drift.rs",
+    "docs/marmot-architecture/convergence-constant-inventory.txt",
+    "scripts/check_c_binding_parity.py",
+    "scripts/check_campaign_toolchain.sh",
+    "scripts/tests/test_campaign_toolchain.sh",
+}
+
 
 def _is_documentation(path: str) -> bool:
     return (
@@ -90,6 +120,16 @@ def _crate_name(path: str) -> str | None:
 
 def _touches_crates(path: str, crates: set[str]) -> bool:
     return _crate_name(path) in crates
+
+
+def _is_recognized_specialist_path(path: str) -> bool:
+    return (
+        _crate_name(path) in CLASSIFIED_WORKSPACE_CRATES
+        or path in ROOT_BUILD_PATHS
+        or path in SPECIALIST_EXACT_PATHS
+        or path.startswith("formal/tamarin/")
+        or path.startswith("formal/tla/")
+    )
 
 
 def classify(paths: list[str], *, force_all: bool = False) -> dict[str, bool]:
@@ -115,14 +155,18 @@ def classify(paths: list[str], *, force_all: bool = False) -> dict[str, bool]:
 
     workflow_changed = ".github/workflows/ci.yml" in normalized
     root_build_changed = any(path in ROOT_BUILD_PATHS for path in normalized)
+    unclassified_path = any(
+        not _is_documentation(path) and not _is_recognized_specialist_path(path)
+        for path in normalized
+    )
 
-    run_c = workflow_changed or root_build_changed or any(
+    run_c = unclassified_path or workflow_changed or root_build_changed or any(
         _touches_crates(path, C_WORKSPACE_CRATES)
         or path == ".github/workflows/c-smoke-nightly.yml"
         or path == "scripts/check_c_binding_parity.py"
         for path in normalized
     )
-    run_conformance = workflow_changed or root_build_changed or any(
+    run_conformance = unclassified_path or workflow_changed or root_build_changed or any(
         _touches_crates(path, CONFORMANCE_WORKSPACE_CRATES)
         or path
         in {
@@ -136,12 +180,12 @@ def classify(paths: list[str], *, force_all: bool = False) -> dict[str, bool]:
         or path.startswith("formal/tla/")
         for path in normalized
     )
-    run_ios = workflow_changed or root_build_changed or any(
+    run_ios = unclassified_path or workflow_changed or root_build_changed or any(
         _touches_crates(path, IOS_WORKSPACE_CRATES)
         or path == ".github/workflows/bindings.yaml"
         for path in normalized
     )
-    run_formal = workflow_changed or any(
+    run_formal = unclassified_path or workflow_changed or any(
         path.startswith("formal/tamarin/")
         or path
         in {

--- a/scripts/classify_ci_changes.py
+++ b/scripts/classify_ci_changes.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Classify changed paths for conservative CI job selection."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+ROOT_BUILD_PATHS = {
+    ".cargo/config.toml",
+    ".config/nextest.toml",
+    ".github/workflows/ci.yml",
+    "Cargo.lock",
+    "Cargo.toml",
+    "Justfile",
+    "rust-toolchain.toml",
+}
+
+# These Markdown files are executable assurance inputs, not documentation-only
+# changes: simulator tests parse them and enforce their contents.
+EXECUTABLE_MARKDOWN = {
+    "crates/cgka-conformance-simulator/CONVERGENCE_ROUTE_MATRIX.md",
+    "crates/cgka-conformance-simulator/MUTATION_MATRIX.md",
+    "crates/cgka-conformance-simulator/PROTOCOL_DECISIONS.md",
+}
+
+C_WORKSPACE_CRATES = {
+    "cgka-engine",
+    "cgka-session",
+    "fs-private",
+    "marmot-account",
+    "marmot-app",
+    "marmot-c",
+    "marmot-forensics",
+    "marmot-markdown",
+    "marmot-uniffi",
+    "storage-sqlite",
+    "traits",
+    "transport-nostr-adapter",
+    "transport-nostr-peeler",
+    "transport-quic-broker",
+    "transport-quic-stream",
+}
+
+CONFORMANCE_WORKSPACE_CRATES = {
+    "cgka-conformance-simulator",
+    "cgka-engine",
+    "cgka-session",
+    "convergence-campaign-runner",
+    "fs-private",
+    "marmot-account",
+    "marmot-app",
+    "marmot-forensics",
+    "marmot-markdown",
+    "storage-sqlite",
+    "traits",
+    "transport-nostr-adapter",
+    "transport-nostr-peeler",
+    "transport-quic-broker",
+    "transport-quic-stream",
+}
+
+IOS_WORKSPACE_CRATES = {
+    "cgka-engine",
+    "cgka-session",
+    "fs-private",
+    "marmot-account",
+    "marmot-forensics",
+    "storage-sqlite",
+    "traits",
+}
+
+
+def _is_documentation(path: str) -> bool:
+    return (
+        (path.endswith(".md") and path not in EXECUTABLE_MARKDOWN)
+        or path.startswith(".github/ISSUE_TEMPLATE/")
+        or path.startswith(".github/PULL_REQUEST_TEMPLATE/")
+    )
+
+
+def _crate_name(path: str) -> str | None:
+    parts = path.split("/", 2)
+    if len(parts) >= 2 and parts[0] == "crates":
+        return parts[1]
+    return None
+
+
+def _touches_crates(path: str, crates: set[str]) -> bool:
+    return _crate_name(path) in crates
+
+
+def classify(paths: list[str], *, force_all: bool = False) -> dict[str, bool]:
+    normalized = sorted({path.strip("/") for path in paths if path.strip("/")})
+    if force_all or not normalized:
+        return {
+            "run_full": True,
+            "run_c": True,
+            "run_conformance": True,
+            "run_ios": True,
+            "run_formal": True,
+        }
+
+    run_full = not all(_is_documentation(path) for path in normalized)
+    if not run_full:
+        return {
+            "run_full": False,
+            "run_c": False,
+            "run_conformance": False,
+            "run_ios": False,
+            "run_formal": False,
+        }
+
+    workflow_changed = ".github/workflows/ci.yml" in normalized
+    root_build_changed = any(path in ROOT_BUILD_PATHS for path in normalized)
+
+    run_c = workflow_changed or root_build_changed or any(
+        _touches_crates(path, C_WORKSPACE_CRATES)
+        or path == ".github/workflows/c-smoke-nightly.yml"
+        or path == "scripts/check_c_binding_parity.py"
+        for path in normalized
+    )
+    run_conformance = workflow_changed or root_build_changed or any(
+        _touches_crates(path, CONFORMANCE_WORKSPACE_CRATES)
+        or path
+        in {
+            ".github/workflows/convergence-hardening.yml",
+            ".github/workflows/simulator-nightly.yml",
+            "Dockerfile.convergence-campaign",
+            "scripts/check_campaign_toolchain.sh",
+            "scripts/tests/test_campaign_toolchain.sh",
+            "docs/marmot-architecture/convergence-constant-inventory.txt",
+        }
+        or path.startswith("formal/tla/")
+        for path in normalized
+    )
+    run_ios = workflow_changed or root_build_changed or any(
+        _touches_crates(path, IOS_WORKSPACE_CRATES)
+        or path == ".github/workflows/bindings.yaml"
+        for path in normalized
+    )
+    run_formal = workflow_changed or any(
+        path.startswith("formal/tamarin/")
+        or path
+        in {
+            "Justfile",
+            "crates/cgka-conformance-simulator/src/policy_cases.rs",
+            "crates/cgka-conformance-simulator/tests/generated_policy_cases.rs",
+            "crates/cgka-conformance-simulator/tests/policy_case_tamarin_drift.rs",
+        }
+        for path in normalized
+    )
+
+    return {
+        "run_full": run_full,
+        "run_c": run_c,
+        "run_conformance": run_conformance,
+        "run_ios": run_ios,
+        "run_formal": run_formal,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--all", action="store_true", dest="force_all")
+    parser.add_argument("--github-output", type=Path)
+    args = parser.parse_args()
+
+    raw = sys.stdin.buffer.read()
+    paths = [item.decode("utf-8") for item in raw.split(b"\0") if item]
+    result = classify(paths, force_all=args.force_all)
+    output = "".join(f"{key}={str(value).lower()}\n" for key, value in result.items())
+    if args.github_output is None:
+        sys.stdout.write(output)
+    else:
+        with args.github_output.open("a", encoding="utf-8") as handle:
+            handle.write(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/classify_ci_changes.py
+++ b/scripts/classify_ci_changes.py
@@ -26,6 +26,10 @@ EXECUTABLE_MARKDOWN = {
     "crates/cgka-conformance-simulator/PROTOCOL_DECISIONS.md",
 }
 
+EXECUTABLE_MARKDOWN_PREFIXES = (
+    "crates/marmot-markdown/tests/golden/",
+)
+
 C_WORKSPACE_CRATES = {
     "cgka-engine",
     "cgka-session",
@@ -104,8 +108,11 @@ SPECIALIST_EXACT_PATHS = {
 
 
 def _is_documentation(path: str) -> bool:
+    executable_markdown = path in EXECUTABLE_MARKDOWN or path.startswith(
+        EXECUTABLE_MARKDOWN_PREFIXES
+    )
     return (
-        (path.endswith(".md") and path not in EXECUTABLE_MARKDOWN)
+        (path.endswith(".md") and not executable_markdown)
         or path.startswith(".github/ISSUE_TEMPLATE/")
         or path.startswith(".github/PULL_REQUEST_TEMPLATE/")
     )
@@ -177,6 +184,7 @@ def classify(paths: list[str], *, force_all: bool = False) -> dict[str, bool]:
             "scripts/tests/test_campaign_toolchain.sh",
             "docs/marmot-architecture/convergence-constant-inventory.txt",
         }
+        or path.startswith("formal/tamarin/")
         or path.startswith("formal/tla/")
         for path in normalized
     )

--- a/scripts/test_classify_ci_changes.py
+++ b/scripts/test_classify_ci_changes.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Regression tests for conservative CI path classification."""
+
+from __future__ import annotations
+
+import unittest
+
+from classify_ci_changes import classify
+
+
+class ClassifyCiChangesTests(unittest.TestCase):
+    def test_documentation_only_change_uses_short_lane(self) -> None:
+        self.assertEqual(
+            classify(["README.md", "docs/marmot-architecture/index.md"]),
+            {
+                "run_full": False,
+                "run_c": False,
+                "run_conformance": False,
+                "run_ios": False,
+                "run_formal": False,
+            },
+        )
+
+    def test_unknown_non_documentation_change_keeps_general_ci(self) -> None:
+        result = classify(["integrations/codex/marmot/src/main.rs"])
+        self.assertTrue(result["run_full"])
+        self.assertFalse(result["run_c"])
+        self.assertFalse(result["run_conformance"])
+        self.assertFalse(result["run_ios"])
+        self.assertFalse(result["run_formal"])
+
+    def test_engine_change_runs_all_compiled_specialists_except_formal_model(self) -> None:
+        result = classify(["crates/cgka-engine/src/lib.rs"])
+        self.assertTrue(result["run_full"])
+        self.assertTrue(result["run_c"])
+        self.assertTrue(result["run_conformance"])
+        self.assertTrue(result["run_ios"])
+        self.assertFalse(result["run_formal"])
+
+    def test_executable_markdown_runs_its_simulator_gate(self) -> None:
+        result = classify(
+            ["crates/cgka-conformance-simulator/PROTOCOL_DECISIONS.md"]
+        )
+        self.assertTrue(result["run_full"])
+        self.assertTrue(result["run_conformance"])
+
+    def test_non_markdown_assurance_inventory_is_not_treated_as_docs(self) -> None:
+        result = classify(
+            ["docs/marmot-architecture/convergence-constant-inventory.txt"]
+        )
+        self.assertTrue(result["run_full"])
+        self.assertTrue(result["run_conformance"])
+
+    def test_formal_model_change_runs_proofs(self) -> None:
+        result = classify(["formal/tamarin/convergence.spthy"])
+        self.assertTrue(result["run_full"])
+        self.assertTrue(result["run_formal"])
+        self.assertFalse(result["run_c"])
+
+    def test_ci_workflow_change_runs_every_lane(self) -> None:
+        result = classify([".github/workflows/ci.yml"])
+        self.assertTrue(all(result.values()))
+
+    def test_empty_or_manual_classification_fails_open_to_full_ci(self) -> None:
+        self.assertTrue(all(classify([]).values()))
+        self.assertTrue(all(classify(["README.md"], force_all=True).values()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_classify_ci_changes.py
+++ b/scripts/test_classify_ci_changes.py
@@ -52,6 +52,12 @@ class ClassifyCiChangesTests(unittest.TestCase):
         self.assertTrue(result["run_full"])
         self.assertTrue(result["run_conformance"])
 
+    def test_markdown_golden_fixture_runs_compiled_consumers(self) -> None:
+        result = classify(["crates/marmot-markdown/tests/golden/kitchen_sink.md"])
+        self.assertTrue(result["run_full"])
+        self.assertTrue(result["run_c"])
+        self.assertTrue(result["run_conformance"])
+
     def test_non_markdown_assurance_inventory_is_not_treated_as_docs(self) -> None:
         result = classify(
             ["docs/marmot-architecture/convergence-constant-inventory.txt"]
@@ -63,7 +69,14 @@ class ClassifyCiChangesTests(unittest.TestCase):
         result = classify(["formal/tamarin/convergence.spthy"])
         self.assertTrue(result["run_full"])
         self.assertTrue(result["run_formal"])
+        self.assertTrue(result["run_conformance"])
         self.assertFalse(result["run_c"])
+
+    def test_shared_tamarin_policy_input_runs_formal_and_conformance(self) -> None:
+        result = classify(["formal/tamarin/policy_cases.json"])
+        self.assertTrue(result["run_full"])
+        self.assertTrue(result["run_formal"])
+        self.assertTrue(result["run_conformance"])
 
     def test_ci_workflow_change_runs_every_lane(self) -> None:
         result = classify([".github/workflows/ci.yml"])

--- a/scripts/test_classify_ci_changes.py
+++ b/scripts/test_classify_ci_changes.py
@@ -21,13 +21,21 @@ class ClassifyCiChangesTests(unittest.TestCase):
             },
         )
 
-    def test_unknown_non_documentation_change_keeps_general_ci(self) -> None:
+    def test_unknown_non_documentation_change_fails_open_to_every_lane(self) -> None:
         result = classify(["integrations/codex/marmot/src/main.rs"])
+        self.assertTrue(all(result.values()))
+
+    def test_known_independent_crate_keeps_specialist_jobs_filtered(self) -> None:
+        result = classify(["crates/cli/src/main.rs"])
         self.assertTrue(result["run_full"])
         self.assertFalse(result["run_c"])
         self.assertFalse(result["run_conformance"])
         self.assertFalse(result["run_ios"])
         self.assertFalse(result["run_formal"])
+
+    def test_new_workspace_crate_fails_open_until_classified(self) -> None:
+        result = classify(["crates/new-workspace-member/src/lib.rs"])
+        self.assertTrue(all(result.values()))
 
     def test_engine_change_runs_all_compiled_specialists_except_formal_model(self) -> None:
         result = classify(["crates/cgka-engine/src/lib.rs"])


### PR DESCRIPTION
## Summary

- add a fail-open changed-path classifier for the main CI workflow
- give documentation-only PRs a short lane while retaining formatting, documentation policy checks, dependency audit, and the stable Required CI aggregate
- conservatively path-gate the C, simulator/vector, iOS, and Tamarin specialist jobs
- preserve the broad WN Agent and QUIC image path sets, excluding only Markdown-only changes
- reduce simulator PR work to the ordinary suite and two process canaries; keep the complete process suite and encrypted full-vector report nightly
- use a debug GCC shared/static C smoke on relevant PRs; run release GCC/Clang/Valgrind coverage nightly and on release tags
- install the pinned cbindgen binary through the existing tool installer instead of rebuilding it in every relevant PR job

## Assurance retained

- unknown non-documentation paths still run the general Rust, CLI, relay, installer, and Hermes CI jobs
- manual or unclassifiable events fail open to every CI lane
- executable simulator Markdown inputs are not treated as documentation-only
- Required CI accepts intentional skips but still fails when classification or any selected job fails
- the existing Simulator Nightly retains all process orchestration and file-backed vector coverage
- C release tags retain the full release linkage and Valgrind smoke

## Validation

- just fast-ci
- just simulator-smoke (396 ordinary tests and 2 process canaries)
- cargo test -p cgka-conformance-simulator --test report_runner report_runner_writes_vector_fixture_reports_and_summary --locked
- ./crates/marmot-c/c-smoke.sh --debug cc
- actionlint on all changed workflows
- shellcheck crates/marmot-c/c-smoke.sh
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added path-based CI selection to run checks relevant to each change.
  - Added nightly and manually triggered C bindings smoke testing with GCC and Clang.
  - Added a faster debug mode for local C smoke tests.

- **Bug Fixes**
  - Documentation-only changes no longer unnecessarily trigger selected image and binary workflows.

- **Documentation**
  - Updated C smoke-test guidance for debug and release modes.

- **Tests**
  - Added coverage for CI change classification.
  - CI smoke tests now focus on selected scenarios for faster feedback.
  - Full conformance reports are now limited to nightly validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->