### PR TITLE
fix(simulator): redeliver capacity-refused relay history

### DIFF
--- a/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
+++ b/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
@@ -273,8 +273,9 @@ restart after sync but before processing, and reverse three-copy competing commi
 profile provenance (including exact distinct-committer and retained-copy counts), every volume/recovery arm,
 terminal-only reconnect, the pre-catch-up zero-delivery boundary, the post-catch-up exact-one boundary, full Bob payload
 multiplicity, exact canonical equivalence, no pending work, active decryptability, and encrypted file-backed
-natural/duplicate canaries. The ordinary test lane executes only two 24-message cases; larger blocks belong in isolated
-manual or scheduled campaigns.
+natural/duplicate canaries. A focused file-backed 384-message natural-history regression crosses the 256-row deferred
+cap and requires retained-history redelivery to satisfy the full strict oracle. Larger catalog blocks otherwise belong
+in isolated manual or scheduled campaigns.
 
 ### `cross-route-restart-permutations/v1`
 

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -475,6 +475,9 @@ blocks contain 24, 96, 384, and 1,024 application messages interleaved with epoc
 reverse history, reverse three-copy replay, natural two-copy incremental plus full repair, reverse two-copy restart
 before backlog processing, and reverse three-copy competing commit waves. Terminal expectations require Bob's exact
 payload multiset, exact canonical equality, no pending work, and an active decryptability probe after recovery.
+Capacity-refused retained objects remain a subject-owned redelivery obligation: later assertion ticks re-query complete
+history after engine progress frees capacity, while a truly full/no-progress loop terminates with a typed resource
+failure.
 
 Run a stateful chat journey directly:
 

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -909,7 +909,9 @@ processing, and reverse three-copy competing commit waves. A pre-reconnect asser
 first backlog payload; the terminal phase requires the last payload exactly once, the complete backlog payload multiset
 exactly once, exact canonical equality, no pending work, and active bidirectional decryptability involving Bob. The
 family always selects the retained-relay subject so reconnect means a durable history query rather than healing an
-in-memory packet partition.
+in-memory packet partition. Capacity-refused retained inputs schedule bounded complete-history redelivery on later
+ticks; strict pending-work closure includes that obligation, and unchanged full-refusal retries fail with a typed
+resource error instead of spinning.
 
 ### General Simulator Integrity Checks
 

--- a/crates/cgka-conformance-simulator/SCENARIO_IR.md
+++ b/crates/cgka-conformance-simulator/SCENARIO_IR.md
@@ -90,6 +90,10 @@ message wall-clock timestamps in whole seconds; virtual time does not rewrite th
 not consume the independent incremental cursor. Each query records queried relays, EOSE relays,
 returned/unique/injected counts, whether the result was quiet, and one of these deliberately distinct claims:
 `relay_eose_only`, `full_history_queried`, `relevant_set_mismatch`, or `relevant_set_equality_verified`.
+If engine ingest refuses retained objects because the deferred-peel capacity is full, the subject keeps a transport
+redelivery obligation and performs another complete-history query on a later tick. The obligation remains visible as
+pending transport work until a retry is admitted, and repeated full refusals without engine progress fail with the
+typed `retained_history_redelivery_no_progress` resource error.
 
 Relay-control actions configure deterministic natural/reverse order and duplicate copies, change per-client event
 visibility through semantic selectors, and equalize selected relay event sets. Reconciliation copies missing events

--- a/crates/cgka-conformance-simulator/src/retained_relay.rs
+++ b/crates/cgka-conformance-simulator/src/retained_relay.rs
@@ -10,17 +10,19 @@ use crate::{
     EngineHarnessSubject, HarnessStorageMode, ScenarioAdminPolicyObservation,
     ScenarioMessageSelectorV2, ScenarioPredicateObservationV2, ScenarioPredicateV2,
     ScenarioRelayV2, ScenarioTopologyV2, ScenarioTransportClass, SubjectCapability,
-    SubjectCreateGroup, SubjectDescriptor, SubjectError, SubjectInviteMembers,
-    SubjectOutboundArtifact, SubjectOutboundKind, SubjectOutboundOutcome, SubjectProgressSnapshot,
-    SubjectRemoveMembers, SubjectSelfUpdate, SubjectSendApplication, SubjectUpdateAdminPolicy,
-    SubjectUpdateGroupData,
+    SubjectCreateGroup, SubjectDescriptor, SubjectError, SubjectFailureCategory,
+    SubjectInviteMembers, SubjectOutboundArtifact, SubjectOutboundKind, SubjectOutboundOutcome,
+    SubjectProgressSnapshot, SubjectRemoveMembers, SubjectSelfUpdate, SubjectSendApplication,
+    SubjectUpdateAdminPolicy, SubjectUpdateGroupData,
 };
 use async_trait::async_trait;
 use cgka_traits::group::ProtocolProfile;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 const DEFAULT_RELAY_ID: &str = "relay:retained-default";
