### PR TITLE
Fix retained anchors across multi-commit convergence

### DIFF
--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -911,6 +911,10 @@ exactly once, exact canonical equality, no pending work, and active bidirectiona
 family always selects the retained-relay subject so reconnect means a durable history query rather than healing an
 in-memory packet partition.
 
+`four_and_eight_competing_wave_cases_converge_with_file_backed_storage` pins the lower four-round control and the
+eight-round `seed=9101`, `case_index=11` regression from mdk#1671. The latter requires a selected path that spans
+several epochs to leave every intermediate retained anchor available to the next frozen convergence generation.
+
 ### General Simulator Integrity Checks
 
 These tests keep the simulator machinery honest.

--- a/crates/cgka-conformance-simulator/src/offline_catchup_family.rs
+++ b/crates/cgka-conformance-simulator/src/offline_catchup_family.rs
@@ -414,3 +414,35 @@ fn retained_relay_topology(clients: &[String]) -> ScenarioTopologyV2 {
 fn labels<const N: usize>(items: [&str; N]) -> Vec<String> {
     items.into_iter().map(String::from).collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{HarnessStorageMode, run_generated_case_report_with_storage_mode};
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn four_and_eight_competing_wave_cases_converge_with_file_backed_storage() {
+        for case_index in [5, 11] {
+            let case = generate_offline_catchup_pressure_case(9_101, case_index);
+            let report = run_generated_case_report_with_storage_mode(
+                &case,
+                None,
+                HarnessStorageMode::TempFileBackedSqlite,
+            )
+            .await
+            .unwrap_or_else(|error| panic!("{}: {error}", case.scenario.name));
+            assert!(
+                report.expectation_failures.is_empty(),
+                "{} expectation failures: {:#?}",
+                case.scenario.name,
+                report.expectation_failures
+            );
+            assert!(
+                report.invariant_failures.is_empty(),
+                "{} invariant failures: {:#?}",
+                case.scenario.name,
+                report.invariant_failures
+            );
+        }
+    }
+}

--- a/crates/cgka-conformance-simulator/src/vector.rs
+++ b/crates/cgka-conformance-simulator/src/vector.rs
@@ -1089,6 +1089,9 @@ pub struct ConvergenceDecisionObservation {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub selected_app_witness_score: Option<u64>,
     pub candidate_count: usize,
+    /// Stable canonicalization error tags emitted for this evaluation.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub error_kinds: Vec<String>,
 }
 
 fn observe_convergence_decision(kind: &AuditEventKind) -> Option<ConvergenceDecisionObservation> {
@@ -1098,6 +1101,7 @@ fn observe_convergence_decision(kind: &AuditEventKind) -> Option<ConvergenceDeci
         decisive_rule,
         selected_branch_id,
         selected_tip_epoch,
+        error_kinds,
         ..
     } = kind
     else {
@@ -1121,6 +1125,7 @@ fn observe_convergence_decision(kind: &AuditEventKind) -> Option<ConvergenceDeci
             .unwrap_or(false),
         selected_app_witness_score: selected_score.and_then(|score| score.app_witness_score),
         candidate_count: candidates.len(),
+        error_kinds: error_kinds.clone(),
     })
 }
 
@@ -1357,6 +1362,7 @@ mod tests {
             witness_quorum_met,
             selected_app_witness_score: Some(selected_app_witness_score),
             candidate_count: 2,
+            error_kinds: Vec::new(),
         }
     }
 
@@ -1987,7 +1993,7 @@ mod tests {
             selected_fork_epoch: Some(1),
             selected_tip_epoch: Some(2),
             losing_branch_ids: vec!["loser".into()],
-            error_kinds: Vec::new(),
+            error_kinds: vec!["missing_retained_anchor".into()],
         };
 
         let projected = observe_convergence_decision(&kind).expect("projects a decision");
@@ -2003,6 +2009,7 @@ mod tests {
         );
         assert_eq!(projected.selected_app_witness_score, Some(2));
         assert_eq!(projected.candidate_count, 2);
+        assert_eq!(projected.error_kinds, vec!["missing_retained_anchor"]);
     }
 
     #[test]
@@ -2143,6 +2150,7 @@ mod tests {
             witness_quorum_met: false,
             selected_app_witness_score: Some(0),
             candidate_count: 1,
+            error_kinds: Vec::new(),
         };
         let settled = convergence_decision("settled", 2, "tip_committer", false, 0);
         let mut carol = observation("carol", 2, 4);
