### PR TITLE
fix(app): version the directory cache schema

### DIFF
--- a/crates/marmot-app/AGENTS.md
+++ b/crates/marmot-app/AGENTS.md
@@ -72,7 +72,8 @@ App runtime bridge for the first real Marmot app surfaces.
   state), `methods.rs` (the split `impl MarmotApp` block: relay-list/profile/key-package/follow-list fetches, the
   public `directory_*`/`*_user_directory` API, directory-cache lifecycle, and in-memory directory-record hydration),
   `cache.rs` (the per-account SQLCipher directory cache, with its independent numbered migration runner in
-  `cache/migrations.rs` and frozen initial schema in `cache/v1.sql`), and `sync.rs` (the directory-subscription sync worker and
+  `cache/migrations.rs`, frozen initial schema in `cache/v1.sql`, and populated/interrupted-upgrade
+  tests in `cache/assurance_tests.rs` using the historical `cache/fixtures/pre_ledger.sql` fixture), and `sync.rs` (the directory-subscription sync worker and
   plan). `mod.rs` re-exports the DTOs so the `marmot_app::...` paths stay stable; private items referenced across these
   files (and from `tests.rs`/sibling test modules) are widened to `pub(crate)`, never narrowed.
 - Keep stateless account relay-list and KeyPackage parsing/validation (relay-list status, KeyPackage tag/metadata

--- a/crates/marmot-app/AGENTS.md
+++ b/crates/marmot-app/AGENTS.md
@@ -71,7 +71,8 @@ App runtime bridge for the first real Marmot app surfaces.
   Nostr profile/follow-list parsing, search-match ranking, and `profile_content_json` — which hold no `MarmotApp`
   state), `methods.rs` (the split `impl MarmotApp` block: relay-list/profile/key-package/follow-list fetches, the
   public `directory_*`/`*_user_directory` API, directory-cache lifecycle, and in-memory directory-record hydration),
