### PR TITLE
test(engine): pin join-epoch anchoring and drop the false snapshot-nesting claim

### DIFF
--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -2892,14 +2892,12 @@ fn apply_openmls_canonicalization_result_inner<S: StorageProvider>(
     //
     // The surrounding durable group snapshot (create/rollback/release in
     // `apply_openmls_canonicalization_result`) intentionally stays OUTSIDE this
-    // boundary: those ops drive their own SQLite transactions and cannot nest
-    // inside an open one. The snapshot guards in-process error returns; this
-    // transaction guards hard crashes mid-merge.
+    // boundary: the snapshot guards in-process error returns; this transaction
+    // guards hard crashes mid-merge.
     storage.with_transaction(|storage| {
-        // No pre-validated own messages here. Snapshot rollforward cannot nest
-        // inside this transaction, and every own commit on the accepted
-        // branch was excluded from `replay_messages` before this call —
-        // either as part of the already-applied prefix or as a
+        // No pre-validated own messages here: every own commit on the
+        // accepted branch was excluded from `replay_messages` before this
+        // call — either as part of the already-applied prefix or as a
         // checkpoint-realizable own-commit run whose exact restore the
         // caller performs itself (`checkpoint_realizable_own_commit_prefix`).
         // Leaving own-application stamps out is also load-bearing: those apps

--- a/crates/cgka-engine/src/publish.rs
+++ b/crates/cgka-engine/src/publish.rs
@@ -99,10 +99,9 @@ impl<S: StorageProvider> Engine<S> {
         let has_pending_commit = mls_group.pending_commit().is_some();
 
         // Snapshot the pre-commit epoch as a fork-recovery anchor. Done outside
-        // the durable transaction below because snapshot capture opens its own
-        // backend transaction (it cannot nest) — but the write is keyed by epoch
-        // and idempotent (`INSERT OR REPLACE`), so a retried confirm re-running
-        // it is harmless.
+        // the durable transaction below; the write is keyed by epoch and
+        // idempotent (`INSERT OR REPLACE`), so a retried confirm re-running it
+        // is harmless.
         if has_pending_commit {
             self.retain_current_epoch_snapshot_for_group(&group_id)?;
         }

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -9834,3 +9834,130 @@ async fn a_deferral_with_only_one_retained_branch_reports_uncontested_lineage() 
         "one retained commit cannot fork with itself; an absent rival looks exactly like missing history, which is what a backfill is for"
     );
 }
+
+/// A joiner anchors its join epoch on its first advance, so a rival forking
+/// from that epoch is adjudicated rather than halting the group.
+///
+/// `do_join_welcome` retains no anchor of its own — the join epoch is anchored
+/// by whatever first carries the device past it, because every advance path
+/// (direct ingest, confirm-published, and the convergence apply that starts at
+/// the live tip) snapshots the pre-advance epoch. That is what keeps a late
+/// joiner out of the `MissingRetainedAnchor` residual, and it is the invariant
+/// [`convergence_rewinds_to_greatest_anchor_at_or_below_traversed_fork_epoch`]
+/// leans on: a rewind base exists at every epoch a device stopped at.
+#[tokio::test]
+async fn joiners_first_advance_anchors_the_join_epoch_so_a_rival_there_adjudicates() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut bob, _bob_storage) = build_client(b"bob");
+    let (mut carol, carol_storage) = build_client(b"carol");
+    let (mut david, _david_storage) = build_client(b"david");
+    let (mut eve, _eve_storage) = build_client(b"eve");
+
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "late-joiner-rival".into(),
+            description: String::new(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![bob.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcome_for(&welcomes, b"bob"))
+        .await
+        .unwrap();
+
+    // Carol joins late, at epoch 2.
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (carol_invite, carol_welcomes, carol_pending) = match alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![carol_kp],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::GroupEvolution {
+            msg,
+            welcomes,
+            pending,
+        } => (msg, welcomes, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(carol_pending).await.unwrap();
+    let carol_invite = route(carol_invite, &group_id);
+    carol
+        .join_welcome(welcome_for(&carol_welcomes, b"carol"))
+        .await
+        .unwrap();
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(2));
+    assert_eq!(
+        carol_storage.list_group_snapshots(&group_id).unwrap(),
+        Vec::<String>::new(),
+        "the join itself retains no anchor"
+    );
+
+    // Bob follows to epoch 2 and forks there.
+    bob.buffer_openmls_convergence_message_at(&group_id, carol_invite, 1_000)
+        .unwrap();
+    bob.converge_stored_openmls_messages_at(&group_id, 1_000_000)
+        .unwrap();
+    let eve_kp = eve.fresh_key_package().await.unwrap();
+    let (bob_rival, _bob_pending) = evolution(
+        bob.send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![eve_kp],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap(),
+    );
+    let bob_rival = route(bob_rival, &group_id);
+
+    // Carol's first advance past the join epoch anchors it.
+    let david_kp = david.fresh_key_package().await.unwrap();
+    let (alice_commit, alice_pending) = evolution(
+        alice
+            .send(SendIntent::Invite {
+                group_id: group_id.clone(),
+                key_packages: vec![david_kp],
+                initial_admins: vec![],
+            })
+            .await
+            .unwrap(),
+    );
+    alice.confirm_published(alice_pending).await.unwrap();
+    carol
+        .buffer_openmls_convergence_message_at(&group_id, route(alice_commit, &group_id), 2_000)
+        .unwrap();
+    carol
+        .converge_stored_openmls_messages_at(&group_id, 2_000_000)
+        .unwrap();
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(3));
+    assert!(
+        carol_storage
+            .list_group_snapshots(&group_id)
+            .unwrap()
+            .contains(&"openmls-retained-anchor-2".to_string()),
+        "the first advance must anchor the join epoch"
+    );
+
+    // So the rival forking from the join epoch is adjudicated, not halted.
+    carol
+        .buffer_openmls_convergence_message_at(&group_id, bob_rival, 3_000)
+        .unwrap();
+    let result = carol
+        .converge_stored_openmls_messages_at(&group_id, 3_000_000)
+        .expect("the join-epoch rival is adjudicated");
+    assert_eq!(result.errors, Vec::new());
+    assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
+    assert!(!carol_storage.get_group(&group_id).unwrap().unrecoverable);
+}

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -9951,6 +9951,7 @@ async fn joiners_first_advance_anchors_the_join_epoch_so_a_rival_there_adjudicat
     );
 
     // So the rival forking from the join epoch is adjudicated, not halted.
