### PR TITLE
Document the signed-commit requirement for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,8 @@ The canonical protocol specification lives in
   WN Agent `v<version> - wn-agent`, and MarmotKit `v<version> - MarmotKit`.
 - Prefer `just release-all <version>` for a full MDK/WN Agent/MarmotKit cohort release, or
   `just release-all-draft <version>` when releases should stay draft for manual publication.
+- Sign every commit before pushing. This repository accepts only cryptographically signed commits;
+  configure Git SSH signing (or another accepted signing method) and verify the signature locally.
 - When adding an `AGENTS.md`, create a sibling `CLAUDE.md` symlink to it.
 
 ## Verification


### PR DESCRIPTION
## Summary

- require every agent-authored commit to be cryptographically signed before push
- require local signature verification before push

## Verification

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`

`just fast-ci` could not run locally because `just` is not installed; GitHub CI will run the complete repository matrix.