-  `cache.rs` (the per-account SQLCipher directory cache), and `sync.rs` (the directory-subscription sync worker and
+  `cache.rs` (the per-account SQLCipher directory cache, with its independent numbered migration runner in
+  `cache/migrations.rs` and frozen initial schema in `cache/v1.sql`), and `sync.rs` (the directory-subscription sync worker and
   plan). `mod.rs` re-exports the DTOs so the `marmot_app::...` paths stay stable; private items referenced across these
   files (and from `tests.rs`/sibling test modules) are widened to `pub(crate)`, never narrowed.
 - Keep stateless account relay-list and KeyPackage parsing/validation (relay-list status, KeyPackage tag/metadata

--- a/crates/marmot-app/README.md
+++ b/crates/marmot-app/README.md
@@ -21,9 +21,12 @@ It owns these local SQLite stores:
 For `N` active signing accounts whose stores have been opened, this is up to `2N + 1` current SQLite files.
 `session.sqlite` contains authoritative protocol and recovery state and has a numbered migration history. The two
 directory tiers are reconcilable caches, but normal upgrades should preserve them; `shared.sqlite3` also contains
-durable installation settings that are not disposable. The per-account directory cache and shared store currently
-initialize tables without independent numbered migration ledgers, so schema evolution for either must not rely on the
-session database's migration version.
+durable installation settings that are not disposable. The per-account cache has its own numbered
+`app_cache_schema_migrations` ledger and refuses versions newer than the binary supports. Each migration commits its
+schema/data changes and ledger row atomically; version 1 validates and adopts existing unversioned tables and converts
+legacy JSON records without discarding directory or search data. Invalid shapes or migration names fail closed.
+The shared store still initializes tables without a numbered ledger; neither tier uses the session database's
+migration version.
 
 The app runtime exposes those projections through account status, group listing/showing, message listing, and
 snapshot-plus-live subscription APIs so CLI and TUI surfaces can inspect app state without opening the databases

--- a/crates/marmot-app/src/directory/cache.rs
+++ b/crates/marmot-app/src/directory/cache.rs
@@ -1,3 +1,5 @@
+mod migrations;
+
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -67,14 +69,13 @@ impl DirectoryCache {
         Self::from_connection(conn).map(Some)
     }
 
-    fn from_connection(conn: Connection) -> Result<Self, AppError> {
-        initialize_schema(&conn)?;
+    fn from_connection(mut conn: Connection) -> Result<Self, AppError> {
+        migrations::run_all(&mut conn)?;
         let cache = Self {
             conn: Arc::new(CloseableConnection::new(conn, CLOSED_DETAIL)),
             #[cfg(test)]
             put_count: Arc::new(AtomicUsize::new(0)),
         };
-        cache.migrate_legacy_json_records()?;
         Ok(cache)
     }
 
@@ -599,14 +600,12 @@ impl DirectoryCache {
         Ok(relays)
     }
 
-    fn migrate_legacy_json_records(&self) -> Result<(), AppError> {
-        let mut conn = self.lock()?;
-        if !Self::table_exists_locked(&conn, "user_directory_records")? {
+    fn migrate_legacy_json_records(conn: &Connection) -> Result<(), AppError> {
+        if !Self::table_exists_locked(conn, "user_directory_records")? {
             return Ok(());
         }
-        let tx = conn.transaction()?;
         let mut statement =
-            tx.prepare("SELECT entry_json FROM user_directory_records ORDER BY account_id_hex")?;
+            conn.prepare("SELECT entry_json FROM user_directory_records ORDER BY account_id_hex")?;
         let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
         let mut json_entries = Vec::new();
         for row in rows {
@@ -616,10 +615,9 @@ impl DirectoryCache {
 
         for json in json_entries {
             let entry = serde_json::from_str::<UserDirectoryRecord>(&json)?;
-            Self::put_with_reason_locked(&tx, &entry, "directory")?;
+            Self::put_with_reason_locked(conn, &entry, "directory")?;
         }
-        tx.execute_batch("DROP TABLE IF EXISTS user_directory_records;")?;
-        tx.commit()?;
+        conn.execute_batch("DROP TABLE user_directory_records;")?;
         Ok(())
     }
 
@@ -673,64 +671,6 @@ pub(crate) struct DirectorySearchGraphRecord {
     pub(crate) follows: Option<Vec<String>>,
     pub(crate) metadata_updated_at: Option<u64>,
     pub(crate) metadata_expires_at: Option<u64>,
-}
-
-fn initialize_schema(conn: &Connection) -> Result<(), AppError> {
-    conn.execute_batch(
-        "CREATE TABLE IF NOT EXISTS directory_users (
-            account_id_hex TEXT PRIMARY KEY NOT NULL,
-            npub TEXT NOT NULL,
-            local_account_json TEXT,
-            profile_json TEXT,
-            relay_lists_json TEXT NOT NULL,
-            key_package_json TEXT,
-            updated_at INTEGER NOT NULL
-        );
-        CREATE TABLE IF NOT EXISTS directory_user_follows (
-            account_id_hex TEXT NOT NULL,
-            follow_account_id_hex TEXT NOT NULL,
-            position INTEGER NOT NULL,
-            updated_at INTEGER NOT NULL,
-            PRIMARY KEY (account_id_hex, follow_account_id_hex)
-        );
-        CREATE INDEX IF NOT EXISTS directory_user_follows_follow_idx
-            ON directory_user_follows(follow_account_id_hex);
-        CREATE TABLE IF NOT EXISTS directory_follow_source_relays (
-            account_id_hex TEXT NOT NULL,
-            relay_url TEXT NOT NULL,
-            position INTEGER NOT NULL,
-            updated_at INTEGER NOT NULL,
-            PRIMARY KEY (account_id_hex, relay_url)
-        );
-        CREATE TABLE IF NOT EXISTS directory_known_user_reasons (
-            account_id_hex TEXT NOT NULL,
-            reason TEXT NOT NULL,
-            first_seen_at INTEGER NOT NULL,
-            last_seen_at INTEGER NOT NULL,
-            PRIMARY KEY (account_id_hex, reason)
-        );
-        CREATE TABLE IF NOT EXISTS directory_search_graph_users (
-            account_id_hex TEXT PRIMARY KEY NOT NULL,
-            npub TEXT NOT NULL,
-            profile_json TEXT,
-            metadata_updated_at INTEGER,
-            metadata_expires_at INTEGER,
-            follows_known INTEGER NOT NULL DEFAULT 0,
-            follows_updated_at INTEGER,
-            created_at INTEGER NOT NULL,
-            updated_at INTEGER NOT NULL
-        );
-        CREATE TABLE IF NOT EXISTS directory_search_graph_follows (
-            account_id_hex TEXT NOT NULL,
-            follow_account_id_hex TEXT NOT NULL,
-            position INTEGER NOT NULL,
-            updated_at INTEGER NOT NULL,
-            PRIMARY KEY (account_id_hex, follow_account_id_hex)
-        );
-        CREATE INDEX IF NOT EXISTS directory_search_graph_follows_follow_idx
-            ON directory_search_graph_follows(follow_account_id_hex);",
-    )?;
-    Ok(())
 }
 
 fn directory_user_row_from_row(
@@ -812,6 +752,159 @@ mod tests {
             relay_lists: AccountRelayListStatus::empty(),
             key_package: None,
         }
+    }
+
+    fn migration_rows(conn: &Connection) -> Vec<(i64, String)> {
+        conn.prepare("SELECT version, name FROM app_cache_schema_migrations ORDER BY version")
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap()
+    }
+
+    #[test]
+    fn migration_fresh_encrypted_cache_and_reopen_are_idempotent() {
+        let (dir, cache) = test_cache();
+        {
+            let conn = cache.lock().unwrap();
+            assert_eq!(
+                migration_rows(&conn),
+                vec![(1, "0001_directory_cache".into())]
+            );
+            let count: i64 = conn.query_row(
+                "SELECT count(*) FROM sqlite_master WHERE name LIKE 'directory_%' AND type IN ('table', 'index')",
+                [], |row| row.get(0)).unwrap();
+            assert_eq!(count, 8);
+            // A repeated migration would attempt to insert or update this ledger.
+            conn.execute_batch("CREATE TRIGGER prevent_migration_insert BEFORE INSERT ON app_cache_schema_migrations BEGIN SELECT RAISE(ABORT, 'rerun'); END;
+                CREATE TRIGGER prevent_migration_update BEFORE UPDATE ON app_cache_schema_migrations BEGIN SELECT RAISE(ABORT, 'rerun'); END;").unwrap();
+        }
+        cache.close().unwrap();
+        let key = SqlCipherKey::new("test-key").unwrap();
+        let cache = DirectoryCache::open(dir.path().join("directory.sqlite3"), &key).unwrap();
+        assert_eq!(
+            migration_rows(&cache.lock().unwrap()),
+            vec![(1, "0001_directory_cache".into())]
+        );
+    }
+
+    #[test]
+    fn migration_adopts_unversioned_cache_preserving_both_tiers() {
+        let (dir, cache) = test_cache();
+        let record = directory_record(account_id(1), vec![account_id(2)]);
+        cache.put(&record).unwrap();
+        cache
+            .remember_search_graph_follows(&account_id(3), "search-only", &[account_id(4)])
+            .unwrap();
+        cache
+            .lock()
+            .unwrap()
+            .execute_batch("DROP TABLE app_cache_schema_migrations")
+            .unwrap();
+        cache.close().unwrap();
+        let key = SqlCipherKey::new("test-key").unwrap();
+        let cache = DirectoryCache::open(dir.path().join("directory.sqlite3"), &key).unwrap();
+        assert_eq!(
+            cache.entry(&record.account_id_hex).unwrap().unwrap(),
+            record
+        );
+        assert!(cache.entry(&account_id(3)).unwrap().is_none());
+        assert_eq!(
+            cache.search_graph_follows(&account_id(3)).unwrap(),
+            Some(vec![account_id(4)])
+        );
+        assert_eq!(migration_rows(&cache.lock().unwrap()).len(), 1);
+    }
+
+    #[test]
+    fn migration_refuses_future_version_and_unexpected_name() {
+        let (dir, cache) = test_cache();
+        cache
+            .lock()
+            .unwrap()
+            .execute(
+                "INSERT INTO app_cache_schema_migrations VALUES (2, 'private-name', 0)",
+                [],
+            )
+            .unwrap();
+        cache.close().unwrap();
+        let key = SqlCipherKey::new("test-key").unwrap();
+        let path = dir.path().join("directory.sqlite3");
+        assert!(matches!(
+            DirectoryCache::open(path.clone(), &key),
+            Err(AppError::Storage(
+                cgka_traits::storage::StorageError::UnsupportedSchemaVersion {
+                    found: 2,
+                    latest_supported: 1
+                }
+            ))
+        ));
+        let conn = Connection::open(&path).unwrap();
+        open_hardened_sqlcipher(&conn, &key, SqlCipherHardening::live_cache()).unwrap();
+        conn.execute_batch(
+            "DELETE FROM app_cache_schema_migrations WHERE version = 2;
+            UPDATE app_cache_schema_migrations SET name = 'private-name'",
+        )
+        .unwrap();
+        drop(conn);
+        let error = DirectoryCache::open(path, &key).unwrap_err();
+        assert!(!error.to_string().contains("private-name"));
+    }
+
+    #[test]
+    fn migration_partial_schema_is_not_adopted() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE directory_users (account_id_hex TEXT PRIMARY KEY NOT NULL)",
+        )
+        .unwrap();
+        assert!(migrations::run_all(&mut conn).is_err());
+        assert!(
+            !DirectoryCache::table_exists_locked(&conn, "directory_search_graph_users").unwrap()
+        );
+        assert!(
+            !DirectoryCache::table_exists_locked(&conn, "app_cache_schema_migrations").unwrap()
+        );
+    }
+
+    #[test]
+    fn migration_legacy_failure_rolls_back_schema_and_data() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE user_directory_records (account_id_hex TEXT PRIMARY KEY, entry_json TEXT NOT NULL)").unwrap();
+        conn.execute(
+            "INSERT INTO user_directory_records VALUES ('a', ?1)",
+            [
+                serde_json::to_string(&directory_record(account_id(1), vec![account_id(2)]))
+                    .unwrap(),
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO user_directory_records VALUES ('b', ?1)",
+            [r#"{"account_id_hex": "private-profile", "npub": 123}"#],
+        )
+        .unwrap();
+        let error = migrations::run_all(&mut conn).unwrap_err();
+        assert!(!error.to_string().contains("private-profile"));
+        assert!(!DirectoryCache::table_exists_locked(&conn, "directory_users").unwrap());
+        assert!(
+            !DirectoryCache::table_exists_locked(&conn, "app_cache_schema_migrations").unwrap()
+        );
+        let count: i64 = conn
+            .query_row("SELECT count(*) FROM user_directory_records", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(count, 2);
+        conn.execute(
+            "DELETE FROM user_directory_records WHERE account_id_hex = 'b'",
+            [],
+        )
+        .unwrap();
+        migrations::run_all(&mut conn).unwrap();
+        assert_eq!(migration_rows(&conn).len(), 1);
+        assert!(!DirectoryCache::table_exists_locked(&conn, "user_directory_records").unwrap());
     }
 
     #[test]
@@ -1096,5 +1189,6 @@ mod tests {
         assert_eq!(entry.follows, vec![bob]);
         assert_eq!(user_count, 1);
         assert!(!legacy_table_exists);
+        assert_eq!(migration_rows(&cache.lock().unwrap()).len(), 1);
     }
 }

--- a/crates/marmot-app/src/directory/cache.rs
+++ b/crates/marmot-app/src/directory/cache.rs
@@ -31,6 +31,13 @@ pub(crate) const SEARCH_GRAPH_PROFILE_TTL_SECONDS: i64 = 24 * 60 * 60;
 /// Message carried by every storage error this cache raises after a close.
 const CLOSED_DETAIL: &str = "directory cache is closed";
 
+#[cfg(test)]
+thread_local! {
+    // Count successful writes before an injected failure, even if SQLite has
+    // already rolled back the transaction when it returns SQLITE_FULL.
+    static LEGACY_RECORDS_CONVERTED: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct DirectoryCache {
     conn: Arc<CloseableConnection>,
@@ -616,6 +623,8 @@ impl DirectoryCache {
         for json in json_entries {
             let entry = serde_json::from_str::<UserDirectoryRecord>(&json)?;
             Self::put_with_reason_locked(conn, &entry, "directory")?;
+            #[cfg(test)]
+            LEGACY_RECORDS_CONVERTED.with(|count| count.set(count.get() + 1));
         }
         conn.execute_batch("DROP TABLE user_directory_records;")?;
         Ok(())

--- a/crates/marmot-app/src/directory/cache/assurance_tests.rs
+++ b/crates/marmot-app/src/directory/cache/assurance_tests.rs
@@ -1,0 +1,257 @@
+//! Populated-database and interrupted-upgrade checks using historical DDL.
+//! All data and keys are synthetic; no installed app databases are accessed.
+use super::*;
+use sha2::{Digest, Sha256};
+use storage_sqlite::{SqlCipherHardening, SqlCipherKey, open_hardened_sqlcipher};
+
+const HISTORICAL_SQL: &str = include_str!("fixtures/pre_ledger.sql");
+const TABLES: &[&str] = &[
+    "directory_users",
+    "directory_user_follows",
+    "directory_follow_source_relays",
+    "directory_known_user_reasons",
+    "directory_search_graph_users",
+    "directory_search_graph_follows",
+];
+
+fn encrypted_connection(path: &std::path::Path) -> Connection {
+    fs_private::ensure_private_db_files(path).unwrap();
+    let conn = Connection::open(path).unwrap();
+    open_hardened_sqlcipher(
+        &conn,
+        &SqlCipherKey::new("synthetic-upgrade-test-key").unwrap(),
+        SqlCipherHardening::live_cache(),
+    )
+    .unwrap();
+    conn
+}
+
+/// Hash every typed value, including rowids, with deterministic row ordering.
+fn snapshot(conn: &Connection, tables: &[&str], limit: i64) -> Vec<(u64, Vec<u8>)> {
+    tables
+        .iter()
+        .map(|table| {
+            let mut statement = conn
+                .prepare(&format!(
+                    "SELECT rowid, * FROM {table} ORDER BY rowid LIMIT {limit}"
+                ))
+                .unwrap();
+            let columns = statement.column_count();
+            let mut rows = statement.query([]).unwrap();
+            let mut hash = Sha256::new();
+            let mut count = 0;
+            while let Some(row) = rows.next().unwrap() {
+                for column in 0..columns {
+                    let value: rusqlite::types::Value = row.get(column).unwrap();
+                    let bytes = format!("{value:?}").into_bytes();
+                    hash.update((bytes.len() as u64).to_le_bytes());
+                    hash.update(bytes);
+                }
+                count += 1;
+            }
+            (count, hash.finalize().to_vec())
+        })
+        .collect()
+}
+
+fn seed_structured(conn: &mut Connection, users: i64) {
+    conn.execute_batch(HISTORICAL_SQL).unwrap();
+    let tx = conn.transaction().unwrap();
+    // Include Unicode, unknown metadata, NULLs, empty JSON, and intentionally
+    // invalid cached JSON: adoption must not inspect or rewrite stored records.
+    tx.execute(
+        r#"WITH RECURSIVE seq(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM seq WHERE n < ?1)
+         INSERT INTO directory_users
+         SELECT printf('%064x',n), 'npub-'||n, NULL,
+             CASE n % 3 WHEN 0 THEN NULL WHEN 1 THEN '{invalid cached JSON'
+             ELSE '{"name":"日本語 🦫","future_field":{"a":[1,null]}}' END,
+             '{}', NULL, n FROM seq"#,
+        [users],
+    )
+    .unwrap();
+    tx.execute_batch(
+        "INSERT INTO directory_user_follows
+             SELECT account_id_hex, 'friend', 0, updated_at FROM directory_users;
+         INSERT INTO directory_follow_source_relays
+             SELECT account_id_hex, 'wss://synthetic.example', 0, updated_at FROM directory_users;
+         INSERT INTO directory_known_user_reasons
+             SELECT account_id_hex, 'directory', updated_at, updated_at FROM directory_users;
+         INSERT INTO directory_search_graph_users
+             SELECT account_id_hex, npub, profile_json, updated_at, updated_at+86400,
+                    1, updated_at, updated_at, updated_at FROM directory_users;
+         INSERT INTO directory_search_graph_follows
+             SELECT * FROM directory_user_follows;",
+    )
+    .unwrap();
+    tx.commit().unwrap();
+}
+
+fn seed_legacy(conn: &mut Connection, users: u64) -> Vec<crate::UserDirectoryRecord> {
+    conn.execute_batch(
+        "CREATE TABLE user_directory_records (
+            account_id_hex TEXT PRIMARY KEY NOT NULL,
+            entry_json TEXT NOT NULL, updated_at INTEGER NOT NULL);",
+    )
+    .unwrap();
+    let tx = conn.transaction().unwrap();
+    let mut expected = Vec::new();
+    for n in 1..=users {
+        let record = crate::UserDirectoryRecord {
+            account_id_hex: format!("{:064x}", n + 1_000_000),
+            npub: format!("synthetic-legacy-{n}"),
+            local_account: None,
+            profile: Some(crate::UserProfileMetadata {
+                name: Some(format!("legacy-{n}")),
+                about: Some("synthetic profile ".repeat(128)),
+                ..Default::default()
+            }),
+            follows: vec!["synthetic-follow".into()],
+            follow_source_relays: vec!["wss://synthetic.example".into()],
+            relay_lists: crate::AccountRelayListStatus::empty(),
+            key_package: None,
+        };
+        tx.execute(
+            "INSERT INTO user_directory_records VALUES (?1, ?2, 0)",
+            params![
+                record.account_id_hex,
+                serde_json::to_string(&record).unwrap()
+            ],
+        )
+        .unwrap();
+        expected.push(record);
+    }
+    tx.commit().unwrap();
+    expected
+}
+
+fn assert_converted(conn: &Connection, expected: &[crate::UserDirectoryRecord]) {
+    for record in expected {
+        let row = DirectoryCache::directory_user_row(conn, &record.account_id_hex)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            DirectoryCache::record_from_directory_user_row(conn, row).unwrap(),
+            *record
+        );
+    }
+}
+
+#[test]
+fn populated_historical_encrypted_cache_preserves_all_120000_rows() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("app-cache.sqlite3");
+    let mut conn = encrypted_connection(&path);
+    seed_structured(&mut conn, 20_000);
+    let before = snapshot(&conn, TABLES, -1);
+    assert!(before.iter().all(|(count, _)| *count == 20_000));
+    drop(conn);
+
+    let started = std::time::Instant::now();
+    let cache = DirectoryCache::open(
+        path.clone(),
+        &SqlCipherKey::new("synthetic-upgrade-test-key").unwrap(),
+    )
+    .unwrap();
+    eprintln!(
+        "historical cache open with 120000 rows: {:?}",
+        started.elapsed()
+    );
+    assert_eq!(snapshot(&cache.lock().unwrap(), TABLES, -1), before);
+    cache.close().unwrap();
+    let conn = encrypted_connection(&path);
+    assert_eq!(snapshot(&conn, TABLES, -1), before);
+    let integrity: String = conn
+        .query_row("PRAGMA integrity_check", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(integrity, "ok");
+}
+
+#[test]
+fn legacy_conversion_disk_full_preserves_both_tiers_and_retries() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut conn = encrypted_connection(&dir.path().join("app-cache.sqlite3"));
+    seed_structured(&mut conn, 25);
+    let expected = seed_legacy(&mut conn, 1_000);
+    let tables = [TABLES, &["user_directory_records"]].concat();
+    let before = snapshot(&conn, &tables, -1);
+    let pages: i64 = conn
+        .pragma_query_value(None, "page_count", |r| r.get(0))
+        .unwrap();
+    // Permit the ledger to be created but not the duplicated legacy records.
+    conn.pragma_update(None, "max_page_count", pages + 4)
+        .unwrap();
+    let error = run_all(&mut conn).unwrap_err();
+    assert!(
+        matches!(error, AppError::Sqlite(rusqlite::Error::SqliteFailure(code, None))
+        if code.code == rusqlite::ErrorCode::DiskFull)
+    );
+    assert_eq!(snapshot(&conn, &tables, -1), before);
+    assert!(!DirectoryCache::table_exists_locked(&conn, "app_cache_schema_migrations").unwrap());
+    conn.pragma_update(None, "max_page_count", pages + 10_000)
+        .unwrap();
+    run_all(&mut conn).unwrap();
+    assert!(!DirectoryCache::table_exists_locked(&conn, "user_directory_records").unwrap());
+    let count: i64 = conn
+        .query_row("SELECT count(*) FROM directory_users", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(count, 1_025);
+    assert_converted(&conn, &expected);
+    // Existing structured rows remain unchanged even alongside legacy records.
+    assert_eq!(snapshot(&conn, TABLES, 25), before[..6]);
+}
+
+/// This test is also the child process: exit bypasses every Rust/SQLite
+/// destructor after conversion and table removal, before the ledger commit.
+#[test]
+fn interrupted_encrypted_legacy_upgrade_recovers_without_losing_records() {
+    const CHILD_PATH: &str = "MDK_DIRECTORY_UPGRADE_CRASH_TEST_PATH";
+    if let Some(path) = std::env::var_os(CHILD_PATH) {
+        let mut conn = encrypted_connection(std::path::Path::new(&path));
+        let interrupted = [Migration {
+            version: 1,
+            name: MIGRATIONS[0].name,
+            apply: |tx| {
+                version_1(tx)?;
+                std::process::exit(77);
+            },
+        }];
+        run(&mut conn, &interrupted).unwrap();
+        panic!("child must exit inside the transaction");
+    }
+    for journal in ["DELETE", "WAL"] {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("app-cache.sqlite3");
+        let mut conn = encrypted_connection(&path);
+        conn.pragma_update(None, "journal_mode", journal).unwrap();
+        seed_structured(&mut conn, 25);
+        let expected = seed_legacy(&mut conn, 1_000);
+        let tables = [TABLES, &["user_directory_records"]].concat();
+        let before = snapshot(&conn, &tables, -1);
+        drop(conn);
+
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .args(["--exact",
+                "directory::cache::migrations::assurance_tests::interrupted_encrypted_legacy_upgrade_recovers_without_losing_records",
+                "--nocapture"])
+            .env(CHILD_PATH, &path)
+            .status().unwrap();
+        assert_eq!(status.code(), Some(77), "{journal}");
+        let mut conn = encrypted_connection(&path);
+        assert_eq!(snapshot(&conn, &tables, -1), before, "{journal}");
+        assert!(
+            !DirectoryCache::table_exists_locked(&conn, "app_cache_schema_migrations").unwrap()
+        );
+        run_all(&mut conn).unwrap();
+        assert!(!DirectoryCache::table_exists_locked(&conn, "user_directory_records").unwrap());
+        let count: i64 = conn
+            .query_row("SELECT count(*) FROM directory_users", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1_025);
+        assert_converted(&conn, &expected);
+        assert_eq!(snapshot(&conn, TABLES, 25), before[..6]);
+        let integrity: String = conn
+            .query_row("PRAGMA integrity_check", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(integrity, "ok");
+    }
+}

--- a/crates/marmot-app/src/directory/cache/assurance_tests.rs
+++ b/crates/marmot-app/src/directory/cache/assurance_tests.rs
@@ -172,10 +172,16 @@ fn legacy_conversion_disk_full_preserves_both_tiers_and_retries() {
     let pages: i64 = conn
         .pragma_query_value(None, "page_count", |r| r.get(0))
         .unwrap();
-    // Permit the ledger to be created but not the duplicated legacy records.
-    conn.pragma_update(None, "max_page_count", pages + 4)
+    // Permit the ledger and some converted records, but not the full conversion.
+    // The progress assertion below guards this premise against allocation changes.
+    conn.pragma_update(None, "max_page_count", pages + 64)
         .unwrap();
+    super::super::LEGACY_RECORDS_CONVERTED.with(|count| count.set(0));
     let error = run_all(&mut conn).unwrap_err();
+    assert!(
+        super::super::LEGACY_RECORDS_CONVERTED.with(|count| count.get()) > 0,
+        "disk exhaustion must occur after at least one legacy record was converted"
+    );
     assert!(
         matches!(error, AppError::Sqlite(rusqlite::Error::SqliteFailure(code, None))
         if code.code == rusqlite::ErrorCode::DiskFull)

--- a/crates/marmot-app/src/directory/cache/assurance_tests.rs
+++ b/crates/marmot-app/src/directory/cache/assurance_tests.rs
@@ -183,6 +183,10 @@ fn legacy_conversion_disk_full_preserves_both_tiers_and_retries() {
         "disk exhaustion must occur after at least one legacy record was converted"
     );
     assert!(
+        super::super::LEGACY_RECORDS_CONVERTED.with(|count| count.get()) < expected.len(),
+        "disk exhaustion must interrupt legacy conversion"
+    );
+    assert!(
         matches!(error, AppError::Sqlite(rusqlite::Error::SqliteFailure(code, None))
         if code.code == rusqlite::ErrorCode::DiskFull)
     );

--- a/crates/marmot-app/src/directory/cache/assurance_tests.rs
+++ b/crates/marmot-app/src/directory/cache/assurance_tests.rs
@@ -146,16 +146,11 @@ fn populated_historical_encrypted_cache_preserves_all_120000_rows() {
     assert!(before.iter().all(|(count, _)| *count == 20_000));
     drop(conn);
 
-    let started = std::time::Instant::now();
     let cache = DirectoryCache::open(
         path.clone(),
         &SqlCipherKey::new("synthetic-upgrade-test-key").unwrap(),
     )
     .unwrap();
-    eprintln!(
-        "historical cache open with 120000 rows: {:?}",
-        started.elapsed()
-    );
     assert_eq!(snapshot(&cache.lock().unwrap(), TABLES, -1), before);
     cache.close().unwrap();
     let conn = encrypted_connection(&path);

--- a/crates/marmot-app/src/directory/cache/fixtures/pre_ledger.sql
+++ b/crates/marmot-app/src/directory/cache/fixtures/pre_ledger.sql
@@ -1,0 +1,54 @@
+-- Historical fixture extracted from 9db9dbc092d52eb7b2d5bc6dcfb1f9beb3125464
+-- crates/marmot-app/src/directory/cache.rs initialize_schema, not current v1.sql.
+CREATE TABLE IF NOT EXISTS directory_users (
+    account_id_hex TEXT PRIMARY KEY NOT NULL,
+    npub TEXT NOT NULL,
+    local_account_json TEXT,
+    profile_json TEXT,
+    relay_lists_json TEXT NOT NULL,
+    key_package_json TEXT,
+    updated_at INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS directory_user_follows (
+    account_id_hex TEXT NOT NULL,
+    follow_account_id_hex TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (account_id_hex, follow_account_id_hex)
+);
+CREATE INDEX IF NOT EXISTS directory_user_follows_follow_idx
+    ON directory_user_follows(follow_account_id_hex);
+CREATE TABLE IF NOT EXISTS directory_follow_source_relays (
+    account_id_hex TEXT NOT NULL,
+    relay_url TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (account_id_hex, relay_url)
+);
+CREATE TABLE IF NOT EXISTS directory_known_user_reasons (
+    account_id_hex TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    first_seen_at INTEGER NOT NULL,
+    last_seen_at INTEGER NOT NULL,
+    PRIMARY KEY (account_id_hex, reason)
+);
+CREATE TABLE IF NOT EXISTS directory_search_graph_users (
+    account_id_hex TEXT PRIMARY KEY NOT NULL,
+    npub TEXT NOT NULL,
+    profile_json TEXT,
+    metadata_updated_at INTEGER,
+    metadata_expires_at INTEGER,
+    follows_known INTEGER NOT NULL DEFAULT 0,
+    follows_updated_at INTEGER,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS directory_search_graph_follows (
+    account_id_hex TEXT NOT NULL,
+    follow_account_id_hex TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (account_id_hex, follow_account_id_hex)
+);
+CREATE INDEX IF NOT EXISTS directory_search_graph_follows_follow_idx
+    ON directory_search_graph_follows(follow_account_id_hex);

--- a/crates/marmot-app/src/directory/cache/migrations.rs
+++ b/crates/marmot-app/src/directory/cache/migrations.rs
@@ -1,0 +1,287 @@
+//! Independent schema history for app-cache.sqlite3, including plaintext legacy imports.
+use cgka_traits::storage::StorageError;
+use rusqlite::{Connection, Transaction, TransactionBehavior, params};
+
+use super::{AppError, DirectoryCache};
+
+struct Migration {
+    version: i64,
+    name: &'static str,
+    apply: fn(&Transaction<'_>) -> Result<(), AppError>,
+}
+
+const MIGRATIONS: &[Migration] = &[Migration {
+    version: 1,
+    name: "0001_directory_cache",
+    apply: version_1,
+}];
+
+const VERSION_1_SQL: &str = include_str!("v1.sql");
+
+pub(super) fn run_all(conn: &mut Connection) -> Result<(), AppError> {
+    // SQLite/JSON errors can contain database-controlled names or values.
+    // Keep the typed downgrade error, but never surface those private details.
+    run(conn, MIGRATIONS).map_err(|error| match error {
+        AppError::Storage(StorageError::UnsupportedSchemaVersion { .. }) => error,
+        _ => StorageError::Backend("directory cache schema migration failed".into()).into(),
+    })
+}
+
+fn run(conn: &mut Connection, migrations: &[Migration]) -> Result<(), AppError> {
+    let mut previous = 0;
+    for migration in migrations {
+        if migration.version <= previous {
+            return Err(invalid_history());
+        }
+        previous = migration.version;
+    }
+    let latest_supported = previous;
+    for migration in migrations {
+        // Lock before reading history so concurrent openers cannot both apply a
+        // migration. Even ledger creation is rolled back on first-open failure.
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        tx.execute_batch(
+            "CREATE TABLE IF NOT EXISTS app_cache_schema_migrations (
+                version INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                applied_at_unix_seconds INTEGER NOT NULL
+            );",
+        )?;
+        let recorded = {
+            let mut statement = tx.prepare(
+                "SELECT version, name FROM app_cache_schema_migrations ORDER BY version",
+            )?;
+            statement
+                .query_map([], |row| {
+                    Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+                })?
+                .collect::<Result<Vec<_>, _>>()?
+        };
+        if let Some((found, _)) = recorded.last()
+            && *found > latest_supported
+        {
+            return Err(StorageError::UnsupportedSchemaVersion {
+                found: *found,
+                latest_supported,
+            }
+            .into());
+        }
+        // History must be a prefix, with exactly the compiled names. Check all
+        // rows before any pending migration can change the database.
+        for (index, (version, name)) in recorded.iter().enumerate() {
+            let Some(expected) = migrations.get(index) else {
+                return Err(invalid_history());
+            };
+            if *version != expected.version || name != expected.name {
+                return Err(invalid_history());
+            }
+        }
+        if !recorded
+            .iter()
+            .any(|(version, _)| *version == migration.version)
+        {
+            (migration.apply)(&tx)?;
+            tx.execute(
+                "INSERT INTO app_cache_schema_migrations
+                    (version, name, applied_at_unix_seconds)
+                 VALUES (?1, ?2, CAST(strftime('%s', 'now') AS INTEGER))",
+                params![migration.version, migration.name],
+            )?;
+        }
+        tx.commit()?;
+    }
+    Ok(())
+}
+
+fn invalid_history() -> AppError {
+    StorageError::Backend("invalid directory cache migration history".into()).into()
+}
+
+fn version_1(tx: &Transaction<'_>) -> Result<(), AppError> {
+    tx.execute_batch(VERSION_1_SQL)?;
+    validate_version_1(tx)?;
+    DirectoryCache::migrate_legacy_json_records(tx)
+}
+
+/// IF NOT EXISTS can adopt an existing table without checking its shape. Use
+/// the frozen v1 DDL as the reference, including types, nullability, defaults,
+/// primary keys and index columns, before blessing an unversioned database.
+/// The reference is empty and memory-only; no cached records leave SQLCipher.
+fn validate_version_1(conn: &Connection) -> Result<(), AppError> {
+    let reference = Connection::open_in_memory()?;
+    reference.execute_batch(VERSION_1_SQL)?;
+    let mut statement = reference.prepare(
+        "SELECT type, name FROM sqlite_master WHERE type IN ('table', 'index')
+         AND name NOT LIKE 'sqlite_%'",
+    )?;
+    let objects = statement.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    })?;
+    for object in objects {
+        let (kind, name) = object?;
+        let object_query = "SELECT type, tbl_name FROM sqlite_master WHERE name = ?1";
+        let expected: (String, String) =
+            reference.query_row(object_query, [&name], |row| Ok((row.get(0)?, row.get(1)?)))?;
+        let actual: (String, String) =
+            conn.query_row(object_query, [&name], |row| Ok((row.get(0)?, row.get(1)?)))?;
+        if actual != expected {
+            return Err(invalid_history());
+        }
+        if kind == "index" {
+            let query = r#"SELECT "unique", partial FROM pragma_index_list(?1) WHERE name = ?2"#;
+            let flags = |db: &Connection| -> rusqlite::Result<(i64, i64)> {
+                db.query_row(query, [&expected.1, &name], |row| {
+                    Ok((row.get(0)?, row.get(1)?))
+                })
+            };
+            if flags(conn)? != flags(&reference)? {
+                return Err(invalid_history());
+            }
+        }
+        // Names come exclusively from our frozen DDL, never stored user data.
+        let query = if kind == "table" {
+            format!(
+                "SELECT name, type, \"notnull\", dflt_value, pk FROM pragma_table_info('{name}') ORDER BY cid"
+            )
+        } else {
+            format!("SELECT name, '', 0, NULL, 0 FROM pragma_index_info('{name}') ORDER BY seqno")
+        };
+        if shape(conn, &query)? != shape(&reference, &query)? {
+            return Err(invalid_history());
+        }
+    }
+    Ok(())
+}
+
+type ColumnShape = (String, String, i64, Option<String>, i64);
+
+fn shape(conn: &Connection, query: &str) -> Result<Vec<ColumnShape>, AppError> {
+    Ok(conn
+        .prepare(query)?
+        .query_map([], |row| {
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+            ))
+        })?
+        .collect::<Result<_, _>>()?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migration_rejects_missing_columns_keys_and_wrong_indexes() {
+        for mutation in [
+            "ALTER TABLE directory_users DROP COLUMN profile_json",
+            "ALTER TABLE directory_search_graph_users DROP COLUMN metadata_expires_at",
+            "DROP TABLE directory_known_user_reasons; CREATE TABLE directory_known_user_reasons (
+                account_id_hex TEXT NOT NULL, reason TEXT NOT NULL,
+                first_seen_at INTEGER NOT NULL, last_seen_at INTEGER NOT NULL)",
+            "DROP INDEX directory_user_follows_follow_idx;
+                CREATE INDEX directory_user_follows_follow_idx ON directory_user_follows(position)",
+            "DROP INDEX directory_user_follows_follow_idx;
+                CREATE UNIQUE INDEX directory_user_follows_follow_idx ON directory_user_follows(follow_account_id_hex)",
+        ] {
+            let mut conn = Connection::open_in_memory().unwrap();
+            conn.execute_batch(VERSION_1_SQL).unwrap();
+            conn.execute_batch(mutation).unwrap();
+            assert!(run_all(&mut conn).is_err(), "{mutation}");
+            assert!(!DirectoryCache::table_exists_locked(&conn, "app_cache_schema_migrations").unwrap());
+        }
+    }
+
+    #[test]
+    fn migration_adopts_frozen_unversioned_schema() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(VERSION_1_SQL).unwrap();
+        conn.execute_batch(
+            "INSERT INTO directory_search_graph_users
+            (account_id_hex, npub, profile_json, metadata_updated_at, metadata_expires_at,
+             follows_known, follows_updated_at, created_at, updated_at)
+            VALUES ('search', 'npub', '{}', 10, 20, 1, 12, 8, 14);
+            INSERT INTO directory_search_graph_follows VALUES ('search', 'friend', 0, 12);",
+        )
+        .unwrap();
+        let before: String = conn
+            .query_row(
+                "SELECT json_array(account_id_hex, npub, profile_json, metadata_updated_at,
+                metadata_expires_at, follows_known, follows_updated_at, created_at, updated_at)
+             FROM directory_search_graph_users",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        run_all(&mut conn).unwrap();
+        let after: String = conn
+            .query_row(
+                "SELECT json_array(account_id_hex, npub, profile_json, metadata_updated_at,
+                metadata_expires_at, follows_known, follows_updated_at, created_at, updated_at)
+             FROM directory_search_graph_users",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(before, after);
+        let friend: String = conn
+            .query_row(
+                "SELECT follow_account_id_hex FROM directory_search_graph_follows",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(friend, "friend");
+    }
+
+    #[test]
+    fn migration_ledger_insert_failure_rolls_back_body() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        run_all(&mut conn).unwrap();
+        conn.execute_batch(
+            "CREATE TRIGGER reject_migration BEFORE INSERT ON app_cache_schema_migrations
+             BEGIN SELECT RAISE(ABORT, 'injected failure'); END;",
+        )
+        .unwrap();
+        let migrations = [
+            Migration {
+                version: 1,
+                name: MIGRATIONS[0].name,
+                apply: version_1,
+            },
+            Migration {
+                version: 2,
+                name: "0002_test",
+                apply: |tx| {
+                    tx.execute_batch(
+                        "CREATE TABLE rollback_probe (value INTEGER);
+                    INSERT INTO rollback_probe VALUES (1);
+                    INSERT INTO directory_known_user_reasons VALUES ('test', 'test', 0, 0);",
+                    )?;
+                    Ok(())
+                },
+            },
+        ];
+        assert!(run(&mut conn, &migrations).is_err());
+        assert!(!DirectoryCache::table_exists_locked(&conn, "rollback_probe").unwrap());
+        let count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM directory_known_user_reasons",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0);
+        let count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM app_cache_schema_migrations",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+}

--- a/crates/marmot-app/src/directory/cache/migrations.rs
+++ b/crates/marmot-app/src/directory/cache/migrations.rs
@@ -18,15 +18,26 @@ const MIGRATIONS: &[Migration] = &[Migration {
 
 const VERSION_1_SQL: &str = include_str!("v1.sql");
 
+/// Open the cache's independent migration domain without exposing stored values.
 pub(super) fn run_all(conn: &mut Connection) -> Result<(), AppError> {
-    // SQLite/JSON errors can contain database-controlled names or values.
-    // Keep the typed downgrade error, but never surface those private details.
     run(conn, MIGRATIONS).map_err(|error| match error {
-        AppError::Storage(StorageError::UnsupportedSchemaVersion { .. }) => error,
+        // These errors are constructed here from static text or version numbers.
+        AppError::Storage(_) => error,
+        // Extended result codes preserve BUSY/IOERR/NOTADB diagnostics without
+        // SQLite's optional message (including user-defined trigger messages).
+        AppError::Sqlite(rusqlite::Error::SqliteFailure(code, _)) => {
+            AppError::Sqlite(rusqlite::Error::SqliteFailure(code, None))
+        }
+        AppError::Json(_) => {
+            StorageError::Serialization("invalid legacy directory cache record".into()).into()
+        }
         _ => StorageError::Backend("directory cache schema migration failed".into()).into(),
     })
 }
 
+/// Mirror storage-sqlite/src/migrations.rs's atomic body-plus-ledger contract.
+/// Keep this runner local: that runner hardcodes the session ledger and owns
+/// session-specific legacy-name reconciliation, neither of which applies here.
 fn run(conn: &mut Connection, migrations: &[Migration]) -> Result<(), AppError> {
     let mut previous = 0;
     for migration in migrations {
@@ -35,11 +46,20 @@ fn run(conn: &mut Connection, migrations: &[Migration]) -> Result<(), AppError> 
         }
         previous = migration.version;
     }
-    let latest_supported = previous;
-    for migration in migrations {
-        // Lock before reading history so concurrent openers cannot both apply a
-        // migration. Even ledger creation is rolled back on first-open failure.
+    // A current cache needs only reads, even while another connection writes.
+    let applied = applied_count(conn, migrations)?;
+    for migration in &migrations[applied..] {
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        // A concurrent opener may have migrated between the read and our lock.
+        // Revalidate under the lock before running any pending body.
+        let applied = applied_count(&tx, migrations)?;
+        if migrations[..applied]
+            .iter()
+            .any(|m| m.version == migration.version)
+        {
+            tx.commit()?;
+            continue;
+        }
         tx.execute_batch(
             "CREATE TABLE IF NOT EXISTS app_cache_schema_migrations (
                 version INTEGER PRIMARY KEY,
@@ -47,50 +67,49 @@ fn run(conn: &mut Connection, migrations: &[Migration]) -> Result<(), AppError> 
                 applied_at_unix_seconds INTEGER NOT NULL
             );",
         )?;
-        let recorded = {
-            let mut statement = tx.prepare(
-                "SELECT version, name FROM app_cache_schema_migrations ORDER BY version",
-            )?;
-            statement
-                .query_map([], |row| {
-                    Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
-                })?
-                .collect::<Result<Vec<_>, _>>()?
-        };
-        if let Some((found, _)) = recorded.last()
-            && *found > latest_supported
-        {
-            return Err(StorageError::UnsupportedSchemaVersion {
-                found: *found,
-                latest_supported,
-            }
-            .into());
-        }
-        // History must be a prefix, with exactly the compiled names. Check all
-        // rows before any pending migration can change the database.
-        for (index, (version, name)) in recorded.iter().enumerate() {
-            let Some(expected) = migrations.get(index) else {
-                return Err(invalid_history());
-            };
-            if *version != expected.version || name != expected.name {
-                return Err(invalid_history());
-            }
-        }
-        if !recorded
-            .iter()
-            .any(|(version, _)| *version == migration.version)
-        {
-            (migration.apply)(&tx)?;
-            tx.execute(
-                "INSERT INTO app_cache_schema_migrations
-                    (version, name, applied_at_unix_seconds)
-                 VALUES (?1, ?2, CAST(strftime('%s', 'now') AS INTEGER))",
-                params![migration.version, migration.name],
-            )?;
-        }
+        (migration.apply)(&tx)?;
+        tx.execute(
+            "INSERT INTO app_cache_schema_migrations
+                (version, name, applied_at_unix_seconds)
+             VALUES (?1, ?2, CAST(strftime('%s', 'now') AS INTEGER))",
+            params![migration.version, migration.name],
+        )?;
         tx.commit()?;
     }
     Ok(())
+}
+
+/// Validate history as an exact prefix and return the number already applied.
+fn applied_count(conn: &Connection, migrations: &[Migration]) -> Result<usize, AppError> {
+    if !DirectoryCache::table_exists_locked(conn, "app_cache_schema_migrations")? {
+        return Ok(0);
+    }
+    let latest_supported = migrations.last().map_or(0, |m| m.version);
+    let mut statement =
+        conn.prepare("SELECT version, name FROM app_cache_schema_migrations ORDER BY version")?;
+    let recorded = statement
+        .query_map([], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    if let Some((found, _)) = recorded.last()
+        && *found > latest_supported
+    {
+        return Err(StorageError::UnsupportedSchemaVersion {
+            found: *found,
+            latest_supported,
+        }
+        .into());
+    }
+    for (index, (version, name)) in recorded.iter().enumerate() {
+        let Some(expected) = migrations.get(index) else {
+            return Err(invalid_history());
+        };
+        if *version != expected.version || name != expected.name {
+            return Err(invalid_history());
+        }
+    }
+    Ok(recorded.len())
 }
 
 fn invalid_history() -> AppError {
@@ -138,16 +157,15 @@ fn validate_version_1(conn: &Connection) -> Result<(), AppError> {
                 return Err(invalid_history());
             }
         }
-        // Names come exclusively from our frozen DDL, never stored user data.
         let query = if kind == "table" {
-            format!(
-                "SELECT name, type, \"notnull\", dflt_value, pk FROM pragma_table_info('{name}') ORDER BY cid"
-            )
+            r#"SELECT name, type, "notnull", dflt_value, pk FROM pragma_table_info(?1) ORDER BY cid"#
         } else {
-            format!("SELECT name, '', 0, NULL, 0 FROM pragma_index_info('{name}') ORDER BY seqno")
+            "SELECT name, '', 0, NULL, 0 FROM pragma_index_info(?1) ORDER BY seqno"
         };
-        if shape(conn, &query)? != shape(&reference, &query)? {
-            return Err(invalid_history());
+        if shape(conn, query, &name)? != shape(&reference, query, &name)? {
+            return Err(
+                StorageError::Backend("invalid directory cache schema shape".into()).into(),
+            );
         }
     }
     Ok(())
@@ -155,10 +173,10 @@ fn validate_version_1(conn: &Connection) -> Result<(), AppError> {
 
 type ColumnShape = (String, String, i64, Option<String>, i64);
 
-fn shape(conn: &Connection, query: &str) -> Result<Vec<ColumnShape>, AppError> {
+fn shape(conn: &Connection, query: &str, name: &str) -> Result<Vec<ColumnShape>, AppError> {
     Ok(conn
         .prepare(query)?
-        .query_map([], |row| {
+        .query_map([name], |row| {
             Ok((
                 row.get(0)?,
                 row.get(1)?,
@@ -173,6 +191,47 @@ fn shape(conn: &Connection, query: &str) -> Result<Vec<ColumnShape>, AppError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn current_cache_migrations_do_not_contend_with_writer() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cache.sqlite3");
+        let mut conn = Connection::open(&path).unwrap();
+        conn.pragma_update(None, "journal_mode", "WAL").unwrap();
+        run_all(&mut conn).unwrap();
+        let writer = Connection::open(&path).unwrap();
+        writer.execute_batch("BEGIN IMMEDIATE").unwrap();
+        conn.busy_timeout(std::time::Duration::ZERO).unwrap();
+        run_all(&mut conn).expect("current history must not acquire a write lock");
+        writer.execute_batch("ROLLBACK").unwrap();
+    }
+
+    #[test]
+    fn migration_errors_preserve_safe_diagnostics_without_trigger_payloads() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        run_all(&mut conn).unwrap();
+        conn.execute_batch(
+            "DELETE FROM app_cache_schema_migrations;
+            CREATE TRIGGER reject_history BEFORE INSERT ON app_cache_schema_migrations
+            BEGIN SELECT RAISE(ABORT, 'private profile data'); END;",
+        )
+        .unwrap();
+        let error = run_all(&mut conn).unwrap_err();
+        assert!(!error.to_string().contains("private profile data"));
+        assert!(
+            matches!(error, AppError::Sqlite(rusqlite::Error::SqliteFailure(code, None))
+            if code.code == rusqlite::ErrorCode::ConstraintViolation)
+        );
+        conn.execute_batch(
+            "DROP TRIGGER reject_history;
+            INSERT INTO app_cache_schema_migrations VALUES (1, 'private name', 0)",
+        )
+        .unwrap();
+        assert_eq!(
+            run_all(&mut conn).unwrap_err().to_string(),
+            "backend failure: invalid directory cache migration history"
+        );
+    }
 
     #[test]
     fn migration_rejects_missing_columns_keys_and_wrong_indexes() {

--- a/crates/marmot-app/src/directory/cache/migrations.rs
+++ b/crates/marmot-app/src/directory/cache/migrations.rs
@@ -344,3 +344,7 @@ mod tests {
         assert_eq!(count, 1);
     }
 }
+
+#[cfg(test)]
+#[path = "assurance_tests.rs"]
+mod assurance_tests;

--- a/crates/marmot-app/src/directory/cache/migrations.rs
+++ b/crates/marmot-app/src/directory/cache/migrations.rs
@@ -116,6 +116,10 @@ fn invalid_history() -> AppError {
     StorageError::Backend("invalid directory cache migration history".into()).into()
 }
 
+fn invalid_shape() -> AppError {
+    StorageError::Backend("invalid directory cache schema shape".into()).into()
+}
+
 fn version_1(tx: &Transaction<'_>) -> Result<(), AppError> {
     tx.execute_batch(VERSION_1_SQL)?;
     validate_version_1(tx)?;
@@ -144,7 +148,7 @@ fn validate_version_1(conn: &Connection) -> Result<(), AppError> {
         let actual: (String, String) =
             conn.query_row(object_query, [&name], |row| Ok((row.get(0)?, row.get(1)?)))?;
         if actual != expected {
-            return Err(invalid_history());
+            return Err(invalid_shape());
         }
         if kind == "index" {
             let query = r#"SELECT "unique", partial FROM pragma_index_list(?1) WHERE name = ?2"#;
@@ -154,7 +158,7 @@ fn validate_version_1(conn: &Connection) -> Result<(), AppError> {
                 })
             };
             if flags(conn)? != flags(&reference)? {
-                return Err(invalid_history());
+                return Err(invalid_shape());
             }
         }
         let query = if kind == "table" {
@@ -163,9 +167,7 @@ fn validate_version_1(conn: &Connection) -> Result<(), AppError> {
             "SELECT name, '', 0, NULL, 0 FROM pragma_index_info(?1) ORDER BY seqno"
         };
         if shape(conn, query, &name)? != shape(&reference, query, &name)? {
-            return Err(
-                StorageError::Backend("invalid directory cache schema shape".into()).into(),
-            );
+            return Err(invalid_shape());
         }
     }
     Ok(())
@@ -249,7 +251,11 @@ mod tests {
             let mut conn = Connection::open_in_memory().unwrap();
             conn.execute_batch(VERSION_1_SQL).unwrap();
             conn.execute_batch(mutation).unwrap();
-            assert!(run_all(&mut conn).is_err(), "{mutation}");
+            assert_eq!(
+                run_all(&mut conn).unwrap_err().to_string(),
+                "backend failure: invalid directory cache schema shape",
+                "{mutation}"
+            );
             assert!(!DirectoryCache::table_exists_locked(&conn, "app_cache_schema_migrations").unwrap());
         }
     }

--- a/crates/marmot-app/src/directory/cache/v1.sql
+++ b/crates/marmot-app/src/directory/cache/v1.sql
@@ -1,0 +1,52 @@
+CREATE TABLE IF NOT EXISTS directory_users (
+    account_id_hex TEXT PRIMARY KEY NOT NULL,
+    npub TEXT NOT NULL,
+    local_account_json TEXT,
+    profile_json TEXT,
+    relay_lists_json TEXT NOT NULL,
+    key_package_json TEXT,
+    updated_at INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS directory_user_follows (
+    account_id_hex TEXT NOT NULL,
+    follow_account_id_hex TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (account_id_hex, follow_account_id_hex)
+);
+CREATE INDEX IF NOT EXISTS directory_user_follows_follow_idx
+    ON directory_user_follows(follow_account_id_hex);
+CREATE TABLE IF NOT EXISTS directory_follow_source_relays (
+    account_id_hex TEXT NOT NULL,
+    relay_url TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (account_id_hex, relay_url)
+);
+CREATE TABLE IF NOT EXISTS directory_known_user_reasons (
+    account_id_hex TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    first_seen_at INTEGER NOT NULL,
+    last_seen_at INTEGER NOT NULL,
+    PRIMARY KEY (account_id_hex, reason)
+);
+CREATE TABLE IF NOT EXISTS directory_search_graph_users (
+    account_id_hex TEXT PRIMARY KEY NOT NULL,
+    npub TEXT NOT NULL,
+    profile_json TEXT,
+    metadata_updated_at INTEGER,
+    metadata_expires_at INTEGER,
+    follows_known INTEGER NOT NULL DEFAULT 0,
+    follows_updated_at INTEGER,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS directory_search_graph_follows (
+    account_id_hex TEXT NOT NULL,
+    follow_account_id_hex TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (account_id_hex, follow_account_id_hex)
+);
+CREATE INDEX IF NOT EXISTS directory_search_graph_follows_follow_idx
+    ON directory_search_graph_follows(follow_account_id_hex);

--- a/crates/marmot-app/src/directory/cache/v1.sql
+++ b/crates/marmot-app/src/directory/cache/v1.sql
@@ -1,3 +1,6 @@
+-- Frozen version 1: IF NOT EXISTS adopts unversioned caches only after
+-- migrations.rs validates their shape. Do not copy this adoption pattern
+-- into later migrations without an explicit predecessor-schema contract.
 CREATE TABLE IF NOT EXISTS directory_users (
     account_id_hex TEXT PRIMARY KEY NOT NULL,
     npub TEXT NOT NULL,

--- a/docs/marmot-architecture/further-context/app-sqlite-storage-boundaries.md
+++ b/docs/marmot-architecture/further-context/app-sqlite-storage-boundaries.md
@@ -53,7 +53,9 @@ The legacy `user_directory_records` JSON conversion and removal of its retired t
 
 Each migration runs under a write transaction together with its ledger insertion. A failure rolls back that migration's
 schema changes, converted records and ledger row; earlier committed migrations remain intact. Reopening a current
-cache skips applied migrations. Recorded names must match the compiled ordered history, and any newer recorded version
+cache validates history with reads only and skips applied migrations; a pending migration rechecks history under
+the write lock to serialize concurrent openers. SQLite result codes and static history errors remain available without
+database-controlled error messages or legacy JSON values. Recorded names must match the compiled ordered history, and any newer recorded version
 returns `UnsupportedSchemaVersion` before a migration body runs. This refuses downgrades across a newer schema; it does
 not reverse committed migrations. SQLCipher hardening, owner-only files, terminal close behavior, and the legacy
 plaintext directory import remain in place.

--- a/docs/marmot-architecture/further-context/app-sqlite-storage-boundaries.md
+++ b/docs/marmot-architecture/further-context/app-sqlite-storage-boundaries.md
@@ -66,3 +66,25 @@ Directory mirroring/reconciliation, session storage, and the retired app-project
 
 Each store needs an independent schema identity because its release cadence, rollback behavior, and durability
 contract can diverge. A session migration version must never be treated as the version of either cache.
+
+## Upgrade Assurance And Limits
+
+The directory-cache assurance tests use DDL extracted independently from
+`9db9dbc092d52eb7b2d5bc6dcfb1f9beb3125464`, where this cache module entered MDK. The structured DDL is unchanged
+across the eight master-lineage revisions touching the cache through `7368c737`. This is repository-history evidence,
+not a census of deployed app builds or databases.
+
+The encrypted populated-cache test adopts 120,000 rows across all six tables and compares hashes of every typed value
+and rowid before and after opening. Nulls, Unicode, unknown metadata and even invalid cached JSON remain untouched:
+ordinary structured adoption does not deserialize or rewrite those records.
+
+Legacy conversion tests combine existing structured records with 1,000 JSON records. They check every converted record
+and preserve existing rows, force SQLite page-limit exhaustion and retry, and exit a child process without destructors
+after conversion/table removal but before the ledger commit. Both rollback-journal and WAL reopen paths recover the
+original data, leave the migration unrecorded, retry successfully and pass SQLite integrity checks.
+
+These tests do not establish a numerical field failure rate or guarantee zero risk. Page-limit exhaustion exercises
+`SQLITE_FULL`, not every operating-system I/O failure; child-process exit is not a device power-loss test. Production-device
+upgrade testing, representative deployed-cache copies and rollout monitoring remain additional evidence. A refused
+malformed schema preserves the file but can still make directory operations unavailable until repaired; preserving data
+and preserving availability are separate requirements.

--- a/docs/marmot-architecture/further-context/app-sqlite-storage-boundaries.md
+++ b/docs/marmot-architecture/further-context/app-sqlite-storage-boundaries.md
@@ -1,7 +1,7 @@
 ---
 title: "App SQLite Storage Boundaries"
 created: 2026-09-04
-updated: 2026-09-04
+updated: 2026-09-05
 tags: [marmot, app-core, sqlite, storage, migrations]
 status: current-implementation
 ---
@@ -42,10 +42,25 @@ current store.
 
 ## Migration Domains
 
-Only `session.sqlite` currently has a numbered migration ledger and future-schema refusal. The two auxiliary stores
-initialize their current tables independently and must receive their own version histories before either schema makes
-a non-additive change.
+Both `session.sqlite` and the per-account `app-cache.sqlite3` have independent numbered migration histories and
+future-schema refusal. The directory cache uses `app_cache_schema_migrations`; it never reads or updates
+`cgka_schema_migrations`.
+
+Cache version 1 creates the six directory/search tables and indexes. Existing unversioned tables are adopted only
+after their columns, types, nullability, defaults, primary keys and index columns match the version-1 shape. Missing
+tables and indexes are created, but malformed existing tables fail rather than being silently marked migrated.
+The legacy `user_directory_records` JSON conversion and removal of its retired table are part of the same migration.
+
+Each migration runs under a write transaction together with its ledger insertion. A failure rolls back that migration's
+schema changes, converted records and ledger row; earlier committed migrations remain intact. Reopening a current
+cache skips applied migrations. Recorded names must match the compiled ordered history, and any newer recorded version
+returns `UnsupportedSchemaVersion` before a migration body runs. This refuses downgrades across a newer schema; it does
+not reverse committed migrations. SQLCipher hardening, owner-only files, terminal close behavior, and the legacy
+plaintext directory import remain in place.
+
+`shared.sqlite3` still initializes its tables without a numbered ledger or future-schema refusal. Versioning that store
+is a separate follow-up; its changes must remain additive and compatible with existing databases in the meantime.
+Directory mirroring/reconciliation, session storage, and the retired app-projection import are unchanged.
 
 Each store needs an independent schema identity because its release cadence, rollback behavior, and durability
-contract can diverge. A session migration version must never be treated as the version of either cache. Until those
-ledgers exist, auxiliary-store changes should remain additive and compatible with already-created databases.
+contract can diverge. A session migration version must never be treated as the version of either cache.

--- a/docs/marmot-architecture/overview/current-state.md
+++ b/docs/marmot-architecture/overview/current-state.md
@@ -1,7 +1,7 @@
 ---
 title: "Current State — Implementations & Spec"
 created: 2026-04-19
-updated: 2026-08-24
+updated: 2026-09-05
 tags: [marmot, overview, current-state, implementations]
 status: overview
 ---
@@ -112,7 +112,9 @@ This repository now has the main engine candidate:
   relay/directory cache, relay-list setup, KeyPackage lookup, runtime subscriptions, and app-facing
   group/message/member methods. Detailed group creation returns the exact chat-list row committed with the local
   projection; founding Welcome fanout stays post-response and its app repair index is reconstructed from
-  engine-authoritative retained obligations.
+  engine-authoritative retained obligations. Its per-account directory cache has an independent numbered migration
+  ledger and future-version refusal; `shared.sqlite3` remains unversioned. See
+  [App SQLite Storage Boundaries](../further-context/app-sqlite-storage-boundaries.md).
 - `crates/cli` — first real CLI, daemon, and TUI surface over `marmot-app`. It is intentionally product-facing rather
   than a lab harness, and its JSON envelope is shaped for daemon/TUI/testing callers.
 - `crates/storage-sqlite` — SQLCipher-backed SQLite storage for Marmot and custom OpenMLS state, with Rust migrations


### PR DESCRIPTION
Opening an older directory cache previously ran unversioned `CREATE TABLE IF NOT EXISTS` statements, which could silently accept incomplete or incompatible tables. This change gives only the per-account directory cache an independent `app_cache_schema_migrations` history, starting with `1 / 0001_directory_cache`.

## Upgrade and rollback contract

- Version 1 creates the six existing directory/search tables and indexes. Its frozen SQL is local to the cache module.
- Existing unversioned tables are adopted after validation of columns, types, nullability, defaults, primary keys, and named indexes. Missing tables/indexes are created; malformed existing shapes are refused.
- Legacy `user_directory_records` conversion and removal run inside version 1. Existing directory and search records survive adoption.
- Each migration body and ledger insertion commit together under an immediate transaction. A failure rolls back that migration's schema/data changes and ledger row, including first-open ledger creation. Earlier committed migrations remain intact.
- Applied history must be a prefix of the compiled ordered list with matching names. Reopening skips applied migrations. Newer recorded versions return the existing typed `AppError::Storage(StorageError::UnsupportedSchemaVersion { ... })`; committed migrations are not reversed for downgrades.
- Migration errors suppress database-controlled names and values. SQLCipher hardening, restrictive files, terminal close behavior, and plaintext directory imports retain their existing paths.

## Scope

No changes to `shared.sqlite3` / `SqliteSharedStorage`, session storage / `cgka_schema_migrations`, directory mirroring or reconciliation, retired `app.sqlite3` projection imports, `AppError`, dependencies, or package/workspace versions. Shared-store versioning remains separate work.

Updated the crate map, crate README, storage-boundary document, and current-state overview, including dated front matter.

## Validation

Rebased onto `origin/master` at `7368c737`, which includes merged PR #1685. Both commits are signed and verified locally.

- `cargo test -p marmot-app directory::cache --lib`: **18 passed**. Includes encrypted creation/reopen, adoption of both data tiers, invalid schemas/history, rollback, future-version refusal, reopening during a concurrent write, and safe SQLite diagnostics.
- `cargo nextest run -p marmot-app --lib --features test-policy-overrides,cgka-engine/test-crash-hooks --locked --profile ci`: **932 passed, 1 skipped**. Nextest reported one slow test and one leaky process (`runtime::tests::co_member_eligibility::an_unaccepted_invite_contributes_nobody`); command exited successfully.
- `cargo test -p marmot-app --test relay_runtime --features test-policy-overrides --locked app_runtime_delete_group_local_removes_projection_without_publishing_leave -- --exact --test-threads=1`: **1 passed**, both before and after review fixes.
- `just fast-ci`: **passed**.
- Required docs stale-marker scan: two matches reviewed; the engine layering TODO remains present in source, and the other match is the scan command itself.
- `git diff --check`: **passed**.

- `cargo test -p marmot-app --test relay_runtime --features test-policy-overrides --locked -- --test-threads=1`: **126 passed, 0 failed**.

GitHub CI for `bf527d79` **passed**, including all four Rust test shards, the full relay-runtime job, simulator/vectors, and Required CI: [run 33950321800](https://github.com/marmot-protocol/mdk/actions/runs/33950321800).

### Earlier results and CI configuration

The originally requested plain `cargo test -p marmot-app` returned 915 passed, 6 failed, 1 ignored in the unit target. Supplemental plain integration runs returned 144 passed, 6 failed, 8 ignored; doc-tests completed with zero tests. Eleven of those failures reproduced locally on the starting master commit, and one passed when rerun alone.

Those commands did **not** match GitHub CI: CI enables `test-policy-overrides`, uses nextest for unit tests, and runs relay-runtime tests serially. Both the starting and current GitHub master CI were green. The successful feature-enabled unit run above supersedes the earlier implication that master CI was failing.

The first PR CI run had a different failure: a five-second runtime-event timeout in `app_runtime_delete_group_local_removes_projection_without_publishing_leave` (125 other relay-runtime tests passed). That timeout has not reproduced in two local runs using CI's features/serial execution; its cause is not established.

## Review follow-up

Current caches validate history using reads only. Pending migrations revalidate under their write lock to prevent races between openers. Static storage diagnostics and SQLite extended result codes survive redaction; JSON values and SQLite message text (including arbitrary trigger payloads) do not. Schema introspection binds object names.

Validation and failed-import preservation remain intentional: silently rebuilding a malformed cache or marking a failed plaintext import checked would violate this PR's explicit preservation and refusal contract. Those recovery-policy changes need separate design.


## Additional populated-cache assurance (404f7ab9)

No production behavior changed in this follow-up: it adds permanent regression tests, an independently extracted
historical schema fixture, and documentation of the evidence and its limits.

- Historical DDL matches all eight master-lineage revisions touching this cache through 7368c737, back to 9db9dbc0.
- An encrypted historical cache containing **120,000 rows across all six tables** upgrades with every typed value and
  rowid unchanged (full-table SHA-256 snapshots), then passes SQLite integrity_check. This includes NULL, Unicode,
  unknown metadata, and invalid cached JSON, which adoption must not parse or rewrite.
- A mixed cache with existing structured data and **1,000 legacy JSON records** survives simulated SQLITE_FULL,
  preserves both tiers and leaves no ledger row, then retries successfully. Every converted legacy record is compared,
  and every pre-existing structured value is preserved.
- Separate child processes exit without destructors after conversion/table removal but before commit. Both DELETE
  journal and WAL recover all original data, refuse to record the interrupted migration, retry successfully, preserve
  existing records and all 1,000 converted records, and pass integrity_check.
- `cargo test -p marmot-app directory::cache --lib -- --nocapture`: **21 passed** (including all three assurance tests).
- `just fast-ci`: **passed**; docs stale-marker scan reviewed; `git diff --check`: **passed**.
- The first run of this follow-up (404f7ab9) failed the simulator direct-output audit because the stress test printed a timing measurement. Commit 9a8925c4 removes that unnecessary print and timer; all preservation assertions remain. The exact audit, all 21 cache tests, and just fast-ci pass locally. GitHub CI passed for ddb1304b; the older green result above belongs to bf527d79.

This establishes stronger synthetic upgrade evidence, not a numerical deployed failure rate or zero-risk guarantee.
No deployed app databases were accessed. SQLite page-limit exhaustion is not every filesystem failure, and process
exit is not device power loss. Representative device/cache upgrades and staged rollout monitoring remain useful before
broad release. Refusing a malformed cache preserves its data but may still interrupt directory operations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added versioned upgrades for per-account directory caches.
  * Existing caches and legacy records migrate automatically while preserving directory data.
  * Cache upgrades now support transactional recovery after interruptions or failures.
  * Large and encrypted caches are supported during migration.

* **Bug Fixes**
  * Invalid, incomplete, or unsupported cache versions are rejected safely.
  * Failed upgrades no longer leave incomplete or corrupted cache data.

* **Documentation**
  * Updated storage architecture and migration guidance for directory and shared caches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



## Final review validation (ddb1304b)

The disk-full test now requires a test-only successful-conversion counter to be positive before the failure. That
assertion exposed that the original page limit failed before the first complete legacy conversion; the limit was
adjusted to allow partial conversion while still exhausting space before completion. The test now explicitly proves
mid-conversion rollback, complete preservation, and successful retry. The test-only counter is absent from production
builds. All three schema-object/index/column mismatch branches also now report the same static schema-shape diagnostic,
distinct from ledger-history corruption.

- `cargo test -p marmot-app directory::cache --lib`: **21 passed**.
- `cargo test -p cgka-conformance-simulator --test tracing_audit --locked`: **4 passed**, including the exact audit that failed CI.
- `just fast-ci` and `git diff --check`: **passed**.
- GitHub run for ddb1304b: [33953646355](https://github.com/marmot-protocol/mdk/actions/runs/33953646355), **passed**, including Simulator and vectors and Required CI.




Final test-only tightening in 125f3552 requires the successful-conversion count to be both positive and less than
the total legacy record count, proving SQLITE_FULL interrupts partial conversion. All three assurance tests and
just fast-ci pass locally. Current CI run [33954221806](https://github.com/marmot-protocol/mdk/actions/runs/33954221806)
is **green after rerunning the failed relay job**; the full run immediately before this four-line assertion addition also passed.



The first attempt on 125f3552 passed Simulator and vectors but encountered two relay-test failures:
`create_group_detailed_returns_durable_emitted_chat_list_row` compared otherwise identical rows with updated_at
one second apart, and `eviction_projects_removed_from_group_notification` timed out. Both passed in a local serial
run with CI features, and the unchanged GitHub relay job passed on one failed-job retry. These intermittent failures
are documented, not claimed to be fixed runtime defects. No assertions were weakened or timeouts extended.
All required checks on 125f3552 are now green.