+    let bob_rival_id = bob_rival.clone();
     carol
         .buffer_openmls_convergence_message_at(&group_id, bob_rival, 3_000)
         .unwrap();
@@ -9960,4 +9961,13 @@ async fn joiners_first_advance_anchors_the_join_epoch_so_a_rival_there_adjudicat
     assert_eq!(result.errors, Vec::new());
     assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
     assert!(!carol_storage.get_group(&group_id).unwrap().unrecoverable);
+
+    // Adjudicated, not merely error-free: Bob wins the epoch-2 tiebreak, so
+    // Carol rolls Alice's commit back and adopts the rival's branch.
+    assert!(committer_wins(&bob.self_id(), &alice.self_id()));
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(3));
+    assert_message_state(&carol_storage, &bob_rival_id, MessageState::Processed);
+    let members = carol.members(&group_id).unwrap();
+    assert!(members.iter().any(|member| member.id == eve.self_id()));
+    assert!(!members.iter().any(|member| member.id == david.self_id()));
 }


### PR DESCRIPTION
Two pieces salvaged from #1666 (closed, superseded by #1675) that stand on their own.

**Join-epoch anchor test.** `do_join_welcome` retains no anchor at the join epoch; the joiner's first advance does (`ingest.rs` retain on direct ingest, the pre-apply retain in convergence, `publish.rs` on confirm). `joiners_first_advance_anchors_the_join_epoch_so_a_rival_there_adjudicates` pins that a rival forking at the join epoch is adjudicated rather than halting: it asserts the anchor, the rival's disposition, the tip epoch, and the rolled-back loser. RED-verified two ways: disabling the pre-apply retain fires the anchor assertion, and with that assertion removed the group halts with `MissingRetainedAnchor`.

**Stale nesting comments.** Three comments claimed snapshot ops "cannot nest" inside `with_transaction`. They can: `with_transaction` is reentrant by flattening on the owning thread (`connection.rs:461-465`), and snapshot capture/restore/checkpoint open a transaction only when the thread owns none (`is_current_thread_transaction_owner` guards). #1675 retains anchors two frames deep. The false premise is deleted; the surviving true reasons stay. `publish.rs`'s pre-transaction retain now has no stated placement rationale; it is idempotent and harmless, and moving it is a separate behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved group convergence for members who join after earlier updates and then advance the group.
  - Competing updates can now be resolved deterministically without incorrectly halting the group or reporting a missing retained anchor.
  - Correct branch selection, rollback, adoption, and member state are preserved during recovery from divergent update histories.

- **Documentation**
  - Clarified safeguards and confirmation-flow behavior in internal documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->