### PR TITLE
Fix wrapped CLI errors and document runtime boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7440,7 +7440,6 @@ name = "wn-cli"
 version = "0.9.17"
 dependencies = [
  "agent-stream-compose",
- "cgka-session",
  "cgka-traits",
  "chrono",
  "clap",

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -14,6 +14,8 @@ versioning through the workspace version in the root `Cargo.toml`.
 - Sender-provided QUIC stream candidates cannot use `--insecure-local` to dial
   private, link-local, CGNAT, ULA, or other non-public network ranges. The
   explicit development opt-in now permits loopback endpoints only.
+- Engine failures now retain the same stable CLI JSON error code whether they
+  reach the app boundary directly or through account/session wrappers.
 
 ## [0.9.17] - 2026-09-02
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,7 +21,6 @@ path = "src/bin/wnd.rs"
 [dependencies]
 agent-stream-compose.workspace = true
 cgka-traits.workspace = true
-cgka-session.workspace = true
 chrono.workspace = true
 clap.workspace = true
 crossterm.workspace = true

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -3,7 +3,7 @@
 use std::net::SocketAddr;
 
 use cgka_traits::error::EngineError;
-use marmot_account::{AccountError, AccountHomeError};
+use marmot_account::AccountHomeError;
 use marmot_app::{AccountRelayListStatus, AppError, MissingRelayListKind};
 use serde_json::{Value, json};
 
@@ -559,12 +559,11 @@ fn account_home_error_json(err: &AccountHomeError) -> Value {
 }
 
 fn app_error_json(err: &AppError) -> Value {
+    if let Some(engine_error) = err.as_engine_error() {
+        return engine_error_json(engine_error);
+    }
     match err {
         AppError::AccountHome(err) => account_home_error_json(err),
-        AppError::Account(AccountError::Engine(err)) => engine_error_json(err),
-        AppError::Account(AccountError::Session(cgka_session::SessionError::Engine(err))) => {
-            engine_error_json(err)
-        }
         AppError::MissingKeyPackage(account) => json!({
             "code": "missing_key_package",
             "message": err.to_string(),
@@ -738,6 +737,8 @@ fn engine_error_json(err: &EngineError) -> Value {
 
 #[cfg(test)]
 mod tests {
+    use marmot_account::AccountError;
+
     use super::*;
 
     #[test]
@@ -826,5 +827,18 @@ mod tests {
         let timed_out = wn_error_json(&WnError::App(AppError::AccountWorkerResponseTimedOut));
         assert_eq!(timed_out["code"], "account_worker_response_timed_out");
         assert_eq!(timed_out["completion_unknown"], true);
+    }
+
+    #[test]
+    fn engine_errors_have_the_same_json_across_app_wrappers() {
+        let rendered = [
+            AppError::Session(EngineError::InvalidWelcome.into()),
+            AppError::Account(AccountError::Session(EngineError::InvalidWelcome.into())),
+            AppError::Account(AccountError::Engine(EngineError::InvalidWelcome)),
+        ]
+        .map(|error| wn_error_json(&WnError::App(error)));
+
+        assert_eq!(rendered[0]["code"], "engine_error");
+        assert!(rendered.windows(2).all(|pair| pair[0] == pair[1]));
     }
 }

--- a/crates/marmot-app/README.md
+++ b/crates/marmot-app/README.md
@@ -6,15 +6,24 @@ It wires the app-owned `AccountHome` to encrypted session storage, the Nostr MLS
 relay-backed transport state. The crate is intentionally below presentation layers like `wn` and above the generic
 account/session/engine crates.
 
-It owns the first app projections:
+It owns these local SQLite stores:
 
-- a per-account SQLCipher directory cache at `accounts/<label>/app-cache.sqlite3` for the Nostr user directory:
-  local-account links, profile metadata, follow-list caches, bounded search-graph edges, discovered user relay lists,
-  and KeyPackages (the root-level `app-cache.sqlite3` is a legacy location that is migrated and then removed);
 - per-account SQLCipher app state in the account's storage database (`accounts/<label>/session.sqlite`) for joined
   groups, app-component profile/image/admin/Nostr-routing projections, pending invite confirmation state, seen relay
   events, and sent/received message projections. The older `accounts/<label>/app.sqlite3` is the legacy projection
-  database; its contents are imported once (tracked by the `legacy-account-projection-v1` marker) and then superseded.
+  database; its contents are imported once (tracked by the `legacy-account-projection-v1` marker) and then superseded;
+- a per-account SQLCipher directory cache at `accounts/<label>/app-cache.sqlite3` for the Nostr user directory:
+  local-account links, profile metadata, follow-list caches, bounded search-graph edges, discovered user relay lists,
+  and KeyPackages (the root-level `app-cache.sqlite3` is a legacy location that is migrated and then removed);
+- an owner-only, unencrypted installation-wide `shared.sqlite3` containing a provenance-stripped public-directory
+  mirror, relay-telemetry and audit-log preferences, and the telemetry installation id.
+
+For `N` active signing accounts whose stores have been opened, this is up to `2N + 1` current SQLite files.
+`session.sqlite` contains authoritative protocol and recovery state and has a numbered migration history. The two
+directory tiers are reconcilable caches, but normal upgrades should preserve them; `shared.sqlite3` also contains
+durable installation settings that are not disposable. The per-account directory cache and shared store currently
+initialize tables without independent numbered migration ledgers, so schema evolution for either must not rely on the
+session database's migration version.
 
 The app runtime exposes those projections through account status, group listing/showing, message listing, and
 snapshot-plus-live subscription APIs so CLI and TUI surfaces can inspect app state without opening the databases

--- a/docs/marmot-architecture/further-context/app-sqlite-storage-boundaries.md
+++ b/docs/marmot-architecture/further-context/app-sqlite-storage-boundaries.md
@@ -1,0 +1,51 @@
+---
+title: "App SQLite Storage Boundaries"
+created: 2026-09-04
+updated: 2026-09-04
+tags: [marmot, app-core, sqlite, storage, migrations]
+status: current-implementation
+---
+
+# App SQLite Storage Boundaries
+
+This page records the current MDK app-layer SQLite inventory. These stores have different authority and durability
+contracts; sharing a file format does not make them one database or one migration domain.
+
+## Current Layout
+
+For `N` active signing accounts whose stores have been opened, the layout has up to `2N + 1` SQLite files:
+
+| Path | Encryption and scope | Authority and recovery contract |
+| --- | --- | --- |
+| `accounts/<label>/session.sqlite` | Per-account SQLCipher | Contains authoritative protocol and recovery state plus durable app projections. It is not disposable and uses the numbered `cgka_schema_migrations` history described by [Storage Format V2](../storage-format-v2.md). |
+| `accounts/<label>/app-cache.sqlite3` | Per-account SQLCipher | Contains derived account-private Nostr directory and bounded search state. It can be reconstructed from `AccountHome` plus the Nostr network, but ordinary upgrades should preserve and migrate it so offline directory behavior and discovery provenance are not discarded. |
+| `shared.sqlite3` | Installation-wide plaintext SQLite, created owner-only | Contains a sanitized public-directory mirror plus durable installation-wide telemetry/audit preferences and the telemetry installation id. The directory rows are reconstructible; the settings and installation id must not be silently discarded with the cache. |
+
+The session database is the only protocol-state authority. The directory stores support app lookup and projection
+behavior and must not become an alternate source of MLS truth.
+
+## Directory Mirroring And Reconciliation
+
+Directory writes mirror the public subset into `shared.sqlite3` and the richer record into each active account cache.
+Reads reconcile independently timestamped components from both tiers. Those cross-database writes are not one atomic
+transaction, so neither directory tier is an authoritative protocol-state boundary.
+
+A read alone does not repair a partial mirror. A later successful save of that directory record reconciles it. Code
+that needs stronger cross-store guarantees must introduce an explicit intent/reconciliation mechanism rather than
+assuming the two SQLite commits are atomic.
+
+## Legacy Imports
+
+The root-level `app-cache.sqlite3` is a legacy plaintext directory location that is imported and removed. Likewise,
+`accounts/<label>/app.sqlite3` is a legacy projection database imported once into `session.sqlite`. Neither is a fourth
+current store.
+
+## Migration Domains
+
+Only `session.sqlite` currently has a numbered migration ledger and future-schema refusal. The two auxiliary stores
+initialize their current tables independently and must receive their own version histories before either schema makes
+a non-additive change.
+
+Each store needs an independent schema identity because its release cadence, rollback behavior, and durability
+contract can diverge. A session migration version must never be treated as the version of either cache. Until those
+ledgers exist, auxiliary-store changes should remain additive and compatible with already-created databases.

--- a/docs/marmot-architecture/further-context/local-daemon-protocol-boundaries.md
+++ b/docs/marmot-architecture/further-context/local-daemon-protocol-boundaries.md
@@ -1,0 +1,48 @@
+---
+title: "Local Daemon Protocol Boundaries"
+created: 2026-09-04
+updated: 2026-09-04
+tags: [marmot, daemon, cli, agent-control, unix-socket]
+status: current-implementation
+---
+
+# Local Daemon Protocol Boundaries
+
+MDK currently has two local Unix-socket protocols. They both use newline-terminated JSON and deliberately bounded
+inbound messages, but they serve different consumers and are not wire-compatible.
+
+## Protocol Comparison
+
+| Property | `wnd` CLI daemon protocol | `wn-agent` agent-control protocol |
+| --- | --- | --- |
+| Consumer | MDK's own CLI and TUI | Local agent integrations |
+| Wire model | Internal `DaemonRequest` variants carrying the CLI command shape | Stable, typed request/response/event DTOs inside `marmot.agent-control.v2` envelopes |
+| Correlation and versioning | No request id or explicit protocol version | Optional correlation id, an explicit protocol label, and request-id idempotency for stream begin |
+| Authorization | Owner-only socket plus same-UID peer checks | Same-UID peer checks by default, or an explicitly configured full-control bearer token |
+| Errors | CLI output envelopes; no protocol-wide retryability field | Typed error responses with an explicit, fail-closed `retryable` field |
+| Size boundary | 1 MiB cap on each inbound daemon request; responses do not yet have a symmetric protocol cap | 1 MiB per-frame cap in the shared agent-control codec |
+| Sensitive input buffers | Request assembly and decoded request bytes use zeroizing buffers; buffered read-ahead is not guaranteed to be erased | The generic frame codec uses ordinary byte buffers |
+
+Both servers accept one request per connection. A non-streaming `wnd` client reads its response to EOF, while its
+subscription clients read newline-delimited stream records until `stream_end` or EOF. Agent control returns a typed
+response envelope or keeps an inbound-subscription connection open for typed event envelopes; the envelope id is
+echoed on those responses and events.
+
+These differences are intentional. The CLI daemon protocol is an internal presentation transport and can evolve with
+the command surface. Agent control is an integration API whose version label, typed data transfer objects, error
+retryability, authentication option, and idempotency behavior are part of its compatibility boundary.
+
+## Framing Consolidation Boundary
+
+The similar newline framing is an implementation pattern, not a shared semantic contract. A future consolidation
+should be limited to a small framing primitive that can:
+
+- enforce a caller-selected payload cap symmetrically;
+- distinguish clean EOF from an incomplete frame;
+- optionally erase its input buffer; and
+- allow the owning protocol to apply its own read and write deadlines.
+
+Protocol versioning, data transfer objects, request ids, authorization, retry semantics, connection lifetime, and
+response framing must remain owned by their respective protocols. Until a shared primitive preserves the CLI daemon's
+zeroization requirement and adds a symmetric response bound, replacing its reader directly with the generic
+agent-control codec would regress the CLI daemon's handling of sensitive request material.

--- a/docs/marmot-architecture/index.md
+++ b/docs/marmot-architecture/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Marmot Architecture — Index"
 created: 2026-04-15
-updated: 2026-08-23
+updated: 2026-09-04
 tags: [marmot, architecture, index]
 ---
 
@@ -159,6 +159,14 @@ These are longer working documents. Go here when you need depth, not orientation
 - **Doc:** [`storage-format-v2.md`](./storage-format-v2.md)
   - **What it covers:** MDK-local storage versioning, normalized protocol-message rows, the explicit stored-message
     binary envelope, legacy compatibility, snapshot-v2 decision gate, and upgrade/downgrade operations.
+
+- **Doc:** [`further-context/app-sqlite-storage-boundaries.md`](./further-context/app-sqlite-storage-boundaries.md)
+  - **What it covers:** Current ownership, durability, reconciliation, legacy-import, and migration contracts for the
+    session, account-directory, and shared SQLite stores.
+
+- **Doc:** [`further-context/local-daemon-protocol-boundaries.md`](./further-context/local-daemon-protocol-boundaries.md)
+  - **What it covers:** Detailed comparison of the `wnd` and `marmot.agent-control.v2` local socket protocols and the
+    narrow boundary for any future shared framing helper.
 
 - **Doc:** [marmot-protocol/marmot](https://github.com/marmot-protocol/marmot)
   - **What it covers:** Marmot v2 protocol draft by stable protocol surface and app component.

--- a/docs/marmot-architecture/overview/app-core-boundary.md
+++ b/docs/marmot-architecture/overview/app-core-boundary.md
@@ -1,7 +1,7 @@
 ---
 title: "App Core Boundary"
 created: 2026-05-15
-updated: 2026-05-17
+updated: 2026-09-04
 tags: [marmot, app-core, cli, tui, swift]
 status: overview
 ---
@@ -25,9 +25,10 @@ session effects and keeps engine storage behind a small account-device API.
 `crates/marmot-account` owns account home orchestration: account records, signing-key storage, session opening,
 transport activation, routing policy, KeyPackage publication, and publish confirmation or rollback.
 
-`crates/marmot-app` owns app-core integration: account projections, shared directory cache, relay-list setup and
-discovery, local development relay support, Nostr SDK relay access, group/message records, and the `AppClient` methods
-used by app surfaces.
+`crates/marmot-app` owns app-core integration: account projections, account-private and shared directory caches,
+relay-list setup and discovery, local development relay support, Nostr SDK relay access, group/message records, and
+the long-running `MarmotAppRuntime` used by app surfaces. `AppClient` remains a lower-level compatibility surface, not
+the preferred host-owned runtime boundary.
 
 `crates/cli` owns commands and output. Its JSON envelope is intentionally stable enough for a future TUI or harness, but
 Swift and other host apps should prefer app-core bindings over shelling out to the CLI.
@@ -36,14 +37,41 @@ Swift and other host apps should prefer app-core bindings over shelling out to t
 
 The current app-core concepts are:
 
-- **Account home:** a platform user-data directory containing account records, app projection databases, shared cache,
+- **Account home:** a platform user-data directory containing account records, per-account databases, a shared store,
   and local development relay state.
 - **Secret store:** platform keychain by default, with a file-backed development store for deterministic tests.
-- **Per-account session DB:** one SQLCipher-backed session database per Marmot account-device identity.
-- **Per-account app projection DB:** group list, app components, seen relay events, and sent/received message records.
-- **Shared app cache:** relay-list and KeyPackage directory state keyed by account id.
-- **App client:** an opened account runtime that can create groups, invite and remove members, update group profile data,
-  send messages, sync transport input, and inspect members.
+- **Per-account session DB:** one SQLCipher-backed durable database per Marmot account-device identity. It contains
+  OpenMLS/Marmot state and the operational app projections needed to preserve groups, messages, delivery state, and
+  recovery obligations.
+- **Per-account directory cache:** an encrypted account-private directory/search view containing local-account links,
+  discovery provenance, profiles, follows, relay lists, KeyPackages, and bounded web-of-trust search state.
+- **Shared store:** an installation-wide public-directory mirror stripped of account-private provenance, plus durable
+  installation-wide telemetry/audit preferences and the telemetry installation id.
+- **App runtime:** the long-running multi-account owner of account workers, relay subscriptions, projections, typed
+  event streams, and storage lifecycle.
+
+## Local SQLite Layout
+
+For `N` active signing accounts whose stores have been opened, the current layout has up to `2N + 1` SQLite files:
+
+| Path | Encryption and scope | Authority and recovery contract |
+| --- | --- | --- |
+| `accounts/<label>/session.sqlite` | Per-account SQLCipher | Contains authoritative protocol and recovery state plus durable app projections. It is not disposable and uses the numbered `cgka_schema_migrations` history described by [Storage Format V2](../storage-format-v2.md). |
+| `accounts/<label>/app-cache.sqlite3` | Per-account SQLCipher | Derived account-private Nostr directory and bounded search state. It can be reconstructed from `AccountHome` plus the Nostr network, but ordinary upgrades should preserve and migrate it so offline directory behavior and discovery provenance are not discarded. |
+| `shared.sqlite3` | Installation-wide plaintext SQLite, created owner-only | Its sanitized public-directory rows are reconstructible cache data. Its telemetry/audit settings and telemetry installation id are durable installation state and must not be silently discarded with the cache. |
+
+Directory writes mirror the public subset into `shared.sqlite3` and the richer record into each active account cache.
+Reads reconcile independently timestamped components from both tiers. Those cross-database writes are not one atomic
+transaction, so neither directory tier is an authoritative protocol-state boundary. A read alone does not repair a
+partial mirror; a later successful save of that directory record reconciles it.
+
+The root-level `app-cache.sqlite3` is a legacy plaintext directory location that is imported and removed. Likewise,
+`accounts/<label>/app.sqlite3` is a legacy projection database imported once into `session.sqlite`; neither is a fourth
+current store.
+
+Only `session.sqlite` currently has a numbered migration ledger and future-schema refusal. The two auxiliary stores
+initialize their current tables independently and must receive their own version histories before either schema makes
+a non-additive change. A session migration version must never be treated as the version of either cache.
 
 ## CLI Contract
 
@@ -81,7 +109,7 @@ A Swift app should bind to `marmot-app`/`marmot-account` shaped APIs rather than
 - inspect and repair relay-list setup;
 - publish/fetch KeyPackages;
 - refresh directory entries;
-- open an account client;
+- start and retain an app runtime;
 - call group, message, membership, archive, and sync methods;
 - render app projection records.
 

--- a/docs/marmot-architecture/overview/app-core-boundary.md
+++ b/docs/marmot-architecture/overview/app-core-boundary.md
@@ -52,26 +52,13 @@ The current app-core concepts are:
 
 ## Local SQLite Layout
 
-For `N` active signing accounts whose stores have been opened, the current layout has up to `2N + 1` SQLite files:
+For `N` active signing accounts whose stores have been opened, the current layout has up to `2N + 1` SQLite files: an
+authoritative SQLCipher `session.sqlite` and a derived SQLCipher `app-cache.sqlite3` per account, plus the
+installation-wide `shared.sqlite3` public-directory and settings store.
 
-| Path | Encryption and scope | Authority and recovery contract |
-| --- | --- | --- |
-| `accounts/<label>/session.sqlite` | Per-account SQLCipher | Contains authoritative protocol and recovery state plus durable app projections. It is not disposable and uses the numbered `cgka_schema_migrations` history described by [Storage Format V2](../storage-format-v2.md). |
-| `accounts/<label>/app-cache.sqlite3` | Per-account SQLCipher | Derived account-private Nostr directory and bounded search state. It can be reconstructed from `AccountHome` plus the Nostr network, but ordinary upgrades should preserve and migrate it so offline directory behavior and discovery provenance are not discarded. |
-| `shared.sqlite3` | Installation-wide plaintext SQLite, created owner-only | Its sanitized public-directory rows are reconstructible cache data. Its telemetry/audit settings and telemetry installation id are durable installation state and must not be silently discarded with the cache. |
-
-Directory writes mirror the public subset into `shared.sqlite3` and the richer record into each active account cache.
-Reads reconcile independently timestamped components from both tiers. Those cross-database writes are not one atomic
-transaction, so neither directory tier is an authoritative protocol-state boundary. A read alone does not repair a
-partial mirror; a later successful save of that directory record reconciles it.
-
-The root-level `app-cache.sqlite3` is a legacy plaintext directory location that is imported and removed. Likewise,
-`accounts/<label>/app.sqlite3` is a legacy projection database imported once into `session.sqlite`; neither is a fourth
-current store.
-
-Only `session.sqlite` currently has a numbered migration ledger and future-schema refusal. The two auxiliary stores
-initialize their current tables independently and must receive their own version histories before either schema makes
-a non-additive change. A session migration version must never be treated as the version of either cache.
+Only the session database currently has a numbered migration ledger. The auxiliary stores need independent migration
+histories before non-additive schema changes. Their authority, reconciliation, durability, and legacy-import contracts
+are detailed in [App SQLite Storage Boundaries](../further-context/app-sqlite-storage-boundaries.md).
 
 ## CLI Contract
 

--- a/docs/marmot-architecture/overview/marmot-app-runtime.md
+++ b/docs/marmot-architecture/overview/marmot-app-runtime.md
@@ -1,7 +1,7 @@
 ---
 title: "Marmot App Runtime Shape"
 created: 2026-05-19
-updated: 2026-08-18
+updated: 2026-09-04
 tags: [marmot, overview, app-runtime, daemon, tui]
 status: implemented-first-slice
 ---
@@ -187,10 +187,36 @@ uploaded artifact.
 
 ## Daemon Boundary
 
-`wnd` should host one `MarmotAppRuntime`. It should accept socket requests, pass intents into the runtime, and stream
-runtime events back to clients.
+`wnd` hosts one `MarmotAppRuntime`. It accepts socket requests, passes intents into the runtime, and streams runtime
+events back to clients.
 
 Daemon responsibilities stay narrow: process lifecycle, socket protocol, request routing, and stream fanout.
+
+MDK currently has two local Unix-socket protocols. They both use newline-terminated JSON and deliberately bounded
+inbound messages, but they serve different trust boundaries and are not wire-compatible:
+
+| Property | `wnd` CLI daemon protocol | `wn-agent` agent-control protocol |
+| --- | --- | --- |
+| Consumer | MDK's own CLI and TUI | Local agent integrations |
+| Wire model | Internal `DaemonRequest` variants carrying the CLI command shape | Stable, typed request/response/event DTOs inside `marmot.agent-control.v2` envelopes |
+| Correlation and versioning | No request id or explicit protocol version | Optional correlation id, an explicit protocol label, and request-id idempotency for stream begin |
+| Authorization | Owner-only socket plus same-UID peer checks | Same-UID peer checks by default, or an explicitly configured full-control bearer token |
+| Errors | CLI output envelopes; no protocol-wide retryability field | Typed error responses with an explicit, fail-closed `retryable` field |
+| Size boundary | 1 MiB cap on each inbound daemon request; responses do not yet have a symmetric protocol cap | 1 MiB per-frame cap in the shared agent-control codec |
+| Sensitive input buffers | Request assembly and decoded request bytes use zeroizing buffers; buffered read-ahead is not guaranteed to be erased | The generic frame codec uses ordinary byte buffers |
+
+Both servers accept one request per connection. A non-streaming `wnd` client reads its response to EOF, while its
+subscription clients read newline-delimited stream records until `stream_end` or EOF. Agent control returns a typed
+response envelope or keeps an inbound-subscription connection open for typed event envelopes; the envelope id is
+echoed on those responses and events.
+
+The similar newline framing is an implementation pattern, not a shared semantic contract. A future consolidation
+should therefore be limited to a small framing primitive that can enforce a caller-selected payload cap, distinguish
+clean EOF from an incomplete frame, and optionally erase its input buffer. Protocol versioning, DTOs, request ids,
+authorization, retry semantics, connection lifetime, and response framing should remain owned by their respective
+protocols. Until such a primitive preserves the CLI daemon's zeroization requirement and adds a symmetric response
+bound, replacing its reader directly with the generic agent-control codec would be a regression rather than a useful
+deduplication.
 
 ## CLI And TUI Boundary
 

--- a/docs/marmot-architecture/overview/marmot-app-runtime.md
+++ b/docs/marmot-architecture/overview/marmot-app-runtime.md
@@ -193,30 +193,13 @@ events back to clients.
 Daemon responsibilities stay narrow: process lifecycle, socket protocol, request routing, and stream fanout.
 
 MDK currently has two local Unix-socket protocols. They both use newline-terminated JSON and deliberately bounded
-inbound messages, but they serve different trust boundaries and are not wire-compatible:
+inbound messages, but they are not wire-compatible. `wnd` exposes MDK's internal CLI command shape, while `wn-agent`
+exposes the versioned, typed `marmot.agent-control.v2` integration protocol.
 
-| Property | `wnd` CLI daemon protocol | `wn-agent` agent-control protocol |
-| --- | --- | --- |
-| Consumer | MDK's own CLI and TUI | Local agent integrations |
-| Wire model | Internal `DaemonRequest` variants carrying the CLI command shape | Stable, typed request/response/event DTOs inside `marmot.agent-control.v2` envelopes |
-| Correlation and versioning | No request id or explicit protocol version | Optional correlation id, an explicit protocol label, and request-id idempotency for stream begin |
-| Authorization | Owner-only socket plus same-UID peer checks | Same-UID peer checks by default, or an explicitly configured full-control bearer token |
-| Errors | CLI output envelopes; no protocol-wide retryability field | Typed error responses with an explicit, fail-closed `retryable` field |
-| Size boundary | 1 MiB cap on each inbound daemon request; responses do not yet have a symmetric protocol cap | 1 MiB per-frame cap in the shared agent-control codec |
-| Sensitive input buffers | Request assembly and decoded request bytes use zeroizing buffers; buffered read-ahead is not guaranteed to be erased | The generic frame codec uses ordinary byte buffers |
-
-Both servers accept one request per connection. A non-streaming `wnd` client reads its response to EOF, while its
-subscription clients read newline-delimited stream records until `stream_end` or EOF. Agent control returns a typed
-response envelope or keeps an inbound-subscription connection open for typed event envelopes; the envelope id is
-echoed on those responses and events.
-
-The similar newline framing is an implementation pattern, not a shared semantic contract. A future consolidation
-should therefore be limited to a small framing primitive that can enforce a caller-selected payload cap, distinguish
-clean EOF from an incomplete frame, and optionally erase its input buffer. Protocol versioning, DTOs, request ids,
-authorization, retry semantics, connection lifetime, and response framing should remain owned by their respective
-protocols. Until such a primitive preserves the CLI daemon's zeroization requirement and adds a symmetric response
-bound, replacing its reader directly with the generic agent-control codec would be a regression rather than a useful
-deduplication.
+Their shared framing pattern is not a shared semantic contract. Any future framing reuse must preserve the CLI
+daemon's stronger request-buffer erasure while leaving versioning, authorization, correlation, retry, and connection
+semantics protocol-owned. See [Local Daemon Protocol Boundaries](../further-context/local-daemon-protocol-boundaries.md)
+for the full comparison and consolidation constraints.
 
 ## CLI And TUI Boundary
 


### PR DESCRIPTION
## Summary

This is the small architecture-review follow-up after #1684. It keeps each concern in a dedicated commit and deliberately leaves schema migrations and framing refactors for separate PRs.

- flatten engine errors consistently through every `AppError` wrapper in CLI JSON output, with a full `WnError` regression test
- remove the CLI's now-unnecessary direct `cgka-session` dependency
- document the three current SQLite store roles, account cardinality, mirrored-write behavior, legacy import paths, and the auxiliary-store migration gap
- document the semantic boundary between the internal `wnd` protocol and versioned `marmot.agent-control.v2`, including what a future shared framing primitive must preserve

## Testing

- `cargo test -p wn-cli error::tests::engine_errors_have_the_same_json_across_app_wrappers -- --exact`
- `just fast-ci`
- documentation stale-marker scan (only the two pre-existing documented matches remain)
- `cargo test -p wn-cli`: all 590 unit tests passed; the integration binary had 13 existing daemon/local-relay failures. The representative `daemon_defaults_create_identities_and_block_loopback_auto_watch_without_manual_sync_or_relay_env` failure was reproduced unchanged on the exact pre-branch `origin/master` commit `94bbb59e`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - CLI JSON errors now preserve the same stable error code for engine failures, whether they occur directly or through account and session operations.

- **Documentation**
  - Expanded storage documentation to describe account session data, directory caches, shared installation storage, migration behavior, and synchronization.
  - Clarified app runtime responsibilities and documented the CLI daemon and agent-control socket protocols, including formats, authorization, limits, and connection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->