@@ -2199,6 +2207,7 @@ mod tests {
             witness_quorum_met: false,
             selected_app_witness_score: None,
             candidate_count: 0,
+            error_kinds: Vec::new(),
         };
         let mut carol = observation("carol", 2, 4);
         carol.convergence_decisions = vec![settled, trailing_empty];

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -852,8 +852,14 @@ fn replay_openmls_messages_prevalidated_output<S: StorageProvider>(
     let guard = SnapshotRollbackGuard::create_group_state(storage, group_id.clone(), snapshot)
         .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
 
-    let result =
-        process_openmls_messages_inner(storage, group_id, messages, own_commits, profile_policy);
+    let result = process_openmls_messages_inner(
+        storage,
+        group_id,
+        messages,
+        own_commits,
+        profile_policy,
+        None,
+    );
     guard
         .commit()
         .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
@@ -2040,8 +2046,15 @@ fn capture_candidate_tip_context<S: StorageProvider>(
 ) -> Result<Option<CandidateTipState>, OpenMlsProjectionError> {
     // A path that fails to replay is simply not a reachable branch state; the
     // BFS already reported that outcome for adjudication.
-    if process_openmls_messages_inner(storage, group_id, messages, own_commits, profile_policy)
-        .is_err()
+    if process_openmls_messages_inner(
+        storage,
+        group_id,
+        messages,
+        own_commits,
+        profile_policy,
+        None,
+    )
+    .is_err()
     {
         return Ok(None);
     }
@@ -2450,6 +2463,7 @@ pub(crate) fn apply_openmls_canonicalization_result_with_profile_policy<S: Stora
             group_id,
             result,
             &replay_messages,
+            max_retained_anchor_rewind,
             profile_policy,
         )?;
         if apply_start_epoch < current_epoch || restore_own_checkpoint {
@@ -2866,6 +2880,7 @@ fn apply_openmls_canonicalization_result_inner<S: StorageProvider>(
     group_id: &GroupId,
     result: &CanonicalizationResult,
     replay_messages: &[TransportMessage],
+    max_retained_anchor_rewind: u64,
     profile_policy: ReplayProfilePolicy,
 ) -> Result<Vec<OpenMlsReplayObservation>, OpenMlsProjectionError> {
     // #157/#424: the convergence-apply multi-write durable sequence
@@ -2896,6 +2911,7 @@ fn apply_openmls_canonicalization_result_inner<S: StorageProvider>(
             replay_messages,
             &PrevalidatedOwnCommits::default(),
             profile_policy,
+            Some(max_retained_anchor_rewind),
         )?;
         update_group_record_from_replay(storage, group_id, &output)?;
         persist_openmls_canonicalization_dispositions(storage, result)?;
@@ -3451,6 +3467,7 @@ fn process_openmls_messages_inner<S: StorageProvider>(
     messages: &[TransportMessage],
     own_commits: &PrevalidatedOwnCommits,
     profile_policy: ReplayProfilePolicy,
+    retain_replayed_anchors: Option<u64>,
 ) -> Result<OpenMlsReplayOutput, OpenMlsProjectionError> {
     let reject_legacy_group_additions = profile_policy.reject_legacy_group_additions
         && storage
@@ -3805,6 +3822,24 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                         reason: format!("current-profile merged state: {error}"),
                         rejection_category: None,
                     })?;
+                if let Some(max_retained_anchor_rewind) = retain_replayed_anchors {
+                    // One frozen pass may adopt several consecutive commits.
+                    // Persist every resulting epoch, not only the final tip:
+                    // input held for the next generation can still fork from
+                    // any intermediate epoch inside the rewind horizon.
+                    let intermediate = OpenMlsReplayOutput {
+                        observations: Vec::new(),
+                        final_epoch: mls_group.epoch().as_u64(),
+                        final_members: marmot_members(&mls_group),
+                        epoch_authenticators: BTreeMap::new(),
+                    };
+                    update_group_record_from_replay(storage, group_id, &intermediate)?;
+                    retain_current_group_epoch_snapshot(
+                        storage,
+                        group_id,
+                        max_retained_anchor_rewind,
+                    )?;
+                }
                 prefix_canonical =
                     prefix_canonical && own_commits.is_canonical(&projection.message_digest);
             }

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -2381,6 +2381,13 @@ async fn engine_materializes_multi_commit_path_from_stored_commits() {
 
     assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
     assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(3));
+    let retained_anchors = carol_storage
+        .list_group_snapshots(&group_id)
+        .expect("retained anchors list");
+    assert!(
+        retained_anchors.contains(&"openmls-retained-anchor-2".to_string()),
+        "a multi-commit apply must retain its intermediate epoch for a later convergence generation: {retained_anchors:?}"
+    );
     assert_eq!(
         result.accepted_commits,
         vec![content_hex(&commit_david), content_hex(&commit_eve)]


### PR DESCRIPTION
## Summary
- retain every intermediate canonical epoch during a multi-commit convergence apply so the next frozen generation can rewind within the configured horizon
- add file-backed four-wave and eight-wave regression coverage for the reported seed/case
- export stable canonicalization error kinds in simulator convergence observations

## Test plan
- [x] confirmed the new intermediate-anchor assertion fails before the fix and passes after it
- [x] replayed `offline-catchup-pressure/v1`, seed `9101`, case `11` from its saved generated input (22/22 expectations passed)
- [x] `cargo test -p cgka-engine --features test-policy-overrides`
- [x] `cargo test -p cgka-conformance-simulator`
- [x] `just fast-ci`

Fixes #1671

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved offline catch-up and multi-commit convergence, preserving intermediate group states needed for reliable rewinds.
  - Added coverage for competing-wave catch-up scenarios and verified successful execution without invariant or expectation failures.
  - Enhanced convergence diagnostics with stable error classifications.

- **Documentation**
  - Documented the `offline-catchup-pressure/v1` regression and required retained-anchor behavior across convergence epochs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->