### PR TITLE
fix(cli): keep insecure QUIC candidates on loopback

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,12 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Sender-provided QUIC stream candidates cannot use `--insecure-local` to dial
+  private, link-local, CGNAT, ULA, or other non-public network ranges. The
+  explicit development opt-in now permits loopback endpoints only.
+
 ## [0.9.17] - 2026-09-02
 
 ### Changed

--- a/crates/cli/src/commands/stream.rs
+++ b/crates/cli/src/commands/stream.rs
@@ -1,9 +1,9 @@
 //! `stream` command namespace handlers (QUIC agent text stream previews) and stream helpers.
 
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 use std::time::Duration;
 
-use cgka_traits::app_components::is_public_ip;
+use cgka_traits::app_components::{is_loopback_candidate_host, reject_non_public_socket_addr};
 use cgka_traits::app_event::{STREAM_CHUNKS_TAG, STREAM_HASH_TAG, STREAM_TAG};
 use cgka_traits::{GroupId, MessageId};
 use marmot_account::AccountHome;
@@ -738,12 +738,11 @@ pub(crate) fn parse_quic_candidate(candidate: &str) -> Result<ParsedQuicCandidat
 /// Resolve a sender-provided `quic://` candidate to a socket address.
 ///
 /// Sender-controlled candidates must not be able to steer the client into
-/// connecting to loopback, private, link-local, ULA, multicast, unspecified, or
-/// broadcast endpoints (SSRF). When `allow_local_endpoint` is false, any resolved
-/// address that is not a safe public unicast address is rejected. The local user
-/// only opts into local endpoints via explicit `--insecure-local`, which sets
-/// `allow_local_endpoint` to true; loopback enforcement for the actual trust mode
-/// still happens in `broker_trust` / `stream_trust`.
+/// connecting to private, link-local, CGNAT, ULA, multicast, unspecified, or
+/// broadcast endpoints (SSRF). Every resolved address passes through the shared
+/// host-safety gate. Explicit `--insecure-local` permits loopback only; every
+/// other non-public address remains rejected. The returned address is the same
+/// address the QUIC endpoint dials, so validation and connection cannot diverge.
 pub(crate) async fn resolve_quic_candidate_addr(
     candidate: &ParsedQuicCandidate,
     allow_local_endpoint: bool,
@@ -757,21 +756,13 @@ pub(crate) async fn resolve_quic_candidate_addr(
     let addr = addrs
         .next()
         .ok_or_else(|| WnError::InvalidQuicCandidate(candidate.original.clone()))?;
-    if !allow_local_endpoint && socket_addr_is_unsafe(addr) {
-        return Err(WnError::UnsafeQuicCandidateEndpoint {
+    reject_non_public_socket_addr(addr, allow_local_endpoint).map_err(|_| {
+        WnError::UnsafeQuicCandidateEndpoint {
             candidate: candidate.original.clone(),
             addr,
-        });
-    }
+        }
+    })?;
     Ok(addr)
-}
-
-/// Whether a resolved candidate address must never be reached from a
-/// sender-controlled `quic://` candidate without explicit local opt-in. Delegates
-/// to the canonical Marmot host-safety classifier so QUIC candidate filtering
-/// cannot drift from the shared SSRF hardening rules.
-fn socket_addr_is_unsafe(addr: SocketAddr) -> bool {
-    !is_public_ip(addr.ip())
 }
 
 pub(crate) fn first_quic_candidate_is_loopback(candidates: &[String]) -> bool {
@@ -789,12 +780,7 @@ pub(crate) fn quic_candidate_host(candidate: &str) -> Option<String> {
 }
 
 fn quic_host_is_loopback(host: &str) -> bool {
-    if host.eq_ignore_ascii_case("localhost") {
-        return true;
-    }
-    host.parse::<IpAddr>()
-        .map(|ip| ip.is_loopback())
-        .unwrap_or(false)
+    is_loopback_candidate_host(host)
 }
 
 fn transcript_hash_from_hex(value: &str) -> Result<[u8; 32], WnError> {

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -98,7 +98,7 @@ pub(crate) enum WnError {
         source: std::io::Error,
     },
     #[error(
-        "QUIC candidate {candidate} resolved to a local/private endpoint {addr}; pass --insecure-local to allow local endpoints"
+        "QUIC candidate {candidate} resolved to a non-public endpoint {addr}; --insecure-local permits loopback endpoints only"
     )]
     UnsafeQuicCandidateEndpoint { candidate: String, addr: SocketAddr },
     #[error("transcript hash must be 32 bytes, got {0}")]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1960,6 +1960,26 @@ mod tests {
         assert!(addr.ip().is_loopback());
     }
 
+    #[tokio::test]
+    async fn resolve_quic_candidate_rejects_non_loopback_endpoints_with_opt_in() {
+        // `--insecure-local` is a loopback-only development escape hatch. It
+        // must not let a sender steer QUIC at other non-public network ranges.
+        for candidate in [
+            "quic://10.0.0.1:4450",        // RFC1918 private
+            "quic://100.64.0.1:4450",      // shared address space
+            "quic://169.254.169.254:4450", // link-local cloud metadata
+            "quic://[fd00::1]:4450",       // IPv6 unique-local (ULA)
+            "quic://[fe80::1]:4450",       // IPv6 unicast link-local
+        ] {
+            let parsed = parse_quic_candidate(candidate).expect("candidate parses");
+            let result = resolve_quic_candidate_addr(&parsed, true).await;
+            assert!(
+                matches!(result, Err(WnError::UnsafeQuicCandidateEndpoint { .. })),
+                "expected {candidate} to remain rejected with opt-in, got {result:?}"
+            );
+        }
+    }
+
     #[test]
     fn candidate_trust_rejects_conflicting_insecure_and_certificate_flags() {
         let result = broker_trust_for_candidate(


### PR DESCRIPTION
## Summary

- validate every resolved sender-provided QUIC candidate with the canonical host-safety gate
- keep `--insecure-local` as a loopback-only development escape hatch instead of allowing every non-public range
- share the canonical literal-loopback classifier and clarify the structured error message
- add regression coverage for RFC1918, CGNAT, link-local metadata, IPv6 ULA, and IPv6 link-local candidates

## Validation

- `cargo test -p wn-cli resolve_quic_candidate -- --nocapture` (4 passed)
- `just fast-ci`

An additional `cargo test -p wn-cli` run passed all 588 unit tests. Its relay-backed integration phase passed 77 of 89 tests; 12 unrelated daemon-startup/relay-convergence tests failed in that parallel run, while the stream safety tests passed.