+const MAX_REDELIVERY_NO_PROGRESS_TURNS: usize = 2;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -106,6 +108,8 @@ pub struct RetainedRelaySubject {
     action_ids: BTreeMap<String, String>,
     semantic_classes: BTreeMap<String, ScenarioTransportClass>,
     sync_observations: Vec<RelaySyncObservationV2>,
+    capacity_refused_redelivery: BTreeMap<String, usize>,
+    redelivery_no_progress_turns: BTreeMap<String, usize>,
 }
 
 impl RetainedRelaySubject {
@@ -188,6 +192,8 @@ impl RetainedRelaySubject {
             action_ids: BTreeMap::new(),
             semantic_classes: BTreeMap::new(),
             sync_observations: Vec::new(),
+            capacity_refused_redelivery: BTreeMap::new(),
+            redelivery_no_progress_turns: BTreeMap::new(),
         })
     }
 
@@ -432,6 +438,35 @@ fn relay_history_sets_equal(
     sets.all(|set| set == first)
 }
 
+fn redelivery_no_progress_turns(
+    previous_turns: usize,
+    attempted_objects: Option<usize>,
+    refused_objects: Option<usize>,
+    before_token: Option<&str>,
+    after_token: Option<&str>,
+) -> Result<usize, SubjectError> {
+    let stalled = attempted_objects.is_some()
+        && attempted_objects == refused_objects
+        && before_token.is_some()
+        && before_token == after_token;
+    if !stalled {
+        return Ok(0);
+    }
+
+    let turns = previous_turns.saturating_add(1);
+    if turns >= MAX_REDELIVERY_NO_PROGRESS_TURNS {
+        return Err(SubjectError::classified(
+            SubjectFailureCategory::Resource,
+            "retained_history_redelivery_no_progress",
+            format!(
+                "retained-history redelivery refused all {} object(s) for {turns} consecutive turns without engine progress",
+                attempted_objects.unwrap_or_default()
+            ),
+        ));
+    }
+    Ok(turns)
+}
+
 #[async_trait]
 impl ConvergenceSubject for RetainedRelaySubject {
     fn descriptor(&self) -> SubjectDescriptor {
@@ -554,7 +589,50 @@ impl ConvergenceSubject for RetainedRelaySubject {
     async fn tick(&mut self, clients: &[String]) -> Result<(), SubjectError> {
         for client in clients {
             if self.online.contains(client) {
-                self.engine.tick(std::slice::from_ref(client)).await?;
+                let retrying = self.capacity_refused_redelivery.get(client).copied();
+                let before = retrying
+                    .is_some()
+                    .then(|| self.engine.structural_progress())
+                    .transpose()?
+                    .map(|snapshot| snapshot.structural_token);
+                if retrying.is_some() {
+                    self.sync_one(client, &ScenarioRelaySyncModeV2::FullHistory)?;
+                }
+
+                let refused = self
+                    .engine
+                    .tick_observing_capacity_refusals(std::slice::from_ref(client))
+                    .await?
+                    .get(client)
+                    .copied();
+                if let Some(refused) = refused {
+                    self.capacity_refused_redelivery
+                        .insert(client.clone(), refused);
+                } else {
+                    self.capacity_refused_redelivery.remove(client);
+                }
+
+                let after = retrying
+                    .is_some()
+                    .then(|| self.engine.structural_progress())
+                    .transpose()?
+                    .map(|snapshot| snapshot.structural_token);
+                let no_progress_turns = redelivery_no_progress_turns(
+                    self.redelivery_no_progress_turns
+                        .get(client)
+                        .copied()
+                        .unwrap_or_default(),
+                    retrying,
+                    refused,
+                    before.as_deref(),
+                    after.as_deref(),
+                )?;
+                if no_progress_turns == 0 {
+                    self.redelivery_no_progress_turns.remove(client);
+                } else {
+                    self.redelivery_no_progress_turns
+                        .insert(client.clone(), no_progress_turns);
+                }
             }
         }
         Ok(())
@@ -617,7 +695,35 @@ impl ConvergenceSubject for RetainedRelaySubject {
     }
 
     fn structural_progress(&mut self) -> Result<SubjectProgressSnapshot, SubjectError> {
-        self.engine.structural_progress()
+        let mut snapshot = self.engine.structural_progress()?;
+        let refused_objects = self
+            .capacity_refused_redelivery
+            .values()
+            .copied()
+            .sum::<usize>();
+        let runnable_refused_objects = self
+            .capacity_refused_redelivery
+            .iter()
+            .filter(|(client, _)| self.online.contains(*client))
+            .map(|(_, count)| *count)
+            .sum::<usize>();
+        if refused_objects > 0 {
+            snapshot.runnable_work = snapshot
+                .runnable_work
+                .saturating_add(runnable_refused_objects);
+            snapshot.transport_delayed_messages = snapshot
+                .transport_delayed_messages
+                .saturating_add(refused_objects);
+            snapshot.structural_token.clear();
+            let encoded = serde_json::to_vec(&snapshot).map_err(|error| {
+                SubjectError::new(
+                    "progress_serialization_failed",
+                    format!("serialize retained-relay progress: {error}"),
+                )
+            })?;
+            snapshot.structural_token = hex::encode(Sha256::digest(encoded));
+        }
+        Ok(snapshot)
     }
 
     fn observe(&mut self, clients: &[String]) -> Result<Vec<ClientObservation>, SubjectError> {
@@ -803,6 +909,24 @@ mod tests {
         ScenarioProcessV2, ScenarioSpec, ScenarioStep, TraceExpectation,
         run_scenario_report_with_subject,
     };
+
+    #[test]
+    fn unchanged_full_refusal_returns_typed_no_progress_failure() {
+        let first =
+            redelivery_no_progress_turns(0, Some(4), Some(4), Some("unchanged"), Some("unchanged"))
+                .expect("first unchanged retry remains within the bound");
+        let error = redelivery_no_progress_turns(
+            first,
+            Some(4),
+            Some(4),
+            Some("unchanged"),
+            Some("unchanged"),
+        )
+        .expect_err("second unchanged retry reaches the no-progress bound");
+
+        assert_eq!(error.category, SubjectFailureCategory::Resource);
+        assert_eq!(error.code, "retained_history_redelivery_no_progress");
+    }
 
     fn split_relay_topology() -> ScenarioTopologyV2 {
         ScenarioTopologyV2 {

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -1263,6 +1263,46 @@ impl EngineHarnessSubject {
                 && candidate.resolution == Some(SubjectOutboundOutcome::Accepted)
         })
     }
+
+    pub(crate) async fn tick_observing_capacity_refusals(
+        &mut self,
+        clients: &[String],
+    ) -> Result<BTreeMap<String, usize>, SubjectError> {
+        let mut capacity_refused = BTreeMap::new();
+        for label in clients {
+            let recipient_tick = self.observed_recipient_ticks;
+            self.observed_recipient_ticks = self.observed_recipient_ticks.saturating_add(1);
+            let inbound = self.bus.mailbox_snapshot(self.client(label)?.bus_id);
+            let pending_replay = (self.replay_capture_target_tick == Some(recipient_tick))
+                .then(|| self.prepare_byte_replay(label))
+                .flatten();
+            let outcomes = self.client_mut(label)?.tick().await;
+            let refused_count = inbound
+                .iter()
+                .zip(&outcomes)
+                .filter(|(_, outcome)| {
+                    matches!(
+                        outcome,
+                        Ok(cgka_traits::ingest::IngestOutcome::ResourceRefused {
+                            resource:
+                                cgka_traits::ingest::InboundResourceLimit::TransportDeferredCapacity,
+                            ..
+                        })
+                    )
+                })
+                .count();
+            if refused_count > 0 {
+                capacity_refused.insert(label.clone(), refused_count);
+            }
+            if let Some(pending_replay) = pending_replay
+                && let Some(replay) = self.complete_byte_replay(pending_replay, &outcomes)
+            {
+                self.last_byte_replay = Some(replay);
+            }
+            ensure_tick_succeeded(outcomes)?;
+        }
+        Ok(capacity_refused)
+    }
 }
 
 #[async_trait]
@@ -1451,21 +1491,9 @@ impl ConvergenceSubject for EngineHarnessSubject {
     }
 
     async fn tick(&mut self, clients: &[String]) -> Result<(), SubjectError> {
-        for label in clients {
-            let recipient_tick = self.observed_recipient_ticks;
-            self.observed_recipient_ticks = self.observed_recipient_ticks.saturating_add(1);
-            let pending_replay = (self.replay_capture_target_tick == Some(recipient_tick))
-                .then(|| self.prepare_byte_replay(label))
-                .flatten();
-            let outcomes = self.client_mut(label)?.tick().await;
-            if let Some(pending_replay) = pending_replay
-                && let Some(replay) = self.complete_byte_replay(pending_replay, &outcomes)
-            {
-                self.last_byte_replay = Some(replay);
-            }
-            ensure_tick_succeeded(outcomes)?;
-        }
-        Ok(())
+        self.tick_observing_capacity_refusals(clients)
+            .await
+            .map(|_| ())
     }
 
     fn activate_virtual_time(&mut self) -> Result<(), SubjectError> {

--- a/crates/cgka-conformance-simulator/tests/offline_catchup_family.rs
+++ b/crates/cgka-conformance-simulator/tests/offline_catchup_family.rs
@@ -330,3 +330,40 @@ async fn smoke_natural_and_duplicate_history_cases_pass_file_backed_strict_oracl
         }));
     }
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn large_natural_history_retries_capacity_refused_relay_objects() {
+    let case = generate_offline_catchup_pressure_case(9101, 12);
+    let report = run_generated_case_report_with_storage_mode(
+        &case,
+        None,
+        HarnessStorageMode::TempFileBackedSqlite,
+    )
+    .await
+    .unwrap_or_else(|error| panic!("{}: {error}", case.scenario.name));
+
+    assert!(
+        report.expectation_failures.is_empty(),
+        "{} expectation failures: {:#?}",
+        case.scenario.name,
+        report.expectation_failures
+    );
+    assert!(
+        report.invariant_failures.is_empty(),
+        "{} invariant failures: {:#?}",
+        case.scenario.name,
+        report.invariant_failures
+    );
+    assert!(
+        report
+            .relay_sync_observations
+            .iter()
+            .filter(|observation| {
+                observation.client == "bob"
+                    && matches!(observation.mode, ScenarioRelaySyncModeV2::FullHistory)
+            })
+            .count()
+            >= 2,
+        "the capacity refusal must cause a bounded complete-history refetch"
+    );
+}


### PR DESCRIPTION
## Summary
- Preserve a retained-relay redelivery obligation when engine ingest reaches the deferred-peel capacity.
- Re-query complete relay history on later ticks, expose the obligation as pending transport work, and fail repeated unchanged full refusals with a typed resource error.
- Add the file-backed 384-application natural-history regression and document the adapter contract.

## Test plan
- [x] New test failed before the fix and passes after.
- [x] cargo test -p cgka-conformance-simulator --test offline_catchup_family
- [x] cargo test -p cgka-conformance-simulator
- [x] just fast-ci

Fixes #1670

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline catch-up when deferred transport capacity is temporarily unavailable.
  * Retained messages are now retried through complete-history synchronization on later processing cycles.
  * Persistent capacity refusal without progress now ends with a clear resource failure instead of repeated retries.

* **Tests**
  * Added coverage for large natural-history catch-up scenarios, including successful redelivery after capacity recovery and stalled retry handling.

* **Documentation**
  * Expanded guidance on retained-message redelivery, capacity limits, and offline catch-up scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->