### PR TITLE
Fix membership reentry convergence after self-remove

### DIFF
--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -108,6 +108,11 @@ Git commit; require a clean build and retain the exact source revision plus comm
     are ordered by execution cost because campaign selection is prefix-only; race arms must retain at least two active
     committers, and bounded decryptability probes must preserve late-join/re-add and roster-tail representatives.
 
+- **Module:** `src/membership_reentry_family.rs`
+  - **Role:** Replay-stable small-group departure/re-entry catalog. Guarantees single and repeated administrative
+    remove/re-add cycles, restart boundaries, self-update and self-leave interactions, fresh post-rejoin traffic,
+    exact terminal equivalence, and the stale-original-Welcome incident archetype.
+
 - **Module:** `src/offline_catchup_family.rs`
   - **Role:** Replay-stable retained-relay backlog catalog. Keeps a founding member offline until the terminal phase,
     scales application and commit volume independently, varies relay order/duplication and recovery shape, and requires
@@ -383,7 +388,9 @@ Keep these aligned with [`README.md`](README.md), [`SCENARIOS.md`](SCENARIOS.md)
   relies on saved-input semantic reduction; upgrade lifecycle remains separate.
 - **Partition policy is scripted, not strategy-driven.** The bus supports partitions; proptest currently drives FIFO /
   Reverse / SeededRandom.
-- **Generated family coverage is broad but not exhaustive.** `chat-journey/v1` covers legal product-shaped membership,
+- **Generated family coverage is broad but not exhaustive.** `membership-reentry/v1` owns bounded single/repeated
+  departure and fresh-Welcome re-entry interactions, including a wider multi-auto-committer self-leave fork.
+  `chat-journey/v1` covers legal product-shaped membership,
   admin, profile, application, offline, reconnect, self-update, and restart histories. `send-leave/v1` records lifecycle
   metadata, `convergence-e2e-delivery/v1` mutates the convergence E2E bridge with duplicate/delay/reorder delivery, and
   `convergence-chaos/v1` covers invite races, group-data races, publish rollback, partitions, leaves, delayed past-epoch

--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -149,6 +149,8 @@ Git commit; require a clean build and retain the exact source revision plus comm
     into the canonical snapshot and scenario-input ledger while legacy `Observe` remains stable for existing fixtures.
     `ProbeBidirectionalDecryptability` actively exercises send, transport peel, MLS decrypt, and application delivery.
     Membership operations include invite, admin removal, leave, and leaf self-update through the same subject contract.
+    V3's `expect_tick_error` records a normalized, expected transport refusal and continues so the same input can be
+    replayed after a later prerequisite state transition.
 
 - **Module:** `src/scenario_ir.rs`
   - **Role:** Canonical ScenarioSpec v2/v3 compiler. It validates input, assigns stable action ids, records the deterministic

--- a/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
+++ b/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
@@ -267,18 +267,18 @@ normal PR path.
 Generates a ten-arm, replay-stable catalog dedicated to membership departure and re-entry. Eight arms use four
 clients and cover one, two, and three remove/re-add cycles; victim restarts; self-updates between cycles;
 self-update/removal and self-leave/removal races; self-leave followed by re-entry; and a stale original Welcome
-followed by a fresh Welcome. The final two arms use eight clients: one lets every incumbent stage a sibling commit for
-the same self-leave before any commit is delivered; the other lets only two to four seeded early committers do so while
-the remaining incumbents receive the winning branch first. Both then re-add the departed member. Every successful re-entry
-sends a uniquely labelled application probe, and terminal oracles require exact canonical equivalence, survivor input
-closure, the precisely named retained join-commit exception for the re-added member, and active bidirectional
-decryptability.
+followed by the trusted removal commit and a fresh Welcome. The final two arms use eight clients: one lets every
+incumbent stage a sibling commit for the same self-leave before any commit is delivered; the other lets only two to
+four seeded early committers do so while the remaining incumbents receive the winning branch first. Both then re-add
+the departed member. Every successful re-entry sends a uniquely labelled application probe, and terminal oracles
+require exact canonical equivalence, survivor input closure, the precisely named retained join-commit exception for
+the re-added member, and active bidirectional decryptability.
 
 `tests/membership_reentry_family.rs` pins deterministic replay, seed variation, prefix stability, family registration,
 cycle counts, and every named interaction. All ten cases execute in the ordinary test lane. Case `7` specifically
-guards that a fully validated, strictly newer re-invitation advances a victim whose delayed older Welcome installed a
-stale active local view. Cases `8` and `9` pin convergence and re-entry after wider all-incumbent and partial-impact
-multi-auto-committer self-leave forks.
+guards that a fresh re-invitation stays retryable while a delayed older Welcome leaves the victim apparently active,
+then succeeds after the victim processes the removal from its trusted branch. Cases `8` and `9` pin convergence and
+re-entry after wider all-incumbent and partial-impact multi-auto-committer self-leave forks.
 
 ### `generate_offline_catchup_pressure_family(seed, cases)`
 

--- a/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
+++ b/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
@@ -243,8 +243,9 @@ misclassified as a no-pending failure.
 The generator is deterministic by family name, independent generator version, seed, and case index, plus a separately
 versioned workload profile when applicable. Existing semantic reduction minimizes a saved failing scenario after
 execution. `tests/stateful_generator.rs` independently replays the legal-action preconditions, checks the complete
-action vocabulary across adjacent cases, runs both profiles through the report path, and verifies that the input
-fixture was saved privately before execution.
+action vocabulary and a remove/re-invite interaction across adjacent cases, runs both profiles through the report path,
+and verifies that the input fixture was saved privately before execution. Removed identities return to the legal invite
+set; a re-added identity can self-update again during its new membership tenure.
 
 ### `generate_large_group_pressure_family(seed, cases)`
 
@@ -260,6 +261,24 @@ provenance, exact retained-join versus strict pending-work coverage, and bounded
 late-join/re-add and roster-tail representatives. The ordinary lane executes 10-member application-heavy and
 incremental-join canaries. The suite compiles all 54 catalog shapes but does not execute large/xlarge cases in the
 normal PR path.
+
+### `generate_membership_reentry_family(seed, cases)`
+
+Generates a ten-arm, replay-stable catalog dedicated to membership departure and re-entry. Eight arms use four
+clients and cover one, two, and three remove/re-add cycles; victim restarts; self-updates between cycles;
+self-update/removal and self-leave/removal races; self-leave followed by re-entry; and a stale original Welcome
+followed by a fresh Welcome. The final two arms use eight clients: one lets every incumbent stage a sibling commit for
+the same self-leave before any commit is delivered; the other lets only two to four seeded early committers do so while
+the remaining incumbents receive the winning branch first. Both then re-add the departed member. Every successful re-entry
+sends a uniquely labelled application probe, and terminal oracles require exact canonical equivalence, survivor input
+closure, the precisely named retained join-commit exception for the re-added member, and active bidirectional
+decryptability.
+
+`tests/membership_reentry_family.rs` pins deterministic replay, seed variation, prefix stability, family registration,
+cycle counts, and every named interaction. All ten cases execute in the ordinary test lane. Case `7` specifically
+guards that a fully validated, strictly newer re-invitation advances a victim whose delayed older Welcome installed a
+stale active local view. Cases `8` and `9` pin convergence and re-entry after wider all-incumbent and partial-impact
+multi-auto-committer self-leave forks.
 
 ### `generate_offline_catchup_pressure_family(seed, cases)`
 

--- a/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
+++ b/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
@@ -276,8 +276,9 @@ the re-added member, and active bidirectional decryptability.
 
 `tests/membership_reentry_family.rs` pins deterministic replay, seed variation, prefix stability, family registration,
 cycle counts, and every named interaction. All ten cases execute in the ordinary test lane. Case `7` specifically
-guards that a fresh re-invitation stays retryable while a delayed older Welcome leaves the victim apparently active,
-then succeeds after the victim processes the removal from its trusted branch. Cases `8` and `9` pin convergence and
+guards that a fresh re-invitation is refused non-terminally while a delayed older Welcome leaves the victim apparently
+active, then replays the byte-identical Welcome successfully after the victim processes the removal from its trusted
+branch. That arm requires complete pending-work closure; cases `8` and `9` pin convergence and
 re-entry after wider all-incumbent and partial-impact multi-auto-committer self-leave forks.
 
 ### `generate_offline_catchup_pressure_family(seed, cases)`

--- a/crates/cgka-conformance-simulator/RUNNING_CAMPAIGNS.md
+++ b/crates/cgka-conformance-simulator/RUNNING_CAMPAIGNS.md
@@ -139,6 +139,7 @@ timeout, and the original failure artifacts remain authoritative.
 | `bounded-convergence-pressure/v1` | Finite self-update/profile/admin pressure under a bounded quiescence contract |
 | `large-group-pressure/v1` | Explicit 10–200 member, admin-population, committer-width, traffic, growth, and churn profiles |
 | `offline-catchup-pressure/v1` | Founding member returns only after a retained 24–1,024-message backlog plus commit pressure |
+| `membership-reentry/v1` | Single/repeated removal and fresh-Welcome re-entry with restart, self-update, self-leave, and stale-Welcome interactions |
 | `cross-route-restart-permutations/v1` | Twelve public app-runtime restart boundaries in the four-party route scenario |
 | `cross-route-exact-restart-permutations/v1` | Exact/private engine companion to the public restart catalog |
 | `chat-journey/v1` | Legality-aware product journeys: membership, profile, app traffic, offline/catch-up, and restart |
@@ -169,6 +170,17 @@ cargo run -p cgka-conformance-simulator --bin cgka-conformance-campaign --locked
   --case-timeout-secs 300 --storage file \
   --out target/convergence-manual/offline-catchup-seed-42
 ```
+
+For `membership-reentry/v1`, ten consecutive cases cover the complete catalog: one clean cycle, two
+cycles, three cycles with victim restarts, self-updates between cycles, a self-update/removal race, self-leave then
+re-entry, self-leave racing administrative removal, and a stale original Welcome followed by a fresh re-invitation.
+The final two arms widen the group to eight members: case `8` lets all seven incumbents stage competing commits for the
+same self-leave before any commit delivery, while case `9` lets only two to four seeded early committers do so before
+the winner reaches the remaining incumbents. All cases are ordinary strict regressions. Case `7` pins the
+replacement-Welcome freshness rule: a delayed older
+Welcome may install a stale active local view, but a fully validated strictly newer re-invitation must replace it and
+restore convergence. Cases `8` and `9` require the all-committer and production-shaped partial-impact fork to converge
+before re-entry.
 
 ## Running vectors and adapter comparisons
 

--- a/crates/cgka-conformance-simulator/RUNNING_CAMPAIGNS.md
+++ b/crates/cgka-conformance-simulator/RUNNING_CAMPAIGNS.md
@@ -173,14 +173,15 @@ cargo run -p cgka-conformance-simulator --bin cgka-conformance-campaign --locked
 
 For `membership-reentry/v1`, ten consecutive cases cover the complete catalog: one clean cycle, two
 cycles, three cycles with victim restarts, self-updates between cycles, a self-update/removal race, self-leave then
-re-entry, self-leave racing administrative removal, and a stale original Welcome followed by a fresh re-invitation.
-The final two arms widen the group to eight members: case `8` lets all seven incumbents stage competing commits for the
-same self-leave before any commit delivery, while case `9` lets only two to four seeded early committers do so before
+re-entry, self-leave racing administrative removal, and a stale original Welcome followed by the trusted removal
+commit and a fresh re-invitation. The final two arms widen the group to eight members: case `8` lets all seven
+incumbents stage competing commits for the same self-leave before any commit delivery, while case `9` lets only two
+to four seeded early committers do so before
 the winner reaches the remaining incumbents. All cases are ordinary strict regressions. Case `7` pins the
-replacement-Welcome freshness rule: a delayed older
-Welcome may install a stale active local view, but a fully validated strictly newer re-invitation must replace it and
-restore convergence. Cases `8` and `9` require the all-committer and production-shaped partial-impact fork to converge
-before re-entry.
+trusted-removal continuity rule: a delayed older Welcome may install a stale active local view, but a newer
+re-invitation remains retryable until the victim processes the removal from its trusted branch. The same Welcome then
+restores convergence. Cases `8` and `9` require the all-committer and production-shaped partial-impact fork to
+converge before re-entry.
 
 ## Running vectors and adapter comparisons
 

--- a/crates/cgka-conformance-simulator/RUNNING_CAMPAIGNS.md
+++ b/crates/cgka-conformance-simulator/RUNNING_CAMPAIGNS.md
@@ -179,8 +179,9 @@ incumbents stage competing commits for the same self-leave before any commit del
 to four seeded early committers do so before
 the winner reaches the remaining incumbents. All cases are ordinary strict regressions. Case `7` pins the
 trusted-removal continuity rule: a delayed older Welcome may install a stale active local view, but a newer
-re-invitation remains retryable until the victim processes the removal from its trusted branch. The same Welcome then
-restores convergence. Cases `8` and `9` require the all-committer and production-shaped partial-impact fork to
+re-invitation is explicitly refused without terminal deduplication. After the victim processes the removal from its
+trusted branch, a byte-identical duplicate of the same Welcome restores convergence with no pending work. Cases `8`
+and `9` require the all-committer and production-shaped partial-impact fork to
 converge before re-entry.
 
 ## Running vectors and adapter comparisons

--- a/crates/cgka-conformance-simulator/SCALING_CAMPAIGNS.md
+++ b/crates/cgka-conformance-simulator/SCALING_CAMPAIGNS.md
@@ -151,12 +151,13 @@ automatically cover later production changes.
 For broad defect discovery, prioritize:
 
 1. `chat-journey/v1` for legal product histories;
-2. `convergence-chaos/v1` for adversarial schedule and traffic breadth;
-3. `bounded-convergence-pressure/v1` for the self-update/admin/profile pressure boundary;
-4. `large-group-pressure/v1` for explicit 10–200 member, administrator-population, committer-width, and traffic
+2. `membership-reentry/v1` for guaranteed single/repeated departure and fresh-Welcome re-entry interactions;
+3. `convergence-chaos/v1` for adversarial schedule and traffic breadth;
+4. `bounded-convergence-pressure/v1` for the self-update/admin/profile pressure boundary;
+5. `large-group-pressure/v1` for explicit 10–200 member, administrator-population, committer-width, and traffic
    profiles;
-5. `admin-churn/v1` for membership and administrator transitions; and
-6. the two twelve-case cross-route restart catalogs as fixed high-value regressions.
+6. `admin-churn/v1` for membership and administrator transitions; and
+7. the two twelve-case cross-route restart catalogs as fixed high-value regressions.
 
 Cover all registered families with a small seed matrix before making one family enormous. Then allocate additional
 cases using measured coverage gaps, failures, slow tails, and recent production changes.
@@ -174,7 +175,9 @@ High-value motifs that should drive future profiles include:
 
 - an offline founding member returning to a large application/commit backlog while group state changes (implemented
   as the retained-relay `offline-catchup-pressure/v1` family; membership-changing extensions remain future work);
-- sustained application traffic interspersed with proposals, commits, administrator handoff, removals, and re-adds;
+- sustained application traffic interspersed with proposals, commits, administrator handoff, removals, and re-adds
+  (the bounded departure/re-entry core is implemented by `membership-reentry/v1`; sustained traffic remains an
+  extension);
 - bounded self-update pressure racing administrator/profile commits, with explicit input closure;
 - restart after publication acceptance, ingest, freeze, selection, application, confirmation, rollback, or retained
   history repair;

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -633,21 +633,21 @@ regression, covers a new semantic edge, or is the smallest readable example of a
 
 ### `membership-reentry/v1`
 
-- Generator: `generate_membership_reentry_family` (generator version `3`).
+- Generator: `generate_membership_reentry_family` (generator version `1`).
 - Setup: the first eight arms use four clients; the final two use eight. A non-admin identity departs and rejoins
   through fresh KeyPackages. Seeded cases vary the victim, delivery order, and partial-impact committer count without
   changing the ten-arm catalog.
 - Pressure: the catalog guarantees one clean cycle, two cycles, three cycles with victim restarts, self-updates between
   cycles, a same-epoch self-update/removal race, self-leave followed by re-entry, self-leave racing administrative
-  removal, delivery of a withheld original Welcome only after that leaf has been removed and before a fresh
-  re-invitation, a wider self-leave for which every incumbent stages a sibling commit before any commit delivery, and
+  removal, delivery of a withheld original Welcome followed by the trusted removal commit and a fresh re-invitation,
+  a wider self-leave for which every incumbent stages a sibling commit before any commit delivery, and
   the corresponding partial-impact timing in which only two to four incumbents commit before the winning branch
   reaches the rest.
 - Expected: every successful re-entry immediately sends an application probe. The terminal oracle requires exact
   canonical equivalence, the final complete roster at the exact epoch, no pending work for survivors, exactly the
   documented retained join-commit exception for the re-added member, and active decryptability in every direction.
 - Status: all ten arms are ordinary executable regressions. The stale-original-Welcome arm at case `7` guards that
-  a fully validated, strictly newer re-invitation replaces a stale active local view and restores exact convergence.
+  a fresh re-invitation waits until the stale active view processes its trusted removal, then restores exact convergence.
   Cases `8` and `9` require convergence and re-entry after all-incumbent and partial-impact multi-auto-committer
   self-leave forks, respectively.
 

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -631,9 +631,30 @@ regression, covers a new semantic edge, or is the smallest readable example of a
   changing production engine or protocol behavior. The original failures remain historical discovery evidence, not
   allowed results.
 
+### `membership-reentry/v1`
+
+- Generator: `generate_membership_reentry_family` (generator version `3`).
+- Setup: the first eight arms use four clients; the final two use eight. A non-admin identity departs and rejoins
+  through fresh KeyPackages. Seeded cases vary the victim, delivery order, and partial-impact committer count without
+  changing the ten-arm catalog.
+- Pressure: the catalog guarantees one clean cycle, two cycles, three cycles with victim restarts, self-updates between
+  cycles, a same-epoch self-update/removal race, self-leave followed by re-entry, self-leave racing administrative
+  removal, delivery of a withheld original Welcome only after that leaf has been removed and before a fresh
+  re-invitation, a wider self-leave for which every incumbent stages a sibling commit before any commit delivery, and
+  the corresponding partial-impact timing in which only two to four incumbents commit before the winning branch
+  reaches the rest.
+- Expected: every successful re-entry immediately sends an application probe. The terminal oracle requires exact
+  canonical equivalence, the final complete roster at the exact epoch, no pending work for survivors, exactly the
+  documented retained join-commit exception for the re-added member, and active decryptability in every direction.
+- Status: all ten arms are ordinary executable regressions. The stale-original-Welcome arm at case `7` guards that
+  a fully validated, strictly newer re-invitation replaces a stale active local view and restores exact convergence.
+  Cases `8` and `9` require convergence and re-entry after all-incumbent and partial-impact multi-auto-committer
+  self-leave forks, respectively.
+
 ### `chat-journey/v1`
 
-- Generator: `generate_stateful_chat_journey_family` (generator version `1`).
+- Generator: `generate_stateful_chat_journey_family` (generator version `2`). Version 2 makes removed identities legal
+  fresh re-invitation candidates and guarantees the remove/re-invite interaction in each eight-case rotation.
 - Setup: a four-participant legality model emits canonical IR v3 while tracking the roster, administrator set,
   connectivity, epoch, group profile, and application deliveries.
 - Profiles: even case indices generate late-invite membership journeys on the engine subject; odd indices generate

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -646,8 +646,9 @@ regression, covers a new semantic edge, or is the smallest readable example of a
 - Expected: every successful re-entry immediately sends an application probe. The terminal oracle requires exact
   canonical equivalence, the final complete roster at the exact epoch, no pending work for survivors, exactly the
   documented retained join-commit exception for the re-added member, and active decryptability in every direction.
-- Status: all ten arms are ordinary executable regressions. The stale-original-Welcome arm at case `7` guards that
-  a fresh re-invitation waits until the stale active view processes its trusted removal, then restores exact convergence.
+- Status: all ten arms are ordinary executable regressions. The stale-original-Welcome arm at case `7` explicitly
+  observes the fresh re-invitation's non-terminal refusal while the stale view is active, then replays a byte-identical
+  Welcome after trusted removal and requires exact convergence with no pending work.
   Cases `8` and `9` require convergence and re-entry after all-incumbent and partial-impact multi-auto-committer
   self-leave forks, respectively.
 

--- a/crates/cgka-conformance-simulator/SCENARIO_IR.md
+++ b/crates/cgka-conformance-simulator/SCENARIO_IR.md
@@ -4,7 +4,7 @@ The simulator has two deliberately separate inputs:
 
 - `ScenarioSpec` v2 and v3 are canonical adapter-neutral JSON IRs. Both contain only a linear sequence of executable
   atomic actions. V2 remains replayable through `schemas/scenario-ir.v2.schema.json`; v3 adds the full
-  `update_group_profile` action through `schemas/scenario-ir.v3.schema.json`.
+  `update_group_profile` action and expected tick-error observation through `schemas/scenario-ir.v3.schema.json`.
 - `ScenarioAuthoringSpec` v1 is human-oriented structure. It may be represented as JSON or YAML, but it is never passed
   to an adapter. The repository compiler deterministically lowers it to canonical JSON first, emitting v2 unless an
   expanded action requires v3. Its schema is `schemas/scenario-authoring.v1.schema.json`.
@@ -29,6 +29,10 @@ Scenario IR v2's `update_group_data` action is the stable name-only operation. S
 `update_group_profile` action carries optional `name` and `description` fields and requires at least one of them. A
 missing field means preserve the adopted canonical value; an explicitly empty string clears that field. The compiler
 rejects the v3 action in a v2 document rather than silently changing v2 serialization or semantics.
+V3 also adds `expect_tick_error`, which ticks exactly one participant, records the normalized error when it matches,
+and lets the scenario continue. It is intended for retryable transport refusals where a later action replays the same
+input after the prerequisite state arrives; an unexpected success or a different error still fails the scenario. An
+adapter must advertise both transport delivery and expected-transport-error observation before this action executes.
 That split is intentional because canonical JSON is persisted in vectors and failure capsules and exchanged with
 external campaign runners; adding fields to an existing action version would change the meaning accepted by a v2
 consumer even when this repository's current fixtures omit them.

--- a/crates/cgka-conformance-simulator/schemas/scenario-ir.v3.schema.json
+++ b/crates/cgka-conformance-simulator/schemas/scenario-ir.v3.schema.json
@@ -43,6 +43,16 @@
         {
           "type": "object",
           "additionalProperties": false,
+          "required": ["type", "client", "error"],
+          "properties": {
+            "type": { "const": "expect_tick_error" },
+            "client": { "type": "string", "minLength": 1 },
+            "error": { "type": "string", "minLength": 1 }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
           "required": ["type", "group", "action"],
           "properties": {
             "type": { "const": "in_group" },

--- a/crates/cgka-conformance-simulator/src/bin/cgka-conformance-campaign.rs
+++ b/crates/cgka-conformance-simulator/src/bin/cgka-conformance-campaign.rs
@@ -824,6 +824,7 @@ mod tests {
             "bounded-convergence-pressure/v1",
             "large-group-pressure/v1",
             "offline-catchup-pressure/v1",
+            "membership-reentry/v1",
             "cross-route-exact-restart-permutations/v1",
             "cross-route-restart-permutations/v1",
             "chat-journey/v1",
@@ -851,6 +852,9 @@ mod tests {
                 }
                 "offline-catchup-pressure/v1" => {
                     cgka_conformance_simulator::generate_offline_catchup_pressure_family(42, 4)
+                }
+                "membership-reentry/v1" => {
+                    cgka_conformance_simulator::generate_membership_reentry_family(42, 4)
                 }
                 "cross-route-exact-restart-permutations/v1" => {
                     cgka_conformance_simulator::generate_cross_route_exact_restart_permutation_family(

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -219,6 +219,9 @@ pub fn generate_family_case(
         crate::OFFLINE_CATCHUP_PRESSURE_FAMILY => {
             crate::generate_offline_catchup_pressure_case(seed, case_index)
         }
+        crate::MEMBERSHIP_REENTRY_FAMILY => {
+            crate::generate_membership_reentry_case(seed, case_index)
+        }
         "cross-route-restart-permutations/v1" => {
             generate_cross_route_restart_permutation_case(seed, case_index)
         }

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -31,6 +31,7 @@ mod failure_capsule;
 pub mod family;
 mod large_group_family;
 pub mod lifecycle_model;
+mod membership_reentry_family;
 pub mod mutation_adequacy;
 pub mod node_protocol;
 mod offline_catchup_family;
@@ -123,6 +124,10 @@ pub use large_group_family::{
     LARGE_GROUP_PRESSURE_FAMILY, LARGE_GROUP_PRESSURE_GENERATOR_VERSION,
     LARGE_GROUP_PRESSURE_PROFILE_VERSION, generate_large_group_pressure_case,
     generate_large_group_pressure_family,
+};
+pub use membership_reentry_family::{
+    MEMBERSHIP_REENTRY_FAMILY, MEMBERSHIP_REENTRY_GENERATOR_VERSION,
+    generate_membership_reentry_case, generate_membership_reentry_family,
 };
 pub use offline_catchup_family::{
     OFFLINE_CATCHUP_PRESSURE_FAMILY, OFFLINE_CATCHUP_PRESSURE_GENERATOR_VERSION,

--- a/crates/cgka-conformance-simulator/src/membership_reentry_family.rs
+++ b/crates/cgka-conformance-simulator/src/membership_reentry_family.rs
@@ -1,0 +1,668 @@
+//! Deterministic membership departure and re-entry scenarios.
+//!
+//! This family keeps most cases small so they can assert exact state, input
+//! closure, and active decryptability cheaply. Two incident-shaped arms use a
+//! wider group to make all or a seed-selected handful of unrelated incumbents
+//! race to commit the same SelfRemove before the departed identity is invited
+//! again. The catalog owns
+//! interactions that broad membership and large-group workloads only reach
+//! incidentally: repeated fresh-Welcome re-entry, self-update/removal races,
+//! self-leave, and stale pre-removal Welcomes.
+
+use crate::{
+    GeneratedScenarioCase, GeneratedSubjectKind, ScenarioAssertionV2, ScenarioMessageSelectorV2,
+    ScenarioOutboundSelection, ScenarioPredicateV2, ScenarioSpec, ScenarioStep,
+    ScenarioTransportClass, SubjectOutboundOutcome, TraceExpectation,
+};
+use rand::rngs::StdRng;
+use rand::seq::SliceRandom;
+use rand::{Rng, SeedableRng};
+
+pub const MEMBERSHIP_REENTRY_FAMILY: &str = "membership-reentry/v1";
+pub const MEMBERSHIP_REENTRY_GENERATOR_VERSION: &str = "3";
+
+const ARM_COUNT: u64 = 10;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ReentryArm {
+    SingleCycle,
+    DoubleCycle,
+    TripleCycleWithRestarts,
+    SelfUpdateBetweenCycles,
+    SelfUpdateRemovalRace,
+    SelfLeaveThenReentry,
+    SelfLeaveRemovalRace,
+    StaleWelcomeThenFreshReentry,
+    SelfLeaveMultiCommitterReentry,
+    SelfLeavePartialMultiCommitterReentry,
+}
+
+impl ReentryArm {
+    fn from_index(case_index: u64) -> Self {
+        match case_index % ARM_COUNT {
+            0 => Self::SingleCycle,
+            1 => Self::DoubleCycle,
+            2 => Self::TripleCycleWithRestarts,
+            3 => Self::SelfUpdateBetweenCycles,
+            4 => Self::SelfUpdateRemovalRace,
+            5 => Self::SelfLeaveThenReentry,
+            6 => Self::SelfLeaveRemovalRace,
+            7 => Self::StaleWelcomeThenFreshReentry,
+            8 => Self::SelfLeaveMultiCommitterReentry,
+            _ => Self::SelfLeavePartialMultiCommitterReentry,
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::SingleCycle => "single-cycle",
+            Self::DoubleCycle => "double-cycle",
+            Self::TripleCycleWithRestarts => "triple-cycle-with-restarts",
+            Self::SelfUpdateBetweenCycles => "self-update-between-cycles",
+            Self::SelfUpdateRemovalRace => "self-update-removal-race",
+            Self::SelfLeaveThenReentry => "self-leave-then-reentry",
+            Self::SelfLeaveRemovalRace => "self-leave-removal-race",
+            Self::StaleWelcomeThenFreshReentry => "stale-welcome-then-fresh-reentry",
+            Self::SelfLeaveMultiCommitterReentry => "self-leave-multi-committer-reentry",
+            Self::SelfLeavePartialMultiCommitterReentry => {
+                "self-leave-partial-multi-committer-reentry"
+            }
+        }
+    }
+}
+
+pub fn generate_membership_reentry_family(seed: u64, cases: usize) -> Vec<GeneratedScenarioCase> {
+    (0..cases)
+        .map(|case_index| generate_membership_reentry_case(seed, case_index as u64))
+        .collect()
+}
+
+pub fn generate_membership_reentry_case(seed: u64, case_index: u64) -> GeneratedScenarioCase {
+    let mut rng = StdRng::seed_from_u64(seed ^ 0x4d45_4d42_4552_5348 ^ case_index.rotate_left(19));
+    let arm = ReentryArm::from_index(case_index);
+    let wide_incident_arm = matches!(
+        arm,
+        ReentryArm::SelfLeaveMultiCommitterReentry
+            | ReentryArm::SelfLeavePartialMultiCommitterReentry
+    );
+    let clients = if wide_incident_arm {
+        labels([
+            "alice", "bob", "carol", "david", "erin", "frank", "grace", "heidi",
+        ])
+    } else {
+        labels(["alice", "bob", "carol", "david"])
+    };
+    let victim = if wide_incident_arm {
+        if rng.gen_bool(0.5) { "grace" } else { "heidi" }
+    } else if rng.gen_bool(0.5) {
+        "carol"
+    } else {
+        "david"
+    };
+    let mut delivery_order = clients.clone();
+    delivery_order.shuffle(&mut rng);
+    let mut steps = Vec::new();
+    let mut expected = Vec::new();
+
+    let mut epoch = if arm == ReentryArm::StaleWelcomeThenFreshReentry {
+        setup_without_victim(
+            &mut steps,
+            &mut expected,
+            case_index,
+            &clients,
+            victim,
+            &delivery_order,
+        );
+        1
+    } else {
+        setup_full_group(
+            &mut steps,
+            &mut expected,
+            case_index,
+            &clients,
+            &delivery_order,
+        );
+        1
+    };
+
+    match arm {
+        ReentryArm::SingleCycle => {
+            epoch = remove_and_readd(
+                &mut steps,
+                &mut expected,
+                &clients,
+                &delivery_order,
+                victim,
+                case_index,
+                0,
+                epoch,
+                false,
+            );
+        }
+        ReentryArm::DoubleCycle => {
+            for cycle in 0..2 {
+                epoch = remove_and_readd(
+                    &mut steps,
+                    &mut expected,
+                    &clients,
+                    &delivery_order,
+                    victim,
+                    case_index,
+                    cycle,
+                    epoch,
+                    false,
+                );
+            }
+        }
+        ReentryArm::TripleCycleWithRestarts => {
+            for cycle in 0..3 {
+                epoch = remove_and_readd(
+                    &mut steps,
+                    &mut expected,
+                    &clients,
+                    &delivery_order,
+                    victim,
+                    case_index,
+                    cycle,
+                    epoch,
+                    true,
+                );
+            }
+        }
+        ReentryArm::SelfUpdateBetweenCycles => {
+            for cycle in 0..2 {
+                epoch = self_update(
+                    &mut steps,
+                    &mut expected,
+                    &clients,
+                    &delivery_order,
+                    victim,
+                    cycle,
+                    epoch,
+                );
+                epoch = remove_and_readd(
+                    &mut steps,
+                    &mut expected,
+                    &clients,
+                    &delivery_order,
+                    victim,
+                    case_index,
+                    cycle,
+                    epoch,
+                    false,
+                );
+            }
+        }
+        ReentryArm::SelfUpdateRemovalRace => {
+            let self_pending = "racing-self-update";
+            steps.push(ScenarioStep::SelfUpdate {
+                client: victim.into(),
+                pending: self_pending.into(),
+            });
+            let remove_pending = "racing-remove";
+            steps.push(ScenarioStep::RemoveMembers {
+                remover: "alice".into(),
+                members: vec![victim.into()],
+                pending: remove_pending.into(),
+            });
+            confirm(&mut steps, &mut expected, victim, self_pending);
+            confirm(&mut steps, &mut expected, "alice", remove_pending);
+            settle_twice(&mut steps, &delivery_order);
+            epoch += 1;
+            assert_client_state(&mut steps, "alice", epoch, clients.len() - 1);
+            epoch = readd_and_probe(
+                &mut steps,
+                &mut expected,
+                &clients,
+                &delivery_order,
+                victim,
+                case_index,
+                0,
+                epoch,
+            );
+        }
+        ReentryArm::SelfLeaveThenReentry => {
+            steps.push(ScenarioStep::Leave {
+                client: victim.into(),
+            });
+            settle_self_leave(&mut steps, &delivery_order);
+            epoch += 1;
+            assert_client_state(&mut steps, "alice", epoch, clients.len() - 1);
+            epoch = readd_and_probe(
+                &mut steps,
+                &mut expected,
+                &clients,
+                &delivery_order,
+                victim,
+                case_index,
+                0,
+                epoch,
+            );
+        }
+        ReentryArm::SelfLeaveRemovalRace => {
+            steps.push(ScenarioStep::Leave {
+                client: victim.into(),
+            });
+            steps.push(ScenarioStep::RemoveMembers {
+                remover: "alice".into(),
+                members: vec![victim.into()],
+                pending: "remove-against-self-leave".into(),
+            });
+            confirm(
+                &mut steps,
+                &mut expected,
+                "alice",
+                "remove-against-self-leave",
+            );
+            settle_twice(&mut steps, &delivery_order);
+            epoch += 1;
+            assert_client_state(&mut steps, "alice", epoch, clients.len() - 1);
+            epoch = readd_and_probe(
+                &mut steps,
+                &mut expected,
+                &clients,
+                &delivery_order,
+                victim,
+                case_index,
+                0,
+                epoch,
+            );
+        }
+        ReentryArm::StaleWelcomeThenFreshReentry => {
+            steps.push(ScenarioStep::InviteMembers {
+                inviter: "alice".into(),
+                invitees: vec![victim.into()],
+                pending: "stale-invite".into(),
+            });
+            confirm(&mut steps, &mut expected, "alice", "stale-invite");
+            steps.push(ScenarioStep::WithholdMessage {
+                selector: ScenarioMessageSelectorV2 {
+                    publication: Some("stale-invite".into()),
+                    class: Some(ScenarioTransportClass::Welcome),
+                    ..Default::default()
+                },
+                label: "stale-original-welcome".into(),
+            });
+            settle(&mut steps, &delivery_order_without(&delivery_order, victim));
+            epoch += 1;
+            assert_client_state(&mut steps, "alice", epoch, clients.len());
+
+            steps.push(ScenarioStep::RemoveMembers {
+                remover: "alice".into(),
+                members: vec![victim.into()],
+                pending: "remove-before-welcome".into(),
+            });
+            confirm(&mut steps, &mut expected, "alice", "remove-before-welcome");
+            settle(&mut steps, &delivery_order_without(&delivery_order, victim));
+            epoch += 1;
+            assert_client_state(&mut steps, "alice", epoch, clients.len() - 1);
+
+            steps.push(ScenarioStep::ReleaseWithheld {
+                label: "stale-original-welcome".into(),
+            });
+            steps.push(ScenarioStep::Tick {
+                clients: vec![victim.into()],
+            });
+            if rng.gen_bool(0.5) {
+                steps.push(ScenarioStep::RestartClient {
+                    client: victim.into(),
+                });
+            }
+            epoch = readd_and_probe(
+                &mut steps,
+                &mut expected,
+                &clients,
+                &delivery_order,
+                victim,
+                case_index,
+                0,
+                epoch,
+            );
+        }
+        ReentryArm::SelfLeaveMultiCommitterReentry => {
+            steps.push(ScenarioStep::Leave {
+                client: victim.into(),
+            });
+            steps.push(ScenarioStep::DeliverAll);
+
+            // Every remaining member observes the standalone SelfRemove before
+            // any resulting commit is delivered. Each therefore stages and
+            // publishes a legitimate sibling commit for the same next epoch,
+            // matching the production incident's unrelated-incumbent fork.
+            let incumbents = delivery_order_without(&delivery_order, victim);
+            steps.push(ScenarioStep::Tick {
+                clients: incumbents.clone(),
+            });
+            for incumbent in &incumbents {
+                steps.push(accept_all_outbound(incumbent));
+            }
+            settle_twice(&mut steps, &delivery_order);
+            epoch += 1;
+            for incumbent in &incumbents {
+                assert_client_state(&mut steps, incumbent, epoch, clients.len() - 1);
+            }
+            epoch = readd_and_probe(
+                &mut steps,
+                &mut expected,
+                &clients,
+                &delivery_order,
+                victim,
+                case_index,
+                0,
+                epoch,
+            );
+        }
+        ReentryArm::SelfLeavePartialMultiCommitterReentry => {
+            steps.push(ScenarioStep::Leave {
+                client: victim.into(),
+            });
+            steps.push(ScenarioStep::DeliverAll);
+
+            // Only a seed-selected handful of incumbents reach their delayed
+            // auto-commit before the first sibling commit arrives. The rest
+            // ingest one of those commits before their timer fires and follow
+            // the winner directly. This preserves the production-shaped
+            // partial-impact timing in which most members progress while a
+            // few early committers must rewind and replay the shared proposal.
+            let incumbents = delivery_order_without(&delivery_order, victim);
+            let committer_count = rng.gen_range(2..=4).min(incumbents.len());
+            let early_committers = incumbents[..committer_count].to_vec();
+            steps.push(ScenarioStep::Tick {
+                clients: early_committers.clone(),
+            });
+            for incumbent in &early_committers {
+                steps.push(accept_all_outbound(incumbent));
+            }
+            settle_twice(&mut steps, &delivery_order);
+            epoch += 1;
+            for incumbent in &incumbents {
+                assert_client_state(&mut steps, incumbent, epoch, clients.len() - 1);
+            }
+            epoch = readd_and_probe(
+                &mut steps,
+                &mut expected,
+                &clients,
+                &delivery_order,
+                victim,
+                case_index,
+                0,
+                epoch,
+            );
+        }
+    }
+
+    steps.push(ScenarioStep::ProbeBidirectionalDecryptability {
+        clients: clients.clone(),
+    });
+    steps.push(ScenarioStep::ObserveExact {
+        clients: clients.clone(),
+    });
+    expected.push(TraceExpectation::ClientsConverged {
+        clients: clients.clone(),
+        epoch: Some(epoch),
+        member_count: Some(clients.len()),
+    });
+    expected.push(TraceExpectation::ClientsExactlyEquivalent {
+        clients: clients.clone(),
+    });
+    expected.push(TraceExpectation::NoPendingWork {
+        clients: clients
+            .iter()
+            .filter(|client| client.as_str() != victim)
+            .cloned()
+            .collect(),
+    });
+    expected.push(TraceExpectation::NoPendingWorkExceptRetainedJoinCommit {
+        client: victim.into(),
+    });
+    expected.push(TraceExpectation::ClientsBidirectionallyDecryptable {
+        clients: clients.clone(),
+    });
+
+    GeneratedScenarioCase {
+        family_name: MEMBERSHIP_REENTRY_FAMILY.into(),
+        generator_version: MEMBERSHIP_REENTRY_GENERATOR_VERSION.into(),
+        seed,
+        case_index,
+        workload_profile: None,
+        subject: GeneratedSubjectKind::Engine,
+        scenario: ScenarioSpec {
+            name: format!(
+                "{MEMBERSHIP_REENTRY_FAMILY}/case-{case_index}/{}",
+                arm.name()
+            ),
+            spec_version: "3".into(),
+            clients,
+            topology: Default::default(),
+            steps,
+        },
+        expected_outcomes: expected,
+    }
+}
+
+fn setup_full_group(
+    steps: &mut Vec<ScenarioStep>,
+    expected: &mut Vec<TraceExpectation>,
+    case_index: u64,
+    clients: &[String],
+    delivery_order: &[String],
+) {
+    steps.push(ScenarioStep::CreateGroup {
+        creator: "alice".into(),
+        name: format!("membership-reentry-{case_index}"),
+        invitees: clients[1..].to_vec(),
+        required_features: vec![],
+        initial_admins: Some(vec!["alice".into()]),
+        pending: "create".into(),
+    });
+    confirm(steps, expected, "alice", "create");
+    settle(steps, delivery_order);
+    steps.push(ScenarioStep::ClearEvents {
+        clients: clients.to_vec(),
+    });
+}
+
+fn setup_without_victim(
+    steps: &mut Vec<ScenarioStep>,
+    expected: &mut Vec<TraceExpectation>,
+    case_index: u64,
+    clients: &[String],
+    victim: &str,
+    delivery_order: &[String],
+) {
+    let invitees = clients
+        .iter()
+        .filter(|client| client.as_str() != "alice" && client.as_str() != victim)
+        .cloned()
+        .collect();
+    steps.push(ScenarioStep::CreateGroup {
+        creator: "alice".into(),
+        name: format!("membership-reentry-{case_index}"),
+        invitees,
+        required_features: vec![],
+        initial_admins: Some(vec!["alice".into()]),
+        pending: "create".into(),
+    });
+    confirm(steps, expected, "alice", "create");
+    settle(steps, &delivery_order_without(delivery_order, victim));
+    steps.push(ScenarioStep::ClearEvents {
+        clients: clients.to_vec(),
+    });
+}
+
+#[allow(clippy::too_many_arguments)]
+fn remove_and_readd(
+    steps: &mut Vec<ScenarioStep>,
+    expected: &mut Vec<TraceExpectation>,
+    clients: &[String],
+    delivery_order: &[String],
+    victim: &str,
+    case_index: u64,
+    cycle: usize,
+    epoch: u64,
+    restart_after_remove: bool,
+) -> u64 {
+    let pending = format!("remove-{cycle}");
+    steps.push(ScenarioStep::RemoveMembers {
+        remover: "alice".into(),
+        members: vec![victim.into()],
+        pending: pending.clone(),
+    });
+    confirm(steps, expected, "alice", &pending);
+    settle(steps, delivery_order);
+    let epoch = epoch + 1;
+    assert_client_state(steps, "alice", epoch, clients.len() - 1);
+    if restart_after_remove {
+        steps.push(ScenarioStep::RestartClient {
+            client: victim.into(),
+        });
+    }
+    readd_and_probe(
+        steps,
+        expected,
+        clients,
+        delivery_order,
+        victim,
+        case_index,
+        cycle,
+        epoch,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn readd_and_probe(
+    steps: &mut Vec<ScenarioStep>,
+    expected: &mut Vec<TraceExpectation>,
+    clients: &[String],
+    delivery_order: &[String],
+    victim: &str,
+    case_index: u64,
+    cycle: usize,
+    epoch: u64,
+) -> u64 {
+    let pending = format!("readd-{cycle}");
+    steps.push(ScenarioStep::InviteMembers {
+        inviter: "alice".into(),
+        invitees: vec![victim.into()],
+        pending: pending.clone(),
+    });
+    confirm(steps, expected, "alice", &pending);
+    settle(steps, delivery_order);
+    let epoch = epoch + 1;
+    assert_client_state(steps, "alice", epoch, clients.len());
+    assert_client_state(steps, victim, epoch, clients.len());
+
+    let payload = format!("membership-reentry:{case_index}:{cycle}:{victim}");
+    steps.push(ScenarioStep::SendAppMessage {
+        sender: victim.into(),
+        payload: payload.clone(),
+    });
+    steps.push(accept_all_outbound(victim));
+    settle(steps, delivery_order);
+    steps.push(ScenarioStep::Assert {
+        assertion: ScenarioAssertionV2::Exactly {
+            predicate: ScenarioPredicateV2::PayloadCount {
+                client: "alice".into(),
+                payload,
+                count: 1,
+            },
+        },
+    });
+    epoch
+}
+
+fn self_update(
+    steps: &mut Vec<ScenarioStep>,
+    expected: &mut Vec<TraceExpectation>,
+    clients: &[String],
+    delivery_order: &[String],
+    victim: &str,
+    cycle: usize,
+    epoch: u64,
+) -> u64 {
+    let pending = format!("self-update-{cycle}");
+    steps.push(ScenarioStep::SelfUpdate {
+        client: victim.into(),
+        pending: pending.clone(),
+    });
+    confirm(steps, expected, victim, &pending);
+    settle(steps, delivery_order);
+    let epoch = epoch + 1;
+    assert_client_state(steps, "alice", epoch, clients.len());
+    epoch
+}
+
+fn settle_self_leave(steps: &mut Vec<ScenarioStep>, delivery_order: &[String]) {
+    steps.push(ScenarioStep::DeliverAll);
+    steps.push(ScenarioStep::Tick {
+        clients: vec!["alice".into()],
+    });
+    steps.push(accept_all_outbound("alice"));
+    settle(steps, delivery_order);
+}
+
+fn settle_twice(steps: &mut Vec<ScenarioStep>, delivery_order: &[String]) {
+    settle(steps, delivery_order);
+    settle(steps, delivery_order);
+}
+
+fn settle(steps: &mut Vec<ScenarioStep>, delivery_order: &[String]) {
+    steps.push(ScenarioStep::DeliverAll);
+    steps.push(ScenarioStep::Tick {
+        clients: delivery_order.to_vec(),
+    });
+}
+
+fn delivery_order_without(delivery_order: &[String], excluded: &str) -> Vec<String> {
+    delivery_order
+        .iter()
+        .filter(|client| client.as_str() != excluded)
+        .cloned()
+        .collect()
+}
+
+fn confirm(
+    steps: &mut Vec<ScenarioStep>,
+    expected: &mut Vec<TraceExpectation>,
+    client: &str,
+    pending: &str,
+) {
+    let step_index = steps.len();
+    steps.push(ScenarioStep::AcknowledgeOutbound {
+        client: client.into(),
+        publication: Some(pending.into()),
+        selection: ScenarioOutboundSelection::All,
+        outcome: SubjectOutboundOutcome::Accepted,
+    });
+    expected.push(TraceExpectation::PendingResolution {
+        step_index,
+        client: client.into(),
+        pending: pending.into(),
+        resolution: "confirmed".into(),
+    });
+}
+
+fn accept_all_outbound(client: &str) -> ScenarioStep {
+    ScenarioStep::AcknowledgeOutbound {
+        client: client.into(),
+        publication: None,
+        selection: ScenarioOutboundSelection::All,
+        outcome: SubjectOutboundOutcome::Accepted,
+    }
+}
+
+fn assert_client_state(steps: &mut Vec<ScenarioStep>, client: &str, epoch: u64, members: usize) {
+    steps.push(ScenarioStep::Assert {
+        assertion: ScenarioAssertionV2::Exactly {
+            predicate: ScenarioPredicateV2::ClientState {
+                client: client.into(),
+                epoch: Some(epoch),
+                member_count: Some(members),
+            },
+        },
+    });
+}
+
+fn labels<const N: usize>(values: [&str; N]) -> Vec<String> {
+    values.into_iter().map(String::from).collect()
+}

--- a/crates/cgka-conformance-simulator/src/membership_reentry_family.rs
+++ b/crates/cgka-conformance-simulator/src/membership_reentry_family.rs
@@ -293,6 +293,14 @@ pub fn generate_membership_reentry_case(seed: u64, case_index: u64) -> Generated
                 pending: "remove-before-welcome".into(),
             });
             confirm(&mut steps, &mut expected, "alice", "remove-before-welcome");
+            steps.push(ScenarioStep::WithholdMessage {
+                selector: ScenarioMessageSelectorV2 {
+                    publication: Some("remove-before-welcome".into()),
+                    class: Some(ScenarioTransportClass::GroupMessage),
+                    ..Default::default()
+                },
+                label: "trusted-removal-after-stale-welcome".into(),
+            });
             settle(&mut steps, &delivery_order_without(&delivery_order, victim));
             epoch += 1;
             assert_client_state(&mut steps, "alice", epoch, clients.len() - 1);
@@ -308,6 +316,14 @@ pub fn generate_membership_reentry_case(seed: u64, case_index: u64) -> Generated
                     client: victim.into(),
                 });
             }
+            // A newer Welcome cannot authenticate its own lineage. Release the
+            // commit from the victim's currently trusted branch first; only
+            // after that removal is applied is the fresh Welcome a re-entry.
+            steps.push(ScenarioStep::ReleaseWithheld {
+                label: "trusted-removal-after-stale-welcome".into(),
+            });
+            settle(&mut steps, &delivery_order);
+            assert_client_state(&mut steps, "alice", epoch, clients.len() - 1);
             epoch = readd_and_probe(
                 &mut steps,
                 &mut expected,

--- a/crates/cgka-conformance-simulator/src/membership_reentry_family.rs
+++ b/crates/cgka-conformance-simulator/src/membership_reentry_family.rs
@@ -316,24 +316,62 @@ pub fn generate_membership_reentry_case(seed: u64, case_index: u64) -> Generated
                     client: victim.into(),
                 });
             }
-            // A newer Welcome cannot authenticate its own lineage. Release the
-            // commit from the victim's currently trusted branch first; only
-            // after that removal is applied is the fresh Welcome a re-entry.
+            // Create the fresh re-invitation while the victim still trusts the
+            // stale active view. Keep one byte-identical duplicate aside so the
+            // first delivery can pin the retryable refusal and the second can
+            // prove the same Welcome succeeds after trusted removal.
+            let pending = "readd-0";
+            steps.push(ScenarioStep::InviteMembers {
+                inviter: "alice".into(),
+                invitees: vec![victim.into()],
+                pending: pending.into(),
+            });
+            confirm(&mut steps, &mut expected, "alice", pending);
+            steps.push(ScenarioStep::DuplicateMessage {
+                selector: ScenarioMessageSelectorV2 {
+                    publication: Some(pending.into()),
+                    class: Some(ScenarioTransportClass::Welcome),
+                    ..Default::default()
+                },
+            });
+            steps.push(ScenarioStep::WithholdMessage {
+                selector: ScenarioMessageSelectorV2 {
+                    publication: Some(pending.into()),
+                    class: Some(ScenarioTransportClass::Welcome),
+                    occurrence: 1,
+                    ..Default::default()
+                },
+                label: "fresh-reentry-welcome-retry".into(),
+            });
+            settle(&mut steps, &delivery_order_without(&delivery_order, victim));
+            epoch += 1;
+            assert_client_state(&mut steps, "alice", epoch, clients.len());
+
+            let refusal_step = steps.len();
+            steps.push(ScenarioStep::ExpectTickError {
+                client: victim.into(),
+                error: "invalid_transition".into(),
+            });
+            expected.push(TraceExpectation::ExpectedError {
+                step_index: refusal_step,
+                client: victim.into(),
+                operation: "tick".into(),
+                error: "invalid_transition".into(),
+            });
+
+            // A newer Welcome cannot authenticate its own lineage. Only after
+            // the victim applies the commit from its currently trusted branch
+            // does the held byte-identical Welcome become a valid re-entry.
             steps.push(ScenarioStep::ReleaseWithheld {
                 label: "trusted-removal-after-stale-welcome".into(),
             });
+            settle_twice(&mut steps, &delivery_order);
+            steps.push(ScenarioStep::ReleaseWithheld {
+                label: "fresh-reentry-welcome-retry".into(),
+            });
             settle(&mut steps, &delivery_order);
-            assert_client_state(&mut steps, "alice", epoch, clients.len() - 1);
-            epoch = readd_and_probe(
-                &mut steps,
-                &mut expected,
-                &clients,
-                &delivery_order,
-                victim,
-                case_index,
-                0,
-                epoch,
-            );
+            assert_client_state(&mut steps, victim, epoch, clients.len());
+            probe_after_readd(&mut steps, &delivery_order, victim, case_index, 0);
         }
         ReentryArm::SelfLeaveMultiCommitterReentry => {
             steps.push(ScenarioStep::Leave {
@@ -421,16 +459,22 @@ pub fn generate_membership_reentry_case(seed: u64, case_index: u64) -> Generated
     expected.push(TraceExpectation::ClientsExactlyEquivalent {
         clients: clients.clone(),
     });
-    expected.push(TraceExpectation::NoPendingWork {
-        clients: clients
-            .iter()
-            .filter(|client| client.as_str() != victim)
-            .cloned()
-            .collect(),
-    });
-    expected.push(TraceExpectation::NoPendingWorkExceptRetainedJoinCommit {
-        client: victim.into(),
-    });
+    if arm == ReentryArm::StaleWelcomeThenFreshReentry {
+        expected.push(TraceExpectation::NoPendingWork {
+            clients: clients.clone(),
+        });
+    } else {
+        expected.push(TraceExpectation::NoPendingWork {
+            clients: clients
+                .iter()
+                .filter(|client| client.as_str() != victim)
+                .cloned()
+                .collect(),
+        });
+        expected.push(TraceExpectation::NoPendingWorkExceptRetainedJoinCommit {
+            client: victim.into(),
+        });
+    }
     expected.push(TraceExpectation::ClientsBidirectionallyDecryptable {
         clients: clients.clone(),
     });
@@ -568,6 +612,17 @@ fn readd_and_probe(
     assert_client_state(steps, "alice", epoch, clients.len());
     assert_client_state(steps, victim, epoch, clients.len());
 
+    probe_after_readd(steps, delivery_order, victim, case_index, cycle);
+    epoch
+}
+
+fn probe_after_readd(
+    steps: &mut Vec<ScenarioStep>,
+    delivery_order: &[String],
+    victim: &str,
+    case_index: u64,
+    cycle: usize,
+) {
     let payload = format!("membership-reentry:{case_index}:{cycle}:{victim}");
     steps.push(ScenarioStep::SendAppMessage {
         sender: victim.into(),
@@ -584,7 +639,6 @@ fn readd_and_probe(
             },
         },
     });
-    epoch
 }
 
 fn self_update(

--- a/crates/cgka-conformance-simulator/src/membership_reentry_family.rs
+++ b/crates/cgka-conformance-simulator/src/membership_reentry_family.rs
@@ -19,7 +19,7 @@ use rand::seq::SliceRandom;
 use rand::{Rng, SeedableRng};
 
 pub const MEMBERSHIP_REENTRY_FAMILY: &str = "membership-reentry/v1";
-pub const MEMBERSHIP_REENTRY_GENERATOR_VERSION: &str = "3";
+pub const MEMBERSHIP_REENTRY_GENERATOR_VERSION: &str = "1";
 
 const ARM_COUNT: u64 = 10;
 

--- a/crates/cgka-conformance-simulator/src/oracle.rs
+++ b/crates/cgka-conformance-simulator/src/oracle.rs
@@ -442,6 +442,7 @@ pub fn scenario_stimuli(spec: &ScenarioSpec) -> Vec<ScenarioStimulus> {
             }
             ScenarioStep::DeliverAll
             | ScenarioStep::Tick { .. }
+            | ScenarioStep::ExpectTickError { .. }
             | ScenarioStep::Observe { .. }
             | ScenarioStep::ObserveExact { .. }
             | ScenarioStep::ObserveAdminPolicy { .. }

--- a/crates/cgka-conformance-simulator/src/process_orchestrator.rs
+++ b/crates/cgka-conformance-simulator/src/process_orchestrator.rs
@@ -1953,6 +1953,7 @@ fn process_relay_control_error(error: ProcessRelayControlError) -> ProcessOrches
 fn action_participant(step: &ScenarioStep) -> Option<String> {
     match step {
         ScenarioStep::ExpectUpdateAdminPolicyError { client, .. }
+        | ScenarioStep::ExpectTickError { client, .. }
         | ScenarioStep::ClearStorageFault { target: client } => Some(client.clone()),
         ScenarioStep::InjectStorageFault { fault } => Some(fault.target.clone()),
         _ => None,

--- a/crates/cgka-conformance-simulator/src/report.rs
+++ b/crates/cgka-conformance-simulator/src/report.rs
@@ -808,7 +808,7 @@ fn next_value(
 }
 
 pub fn report_usage() -> &'static str {
-    "Usage: cgka-conformance-simulator-report [--replay-capsule FILE | --generated-input FILE ... [--adapter engine|retained-relay|app-runtime] | --vectors FILE_OR_DIR ... | --family send-leave/v1|convergence-e2e-delivery/v1|convergence-chaos/v1|admin-churn/v1|adversarial-reliability/v1|bounded-convergence-pressure/v1|large-group-pressure/v1|offline-catchup-pressure/v1|cross-route-restart-permutations/v1|cross-route-exact-restart-permutations/v1|chat-journey/v1 --seed N --cases N] [--out DIR] [--storage memory|file] [--strict-oracle|--allow-weak-oracle] [--capture-sensitive-replay] [--minimization-wall-time-secs N] [--minimization-max-trials N] [--minimization-trial-timeout-secs N]"
+    "Usage: cgka-conformance-simulator-report [--replay-capsule FILE | --generated-input FILE ... [--adapter engine|retained-relay|app-runtime] | --vectors FILE_OR_DIR ... | --family send-leave/v1|convergence-e2e-delivery/v1|convergence-chaos/v1|admin-churn/v1|adversarial-reliability/v1|bounded-convergence-pressure/v1|large-group-pressure/v1|offline-catchup-pressure/v1|membership-reentry/v1|cross-route-restart-permutations/v1|cross-route-exact-restart-permutations/v1|chat-journey/v1 --seed N --cases N] [--out DIR] [--storage memory|file] [--strict-oracle|--allow-weak-oracle] [--capture-sensitive-replay] [--minimization-wall-time-secs N] [--minimization-max-trials N] [--minimization-trial-timeout-secs N]"
 }
 
 #[cfg(test)]

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -132,6 +132,13 @@ pub enum ScenarioStep {
     Tick {
         clients: Vec<String>,
     },
+    /// Tick one participant and require the adapter to surface the named
+    /// normalized error. This keeps an expected, retryable transport refusal
+    /// in the trace without terminating the rest of the scenario.
+    ExpectTickError {
+        client: String,
+        error: String,
+    },
     /// Advance both convergence-clock domains without waking a participant.
     /// Use `Tick` to select which participant runtimes observe elapsed time.
     AdvanceTime {
@@ -248,6 +255,7 @@ impl ScenarioStep {
         "leave",
         "deliver_all",
         "tick",
+        "expect_tick_error",
         "advance_time",
         "await_quiescence",
         "observe",
@@ -311,6 +319,7 @@ impl ScenarioStep {
             ScenarioStep::Leave { .. } => "leave",
             ScenarioStep::DeliverAll => "deliver_all",
             ScenarioStep::Tick { .. } => "tick",
+            ScenarioStep::ExpectTickError { .. } => "expect_tick_error",
             ScenarioStep::AdvanceTime { .. } => "advance_time",
             ScenarioStep::AwaitQuiescence { .. } => "await_quiescence",
             ScenarioStep::Observe { .. } => "observe",
@@ -921,6 +930,31 @@ async fn execute_scenario_step(
                         step_index,
                         client: client_label,
                         operation: "update_admin_policy".into(),
+                        error: actual.code,
+                    });
+                }
+            }
+        }
+        ScenarioStep::ExpectTickError { client, error } => {
+            let client_label = client.clone();
+            match subject.tick(std::slice::from_ref(client)).await {
+                Ok(()) => {
+                    return Err(err(
+                        step_index,
+                        format!("tick unexpectedly succeeded; expected {error}"),
+                    ));
+                }
+                Err(actual) => {
+                    if &actual.code != error {
+                        return Err(err(
+                            step_index,
+                            format!("tick failed with {}; expected {error}", actual.code),
+                        ));
+                    }
+                    error_observations.push(ScenarioErrorObservation {
+                        step_index,
+                        client: client_label,
+                        operation: "tick".into(),
                         error: actual.code,
                     });
                 }

--- a/crates/cgka-conformance-simulator/src/scenario_ir.rs
+++ b/crates/cgka-conformance-simulator/src/scenario_ir.rs
@@ -16,12 +16,13 @@ use crate::{
 
 /// Stable canonical version for the original Scenario IR action set.
 pub const SCENARIO_IR_V2_VERSION: &str = "2";
-/// Canonical version that adds full group-profile updates.
+/// Canonical version that adds full group-profile updates and expected tick
+/// errors for retryable transport refusals.
 pub const SCENARIO_IR_V3_VERSION: &str = "3";
 /// Newest Scenario IR version emitted when newly authored actions require it.
 pub const SCENARIO_IR_LATEST_VERSION: &str = SCENARIO_IR_V3_VERSION;
 /// Action kinds introduced after Scenario IR v2.
-pub const SCENARIO_IR_V3_ONLY_STEP_KINDS: &[&str] = &["update_group_profile"];
+pub const SCENARIO_IR_V3_ONLY_STEP_KINDS: &[&str] = &["update_group_profile", "expect_tick_error"];
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ScenarioActionScheduleV2 {
@@ -336,6 +337,7 @@ fn validate_step(
         }
         ScenarioStep::SelfUpdate { client, .. }
         | ScenarioStep::UpdateGroupData { client, .. }
+        | ScenarioStep::ExpectTickError { client, .. }
         | ScenarioStep::Leave { client }
         | ScenarioStep::RestartClient { client }
         | ScenarioStep::SetClientOffline { client }

--- a/crates/cgka-conformance-simulator/src/stateful_generator.rs
+++ b/crates/cgka-conformance-simulator/src/stateful_generator.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 pub const STATEFUL_CHAT_JOURNEY_FAMILY: &str = "chat-journey/v1";
-pub const STATEFUL_CHAT_JOURNEY_GENERATOR_VERSION: &str = "1";
+pub const STATEFUL_CHAT_JOURNEY_GENERATOR_VERSION: &str = "2";
 
 const CLIENTS: [&str; 4] = ["alice", "bob", "carol", "david"];
 
@@ -76,7 +76,7 @@ struct JourneyModel {
     members: BTreeSet<String>,
     admins: BTreeSet<String>,
     online: BTreeSet<String>,
-    never_joined: BTreeSet<String>,
+    non_members: BTreeSet<String>,
     group_name: String,
     group_description: String,
     received_payloads: BTreeMap<String, Vec<String>>,
@@ -92,7 +92,7 @@ impl JourneyModel {
     fn new(case_index: u64, profile: JourneyProfile) -> Self {
         let group_name = format!("chat-journey-{case_index}");
         let clients = client_labels();
-        let (members, never_joined, founding_invitees) = match profile {
+        let (members, non_members, founding_invitees) = match profile {
             JourneyProfile::Membership => (
                 BTreeSet::from(["alice".into(), "bob".into()]),
                 BTreeSet::from(["carol".into(), "david".into()]),
@@ -111,7 +111,7 @@ impl JourneyModel {
             members,
             admins: BTreeSet::from(["alice".into()]),
             online: clients.iter().cloned().collect(),
-            never_joined,
+            non_members,
             group_name: group_name.clone(),
             group_description: String::new(),
             received_payloads: clients
@@ -149,7 +149,7 @@ impl JourneyModel {
 
         if self.profile == JourneyProfile::Membership && self.online.contains("alice") {
             actions.extend(
-                self.never_joined
+                self.non_members
                     .iter()
                     .cloned()
                     .map(|invitee| JourneyAction::Invite { invitee }),
@@ -239,7 +239,7 @@ impl JourneyModel {
     fn apply(&mut self, action: JourneyAction) {
         match action {
             JourneyAction::Invite { invitee } => {
-                debug_assert!(self.never_joined.contains(&invitee));
+                debug_assert!(self.non_members.contains(&invitee));
                 let pending = self.next_publication("invite");
                 self.steps.push(ScenarioStep::InviteMembers {
                     inviter: "alice".into(),
@@ -247,7 +247,8 @@ impl JourneyModel {
                     pending: pending.clone(),
                 });
                 self.members.insert(invitee.clone());
-                self.never_joined.remove(&invitee);
+                self.non_members.remove(&invitee);
+                self.online.insert(invitee.clone());
                 self.confirmed_mutation("alice", &pending);
             }
             JourneyAction::Remove { member } => {
@@ -260,7 +261,8 @@ impl JourneyModel {
                     pending: pending.clone(),
                 });
                 self.members.remove(&member);
-                self.online.remove(&member);
+                self.non_members.insert(member.clone());
+                self.self_updated_clients.remove(&member);
                 self.confirmed_mutation("alice", &pending);
             }
             JourneyAction::Send { sender } => {
@@ -563,7 +565,19 @@ pub fn generate_stateful_chat_journey_case(seed: u64, case_index: u64) -> Genera
     };
     if required_kind != JourneyActionKind::Restart {
         let action = model.choose_kind(&mut rng, required_kind);
+        let removed_member = match &action {
+            JourneyAction::Remove { member } if profile == JourneyProfile::Membership => {
+                Some(member.clone())
+            }
+            _ => None,
+        };
         model.apply(action);
+        // A membership-profile case in every eight-case rotation guarantees
+        // the remove -> fresh re-invite interaction. Removed identities remain
+        // legal invite candidates for later random actions as well.
+        if let Some(invitee) = removed_member {
+            model.apply(JourneyAction::Invite { invitee });
+        }
     }
 
     let extra_actions = 4 + rng.gen_range(0..5);

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -38,6 +38,7 @@ pub enum SubjectCapability {
     GroupMutation,
     ApplicationMessaging,
     TransportDelivery,
+    ExpectedTransportErrorObservation,
     EventObservation,
     ExactConformanceObservation,
     ActiveDecryptabilityProbe,
@@ -64,6 +65,7 @@ impl SubjectCapability {
             Self::GroupMutation => "group_mutation",
             Self::ApplicationMessaging => "application_messaging",
             Self::TransportDelivery => "transport_delivery",
+            Self::ExpectedTransportErrorObservation => "expected_transport_error_observation",
             Self::EventObservation => "event_observation",
             Self::ExactConformanceObservation => "exact_conformance_observation",
             Self::ActiveDecryptabilityProbe => "active_decryptability_probe",
@@ -615,6 +617,11 @@ pub fn required_capabilities(step: &ScenarioStep) -> Vec<SubjectCapability> {
             capabilities.push(SubjectCapability::OutboundPublication);
         }
         capabilities
+    } else if matches!(step, ScenarioStep::ExpectTickError { .. }) {
+        vec![
+            SubjectCapability::TransportDelivery,
+            SubjectCapability::ExpectedTransportErrorObservation,
+        ]
     } else {
         vec![match step {
             ScenarioStep::CreateGroup { .. }
@@ -667,6 +674,7 @@ pub fn required_capabilities(step: &ScenarioStep) -> Vec<SubjectCapability> {
             ScenarioStep::Barrier { .. } => unreachable!("handled above"),
             ScenarioStep::Assert { .. } => unreachable!("handled above"),
             ScenarioStep::AwaitQuiescence { .. } => unreachable!("handled above"),
+            ScenarioStep::ExpectTickError { .. } => unreachable!("handled above"),
             ScenarioStep::InGroup { .. } => unreachable!("handled above"),
         }]
     }
@@ -842,6 +850,7 @@ impl EngineHarnessSubject {
             SubjectCapability::GroupMutation,
             SubjectCapability::ApplicationMessaging,
             SubjectCapability::TransportDelivery,
+            SubjectCapability::ExpectedTransportErrorObservation,
             SubjectCapability::EventObservation,
             SubjectCapability::ExactConformanceObservation,
             SubjectCapability::ActiveDecryptabilityProbe,

--- a/crates/cgka-conformance-simulator/tests/AGENTS.md
+++ b/crates/cgka-conformance-simulator/tests/AGENTS.md
@@ -37,6 +37,11 @@ determinism, reachability, interaction-coverage, and promotion checks when addin
     oracles, exact retained-join pending-work classification, sampled delivery/decryptability coverage, and the normal
     mid-size application and incremental-join executable canaries.
 
+- **File:** `membership_reentry_family.rs`
+  - **Owns:** Deterministic single/repeated departure and fresh-Welcome re-entry, restart/self-update/self-leave
+    interactions, stale-Welcome recovery, strict terminal state/input/decryptability oracles, and family registration
+    and prefix stability.
+
 - **File:** `offline_catchup_family.rs`
   - **Owns:** Deterministic offline-backlog volume/recovery profiles, retained-relay enforcement, terminal-only
     reconnect, exact backlog multiplicity, strict pending-work/equivalence/decryptability oracles, and file-backed

--- a/crates/cgka-conformance-simulator/tests/membership_reentry_family.rs
+++ b/crates/cgka-conformance-simulator/tests/membership_reentry_family.rs
@@ -63,10 +63,17 @@ fn complete_catalog_guarantees_reentry_and_high_risk_interactions() {
             expectation,
             TraceExpectation::ClientsBidirectionallyDecryptable { .. }
         )));
-        assert!(case.expected_outcomes.iter().any(|expectation| matches!(
-            expectation,
-            TraceExpectation::NoPendingWorkExceptRetainedJoinCommit { .. }
-        )));
+        if case.case_index == 7 {
+            assert!(case.expected_outcomes.iter().any(|expectation| matches!(
+                expectation,
+                TraceExpectation::NoPendingWork { clients } if clients == &case.scenario.clients
+            )));
+        } else {
+            assert!(case.expected_outcomes.iter().any(|expectation| matches!(
+                expectation,
+                TraceExpectation::NoPendingWorkExceptRetainedJoinCommit { .. }
+            )));
+        }
     }
 
     assert!(
@@ -92,6 +99,52 @@ fn complete_catalog_guarantees_reentry_and_high_risk_interactions() {
         step,
         ScenarioStep::WithholdMessage { label, .. } if label == "stale-original-welcome"
     )));
+    let case_7_steps = &cases[7].scenario.steps;
+    let step_index = |predicate: &dyn Fn(&ScenarioStep) -> bool| {
+        case_7_steps
+            .iter()
+            .position(predicate)
+            .expect("case 7 must contain the expected retry step")
+    };
+    let fresh_invite = step_index(
+        &|step| matches!(step, ScenarioStep::InviteMembers { pending, .. } if pending == "readd-0"),
+    );
+    let refused_fresh_welcome = step_index(&|step| {
+        matches!(
+            step,
+            ScenarioStep::ExpectTickError { error, .. } if error == "invalid_transition"
+        )
+    });
+    let trusted_removal = step_index(&|step| {
+        matches!(
+            step,
+            ScenarioStep::ReleaseWithheld { label }
+                if label == "trusted-removal-after-stale-welcome"
+        )
+    });
+    let welcome_retry = step_index(&|step| {
+        matches!(
+            step,
+            ScenarioStep::ReleaseWithheld { label }
+                if label == "fresh-reentry-welcome-retry"
+        )
+    });
+    assert!(fresh_invite < refused_fresh_welcome);
+    assert!(refused_fresh_welcome < trusted_removal);
+    assert!(trusted_removal < welcome_retry);
+    assert!(
+        cases[7]
+            .expected_outcomes
+            .iter()
+            .any(|expectation| matches!(
+                expectation,
+                TraceExpectation::ExpectedError {
+                    operation,
+                    error,
+                    ..
+                } if operation == "tick" && error == "invalid_transition"
+            ))
+    );
     assert_eq!(cases[8].scenario.clients.len(), 8);
     assert!(cases[8].scenario.steps.iter().any(|step| matches!(
         step,

--- a/crates/cgka-conformance-simulator/tests/membership_reentry_family.rs
+++ b/crates/cgka-conformance-simulator/tests/membership_reentry_family.rs
@@ -1,0 +1,241 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use cgka_conformance_simulator::{
+    MEMBERSHIP_REENTRY_FAMILY, MEMBERSHIP_REENTRY_GENERATOR_VERSION, ScenarioStep,
+    TraceExpectation, compile_scenario, generate_family_case, generate_membership_reentry_case,
+    generate_membership_reentry_family, run_generated_case_report,
+};
+
+const COMPLETE_CATALOG_CASES: usize = 10;
+const MULTI_COMMITTER_INCIDENT_CASE: u64 = 8;
+const PARTIAL_MULTI_COMMITTER_INCIDENT_CASE: u64 = 9;
+
+#[test]
+fn catalog_is_deterministic_prefix_stable_registered_and_varies_by_seed() {
+    let seed = 0x5eed;
+    let short = generate_membership_reentry_family(seed, COMPLETE_CATALOG_CASES);
+    let long = generate_membership_reentry_family(seed, COMPLETE_CATALOG_CASES * 2);
+
+    assert_eq!(
+        short,
+        generate_membership_reentry_family(seed, COMPLETE_CATALOG_CASES)
+    );
+    assert_eq!(short, long[..short.len()]);
+    assert_ne!(
+        short,
+        generate_membership_reentry_family(seed + 1, COMPLETE_CATALOG_CASES)
+    );
+    for (case_index, case) in short.iter().enumerate() {
+        assert_eq!(case.family_name, MEMBERSHIP_REENTRY_FAMILY);
+        assert_eq!(case.generator_version, MEMBERSHIP_REENTRY_GENERATOR_VERSION);
+        assert_eq!(
+            case,
+            &generate_family_case(MEMBERSHIP_REENTRY_FAMILY, seed, case_index as u64)
+                .expect("membership-reentry family is registered")
+        );
+        compile_scenario(&case.scenario)
+            .unwrap_or_else(|error| panic!("{}: {error}", case.scenario.name));
+    }
+}
+
+#[test]
+fn complete_catalog_guarantees_reentry_and_high_risk_interactions() {
+    let cases = generate_membership_reentry_family(2026, COMPLETE_CATALOG_CASES);
+    let expected_cycles = [1, 2, 3, 2, 1, 1, 1, 1, 1, 1];
+
+    for (case, expected_cycle_count) in cases.iter().zip(expected_cycles) {
+        let readds = case
+            .scenario
+            .steps
+            .iter()
+            .filter(|step| matches!(step, ScenarioStep::InviteMembers { pending, .. } if pending.starts_with("readd-")))
+            .count();
+        assert_eq!(
+            readds, expected_cycle_count,
+            "{} must retain its declared re-entry count",
+            case.scenario.name
+        );
+        assert!(case.expected_outcomes.iter().any(|expectation| matches!(
+            expectation,
+            TraceExpectation::ClientsExactlyEquivalent { .. }
+        )));
+        assert!(case.expected_outcomes.iter().any(|expectation| matches!(
+            expectation,
+            TraceExpectation::ClientsBidirectionallyDecryptable { .. }
+        )));
+        assert!(case.expected_outcomes.iter().any(|expectation| matches!(
+            expectation,
+            TraceExpectation::NoPendingWorkExceptRetainedJoinCommit { .. }
+        )));
+    }
+
+    assert!(
+        cases[2]
+            .scenario
+            .steps
+            .iter()
+            .any(|step| matches!(step, ScenarioStep::RestartClient { .. }))
+    );
+    assert!(cases[3..=4].iter().all(|case| {
+        case.scenario
+            .steps
+            .iter()
+            .any(|step| matches!(step, ScenarioStep::SelfUpdate { .. }))
+    }));
+    assert!(cases[5..=6].iter().all(|case| {
+        case.scenario
+            .steps
+            .iter()
+            .any(|step| matches!(step, ScenarioStep::Leave { .. }))
+    }));
+    assert!(cases[7].scenario.steps.iter().any(|step| matches!(
+        step,
+        ScenarioStep::WithholdMessage { label, .. } if label == "stale-original-welcome"
+    )));
+    assert_eq!(cases[8].scenario.clients.len(), 8);
+    assert!(cases[8].scenario.steps.iter().any(|step| matches!(
+        step,
+        ScenarioStep::Tick { clients } if clients.len() == 7
+    )));
+    assert_eq!(
+        cases[8]
+            .scenario
+            .steps
+            .iter()
+            .filter(|step| matches!(
+                step,
+                ScenarioStep::AcknowledgeOutbound {
+                    publication: None,
+                    ..
+                }
+            ))
+            .count(),
+        8,
+        "seven competing SelfRemove committers plus the re-added member's probe message"
+    );
+    assert_eq!(cases[9].scenario.clients.len(), 8);
+    let partial_committer_count = cases[9]
+        .scenario
+        .steps
+        .iter()
+        .find_map(|step| match step {
+            ScenarioStep::Tick { clients } if (2..=4).contains(&clients.len()) => {
+                Some(clients.len())
+            }
+            _ => None,
+        })
+        .expect("partial-impact arm ticks only a handful of early committers");
+    assert_eq!(
+        cases[9]
+            .scenario
+            .steps
+            .iter()
+            .filter(|step| matches!(
+                step,
+                ScenarioStep::AcknowledgeOutbound {
+                    publication: None,
+                    ..
+                }
+            ))
+            .count(),
+        partial_committer_count + 1,
+        "only the early competing committers and re-added member's probe are auto-acknowledged"
+    );
+
+    let mut removals_by_case = BTreeMap::new();
+    for case in &cases {
+        let removed = case
+            .scenario
+            .steps
+            .iter()
+            .filter_map(|step| match step {
+                ScenarioStep::RemoveMembers { members, .. } => Some(members.clone()),
+                _ => None,
+            })
+            .flatten()
+            .collect::<BTreeSet<_>>();
+        let readded = case
+            .scenario
+            .steps
+            .iter()
+            .filter_map(|step| match step {
+                ScenarioStep::InviteMembers {
+                    invitees, pending, ..
+                } if pending.starts_with("readd-") => Some(invitees.clone()),
+                _ => None,
+            })
+            .flatten()
+            .collect::<BTreeSet<_>>();
+        if !removed.is_empty() {
+            assert_eq!(
+                removed, readded,
+                "{} re-adds its victim",
+                case.scenario.name
+            );
+        }
+        removals_by_case.insert(case.case_index, removed);
+    }
+    assert_eq!(removals_by_case.len(), COMPLETE_CATALOG_CASES);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ordinary_catalog_passes_strict_runtime_oracles() {
+    for case_index in 0..COMPLETE_CATALOG_CASES as u64 {
+        let case = generate_membership_reentry_case(2026, case_index);
+        let report = run_generated_case_report(&case, None)
+            .await
+            .unwrap_or_else(|error| panic!("{}: {error}", case.scenario.name));
+        assert!(
+            report.expectation_failures.is_empty(),
+            "{} expectation failures: {:#?}",
+            case.scenario.name,
+            report.expectation_failures
+        );
+        assert!(
+            report.invariant_failures.is_empty(),
+            "{} invariant failures: {:#?}",
+            case.scenario.name,
+            report.invariant_failures
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn multi_committer_self_leave_reentry_passes_strict_runtime_oracles() {
+    let case = generate_membership_reentry_case(2026, MULTI_COMMITTER_INCIDENT_CASE);
+    let report = run_generated_case_report(&case, None)
+        .await
+        .unwrap_or_else(|error| panic!("{}: {error}", case.scenario.name));
+    assert!(
+        report.expectation_failures.is_empty(),
+        "{} expectation failures: {:#?}",
+        case.scenario.name,
+        report.expectation_failures
+    );
+    assert!(
+        report.invariant_failures.is_empty(),
+        "{} invariant failures: {:#?}",
+        case.scenario.name,
+        report.invariant_failures
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn partial_multi_committer_self_leave_reentry_passes_strict_runtime_oracles() {
+    let case = generate_membership_reentry_case(2026, PARTIAL_MULTI_COMMITTER_INCIDENT_CASE);
+    let report = run_generated_case_report(&case, None)
+        .await
+        .unwrap_or_else(|error| panic!("{}: {error}", case.scenario.name));
+    assert!(
+        report.expectation_failures.is_empty(),
+        "{} expectation failures: {:#?}",
+        case.scenario.name,
+        report.expectation_failures
+    );
+    assert!(
+        report.invariant_failures.is_empty(),
+        "{} invariant failures: {:#?}",
+        case.scenario.name,
+        report.invariant_failures
+    );
+}

--- a/crates/cgka-conformance-simulator/tests/scenario_ir.rs
+++ b/crates/cgka-conformance-simulator/tests/scenario_ir.rs
@@ -6,8 +6,8 @@ use cgka_conformance_simulator::{
     HarnessStorageMode, SCENARIO_IR_V3_ONLY_STEP_KINDS, ScenarioAccountV2, ScenarioAssertionV2,
     ScenarioComparison, ScenarioDeviceV2, ScenarioMessageSelectorV2, ScenarioPredicateV2,
     ScenarioProcessV2, ScenarioResourceMetric, ScenarioSpec, ScenarioStep, ScenarioTopologyV2,
-    ScenarioTransportClass, SubjectOutboundOutcome, VectorFixture, compile_scenario,
-    run_scenario_report, run_vector_fixture_report_with_capture,
+    ScenarioTransportClass, SubjectCapability, SubjectOutboundOutcome, VectorFixture,
+    compile_scenario, run_scenario_report, run_vector_fixture_report_with_capture,
 };
 
 fn topology_for_accounts(entries: &[(&str, &str)]) -> ScenarioTopologyV2 {
@@ -76,7 +76,7 @@ fn v2_schema_declares_every_v2_executable_step_kind() {
 }
 
 #[test]
-fn v3_schema_adds_full_group_profile_updates_without_rewriting_v2() {
+fn v3_schema_adds_post_v2_actions_without_rewriting_v2() {
     let v2_schema: serde_json::Value =
         serde_json::from_str(include_str!("../schemas/scenario-ir.v2.schema.json"))
             .expect("scenario IR v2 schema parses");
@@ -128,6 +128,45 @@ fn v3_schema_adds_full_group_profile_updates_without_rewriting_v2() {
             .copied()
             .collect::<BTreeSet<_>>()
     );
+}
+
+#[test]
+fn expected_tick_error_is_v3_only_and_validates_its_client() {
+    let mut scenario = ScenarioSpec {
+        name: "scenario-ir/expected-tick-error-v3".into(),
+        spec_version: "3".into(),
+        clients: vec!["alice".into()],
+        topology: Default::default(),
+        steps: vec![ScenarioStep::ExpectTickError {
+            client: "alice".into(),
+            error: "invalid_transition".into(),
+        }],
+    };
+
+    let compiled = compile_scenario(&scenario).expect("v3 expected tick error compiles");
+    assert_eq!(
+        compiled.actions[0].schedule.action_type,
+        "expect_tick_error"
+    );
+    assert_eq!(
+        compiled.actions[0].schedule.required_capabilities,
+        BTreeSet::from([
+            SubjectCapability::TransportDelivery,
+            SubjectCapability::ExpectedTransportErrorObservation,
+        ])
+    );
+
+    scenario.spec_version = "2".into();
+    let error = compile_scenario(&scenario).expect_err("v2 must reject the v3 action");
+    assert!(error.message.contains("requires ScenarioSpec version 3"));
+
+    scenario.spec_version = "3".into();
+    scenario.steps = vec![ScenarioStep::ExpectTickError {
+        client: "bob".into(),
+        error: "invalid_transition".into(),
+    }];
+    let error = compile_scenario(&scenario).expect_err("unknown client must fail");
+    assert!(error.message.contains("unknown client bob"));
 }
 
 #[test]

--- a/crates/cgka-conformance-simulator/tests/stateful_generator.rs
+++ b/crates/cgka-conformance-simulator/tests/stateful_generator.rs
@@ -12,6 +12,7 @@ fn generated_journeys_are_deterministic_legal_canonical_ir() {
     assert_eq!(cases, generate_stateful_chat_journey_family(0x5eed, 8));
 
     let mut corpus_kinds = BTreeSet::new();
+    let mut observed_reentry = false;
     for (case_index, case) in cases.iter().enumerate() {
         assert_eq!(case.scenario.spec_version, "3");
         compile_scenario(&case.scenario).expect("generated canonical IR compiles");
@@ -24,6 +25,7 @@ fn generated_journeys_are_deterministic_legal_canonical_ir() {
             .map(ScenarioStep::kind)
             .collect::<BTreeSet<_>>();
         corpus_kinds.extend(kinds.iter().copied());
+        observed_reentry |= contains_remove_then_reinvite(&case.scenario.steps);
         assert!(kinds.contains("update_group_profile"));
         assert!(kinds.contains("send_app_message"));
         assert!(kinds.contains("observe_exact"));
@@ -46,6 +48,11 @@ fn generated_journeys_are_deterministic_legal_canonical_ir() {
             assert!(kinds.contains("await_quiescence"));
         }
     }
+
+    assert!(
+        observed_reentry,
+        "the eight-case rotation must exercise a removed identity's fresh re-invitation"
+    );
 
     for required in [
         "invite_members",
@@ -188,6 +195,7 @@ fn assert_legal_journey(steps: &[ScenarioStep]) {
                 for invitee in invitees {
                     assert!(!members.contains(invitee));
                     members.insert(invitee.clone());
+                    online.insert(invitee.clone());
                 }
             }
             ScenarioStep::RemoveMembers {
@@ -201,7 +209,6 @@ fn assert_legal_journey(steps: &[ScenarioStep]) {
                 for member in removed {
                     assert!(members.remove(member));
                     admins.remove(member);
-                    online.remove(member);
                 }
             }
             ScenarioStep::SelfUpdate { client, .. }
@@ -241,4 +248,22 @@ fn assert_legal_journey(steps: &[ScenarioStep]) {
             _ => {}
         }
     }
+}
+
+fn contains_remove_then_reinvite(steps: &[ScenarioStep]) -> bool {
+    let mut removed = BTreeSet::new();
+    for step in steps {
+        match step {
+            ScenarioStep::RemoveMembers { members, .. } => {
+                removed.extend(members.iter().cloned());
+            }
+            ScenarioStep::InviteMembers { invitees, .. }
+                if invitees.iter().any(|invitee| removed.contains(invitee)) =>
+            {
+                return true;
+            }
+            _ => {}
+        }
+    }
+    false
 }

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -316,8 +316,15 @@ impl<S: StorageProvider> Engine<S> {
         &self,
         group_id: &GroupId,
     ) -> Result<CanonicalizationPolicy, OpenMlsProjectionError> {
-        let Some(policy_bytes) = self
-            .storage
+        self.convergence_policy_for_group_on_storage(&self.storage, group_id)
+    }
+
+    fn convergence_policy_for_group_on_storage(
+        &self,
+        storage: &S,
+        group_id: &GroupId,
+    ) -> Result<CanonicalizationPolicy, OpenMlsProjectionError> {
+        let Some(policy_bytes) = storage
             .convergence_policy(group_id)
             .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?
         else {
@@ -331,6 +338,28 @@ impl<S: StorageProvider> Engine<S> {
         let policy = decode_convergence_policy(&policy_bytes)?;
         self.accept_convergence_policy(&policy)?;
         Ok(policy)
+    }
+
+    pub(crate) fn retain_current_epoch_snapshot_on_storage(
+        &self,
+        storage: &S,
+        group_id: &GroupId,
+    ) -> Result<(), cgka_traits::error::EngineError> {
+        let policy = self
+            .convergence_policy_for_group_on_storage(storage, group_id)
+            .map_err(|error| {
+                cgka_traits::error::EngineError::Backend(format!(
+                    "load convergence policy: {error}"
+                ))
+            })?;
+        retain_current_group_epoch_snapshot(
+            storage,
+            group_id,
+            policy.convergence.max_rewind_commits,
+        )
+        .map_err(|error| {
+            cgka_traits::error::EngineError::Backend(format!("retain anchor: {error}"))
+        })
     }
 
     pub(crate) fn convergence_policy_for_group(

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -1039,6 +1039,26 @@ impl<S: StorageProvider> Engine<S> {
                         Err(cgka_traits::storage::StorageError::NotFound) => (false, false),
                         Err(error) => return Err(EngineError::Storage(error)),
                     };
+                if local_state_is_stale
+                    && let Some(state) = self.epoch_manager.state(&group_id)
+                    && state.is_resolving_local_publish()
+                {
+                    // The held publication belongs to the local group copy
+                    // this replacement would discard. Let its explicit
+                    // confirm/rollback transition finish first; otherwise the
+                    // durable replacement can commit while `set_stable` below
+                    // correctly refuses to overwrite PendingPublish/Merging,
+                    // splitting the epoch manager from the installed group.
+                    // This error is deliberately non-terminal for Welcome
+                    // deduplication, so the identical Welcome can be retried.
+                    return Err(EngineError::InvalidTransition(
+                        cgka_traits::engine_state::InvalidTransition {
+                            from: state.name(),
+                            to: "JoinWelcome",
+                            reason: "replacement Welcome requires the local publication to resolve",
+                        },
+                    ));
+                }
                 if local_state_is_stale {
                     self.clear_live_openmls_group_on_storage(storage, &group_id)?;
                 }

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -1002,43 +1002,56 @@ impl<S: StorageProvider> Engine<S> {
                 }
 
                 let mut superseded: Vec<(MessageId, EpochId)> = Vec::new();
-                let (local_state_is_stale, repaired_unrecoverable) =
-                    match storage.get_group(&group_id) {
-                        Ok(group) => {
-                            let self_is_recorded_member = group
-                                .members
-                                .iter()
-                                .any(|member| &member.id == self.identity.self_id());
-                            if self_is_recorded_member
-                                && !group.unrecoverable
-                                && incoming_epoch <= group.epoch
-                            {
+                let (local_state_is_stale, repaired_unrecoverable) = match storage
+                    .get_group(&group_id)
+                {
+                    Ok(group) => {
+                        let self_is_recorded_member = group
+                            .members
+                            .iter()
+                            .any(|member| &member.id == self.identity.self_id());
+                        if self_is_recorded_member && !group.unrecoverable {
+                            if incoming_epoch <= group.epoch {
                                 // A distinct transport/content id does not make a
                                 // same- or older-epoch Welcome for an already-active
                                 // group a rejoin. Reject before OpenMLS staging and
                                 // let the surrounding transaction restore KeyPackage
                                 // consumption and every tentative write.
-                                //
-                                // A strictly newer Welcome is different: local state
-                                // can still list this device because a delayed older
-                                // Welcome was accepted after the device had already
-                                // been removed elsewhere. A later legitimate re-add
-                                // must be allowed through the fully authenticated
-                                // replacement path below rather than being mistaken
-                                // for a duplicate solely from that stale local view.
                                 return Err(EngineError::WelcomeAlreadyProcessed);
                             }
-                            // Unrecoverable is the explicit exception: a fully
-                            // authenticated replacement Welcome is a protocol-defined
-                            // repair even though the frozen record still lists us as
-                            // a member. The surrounding transaction restores the old
-                            // OpenMLS state and KeyPackage on any later validation
-                            // failure, so clearing the live rows remains tentative.
-                            (true, group.unrecoverable)
+
+                            // Epoch freshness is not branch continuity. A member can
+                            // fork the same group id, advance that fork, rewrite its
+                            // admin component, and issue a cryptographically valid
+                            // newer Welcome. Replacing healthy active state here would
+                            // let that uncorroborated fork destroy the trusted branch.
+                            //
+                            // A legitimate re-entry remains possible after this engine
+                            // processes the current branch's removal, at which point the
+                            // durable record no longer lists this identity. This error is
+                            // deliberately non-terminal so that exact Welcome can be
+                            // retried after the trusted removal arrives. Consulting the
+                            // durable record also closes the cold-start window before the
+                            // epoch manager has been hydrated.
+                            return Err(EngineError::InvalidTransition(
+                                cgka_traits::engine_state::InvalidTransition {
+                                    from: "ActiveMember",
+                                    to: "JoinWelcome",
+                                    reason: "replacement Welcome requires trusted removal evidence",
+                                },
+                            ));
                         }
-                        Err(cgka_traits::storage::StorageError::NotFound) => (false, false),
-                        Err(error) => return Err(EngineError::Storage(error)),
-                    };
+                        // Unrecoverable is the explicit exception: a fully
+                        // authenticated replacement Welcome is a protocol-defined
+                        // repair even though the frozen record still lists us as
+                        // a member. The surrounding transaction restores the old
+                        // OpenMLS state and KeyPackage on any later validation
+                        // failure, so clearing the live rows remains tentative.
+                        (true, group.unrecoverable)
+                    }
+                    Err(cgka_traits::storage::StorageError::NotFound) => (false, false),
+                    Err(error) => return Err(EngineError::Storage(error)),
+                };
                 if local_state_is_stale
                     && let Some(state) = self.epoch_manager.state(&group_id)
                     && state.is_resolving_local_publish()

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -950,8 +950,8 @@ impl<S: StorageProvider> Engine<S> {
         // Building a group from a staged Welcome performs the same multi-row
         // OpenMLS store as group creation. Keep KeyPackage consumption, stale
         // live-state clearing, that store, every Marmot post-check, the
-        // discoverable group record, capability cache, and both durable
-        // Welcome dispositions in one transaction.
+        // discoverable group record, joined-epoch recovery anchor, capability
+        // cache, and both durable Welcome dispositions in one transaction.
         let (group_id, mls_group, welcome_sender_id, repaired_unrecoverable, superseded) =
             self.storage.with_transaction(|storage| {
                 let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, storage.mls_storage());
@@ -990,6 +990,13 @@ impl<S: StorageProvider> Engine<S> {
                         .as_slice()
                         .to_vec(),
                 );
+                // The epoch is still unverified at this point. It is used only
+                // to decide whether a distinct Welcome is worth attempting as
+                // a replacement for local live state. Every replacement write
+                // remains inside this transaction and is committed only after
+                // OpenMLS verifies the GroupInfo and the Marmot membership,
+                // capability, and admin checks below all succeed.
+                let incoming_epoch = EpochId(processed.unverified_group_info().epoch().as_u64());
                 if storage.disband_tombstone(&group_id)?.is_some() {
                     return Err(EngineError::InvalidWelcome);
                 }
@@ -1002,12 +1009,23 @@ impl<S: StorageProvider> Engine<S> {
                                 .members
                                 .iter()
                                 .any(|member| &member.id == self.identity.self_id());
-                            if self_is_recorded_member && !group.unrecoverable {
+                            if self_is_recorded_member
+                                && !group.unrecoverable
+                                && incoming_epoch <= group.epoch
+                            {
                                 // A distinct transport/content id does not make a
-                                // second normal Welcome for an already-active group
-                                // a rejoin. Reject before OpenMLS staging and let
-                                // the surrounding transaction restore KeyPackage
+                                // same- or older-epoch Welcome for an already-active
+                                // group a rejoin. Reject before OpenMLS staging and
+                                // let the surrounding transaction restore KeyPackage
                                 // consumption and every tentative write.
+                                //
+                                // A strictly newer Welcome is different: local state
+                                // can still list this device because a delayed older
+                                // Welcome was accepted after the device had already
+                                // been removed elsewhere. A later legitimate re-add
+                                // must be allowed through the fully authenticated
+                                // replacement path below rather than being mistaken
+                                // for a duplicate solely from that stale local view.
                                 return Err(EngineError::WelcomeAlreadyProcessed);
                             }
                             // Unrecoverable is the explicit exception: a fully
@@ -1202,6 +1220,14 @@ impl<S: StorageProvider> Engine<S> {
                     lifecycle.last_consumed_at = Some(joined_at);
                     maintenance.put_key_package_lifecycle(&lifecycle)?;
                 }
+
+                // A Welcome-installed member must retain the joined epoch
+                // before it can safely advance locally. Otherwise a sibling
+                // commit authored from this epoch but delivered after our own
+                // publish cannot be peeled and never enters convergence. Keep
+                // the anchor in this transaction so a snapshot failure also
+                // restores the consumed KeyPackage and every staged join row.
+                self.retain_current_epoch_snapshot_on_storage(storage, &group_id)?;
 
                 Ok::<_, EngineError>((
                     group_id,

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -1258,8 +1258,17 @@ fn seed_stored_openmls_graph_inputs<S: StorageProvider>(
                     state: record.state,
                 });
             }
+            // A proposal consumed by this device's locally confirmed commit
+            // is `Processed`, but it is still a prerequisite for replaying a
+            // sibling commit that references the same proposal. Excluding it
+            // makes every committer able to materialize only its own
+            // checkpointed branch, so each independently declares its local
+            // sibling canonical. Re-admit retained processed proposals to the
+            // candidate graph exactly like processed commits and application
+            // witnesses; canonical apply skips one already consumed by an
+            // accepted prefix using its authenticated source epoch.
             OpenMlsContentKind::Proposal
-                if record_state_is_canonicalization_input(record.state)
+                if record_state_can_contribute_to_openmls_graph(record.state)
                     && source_epoch.is_some_and(|epoch| epoch >= retained_anchor_epoch) =>
             {
                 pending_messages.push(message)
@@ -3030,16 +3039,6 @@ fn required_capabilities_from_group(
         caps.app_components = components;
     }
     caps
-}
-
-fn record_state_is_canonicalization_input(state: MessageState) -> bool {
-    matches!(
-        state,
-        MessageState::Sent
-            | MessageState::Created
-            | MessageState::Retryable
-            | MessageState::ConvergenceDeferred
-    )
 }
 
 /// Whether a stored row in this state is an input to the OpenMLS graph the

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -1268,8 +1268,7 @@ fn seed_stored_openmls_graph_inputs<S: StorageProvider>(
             // witnesses; canonical apply skips one already consumed by an
             // accepted prefix using its authenticated source epoch.
             OpenMlsContentKind::Proposal
-                if record_state_can_contribute_to_openmls_graph(record.state)
-                    && source_epoch.is_some_and(|epoch| epoch >= retained_anchor_epoch) =>
+                if source_epoch.is_some_and(|epoch| epoch >= retained_anchor_epoch) =>
             {
                 pending_messages.push(message)
             }
@@ -3100,7 +3099,7 @@ fn message_state_for_dropped_reason(reason: DroppedMessageReason) -> MessageStat
 ///   tip convergence settled on — the commit that advances the group to its
 ///   epoch has not been selected yet (ordinary out-of-order relay delivery,
 ///   mdk#144). Persisting it as the terminal `EpochInvalidated` would
-///   permanently drop it: `record_state_is_canonicalization_input` never
+///   permanently drop it: `record_state_can_contribute_to_openmls_graph` never
 ///   re-admits `EpochInvalidated`, so the buffered message could never re-enter
 ///   convergence once that commit arrives. Keep it `Retryable` so a later
 ///   canonicalize pass re-feeds and applies it; ordinary current results do not

--- a/crates/cgka-engine/tests/epoch_sealed_transport.rs
+++ b/crates/cgka-engine/tests/epoch_sealed_transport.rs
@@ -118,7 +118,7 @@ async fn ordinary_delivery_still_converges_when_the_transport_seals_per_epoch() 
     // The visibility model must not break the uncontested path: a member that
     // shares the sender's epoch state peels and applies exactly as before.
     let mut alice = build_client(b"sealed-alice");
-    let mut bob = build_client(b"sealed-bob");
+    let (mut bob, bob_storage) = build_client_with_storage(b"sealed-bob");
     let mut carol = build_client(b"sealed-carol");
 
     let bob_kp = bob.fresh_key_package().await.unwrap();
@@ -144,6 +144,13 @@ async fn ordinary_delivery_still_converges_when_the_transport_seals_per_epoch() 
         other => panic!("unexpected create result: {other:?}"),
     };
     bob.join_welcome(welcome).await.unwrap();
+    assert!(
+        bob_storage
+            .list_group_snapshots(&group_id)
+            .unwrap()
+            .contains(&"openmls-retained-anchor-1".to_string()),
+        "a Welcome join must atomically retain its joined epoch for later sibling-branch peeling"
+    );
 
     let carol_kp = carol.fresh_key_package().await.unwrap();
     let commit = match alice

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -121,6 +121,22 @@ fn content_id(msg: &TransportMessage) -> MessageId {
     MessageId::new(Sha256::digest(&msg.payload).to_vec())
 }
 
+fn take_welcome_for(
+    welcomes: &mut Vec<TransportMessage>,
+    recipient: &MemberId,
+) -> TransportMessage {
+    let index = welcomes
+        .iter()
+        .position(|welcome| {
+            matches!(
+                &welcome.envelope,
+                TransportEnvelope::Welcome { recipient: target } if target == recipient
+            )
+        })
+        .expect("welcome for recipient");
+    welcomes.remove(index)
+}
+
 /// Encode a `marmot.group.admin-policy.v1` state from raw 32-byte account keys,
 /// sorted + deduped per the component rules. Mirrors the same-named helper in
 /// `tests/update_group_data.rs`; kept file-local so this test file stays
@@ -1903,6 +1919,143 @@ async fn readd_after_remove_produces_fresh_welcome_join() {
     );
 }
 
+/// A delayed Welcome can install an apparently active local view after the
+/// rest of the group has already removed that identity. A later, strictly
+/// newer re-add Welcome must replace that stale view, while an older Welcome
+/// must never downgrade an already-current client.
+#[tokio::test]
+async fn newer_readd_welcome_replaces_stale_active_view_without_allowing_downgrade() {
+    let mut alice = build_client(b"alice-stale-welcome");
+    let mut bob = build_client(b"bob-stale-welcome");
+    let (mut carol, carol_storage) = build_with_storage(b"carol-stale-welcome");
+    let mut david = build_client(b"david-stale-welcome");
+
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "stale Welcome re-entry".into(),
+            description: "".into(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let bob_welcome = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            alice.confirm_published(pending).await.unwrap();
+            welcomes.remove(0)
+        }
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    bob.join_welcome(bob_welcome).await.unwrap();
+
+    // Alice adds Carol and David at epoch 2, but both Welcomes are delayed.
+    let carol_id = carol.self_id().clone();
+    let david_id = david.self_id().clone();
+    let initial_invite = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![
+                carol.fresh_key_package().await.unwrap(),
+                david.fresh_key_package().await.unwrap(),
+            ],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (initial_pending, mut stale_welcomes) = match initial_invite {
+        SendResult::GroupEvolution {
+            pending, welcomes, ..
+        } => (pending, welcomes),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(initial_pending).await.unwrap();
+    let stale_carol_welcome = take_welcome_for(&mut stale_welcomes, &carol_id);
+    let stale_david_welcome = take_welcome_for(&mut stale_welcomes, &david_id);
+    assert_eq!(alice.epoch(&group_id).unwrap().0, 2);
+
+    // The canonical group removes both identities at epoch 3 before either
+    // delayed Welcome is delivered.
+    let remove = alice
+        .send(SendIntent::RemoveMembers {
+            group_id: group_id.clone(),
+            members: vec![carol_id.clone(), david_id.clone()],
+        })
+        .await
+        .unwrap();
+    let remove_pending = match remove {
+        SendResult::GroupEvolution { pending, .. } => pending,
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(remove_pending).await.unwrap();
+    assert_eq!(alice.epoch(&group_id).unwrap().0, 3);
+
+    // Carol now accepts the delayed epoch-2 Welcome. Her local record says
+    // she is active even though the canonical group removed her at epoch 3.
+    carol.join_welcome(stale_carol_welcome).await.unwrap();
+    assert_eq!(carol.epoch(&group_id).unwrap().0, 2);
+    drop(carol);
+    let mut carol = build_client_on_storage(b"carol-stale-welcome", carol_storage);
+    carol.hydrate_all_stored_groups().unwrap();
+    assert_eq!(
+        carol.epoch(&group_id).unwrap().0,
+        2,
+        "restart must preserve the stale active view"
+    );
+
+    // A legitimate re-add advances the canonical group to epoch 4. Carol's
+    // strictly newer Welcome must repair her stale active view.
+    let readd = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![
+                carol.fresh_key_package().await.unwrap(),
+                david.fresh_key_package().await.unwrap(),
+            ],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (readd_pending, mut fresh_welcomes) = match readd {
+        SendResult::GroupEvolution {
+            pending, welcomes, ..
+        } => (pending, welcomes),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(readd_pending).await.unwrap();
+    let fresh_carol_welcome = take_welcome_for(&mut fresh_welcomes, &carol_id);
+    let fresh_david_welcome = take_welcome_for(&mut fresh_welcomes, &david_id);
+
+    carol.join_welcome(fresh_carol_welcome).await.unwrap();
+    assert_eq!(carol.epoch(&group_id).unwrap().0, 4);
+    assert_eq!(
+        carol.members(&group_id).unwrap(),
+        alice.members(&group_id).unwrap()
+    );
+
+    // David takes the fresh Welcome first. His still-unconsumed epoch-2
+    // Welcome is distinct valid MLS material, but it must not replace epoch 4.
+    david.join_welcome(fresh_david_welcome).await.unwrap();
+    let downgrade_error = david
+        .join_welcome(stale_david_welcome)
+        .await
+        .expect_err("an older Welcome must not downgrade active group state");
+    assert!(matches!(
+        downgrade_error,
+        EngineError::WelcomeAlreadyProcessed
+    ));
+    assert_eq!(david.epoch(&group_id).unwrap().0, 4);
+    assert_eq!(
+        david.members(&group_id).unwrap(),
+        alice.members(&group_id).unwrap()
+    );
+}
+
 #[tokio::test]
 async fn own_leaf_index_reports_mls_index_after_blank_leaf() {
     let mut alice = build_client(b"alice");
@@ -2113,6 +2266,100 @@ async fn join_rejects_welcome_authored_by_existing_non_admin() {
         matches!(err, EngineError::NotGroupAdmin { .. }),
         "expected NotGroupAdmin for non-admin Welcome signer, got {err:?}"
     );
+}
+
+#[tokio::test]
+async fn rejected_newer_welcome_rolls_back_active_group_replacement() {
+    let mut alice = build_client(b"alice-active-replacement");
+    let (mut bob, bob_storage) = build_with_storage(b"bob-active-replacement");
+    let (mut carol, carol_storage) = build_with_storage(b"carol-active-replacement");
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "active replacement rollback".into(),
+            description: "".into(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (bob_welcome, carol_welcome) = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            alice.confirm_published(pending).await.unwrap();
+            (
+                take_welcome_for(&mut welcomes, &bob.self_id()),
+                take_welcome_for(&mut welcomes, &carol.self_id()),
+            )
+        }
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    bob.join_welcome(bob_welcome).await.unwrap();
+    carol.join_welcome(carol_welcome).await.unwrap();
+
+    // Alice removes Carol and Bob applies that commit, while Carol deliberately
+    // retains her epoch-1 active view. Bob can now construct an MLS-valid Add
+    // for Carol at a newer epoch, but remains unauthorized by Marmot policy.
+    let remove = alice
+        .send(SendIntent::RemoveMembers {
+            group_id: group_id.clone(),
+            members: vec![carol.self_id().clone()],
+        })
+        .await
+        .unwrap();
+    let (remove_commit, remove_pending) = match remove {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(remove_pending).await.unwrap();
+    let routed_remove = TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..remove_commit
+    };
+    assert!(matches!(
+        bob.ingest(routed_remove).await.unwrap(),
+        IngestOutcome::Buffered { .. }
+    ));
+    converge_buffered_commit(&mut bob, &group_id);
+    assert_eq!(bob.epoch(&group_id).unwrap().0, 2);
+    assert_eq!(carol.epoch(&group_id).unwrap().0, 1);
+
+    let before = carol_storage.get_group(&group_id).unwrap();
+    let carol_replacement_kp = carol.fresh_key_package().await.unwrap();
+    let unauthorized_newer_welcome = welcome_from_existing_non_admin(
+        &bob_storage,
+        &bob.self_id(),
+        &group_id,
+        &carol_replacement_kp,
+    );
+
+    let error = carol
+        .join_welcome(unauthorized_newer_welcome)
+        .await
+        .expect_err("a newer Welcome from a non-admin must be rejected");
+    assert!(
+        matches!(error, EngineError::NotGroupAdmin { .. }),
+        "expected NotGroupAdmin after authenticated staging, got {error:?}"
+    );
+    assert_eq!(
+        carol_storage.get_group(&group_id).unwrap(),
+        before,
+        "failed replacement must restore the original Marmot group record"
+    );
+    assert_eq!(carol.epoch(&group_id).unwrap(), before.epoch);
+    let payload = app_payload_for(&carol, b"original state remains usable");
+    carol
+        .send(SendIntent::AppMessage { group_id, payload })
+        .await
+        .expect("failed replacement must leave the original live group usable");
 }
 
 #[tokio::test]

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -1920,11 +1920,12 @@ async fn readd_after_remove_produces_fresh_welcome_join() {
 }
 
 /// A delayed Welcome can install an apparently active local view after the
-/// rest of the group has already removed that identity. A later, strictly
-/// newer re-add Welcome must replace that stale view, while an older Welcome
-/// must never downgrade an already-current client.
+/// rest of the group has already removed that identity. A fresh re-add Welcome
+/// must wait for the trusted removal commit instead of replacing active state
+/// based on its uncorroborated epoch, and an older Welcome must never downgrade
+/// an already-current client.
 #[tokio::test]
-async fn newer_readd_welcome_replaces_stale_active_view_without_allowing_downgrade() {
+async fn readd_welcome_waits_for_trusted_removal_across_pending_publish_restart() {
     let mut alice = build_client(b"alice-stale-welcome");
     let mut bob = build_client(b"bob-stale-welcome");
     let (mut carol, carol_storage) = build_with_storage(b"carol-stale-welcome");
@@ -1988,8 +1989,8 @@ async fn newer_readd_welcome_replaces_stale_active_view_without_allowing_downgra
         })
         .await
         .unwrap();
-    let remove_pending = match remove {
-        SendResult::GroupEvolution { pending, .. } => pending,
+    let (remove_commit, remove_pending) = match remove {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
         other => panic!("expected GroupEvolution, got {other:?}"),
     };
     alice.confirm_published(remove_pending).await.unwrap();
@@ -1999,17 +2000,8 @@ async fn newer_readd_welcome_replaces_stale_active_view_without_allowing_downgra
     // she is active even though the canonical group removed her at epoch 3.
     carol.join_welcome(stale_carol_welcome).await.unwrap();
     assert_eq!(carol.epoch(&group_id).unwrap().0, 2);
-    drop(carol);
-    let mut carol = build_client_on_storage(b"carol-stale-welcome", carol_storage.clone());
-    carol.hydrate_all_stored_groups().unwrap();
-    assert_eq!(
-        carol.epoch(&group_id).unwrap().0,
-        2,
-        "restart must preserve the stale active view"
-    );
-
-    // A legitimate re-add advances the canonical group to epoch 4. Carol's
-    // strictly newer Welcome must repair her stale active view.
+    // A legitimate re-add advances the canonical group to epoch 4. Its epoch
+    // alone cannot prove that it descends from Carol's trusted local branch.
     let readd = alice
         .send(SendIntent::Invite {
             group_id: group_id.clone(),
@@ -2031,45 +2023,95 @@ async fn newer_readd_welcome_replaces_stale_active_view_without_allowing_downgra
     let fresh_carol_welcome = take_welcome_for(&mut fresh_welcomes, &carol_id);
     let fresh_david_welcome = take_welcome_for(&mut fresh_welcomes, &david_id);
 
-    // Carol can still stage work against her stale active view. A replacement
-    // must wait for that publication's explicit outcome rather than discard
-    // its MLS state and leave the epoch manager pointing at the old copy.
+    // Carol can still stage work against her stale active view. Drop the engine
+    // with that publication unresolved, then rebuild without hydration to pin
+    // the cold-start path: the durable active record must close the replacement
+    // window even while the epoch manager is empty.
     let held_update = carol
         .send(SendIntent::SelfUpdate {
             group_id: group_id.clone(),
         })
         .await
         .unwrap();
-    let held_pending = match held_update {
+    let _held_pending = match held_update {
         SendResult::GroupEvolution { pending, .. } => pending,
         other => panic!("expected GroupEvolution, got {other:?}"),
     };
     let stale_record = carol_storage.get_group(&group_id).unwrap();
-    let held_epoch = carol.epoch(&group_id).unwrap();
-    let held_error = carol
+    drop(carol);
+    let mut carol = build_client_on_storage(b"carol-stale-welcome", carol_storage.clone());
+    assert!(
+        load_group_and_signer(&carol_storage, &carol.self_id(), &group_id)
+            .0
+            .pending_commit()
+            .is_some(),
+        "the staged self-update must survive restart before hydration"
+    );
+
+    let cold_start_error = carol
         .join_welcome(fresh_carol_welcome.clone())
         .await
-        .expect_err("replacement must wait for the held publication outcome");
+        .expect_err("an unhydrated restart must not replace active state");
     assert!(matches!(
-        held_error,
+        cold_start_error,
         EngineError::InvalidTransition(ref error)
-            if error.from == "PendingPublish" && error.to == "JoinWelcome"
+            if error.from == "ActiveMember" && error.to == "JoinWelcome"
     ));
     assert_eq!(
         carol_storage.get_group(&group_id).unwrap(),
         stale_record,
-        "refused replacement must leave the durable stale view intact"
+        "cold-start refusal must leave the durable active view intact"
     );
-    assert_eq!(
-        carol.epoch(&group_id).unwrap(),
-        held_epoch,
-        "refused replacement must preserve the held epoch-manager state"
+    assert!(
+        load_group_and_signer(&carol_storage, &carol.self_id(), &group_id)
+            .0
+            .pending_commit()
+            .is_some(),
+        "cold-start refusal must not orphan or discard the pending commit"
     );
-    carol.publish_failed(held_pending).await.unwrap();
-    assert_eq!(carol.epoch(&group_id).unwrap(), stale_record.epoch);
 
-    // The refusal is retryable: rolling back the stale publication restores
-    // Stable, and the identical Welcome can now atomically replace that view.
+    // Hydration restores the publication obligation. Resolve it, then prove
+    // that even Stable active state cannot be replaced without continuity.
+    carol.hydrate_all_stored_groups().unwrap();
+    let restored = carol.drain_auto_publish();
+    assert_eq!(
+        restored.len(),
+        1,
+        "hydrate must restore the staged publication"
+    );
+    carol.publish_failed(restored[0].pending).await.unwrap();
+    assert_eq!(carol.epoch(&group_id).unwrap(), stale_record.epoch);
+    let active_error = carol
+        .join_welcome(fresh_carol_welcome.clone())
+        .await
+        .expect_err("a newer epoch is not trusted branch continuity");
+    assert!(matches!(
+        active_error,
+        EngineError::InvalidTransition(ref error)
+            if error.from == "ActiveMember" && error.to == "JoinWelcome"
+    ));
+
+    // Once Carol processes the removal from her trusted epoch-2 branch, the
+    // exact same Welcome is a legitimate retry and installs the epoch-4 rejoin.
+    let routed_remove = TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..remove_commit
+    };
+    assert!(matches!(
+        carol.ingest(routed_remove).await.unwrap(),
+        IngestOutcome::Buffered { .. }
+    ));
+    converge_buffered_commit(&mut carol, &group_id);
+    assert!(
+        !carol
+            .members(&group_id)
+            .unwrap()
+            .iter()
+            .any(|member| member.id == carol_id),
+        "trusted removal must clear Carol's active membership before re-entry"
+    );
     carol.join_welcome(fresh_carol_welcome).await.unwrap();
     assert_eq!(carol.epoch(&group_id).unwrap().0, 4);
     assert_eq!(
@@ -2308,7 +2350,7 @@ async fn join_rejects_welcome_authored_by_existing_non_admin() {
 }
 
 #[tokio::test]
-async fn rejected_newer_welcome_rolls_back_active_group_replacement() {
+async fn active_group_rejects_newer_welcome_from_self_promoted_fork() {
     let mut alice = build_client(b"alice-active-replacement");
     let (mut bob, bob_storage) = build_with_storage(b"bob-active-replacement");
     let (mut carol, carol_storage) = build_with_storage(b"carol-active-replacement");
@@ -2343,8 +2385,9 @@ async fn rejected_newer_welcome_rolls_back_active_group_replacement() {
     carol.join_welcome(carol_welcome).await.unwrap();
 
     // Alice removes Carol and Bob applies that commit, while Carol deliberately
-    // retains her epoch-1 active view. Bob can now construct an MLS-valid Add
-    // for Carol at a newer epoch, but remains unauthorized by Marmot policy.
+    // retains her epoch-1 active view. Bob can now fork from that newer state,
+    // add Carol, and self-promote in the same commit. The sibling bootstrap test
+    // proves this Welcome passes the incoming branch's admin check.
     let remove = alice
         .send(SendIntent::RemoveMembers {
             group_id: group_id.clone(),
@@ -2373,20 +2416,29 @@ async fn rejected_newer_welcome_rolls_back_active_group_replacement() {
 
     let before = carol_storage.get_group(&group_id).unwrap();
     let carol_replacement_kp = carol.fresh_key_package().await.unwrap();
-    let unauthorized_newer_welcome = welcome_from_existing_non_admin(
+    let forged_admins = encode_admin_policy_for_test(&[
+        alice.self_id().as_slice().to_vec(),
+        bob.self_id().as_slice().to_vec(),
+    ]);
+    let unauthorized_newer_welcome = welcome_from_fork_with_self_promoted_admin(
         &bob_storage,
         &bob.self_id(),
         &group_id,
         &carol_replacement_kp,
+        forged_admins,
     );
 
     let error = carol
         .join_welcome(unauthorized_newer_welcome)
         .await
-        .expect_err("a newer Welcome from a non-admin must be rejected");
+        .expect_err("a newer self-promoted fork must not replace active state");
     assert!(
-        matches!(error, EngineError::NotGroupAdmin { .. }),
-        "expected NotGroupAdmin after authenticated staging, got {error:?}"
+        matches!(
+            error,
+            EngineError::InvalidTransition(ref error)
+                if error.from == "ActiveMember" && error.to == "JoinWelcome"
+        ),
+        "expected active-state continuity refusal, got {error:?}"
     );
     assert_eq!(
         carol_storage.get_group(&group_id).unwrap(),

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -2000,7 +2000,7 @@ async fn newer_readd_welcome_replaces_stale_active_view_without_allowing_downgra
     carol.join_welcome(stale_carol_welcome).await.unwrap();
     assert_eq!(carol.epoch(&group_id).unwrap().0, 2);
     drop(carol);
-    let mut carol = build_client_on_storage(b"carol-stale-welcome", carol_storage);
+    let mut carol = build_client_on_storage(b"carol-stale-welcome", carol_storage.clone());
     carol.hydrate_all_stored_groups().unwrap();
     assert_eq!(
         carol.epoch(&group_id).unwrap().0,
@@ -2031,6 +2031,45 @@ async fn newer_readd_welcome_replaces_stale_active_view_without_allowing_downgra
     let fresh_carol_welcome = take_welcome_for(&mut fresh_welcomes, &carol_id);
     let fresh_david_welcome = take_welcome_for(&mut fresh_welcomes, &david_id);
 
+    // Carol can still stage work against her stale active view. A replacement
+    // must wait for that publication's explicit outcome rather than discard
+    // its MLS state and leave the epoch manager pointing at the old copy.
+    let held_update = carol
+        .send(SendIntent::SelfUpdate {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    let held_pending = match held_update {
+        SendResult::GroupEvolution { pending, .. } => pending,
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    let stale_record = carol_storage.get_group(&group_id).unwrap();
+    let held_epoch = carol.epoch(&group_id).unwrap();
+    let held_error = carol
+        .join_welcome(fresh_carol_welcome.clone())
+        .await
+        .expect_err("replacement must wait for the held publication outcome");
+    assert!(matches!(
+        held_error,
+        EngineError::InvalidTransition(ref error)
+            if error.from == "PendingPublish" && error.to == "JoinWelcome"
+    ));
+    assert_eq!(
+        carol_storage.get_group(&group_id).unwrap(),
+        stale_record,
+        "refused replacement must leave the durable stale view intact"
+    );
+    assert_eq!(
+        carol.epoch(&group_id).unwrap(),
+        held_epoch,
+        "refused replacement must preserve the held epoch-manager state"
+    );
+    carol.publish_failed(held_pending).await.unwrap();
+    assert_eq!(carol.epoch(&group_id).unwrap(), stale_record.epoch);
+
+    // The refusal is retryable: rolling back the stale publication restores
+    // Stable, and the identical Welcome can now atomically replace that view.
     carol.join_welcome(fresh_carol_welcome).await.unwrap();
     assert_eq!(carol.epoch(&group_id).unwrap().0, 4);
     assert_eq!(

--- a/crates/cgka-engine/tests/update_group_data.rs
+++ b/crates/cgka-engine/tests/update_group_data.rs
@@ -2288,6 +2288,9 @@ async fn rebuilt_engine_convergence_withdraws_own_confirmed_rename_by_stamped_or
     drop(loser_engine);
     let mut loser =
         build_with_storage_and_peeler(loser_id, loser_storage.clone(), ephemeral_peeler());
+    loser
+        .hydrate_all_stored_groups()
+        .expect("restart hydrates the durable group before convergence replay");
     loser.drain_events();
     loser
         .buffer_openmls_convergence_message_at(&gid, route_to_group(&winner_commit, &gid), 1_000)
@@ -2464,6 +2467,9 @@ async fn rebuilt_engine_convergence_keeps_own_confirmed_rename_when_it_wins_sele
     drop(winner);
     let mut winner =
         build_with_storage_and_peeler(winner_id, winner_storage.clone(), ephemeral_peeler());
+    winner
+        .hydrate_all_stored_groups()
+        .expect("restart hydrates the durable group before convergence replay");
     winner.drain_events();
     winner
         .buffer_openmls_convergence_message_at(&gid, route_to_group(&loser_commit, &gid), 1_000)
@@ -2627,6 +2633,11 @@ async fn mutually_rebuilt_engines_converge_on_same_branch_after_concurrent_renam
     let mut alice =
         build_with_storage_and_peeler(b"alice", alice_storage.clone(), ephemeral_peeler());
     let mut bob = build_with_storage_and_peeler(b"bob", bob_storage.clone(), ephemeral_peeler());
+    alice
+        .hydrate_all_stored_groups()
+        .expect("alice restart hydrates the durable group before convergence replay");
+    bob.hydrate_all_stored_groups()
+        .expect("bob restart hydrates the durable group before convergence replay");
     alice.drain_events();
     bob.drain_events();
     alice
@@ -2887,6 +2898,9 @@ async fn rebuilt_winner_applies_own_selfremove_commit_without_replaying_consumed
     drop(winner);
     let mut winner =
         build_with_storage_and_peeler(winner_id, winner_storage.clone(), mock_peeler());
+    winner
+        .hydrate_all_stored_groups()
+        .expect("restart hydrates the durable group before convergence replay");
     winner.drain_events();
 
     // Re-open carol's consumed proposal as a pending convergence input on the

--- a/integrations/hermes/marmot/tests/test_dev_scripts.sh
+++ b/integrations/hermes/marmot/tests/test_dev_scripts.sh
@@ -74,6 +74,7 @@ env \
         --root "$local_ref_root" \
         --hermes-ref "$(printf 'ab%.0s' {1..20})" \
         --no-enable-plugin
+[ "$(grep -c '^count=' "$local_ref_capture")" -eq 1 ]
 [ "$(grep -Fxc 'count=1' "$local_ref_capture")" -eq 1 ]
 [ "$(grep -Fxc 'key=http.https://github.com/.extraheader' "$local_ref_capture")" -eq 1 ]
 [ "$(grep -Fxc "value=AUTHORIZATION: basic $expected_basic" "$local_ref_capture")" -eq 1 ]

--- a/integrations/hermes/marmot/tests/test_dev_scripts.sh
+++ b/integrations/hermes/marmot/tests/test_dev_scripts.sh
@@ -61,6 +61,23 @@ if grep -F 'test-actions-token' "$auth_capture" >/dev/null; then
     exit 1
 fi
 
+# A pinned commit already present in a successful full clone must be checked
+# out locally instead of making a redundant fetch. This keeps the CI setup from
+# failing when GitHub rate-limits a second request immediately after the clone.
+local_ref_capture="$tmp_parent/github-local-ref-capture"
+local_ref_root="$tmp_parent/github-local-ref"
+env \
+    PATH="$auth_fake_bin:$PATH" \
+    GITHUB_TOKEN="test-actions-token" \
+    AUTH_CAPTURE="$local_ref_capture" \
+    "$repo_root/scripts/hermes_marmot_dev_setup.sh" \
+        --root "$local_ref_root" \
+        --hermes-ref "$(printf 'ab%.0s' {1..20})" \
+        --no-enable-plugin
+[ "$(grep -Fxc 'count=1' "$local_ref_capture")" -eq 1 ]
+[ "$(grep -Fxc 'key=http.https://github.com/.extraheader' "$local_ref_capture")" -eq 1 ]
+[ "$(grep -Fxc "value=AUTHORIZATION: basic $expected_basic" "$local_ref_capture")" -eq 1 ]
+
 "$repo_root/scripts/hermes_marmot_dev_setup.sh" \
     --root "$dev_root" \
     --skip-hermes-install \

--- a/scripts/hermes_marmot_dev_setup.sh
+++ b/scripts/hermes_marmot_dev_setup.sh
@@ -247,14 +247,42 @@ clone_hermes_repo() {
     return 1
 }
 
+fetch_hermes_ref() {
+    local attempt=1
+    local max_attempts=5
+    local delay=8
+    while [ "$attempt" -le "$max_attempts" ]; do
+        if git_with_github_auth -C "$hermes_repo" fetch origin "$hermes_ref"; then
+            return 0
+        fi
+        if [ "$attempt" -lt "$max_attempts" ]; then
+            echo "warning: hermes ref fetch failed (attempt ${attempt}/${max_attempts}); retrying in ${delay}s" >&2
+            sleep "$delay"
+            delay=$((delay * 2))
+        fi
+        attempt=$((attempt + 1))
+    done
+    echo "error: failed to fetch Hermes ref after ${max_attempts} attempts" >&2
+    return 1
+}
+
 install_hermes() {
     if [ ! -d "$hermes_repo/.git" ]; then
         clone_hermes_repo "$hermes_repo"
     fi
 
     if [ -n "$hermes_ref" ]; then
-        git_with_github_auth -C "$hermes_repo" fetch origin "$hermes_ref"
-        git -C "$hermes_repo" checkout --detach FETCH_HEAD
+        if [[ "$hermes_ref" =~ ^[0-9a-fA-F]{40}$ ]] \
+            && git -C "$hermes_repo" cat-file -e "${hermes_ref}^{commit}" 2>/dev/null; then
+            # A normal full clone already contains the pinned commit when it is
+            # reachable from the default branch. Avoid a second GitHub request:
+            # under shared-runner pressure that redundant fetch can be 429'd
+            # immediately after the clone itself finally succeeds.
+            git -C "$hermes_repo" checkout --detach "$hermes_ref"
+        else
+            fetch_hermes_ref
+            git -C "$hermes_repo" checkout --detach FETCH_HEAD
+        fi
     fi
 
     if ensure_uv; then


### PR DESCRIPTION
## Summary

- require trusted-branch removal evidence before any healthy active group can accept a replacement Welcome; a larger incoming epoch alone is never treated as branch continuity
- keep newer Welcomes retryable while the recipient is still active, including immediately after restart before epoch-manager hydration
- preserve unresolved local publication state across a refused re-Welcome and restore it during hydration
- atomically retain the joined epoch when installing a Welcome so later sibling branches can be peeled and replayed
- retain processed proposals as candidate-graph prerequisites when sibling commits reference the same SelfRemove proposal
- add the `membership-reentry/v1` family covering repeated remove/re-add cycles, re-Welcomes, restarts, self-updates, and large multi-committer timing shapes
- extend chat-journey generation so removed identities can be legally reinvited

## Why

Audit evidence from a production-shaped group showed a member leaving and later being added again around competing epoch branches. Some participants progressed while early committers remained stranded. Participant data is incomplete, so the exact identity re-add cannot be proven, but the observed partial-convergence shape is reproduced by the new large-group scenarios.

The failures had three cooperating causes: a delayed Welcome could install a stale active view after the canonical branch had removed that identity, Welcome-installed groups lacked a joined-epoch rewind anchor, and locally processed SelfRemove proposals were unavailable when replaying sibling commits. Re-entry now waits until the recipient processes removal from its currently trusted branch. This also prevents a member from replacing an active victim's state with a newer self-promoted fork, and it closes the cold-start window where an unhydrated epoch manager did not reveal a pending publication.

`Unrecoverable` repair remains the explicit exception: it can still install a fully validated replacement Welcome because the local branch is already terminally frozen.

## Validation

- `just fast-ci`
- `cargo nextest run -p cgka-engine --features test-policy-overrides,test-crash-hooks --locked --profile ci`: 523 passed, 1 skipped
- `cargo nextest run -p cgka-conformance-simulator --locked --profile ci`: 451 passed, 8 skipped
- targeted invite/rejoin test binary: 38 passed
- `membership-reentry/v1` post-fix sweep: 90 of 90 strict cases passed across nine seeds

No workspace package version or conformance fixture version is changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added coverage for membership departure and re-entry workflows, including restart, removal, self-update, stale invitation, and multi-committer scenarios.
  - Re-invitations now support recovery after trusted removal processing while preserving converged group state.

- **Bug Fixes**
  - Improved handling of stale or replacement invitations to prevent unintended active-state replacement.
  - Strengthened recovery and convergence behavior after restarts and pending operations.
  - Development setup now retries remote commit retrieval and avoids redundant fetches when commits are already available.

- **Documentation**
  - Updated simulator scenario catalogs, campaign priorities, and coverage guidance for membership re-entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->