### PR TITLE
Preserve outbox inbox metadata during login and invite discovery

### DIFF
--- a/crates/marmot-app/src/directory/member_key_packages.rs
+++ b/crates/marmot-app/src/directory/member_key_packages.rs
@@ -663,6 +663,69 @@ impl MarmotApp {
                 }
             }
         }
+
+        // NIP-65 write relays are the target account's outboxes. Reconcile a
+        // current kind-10050 from those outboxes even when the discovery relay
+        // already returned an older inbox list. Keep this set operation bounded
+        // and preserve positive first-hop metadata if an outbox is unavailable;
+        // only an unconfirmed empty result becomes a typed relay error.
+        let second_hop_specs = needs_discovery
+            .into_iter()
+            .filter_map(|index| {
+                let endpoints = self.retain_safe_discovered_endpoints(
+                    targets[index]
+                        .relay_lists
+                        .nip65
+                        .relays
+                        .iter()
+                        .cloned()
+                        .map(TransportEndpoint)
+                        .collect(),
+                    "member inbox outbox discovery",
+                );
+                (!endpoints.is_empty()).then_some((
+                    index,
+                    targets[index].account_id_hex.clone(),
+                    endpoints,
+                ))
+            })
+            .collect::<Vec<_>>();
+        let app = self.clone();
+        let work = second_hop_specs
+            .into_iter()
+            .map(move |(index, account_id, endpoints)| {
+                let app = app.clone();
+                async move {
+                    let result = app
+                        .fetch_account_relay_list_status_for_account_id(&account_id, endpoints)
+                        .await;
+                    (index, result)
+                }
+            });
+        let second_hop_results = stream::iter(work)
+            .buffered(MEMBER_RESOLUTION_RELAY_CONCURRENCY)
+            .collect::<Vec<_>>()
+            .await;
+        for (index, result) in second_hop_results {
+            match result {
+                Ok(status) => {
+                    targets[index].relay_lists =
+                        merge_member_relay_lists(targets[index].relay_lists.clone(), status);
+                    failures.retain(|(failed_index, _)| *failed_index != index);
+                }
+                Err(error) if targets[index].relay_lists.inbox.relays.is_empty() => {
+                    if !failures
+                        .iter()
+                        .any(|(failed_index, _)| *failed_index == index)
+                    {
+                        failures.push((index, error));
+                    }
+                }
+                Err(_) => {
+                    failures.retain(|(failed_index, _)| *failed_index != index);
+                }
+            }
+        }
         failures
     }
 

--- a/crates/marmot-app/src/directory/member_key_packages.rs
+++ b/crates/marmot-app/src/directory/member_key_packages.rs
@@ -22,10 +22,10 @@ use transport_nostr_adapter::{
 
 use crate::key_package_records::{
     fresh_or_cached_key_package, fresh_relay_list_status_from_records,
-    latest_fresh_key_package_from_records, validated_cached_key_package,
+    latest_fresh_key_package_from_records, merge_relay_list_status, validated_cached_key_package,
 };
 use crate::relay_plane::DirectoryEventQuery;
-use crate::{AccountRelayListStatus, AppError, FetchedKeyPackage, MarmotApp, push_unique_strings};
+use crate::{AccountRelayListStatus, AppError, FetchedKeyPackage, MarmotApp};
 
 /// Maximum authors placed in one Nostr directory filter.
 pub(crate) const MEMBER_RESOLUTION_AUTHORS_PER_QUERY: usize = 32;
@@ -175,38 +175,8 @@ struct MemberTarget {
     account_id_hex: String,
     local_label: Option<String>,
     relay_lists: AccountRelayListStatus,
-}
-
-/// Merge relay-list observations without allowing stale discovery to clobber
-/// newer cached state.
-///
-/// Each list is replaced only by a strictly newer `created_at`; ties retain the
-/// current value. Timestamp-less (`created_at == 0`) state may fill an empty
-/// timestamp-less slot, which supports setup-derived and fixture-built state
-/// without overriding a timestamped directory event.
-fn merge_member_relay_lists(
-    mut current: AccountRelayListStatus,
-    candidate: AccountRelayListStatus,
-) -> AccountRelayListStatus {
-    if candidate.nip65.created_at > current.nip65.created_at
-        || (candidate.nip65.created_at == 0
-            && current.nip65.created_at == 0
-            && current.nip65.relays.is_empty()
-            && !candidate.nip65.relays.is_empty())
-    {
-        current.nip65 = candidate.nip65;
-    }
-    if candidate.inbox.created_at > current.inbox.created_at
-        || (candidate.inbox.created_at == 0
-            && current.inbox.created_at == 0
-            && current.inbox.relays.is_empty()
-            && !candidate.inbox.relays.is_empty())
-    {
-        current.inbox = candidate.inbox;
-    }
-    push_unique_strings(&mut current.bootstrap_relays, candidate.bootstrap_relays);
-    current.refresh();
-    current
+    cached_relay_lists: AccountRelayListStatus,
+    relay_records: Vec<crate::relay_plane::DirectoryRelayEventRecord>,
 }
 
 #[allow(dead_code)]
@@ -313,7 +283,9 @@ impl MarmotApp {
             targets.push(MemberTarget {
                 account_id_hex,
                 local_label: local.map(|account| account.label),
-                relay_lists,
+                relay_lists: relay_lists.clone(),
+                cached_relay_lists: relay_lists,
+                relay_records: Vec::new(),
             });
         }
 
@@ -321,6 +293,7 @@ impl MarmotApp {
             .map(|_| None)
             .collect::<Vec<Option<Result<KeyPackage, AppError>>>>();
         let mut unresolved = Vec::new();
+        let mut fresh_prewarmed_routes = HashSet::new();
         let mut reused_members = 0usize;
         for (index, target) in targets.iter_mut().enumerate() {
             if let Some(label) = &target.local_label
@@ -349,12 +322,30 @@ impl MarmotApp {
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .get(&target.account_id_hex);
             if let Some(mut fetched) = prefetched {
-                target.relay_lists = merge_member_relay_lists(
+                target.relay_lists = merge_relay_list_status(
                     target.relay_lists.clone(),
                     fetched.relay_lists.clone(),
                 );
+                target.cached_relay_lists = target.relay_lists.clone();
                 fetched.relay_lists = target.relay_lists.clone();
                 if let Ok(key_package) = self.accept_prefetched_key_package(purpose, fetched) {
+                    if !target.relay_lists.nip65.relays.is_empty()
+                        && !self
+                            .retain_safe_discovered_endpoints(
+                                target
+                                    .relay_lists
+                                    .inbox
+                                    .relays
+                                    .iter()
+                                    .cloned()
+                                    .map(TransportEndpoint)
+                                    .collect(),
+                                "member prewarm inbox readiness",
+                            )
+                            .is_empty()
+                    {
+                        fresh_prewarmed_routes.insert(index);
+                    }
                     outcomes[index] = Some(Ok(key_package));
                     reused_members += 1;
                     continue;
@@ -363,25 +354,11 @@ impl MarmotApp {
             unresolved.push(index);
         }
 
-        let relay_list_unresolved = targets
-            .iter()
-            .enumerate()
-            .filter_map(|(index, target)| {
-                let safe_inbox = self.retain_safe_discovered_endpoints(
-                    target
-                        .relay_lists
-                        .inbox
-                        .relays
-                        .iter()
-                        .cloned()
-                        .map(TransportEndpoint)
-                        .collect(),
-                    "member invite inbox discovery",
-                );
-                (safe_inbox.is_empty()
-                    || (outcomes[index].is_none() && target.relay_lists.nip65.relays.is_empty()))
-                .then_some(index)
-            })
+        // Durable projections have unknown observation age and need a bounded
+        // refresh. Process-local prewarm entries have an enforced TTL and were
+        // already resolved through the outbox path during composition.
+        let relay_list_unresolved = (0..targets.len())
+            .filter(|index| !fresh_prewarmed_routes.contains(index))
             .collect::<Vec<_>>();
         if !relay_list_unresolved.is_empty() {
             for (index, error) in self
@@ -534,7 +511,7 @@ impl MarmotApp {
                 .map(|endpoint| endpoint.0.clone())
                 .collect();
         }
-        merge_member_relay_lists(target.relay_lists.clone(), status)
+        merge_relay_list_status(target.cached_relay_lists.clone(), status)
     }
 
     async fn resolve_missing_relay_lists(
@@ -578,14 +555,14 @@ impl MarmotApp {
             .map(move |(indices, endpoints, queries)| {
                 let app = app.clone();
                 async move {
-                    let records = app
+                    let outcome = app
                         .relay_plane
-                        .fetch_directory_events(endpoints.clone(), queries)
+                        .fetch_directory_events_with_completion(endpoints.clone(), queries)
                         .await
                         .map_err(|error| {
                             AppError::RelayDirectory(format!("fetch relay lists: {error}"))
                         });
-                    (indices, endpoints, records)
+                    (indices, endpoints, outcome)
                 }
             });
         let batches = stream::iter(requests)
@@ -594,21 +571,37 @@ impl MarmotApp {
             .await;
 
         let mut failures = Vec::new();
+        let mut completed_discovery = HashSet::new();
         for (indices, endpoints, result) in batches {
             match result {
-                Ok(records) => {
+                Ok(outcome) => {
                     for index in indices {
+                        if outcome.complete {
+                            completed_discovery.insert(index);
+                        }
                         let account_id = &targets[index].account_id_hex;
-                        let account_records = records
+                        let account_records = outcome
+                            .records
                             .iter()
                             .filter(|record| record.event.pubkey == *account_id)
                             .cloned()
                             .collect::<Vec<_>>();
+                        targets[index].relay_records.extend(account_records);
+                        let relay_records = targets[index].relay_records.clone();
                         targets[index].relay_lists = self.relay_lists_from_records(
                             &targets[index],
-                            account_records,
+                            relay_records,
                             &endpoints,
                         );
+                        if !outcome.complete && targets[index].relay_lists.inbox.relays.is_empty() {
+                            failures.push((
+                                index,
+                                AppError::RelayDirectory(
+                                    "relay-list absence was not authoritatively established"
+                                        .to_owned(),
+                                ),
+                            ));
+                        }
                     }
                 }
                 Err(_) => {
@@ -634,28 +627,44 @@ impl MarmotApp {
                                     )
                                 })
                                 .collect::<Vec<_>>();
-                            let records = app
+                            let outcome = app
                                 .relay_plane
-                                .fetch_directory_events(endpoints.clone(), queries)
+                                .fetch_directory_events_with_completion(endpoints.clone(), queries)
                                 .await
                                 .map_err(|error| {
                                     AppError::RelayDirectory(format!("fetch relay lists: {error}"))
                                 });
-                            (index, endpoints, records)
+                            (index, endpoints, outcome)
                         }
                     });
                     let results = stream::iter(work)
                         .buffered(MEMBER_RESOLUTION_FALLBACK_CONCURRENCY)
                         .collect::<Vec<_>>()
                         .await;
-                    for (index, endpoints, records) in results {
-                        match records {
-                            Ok(records) => {
+                    for (index, endpoints, outcome) in results {
+                        match outcome {
+                            Ok(outcome) => {
+                                if outcome.complete {
+                                    completed_discovery.insert(index);
+                                }
+                                targets[index].relay_records.extend(outcome.records);
+                                let relay_records = targets[index].relay_records.clone();
                                 targets[index].relay_lists = self.relay_lists_from_records(
                                     &targets[index],
-                                    records,
+                                    relay_records,
                                     &endpoints,
                                 );
+                                if !outcome.complete
+                                    && targets[index].relay_lists.inbox.relays.is_empty()
+                                {
+                                    failures.push((
+                                        index,
+                                        AppError::RelayDirectory(
+                                            "relay-list absence was not authoritatively established"
+                                                .to_owned(),
+                                        ),
+                                    ));
+                                }
                             }
                             Err(error) => failures.push((index, error)),
                         }
@@ -664,65 +673,169 @@ impl MarmotApp {
             }
         }
 
-        // NIP-65 write relays are the target account's outboxes. Reconcile a
-        // current kind-10050 from those outboxes even when the discovery relay
-        // already returned an older inbox list. Keep this set operation bounded
-        // and preserve positive first-hop metadata if an outbox is unavailable;
-        // only an unconfirmed empty result becomes a typed relay error.
-        let second_hop_specs = needs_discovery
-            .into_iter()
-            .filter_map(|index| {
-                let endpoints = self.retain_safe_discovered_endpoints(
-                    targets[index]
-                        .relay_lists
-                        .nip65
-                        .relays
-                        .iter()
-                        .cloned()
-                        .map(TransportEndpoint)
-                        .collect(),
-                    "member inbox outbox discovery",
-                );
-                (!endpoints.is_empty()).then_some((
-                    index,
-                    targets[index].account_id_hex.clone(),
-                    endpoints,
-                ))
-            })
-            .collect::<Vec<_>>();
+        // Group targets by the same safe outbox set so each relay receives one
+        // bounded multi-author request. This keeps prewarm pure: persistence
+        // happens only after the whole member-resolution pass succeeds.
+        let mut by_outboxes = BTreeMap::<Vec<TransportEndpoint>, Vec<usize>>::new();
+        for index in needs_discovery {
+            let outbox_endpoints = self.retain_safe_discovered_endpoints(
+                targets[index]
+                    .relay_lists
+                    .nip65
+                    .relays
+                    .iter()
+                    .cloned()
+                    .map(TransportEndpoint)
+                    .collect(),
+                "member inbox outbox discovery",
+            );
+            // A completed first-hop query already covered both relay-list kinds
+            // on these endpoints. Only genuinely new outboxes need another hop;
+            // incomplete reads remain eligible for the bounded retry.
+            let outbox_endpoints = outbox_endpoints
+                .into_iter()
+                .filter(|endpoint| {
+                    !completed_discovery.contains(&index) || !endpoints.contains(endpoint)
+                })
+                .collect::<Vec<_>>();
+            if !outbox_endpoints.is_empty() {
+                by_outboxes.entry(outbox_endpoints).or_default().push(index);
+            }
+        }
+        let mut second_hop_specs = Vec::new();
+        for (endpoints, indices) in by_outboxes {
+            for chunk in indices.chunks(MEMBER_RESOLUTION_AUTHORS_PER_QUERY) {
+                let indices = chunk.to_vec();
+                let authors = indices
+                    .iter()
+                    .map(|index| targets[*index].account_id_hex.clone())
+                    .collect::<Vec<_>>();
+                let queries = [KIND_NIP65_RELAY_LIST, KIND_MARMOT_INBOX_RELAY_LIST]
+                    .into_iter()
+                    .map(|kind| {
+                        DirectoryEventQuery::new(
+                            kind,
+                            authors.clone(),
+                            authors.len() * RELAY_LIST_EVENTS_PER_AUTHOR,
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                second_hop_specs.push((indices, endpoints.clone(), queries));
+            }
+        }
         let app = self.clone();
+        let account_ids = targets
+            .iter()
+            .map(|target| target.account_id_hex.clone())
+            .collect::<Vec<_>>();
         let work = second_hop_specs
             .into_iter()
-            .map(move |(index, account_id, endpoints)| {
+            .map(move |(indices, endpoints, queries)| {
                 let app = app.clone();
+                let authors = indices
+                    .iter()
+                    .map(|index| account_ids[*index].clone())
+                    .collect::<Vec<_>>();
                 async move {
-                    let result = app
-                        .fetch_account_relay_list_status_for_account_id(&account_id, endpoints)
-                        .await;
-                    (index, result)
+                    let outcome = app
+                        .relay_plane
+                        .fetch_directory_events_with_completion(endpoints.clone(), queries.clone())
+                        .await
+                        .map_err(|error| {
+                            AppError::RelayDirectory(format!("fetch outbox relay lists: {error}"))
+                        });
+                    if outcome.is_ok() || indices.len() == 1 {
+                        return vec![(indices, endpoints, outcome)];
+                    }
+                    // Keep the same bounded single-author fallback on the
+                    // advertised outbox as on discovery relays. A rejected
+                    // multi-author query is not evidence of missing metadata.
+                    stream::iter(indices.into_iter().enumerate().map(|(offset, index)| {
+                        let app = app.clone();
+                        let endpoints = endpoints.clone();
+                        let queries = queries
+                            .iter()
+                            .map(|query| {
+                                DirectoryEventQuery::new(
+                                    query.kind,
+                                    vec![authors[offset].clone()],
+                                    RELAY_LIST_EVENTS_PER_AUTHOR,
+                                )
+                            })
+                            .collect();
+                        async move {
+                            let outcome = app
+                                .relay_plane
+                                .fetch_directory_events_with_completion(endpoints.clone(), queries)
+                                .await
+                                .map_err(|error| {
+                                    AppError::RelayDirectory(format!(
+                                        "fetch outbox relay lists: {error}"
+                                    ))
+                                });
+                            (vec![index], endpoints, outcome)
+                        }
+                    }))
+                    .buffered(MEMBER_RESOLUTION_FALLBACK_CONCURRENCY)
+                    .collect::<Vec<_>>()
+                    .await
                 }
             });
         let second_hop_results = stream::iter(work)
             .buffered(MEMBER_RESOLUTION_RELAY_CONCURRENCY)
             .collect::<Vec<_>>()
             .await;
-        for (index, result) in second_hop_results {
+        for (indices, endpoints, result) in second_hop_results.into_iter().flatten() {
             match result {
-                Ok(status) => {
-                    targets[index].relay_lists =
-                        merge_member_relay_lists(targets[index].relay_lists.clone(), status);
-                    failures.retain(|(failed_index, _)| *failed_index != index);
-                }
-                Err(error) if targets[index].relay_lists.inbox.relays.is_empty() => {
-                    if !failures
-                        .iter()
-                        .any(|(failed_index, _)| *failed_index == index)
-                    {
-                        failures.push((index, error));
+                Ok(outcome) => {
+                    for index in indices {
+                        let account_id = &targets[index].account_id_hex;
+                        let records = outcome
+                            .records
+                            .iter()
+                            .filter(|record| record.event.pubkey == *account_id)
+                            .cloned()
+                            .collect::<Vec<_>>();
+                        targets[index].relay_records.extend(records);
+                        let relay_records = targets[index].relay_records.clone();
+                        targets[index].relay_lists = self.relay_lists_from_records(
+                            &targets[index],
+                            relay_records,
+                            &endpoints,
+                        );
+                        if outcome.complete || !targets[index].relay_lists.inbox.relays.is_empty() {
+                            failures.retain(|(failed_index, _)| *failed_index != index);
+                        } else if !failures
+                            .iter()
+                            .any(|(failed_index, _)| *failed_index == index)
+                        {
+                            failures.push((
+                                index,
+                                AppError::RelayDirectory(
+                                    "relay-list absence was not authoritatively established"
+                                        .to_owned(),
+                                ),
+                            ));
+                        }
                     }
                 }
                 Err(_) => {
-                    failures.retain(|(failed_index, _)| *failed_index != index);
+                    for index in indices {
+                        if targets[index].relay_lists.inbox.relays.is_empty()
+                            && !failures
+                                .iter()
+                                .any(|(failed_index, _)| *failed_index == index)
+                        {
+                            failures.push((
+                                index,
+                                AppError::RelayDirectory(
+                                    "fetch outbox relay lists failed".to_owned(),
+                                ),
+                            ));
+                        } else if !targets[index].relay_lists.inbox.relays.is_empty() {
+                            failures.retain(|(failed_index, _)| *failed_index != index);
+                        }
+                    }
                 }
             }
         }

--- a/crates/marmot-app/src/directory/member_key_packages.rs
+++ b/crates/marmot-app/src/directory/member_key_packages.rs
@@ -24,7 +24,7 @@ use crate::key_package_records::{
     fresh_or_cached_key_package, fresh_relay_list_status_from_records,
     latest_fresh_key_package_from_records, merge_relay_list_status, validated_cached_key_package,
 };
-use crate::relay_plane::DirectoryEventQuery;
+use crate::relay_plane::{DirectoryEventQuery, DirectoryFetchOutcome};
 use crate::{AccountRelayListStatus, AppError, FetchedKeyPackage, MarmotApp};
 
 /// Maximum authors placed in one Nostr directory filter.
@@ -34,7 +34,10 @@ const MEMBER_RESOLUTION_RELAY_CONCURRENCY: usize = 4;
 /// Existing per-member fallback concurrency, retained for incompatible relays.
 const MEMBER_RESOLUTION_FALLBACK_CONCURRENCY: usize = 8;
 /// One complete set resolution is bounded even when several relay sets stall.
-const MEMBER_RESOLUTION_DEADLINE: Duration = Duration::from_secs(10);
+// Three network stages, each with a bounded single-author retry, can each
+// consume a 5s connection budget plus a 3s fetch budget. Keep enough time for
+// those stages and local validation while retaining one overall deadline.
+const MEMBER_RESOLUTION_DEADLINE: Duration = Duration::from_secs(50);
 const KEY_PACKAGE_EVENTS_PER_AUTHOR: usize = 12;
 const RELAY_LIST_EVENTS_PER_AUTHOR: usize = 4;
 const MEMBER_PREWARM_CACHE_LIMIT: usize = 256;
@@ -77,6 +80,34 @@ mod tests {
             Instant::now() - MEMBER_PREWARM_CACHE_TTL - Duration::from_secs(1);
         assert!(cache.get(&newest).is_none());
         assert!(!cache.order.contains(&newest));
+    }
+
+    #[tokio::test]
+    async fn composition_prewarm_reuse_preserves_original_freshness_deadline() {
+        let (_directory, app, accounts, _fetcher) =
+            crate::tests::member_resolution_fixture(1, false).await;
+        let id = &accounts[0].account_id_hex;
+        app.prewarm_group_member_key_packages(&[id.as_str()])
+            .await
+            .unwrap();
+        let original = Instant::now() - Duration::from_secs(240);
+        app.member_key_package_prewarm_cache
+            .lock()
+            .unwrap()
+            .entries
+            .get_mut(id)
+            .unwrap()
+            .inserted_at = original;
+        for _ in 0..3 {
+            app.prewarm_group_member_key_packages(&[id.as_str()])
+                .await
+                .unwrap();
+        }
+        let mut cache = app.member_key_package_prewarm_cache.lock().unwrap();
+        assert_eq!(cache.entries.get(id).unwrap().inserted_at, original);
+        cache.entries.get_mut(id).unwrap().inserted_at =
+            Instant::now() - MEMBER_PREWARM_CACHE_TTL - Duration::from_secs(1);
+        assert!(cache.get(id).is_none());
     }
 }
 
@@ -328,7 +359,19 @@ impl MarmotApp {
                 );
                 target.cached_relay_lists = target.relay_lists.clone();
                 fetched.relay_lists = target.relay_lists.clone();
-                if let Ok(key_package) = self.accept_prefetched_key_package(purpose, fetched) {
+                // Reuse must not restart the observation TTL. Only newly
+                // fetched packages enter through accept_prefetched_key_package.
+                let accepted = self.validate_member_key_package_current(
+                    &fetched.account_id_hex,
+                    fetched.key_package.clone(),
+                );
+                let accepted = accepted.and_then(|key_package| {
+                    if purpose == MemberResolutionPurpose::Commit {
+                        self.remember_directory_key_package(&fetched)?;
+                    }
+                    Ok(key_package)
+                });
+                if let Ok(key_package) = accepted {
                     if !target.relay_lists.nip65.relays.is_empty()
                         && !self
                             .retain_safe_discovered_endpoints(
@@ -388,6 +431,8 @@ impl MarmotApp {
                 for target in &targets {
                     if !target.relay_lists.nip65.relays.is_empty()
                         || !target.relay_lists.inbox.relays.is_empty()
+                        || target.relay_lists.nip65.created_at > 0
+                        || target.relay_lists.inbox.created_at > 0
                     {
                         self.remember_directory_relay_lists(
                             &target.account_id_hex,
@@ -514,6 +559,131 @@ impl MarmotApp {
         merge_relay_list_status(target.cached_relay_lists.clone(), status)
     }
 
+    /// Run one metadata hop with identical batching, partial-record retention,
+    /// and bounded per-author fallback on both discovery and advertised relays.
+    /// Completion belongs to this hop only; callers reconcile hops separately.
+    async fn resolve_relay_list_hop(
+        &self,
+        targets: &mut [MemberTarget],
+        groups: Vec<(Vec<TransportEndpoint>, Vec<usize>)>,
+    ) -> HashSet<usize> {
+        let specs = groups
+            .into_iter()
+            .flat_map(|(endpoints, indices)| {
+                indices
+                    .chunks(MEMBER_RESOLUTION_AUTHORS_PER_QUERY)
+                    .map(|chunk| {
+                        let members = chunk
+                            .iter()
+                            .map(|index| (*index, targets[*index].account_id_hex.clone()))
+                            .collect::<Vec<_>>();
+                        (endpoints.clone(), members)
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        let app = self.clone();
+        let work = specs.into_iter().map(move |(endpoints, members)| {
+            let app = app.clone();
+            async move {
+                let authors = members.iter().map(|(_, id)| id.clone()).collect::<Vec<_>>();
+                let queries = [KIND_NIP65_RELAY_LIST, KIND_MARMOT_INBOX_RELAY_LIST]
+                    .into_iter()
+                    .map(|kind| {
+                        DirectoryEventQuery::new(
+                            kind,
+                            authors.clone(),
+                            authors.len() * RELAY_LIST_EVENTS_PER_AUTHOR,
+                        )
+                    })
+                    .collect();
+                let result = app
+                    .relay_plane
+                    .fetch_directory_events_with_completion(endpoints.clone(), queries)
+                    .await;
+                let outcome = result.unwrap_or_default();
+                if members.len() == 1 || outcome.complete {
+                    return members
+                        .into_iter()
+                        .map(|(index, _)| (index, endpoints.clone(), outcome.clone()))
+                        .collect::<Vec<_>>();
+                }
+                // CLOSED and other incomplete outcomes need the same fallback
+                // as transport errors. Retain positive batch records even when
+                // the single-author retry also fails.
+                stream::iter(members.into_iter().map(|(index, account_id)| {
+                    let app = app.clone();
+                    let endpoints = endpoints.clone();
+                    let mut records = outcome
+                        .records
+                        .iter()
+                        .filter(|record| record.event.pubkey == account_id)
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    async move {
+                        let queries = [KIND_NIP65_RELAY_LIST, KIND_MARMOT_INBOX_RELAY_LIST]
+                            .into_iter()
+                            .map(|kind| {
+                                DirectoryEventQuery::new(
+                                    kind,
+                                    vec![account_id.clone()],
+                                    RELAY_LIST_EVENTS_PER_AUTHOR,
+                                )
+                            })
+                            .collect();
+                        let retry = app
+                            .relay_plane
+                            .fetch_directory_events_with_completion(endpoints.clone(), queries)
+                            .await
+                            .unwrap_or_default();
+                        records.extend(retry.records);
+                        (
+                            index,
+                            endpoints,
+                            DirectoryFetchOutcome {
+                                records,
+                                complete: retry.complete,
+                            },
+                        )
+                    }
+                }))
+                .buffered(MEMBER_RESOLUTION_FALLBACK_CONCURRENCY)
+                .collect::<Vec<_>>()
+                .await
+            }
+        });
+        let results = stream::iter(work)
+            .buffered(MEMBER_RESOLUTION_RELAY_CONCURRENCY)
+            .collect::<Vec<_>>()
+            .await;
+        let mut completed = HashSet::new();
+        for (index, endpoints, outcome) in results.into_iter().flatten() {
+            let account_id = targets[index].account_id_hex.clone();
+            targets[index].relay_records.extend(
+                outcome
+                    .records
+                    .into_iter()
+                    .filter(|record| record.event.pubkey == account_id),
+            );
+            targets[index].relay_lists = self.relay_lists_from_records(
+                &targets[index],
+                targets[index].relay_records.clone(),
+                &endpoints,
+            );
+            if outcome.complete
+                && !fresh_relay_list_status_from_records(
+                    &account_id,
+                    targets[index].relay_records.clone(),
+                    self.directory_freshness(),
+                )
+                .rejected_future
+            {
+                completed.insert(index);
+            }
+        }
+        completed
+    }
+
     async fn resolve_missing_relay_lists(
         &self,
         targets: &mut [MemberTarget],
@@ -527,157 +697,19 @@ impl MarmotApp {
         if endpoints.is_empty() {
             return Vec::new();
         }
-
-        let request_specs = needs_discovery
-            .chunks(MEMBER_RESOLUTION_AUTHORS_PER_QUERY)
-            .map(|chunk| {
-                let indices = chunk.to_vec();
-                let authors = chunk
-                    .iter()
-                    .map(|index| targets[*index].account_id_hex.clone())
-                    .collect::<Vec<_>>();
-                let queries = [KIND_NIP65_RELAY_LIST, KIND_MARMOT_INBOX_RELAY_LIST]
-                    .into_iter()
-                    .map(|kind| {
-                        DirectoryEventQuery::new(
-                            kind,
-                            authors.clone(),
-                            authors.len() * RELAY_LIST_EVENTS_PER_AUTHOR,
-                        )
-                    })
-                    .collect::<Vec<_>>();
-                (indices, endpoints.clone(), queries)
-            })
-            .collect::<Vec<_>>();
-        let app = self.clone();
-        let requests = request_specs
-            .into_iter()
-            .map(move |(indices, endpoints, queries)| {
-                let app = app.clone();
-                async move {
-                    let outcome = app
-                        .relay_plane
-                        .fetch_directory_events_with_completion(endpoints.clone(), queries)
-                        .await
-                        .map_err(|error| {
-                            AppError::RelayDirectory(format!("fetch relay lists: {error}"))
-                        });
-                    (indices, endpoints, outcome)
-                }
-            });
-        let batches = stream::iter(requests)
-            .buffered(MEMBER_RESOLUTION_RELAY_CONCURRENCY)
-            .collect::<Vec<_>>()
+        let completed_discovery = self
+            .resolve_relay_list_hop(targets, vec![(endpoints.clone(), needs_discovery.clone())])
             .await;
+        let incomplete_discovery = needs_discovery
+            .iter()
+            .copied()
+            .filter(|index| !completed_discovery.contains(index))
+            .collect::<HashSet<_>>();
 
-        let mut failures = Vec::new();
-        let mut completed_discovery = HashSet::new();
-        for (indices, endpoints, result) in batches {
-            match result {
-                Ok(outcome) => {
-                    for index in indices {
-                        if outcome.complete {
-                            completed_discovery.insert(index);
-                        }
-                        let account_id = &targets[index].account_id_hex;
-                        let account_records = outcome
-                            .records
-                            .iter()
-                            .filter(|record| record.event.pubkey == *account_id)
-                            .cloned()
-                            .collect::<Vec<_>>();
-                        targets[index].relay_records.extend(account_records);
-                        let relay_records = targets[index].relay_records.clone();
-                        targets[index].relay_lists = self.relay_lists_from_records(
-                            &targets[index],
-                            relay_records,
-                            &endpoints,
-                        );
-                        if !outcome.complete && targets[index].relay_lists.inbox.relays.is_empty() {
-                            failures.push((
-                                index,
-                                AppError::RelayDirectory(
-                                    "relay-list absence was not authoritatively established"
-                                        .to_owned(),
-                                ),
-                            ));
-                        }
-                    }
-                }
-                Err(_) => {
-                    // Preserve the established single-author behavior for
-                    // relays that reject multi-author query shapes without
-                    // promoting composition-only strangers into durable cache.
-                    let specs = indices
-                        .into_iter()
-                        .map(|index| (index, targets[index].account_id_hex.clone()))
-                        .collect::<Vec<_>>();
-                    let app = self.clone();
-                    let work = specs.into_iter().map(move |(index, account_id)| {
-                        let app = app.clone();
-                        let endpoints = endpoints.clone();
-                        async move {
-                            let queries = [KIND_NIP65_RELAY_LIST, KIND_MARMOT_INBOX_RELAY_LIST]
-                                .into_iter()
-                                .map(|kind| {
-                                    DirectoryEventQuery::new(
-                                        kind,
-                                        vec![account_id.clone()],
-                                        RELAY_LIST_EVENTS_PER_AUTHOR,
-                                    )
-                                })
-                                .collect::<Vec<_>>();
-                            let outcome = app
-                                .relay_plane
-                                .fetch_directory_events_with_completion(endpoints.clone(), queries)
-                                .await
-                                .map_err(|error| {
-                                    AppError::RelayDirectory(format!("fetch relay lists: {error}"))
-                                });
-                            (index, endpoints, outcome)
-                        }
-                    });
-                    let results = stream::iter(work)
-                        .buffered(MEMBER_RESOLUTION_FALLBACK_CONCURRENCY)
-                        .collect::<Vec<_>>()
-                        .await;
-                    for (index, endpoints, outcome) in results {
-                        match outcome {
-                            Ok(outcome) => {
-                                if outcome.complete {
-                                    completed_discovery.insert(index);
-                                }
-                                targets[index].relay_records.extend(outcome.records);
-                                let relay_records = targets[index].relay_records.clone();
-                                targets[index].relay_lists = self.relay_lists_from_records(
-                                    &targets[index],
-                                    relay_records,
-                                    &endpoints,
-                                );
-                                if !outcome.complete
-                                    && targets[index].relay_lists.inbox.relays.is_empty()
-                                {
-                                    failures.push((
-                                        index,
-                                        AppError::RelayDirectory(
-                                            "relay-list absence was not authoritatively established"
-                                                .to_owned(),
-                                        ),
-                                    ));
-                                }
-                            }
-                            Err(error) => failures.push((index, error)),
-                        }
-                    }
-                }
-            }
-        }
-
-        // Group targets by the same safe outbox set so each relay receives one
-        // bounded multi-author request. This keeps prewarm pure: persistence
-        // happens only after the whole member-resolution pass succeeds.
+        // Group the same safe outbox sets before querying. This remains pure:
+        // only commit-purpose resolution persists the observed metadata.
         let mut by_outboxes = BTreeMap::<Vec<TransportEndpoint>, Vec<usize>>::new();
-        for index in needs_discovery {
+        for index in needs_discovery.iter().copied() {
             let outbox_endpoints = self.retain_safe_discovered_endpoints(
                 targets[index]
                     .relay_lists
@@ -689,157 +721,54 @@ impl MarmotApp {
                     .collect(),
                 "member inbox outbox discovery",
             );
-            // A completed first-hop query already covered both relay-list kinds
-            // on these endpoints. Only genuinely new outboxes need another hop;
-            // incomplete reads remain eligible for the bounded retry.
-            let outbox_endpoints = outbox_endpoints
+            let mut outbox_endpoints = outbox_endpoints
                 .into_iter()
                 .filter(|endpoint| {
                     !completed_discovery.contains(&index) || !endpoints.contains(endpoint)
                 })
                 .collect::<Vec<_>>();
+            outbox_endpoints.sort();
             if !outbox_endpoints.is_empty() {
                 by_outboxes.entry(outbox_endpoints).or_default().push(index);
             }
         }
-        let mut second_hop_specs = Vec::new();
-        for (endpoints, indices) in by_outboxes {
-            for chunk in indices.chunks(MEMBER_RESOLUTION_AUTHORS_PER_QUERY) {
-                let indices = chunk.to_vec();
-                let authors = indices
-                    .iter()
-                    .map(|index| targets[*index].account_id_hex.clone())
-                    .collect::<Vec<_>>();
-                let queries = [KIND_NIP65_RELAY_LIST, KIND_MARMOT_INBOX_RELAY_LIST]
-                    .into_iter()
-                    .map(|kind| {
-                        DirectoryEventQuery::new(
-                            kind,
-                            authors.clone(),
-                            authors.len() * RELAY_LIST_EVENTS_PER_AUTHOR,
-                        )
-                    })
-                    .collect::<Vec<_>>();
-                second_hop_specs.push((indices, endpoints.clone(), queries));
-            }
-        }
-        let app = self.clone();
-        let account_ids = targets
-            .iter()
-            .map(|target| target.account_id_hex.clone())
-            .collect::<Vec<_>>();
-        let work = second_hop_specs
-            .into_iter()
-            .map(move |(indices, endpoints, queries)| {
-                let app = app.clone();
-                let authors = indices
-                    .iter()
-                    .map(|index| account_ids[*index].clone())
-                    .collect::<Vec<_>>();
-                async move {
-                    let outcome = app
-                        .relay_plane
-                        .fetch_directory_events_with_completion(endpoints.clone(), queries.clone())
-                        .await
-                        .map_err(|error| {
-                            AppError::RelayDirectory(format!("fetch outbox relay lists: {error}"))
-                        });
-                    if outcome.is_ok() || indices.len() == 1 {
-                        return vec![(indices, endpoints, outcome)];
-                    }
-                    // Keep the same bounded single-author fallback on the
-                    // advertised outbox as on discovery relays. A rejected
-                    // multi-author query is not evidence of missing metadata.
-                    stream::iter(indices.into_iter().enumerate().map(|(offset, index)| {
-                        let app = app.clone();
-                        let endpoints = endpoints.clone();
-                        let queries = queries
-                            .iter()
-                            .map(|query| {
-                                DirectoryEventQuery::new(
-                                    query.kind,
-                                    vec![authors[offset].clone()],
-                                    RELAY_LIST_EVENTS_PER_AUTHOR,
-                                )
-                            })
-                            .collect();
-                        async move {
-                            let outcome = app
-                                .relay_plane
-                                .fetch_directory_events_with_completion(endpoints.clone(), queries)
-                                .await
-                                .map_err(|error| {
-                                    AppError::RelayDirectory(format!(
-                                        "fetch outbox relay lists: {error}"
-                                    ))
-                                });
-                            (vec![index], endpoints, outcome)
-                        }
-                    }))
-                    .buffered(MEMBER_RESOLUTION_FALLBACK_CONCURRENCY)
-                    .collect::<Vec<_>>()
-                    .await
-                }
-            });
-        let second_hop_results = stream::iter(work)
-            .buffered(MEMBER_RESOLUTION_RELAY_CONCURRENCY)
-            .collect::<Vec<_>>()
+        let attempted_outbox = by_outboxes
+            .values()
+            .flatten()
+            .copied()
+            .collect::<HashSet<_>>();
+        let completed_outbox = self
+            .resolve_relay_list_hop(targets, by_outboxes.into_iter().collect())
             .await;
-        for (indices, endpoints, result) in second_hop_results.into_iter().flatten() {
-            match result {
-                Ok(outcome) => {
-                    for index in indices {
-                        let account_id = &targets[index].account_id_hex;
-                        let records = outcome
-                            .records
+        needs_discovery
+            .into_iter()
+            .filter(|index| {
+                let has_inbox = !self
+                    .retain_safe_discovered_endpoints(
+                        targets[*index]
+                            .relay_lists
+                            .inbox
+                            .relays
                             .iter()
-                            .filter(|record| record.event.pubkey == *account_id)
                             .cloned()
-                            .collect::<Vec<_>>();
-                        targets[index].relay_records.extend(records);
-                        let relay_records = targets[index].relay_records.clone();
-                        targets[index].relay_lists = self.relay_lists_from_records(
-                            &targets[index],
-                            relay_records,
-                            &endpoints,
-                        );
-                        if outcome.complete || !targets[index].relay_lists.inbox.relays.is_empty() {
-                            failures.retain(|(failed_index, _)| *failed_index != index);
-                        } else if !failures
-                            .iter()
-                            .any(|(failed_index, _)| *failed_index == index)
-                        {
-                            failures.push((
-                                index,
-                                AppError::RelayDirectory(
-                                    "relay-list absence was not authoritatively established"
-                                        .to_owned(),
-                                ),
-                            ));
-                        }
-                    }
-                }
-                Err(_) => {
-                    for index in indices {
-                        if targets[index].relay_lists.inbox.relays.is_empty()
-                            && !failures
-                                .iter()
-                                .any(|(failed_index, _)| *failed_index == index)
-                        {
-                            failures.push((
-                                index,
-                                AppError::RelayDirectory(
-                                    "fetch outbox relay lists failed".to_owned(),
-                                ),
-                            ));
-                        } else if !targets[index].relay_lists.inbox.relays.is_empty() {
-                            failures.retain(|(failed_index, _)| *failed_index != index);
-                        }
-                    }
-                }
-            }
-        }
-        failures
+                            .map(TransportEndpoint)
+                            .collect(),
+                        "member invite inbox completion",
+                    )
+                    .is_empty();
+                !has_inbox
+                    && (incomplete_discovery.contains(index)
+                        || (attempted_outbox.contains(index) && !completed_outbox.contains(index)))
+            })
+            .map(|index| {
+                (
+                    index,
+                    AppError::RelayDirectory(
+                        "relay-list absence was not authoritatively established".to_owned(),
+                    ),
+                )
+            })
+            .collect()
     }
 
     async fn resolve_missing_key_packages(

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -99,34 +99,16 @@ impl MarmotApp {
             )
             .await
             .map_err(|e| AppError::RelayDirectory(format!("fetch relay lists: {e}")))?;
-        let observed_nip65 = records.iter().any(|record| {
-            record.event.pubkey == account_id_hex
-                && record.event.kind == KIND_NIP65_RELAY_LIST
-                && freshness.accepts(record)
-        });
-        let observed_inbox = records.iter().any(|record| {
-            record.event.pubkey == account_id_hex
-                && record.event.kind == KIND_MARMOT_INBOX_RELAY_LIST
-                && freshness.accepts(record)
-        });
         let selection = fresh_relay_list_status_from_records(&account_id_hex, records, freshness);
-        let mut status = selection.value;
-        if !observed_nip65 || !observed_inbox {
+        let cached = {
             let app = self.clone();
             let account_id = account_id_hex.clone();
-            let cached = blocking_app_task(move || {
-                app.account_relay_list_status_for_account_id(&account_id)
-            })
-            .await?;
-            if !observed_nip65 {
-                status.nip65 = cached.nip65;
-            }
-            if !observed_inbox {
-                status.inbox = cached.inbox;
-            }
-            push_unique_strings(&mut status.bootstrap_relays, cached.bootstrap_relays);
-            status.refresh();
-        }
+            blocking_app_task(move || app.account_relay_list_status_for_account_id(&account_id))
+                .await?
+        };
+        // The one-hop diagnostic and target-aware resolver share the same
+        // per-kind anti-clobber rule; observing an older record is not freshness.
+        let mut status = merge_relay_list_status(cached, selection.value);
         if status.bootstrap_relays.is_empty() {
             status.bootstrap_relays = bootstrap_relays
                 .iter()
@@ -192,40 +174,52 @@ impl MarmotApp {
         );
         let mut complete = first.complete;
         if !outbox_relays.is_empty() {
-            let second = self
+            match self
                 .relay_plane
                 .fetch_directory_events_with_completion(
                     outbox_relays,
                     relay_list_queries(account_id_hex.clone()),
                 )
                 .await
-                .map_err(|e| AppError::RelayDirectory(format!("fetch outbox relay lists: {e}")))?;
-            complete &= second.complete;
-            records.extend(second.records);
+            {
+                Ok(second) => {
+                    complete &= second.complete;
+                    records.extend(second.records);
+                }
+                Err(_) => complete = false,
+            }
         }
 
-        let observed =
-            fresh_relay_list_status_from_records(&account_id_hex, records, freshness).value;
-        let mut status = merge_relay_list_status(cached, observed);
-        if status.bootstrap_relays.is_empty() {
-            status.bootstrap_relays = discovery_relays
-                .iter()
-                .map(|endpoint| endpoint.0.clone())
-                .collect();
-        }
-        {
+        let observed = fresh_relay_list_status_from_records(&account_id_hex, records, freshness);
+        // A rejected future-dated declaration is not evidence of absence.
+        complete &= !observed.rejected_future;
+        let mut status = merge_relay_list_status(cached, observed.value);
+        // Persist signed observations (including explicit-empty lists) and
+        // valid cached metadata even when discovery was incomplete. Do not
+        // durably turn the caller's discovery fallback into claimed account
+        // metadata merely because a lookup failed.
+        if status.nip65.created_at > 0 || status.inbox.created_at > 0 {
             let app = self.clone();
             let account_id = account_id_hex.clone();
             let remembered = status.clone();
             blocking_app_task(move || app.remember_directory_relay_lists(&account_id, &remembered))
                 .await?;
         }
+        if status.bootstrap_relays.is_empty() {
+            status.bootstrap_relays = discovery_relays
+                .iter()
+                .map(|endpoint| endpoint.0.clone())
+                .collect();
+        }
 
         let explicit_empty = (status.nip65.created_at > 0 && status.nip65.relays.is_empty())
             || (status.inbox.created_at > 0 && status.inbox.relays.is_empty());
         let uncertain_absence =
             !complete && (status.nip65.relays.is_empty() || status.inbox.relays.is_empty());
-        if explicit_empty || uncertain_absence {
+        if explicit_empty {
+            return Err(AppError::MissingRelayLists(status.missing.clone()));
+        }
+        if uncertain_absence {
             return Err(AppError::RelayDirectory(
                 "relay-list absence was not authoritatively established".to_owned(),
             ));
@@ -1102,7 +1096,7 @@ impl MarmotApp {
             .directory_entry_for_account_id(account_id_hex)?
             .unwrap_or_else(|| self.empty_directory_record(account_id_hex));
         entry.account_id_hex = account_id_hex.to_owned();
-        entry.relay_lists = relay_lists.clone();
+        entry.relay_lists = merge_relay_list_status(entry.relay_lists, relay_lists.clone());
         self.save_directory_entry(&entry)
     }
 
@@ -1114,7 +1108,7 @@ impl MarmotApp {
             .directory_entry_for_account_id(&fetched.account_id_hex)?
             .unwrap_or_else(|| self.empty_directory_record(&fetched.account_id_hex));
         entry.account_id_hex = fetched.account_id_hex.clone();
-        entry.relay_lists = fetched.relay_lists.clone();
+        entry.relay_lists = merge_relay_list_status(entry.relay_lists, fetched.relay_lists.clone());
         entry.key_package = Some(DirectoryKeyPackage {
             key_package_id: fetched.key_package_id.clone(),
             key_package_ref_hex: fetched.key_package_ref_hex.clone(),

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -36,7 +36,8 @@ use crate::ids::{
 };
 use crate::key_package_records::{
     fresh_or_cached_key_package, fresh_relay_list_status_from_records, key_package_from_record,
-    latest_fresh_key_package_from_records, publish_endpoints_from_bootstrap, relay_list_queries,
+    latest_fresh_key_package_from_records, merge_relay_list_status,
+    publish_endpoints_from_bootstrap, relay_list_queries,
 };
 use crate::relay_plane::{DirectoryEventQuery, DirectoryRelayEventRecord as RelayEventRecord};
 use crate::{
@@ -156,9 +157,29 @@ impl MarmotApp {
         account_id_hex: &str,
         discovery_relays: Vec<TransportEndpoint>,
     ) -> Result<AccountRelayListStatus, AppError> {
-        let first_hop = self
-            .fetch_account_relay_list_status_for_account_id(account_id_hex, discovery_relays)
-            .await?;
+        let public_key =
+            PublicKey::parse(account_id_hex).map_err(|_| AppError::InvalidPublicKey)?;
+        let account_id_hex = public_key.to_hex();
+        let discovery_relays = self.directory_source_relays(&discovery_relays);
+        let freshness = self.directory_freshness();
+        let cached = {
+            let app = self.clone();
+            let account_id = account_id_hex.clone();
+            blocking_app_task(move || app.account_relay_list_status_for_account_id(&account_id))
+                .await?
+        };
+        let first = self
+            .relay_plane
+            .fetch_directory_events_with_completion(
+                discovery_relays.clone(),
+                relay_list_queries(account_id_hex.clone()),
+            )
+            .await
+            .map_err(|e| AppError::RelayDirectory(format!("fetch relay lists: {e}")))?;
+        let mut records = first.records;
+        let first_observed =
+            fresh_relay_list_status_from_records(&account_id_hex, records.clone(), freshness).value;
+        let first_hop = merge_relay_list_status(cached.clone(), first_observed);
         let outbox_relays = self.retain_safe_discovered_endpoints(
             first_hop
                 .nip65
@@ -169,17 +190,47 @@ impl MarmotApp {
                 .collect(),
             "account inbox outbox discovery",
         );
-        if outbox_relays.is_empty() {
-            return Ok(first_hop);
+        let mut complete = first.complete;
+        if !outbox_relays.is_empty() {
+            let second = self
+                .relay_plane
+                .fetch_directory_events_with_completion(
+                    outbox_relays,
+                    relay_list_queries(account_id_hex.clone()),
+                )
+                .await
+                .map_err(|e| AppError::RelayDirectory(format!("fetch outbox relay lists: {e}")))?;
+            complete &= second.complete;
+            records.extend(second.records);
         }
-        match self
-            .fetch_account_relay_list_status_for_account_id(account_id_hex, outbox_relays)
-            .await
+
+        let observed =
+            fresh_relay_list_status_from_records(&account_id_hex, records, freshness).value;
+        let mut status = merge_relay_list_status(cached, observed);
+        if status.bootstrap_relays.is_empty() {
+            status.bootstrap_relays = discovery_relays
+                .iter()
+                .map(|endpoint| endpoint.0.clone())
+                .collect();
+        }
         {
-            Ok(status) => Ok(status),
-            Err(_) if !first_hop.inbox.relays.is_empty() => Ok(first_hop),
-            Err(error) => Err(error),
+            let app = self.clone();
+            let account_id = account_id_hex.clone();
+            let remembered = status.clone();
+            blocking_app_task(move || app.remember_directory_relay_lists(&account_id, &remembered))
+                .await?;
         }
+
+        let explicit_empty = (status.nip65.created_at > 0 && status.nip65.relays.is_empty())
+            || (status.inbox.created_at > 0 && status.inbox.relays.is_empty());
+        let uncertain_absence =
+            !complete && (status.nip65.relays.is_empty() || status.inbox.relays.is_empty());
+        if explicit_empty || uncertain_absence {
+            return Err(AppError::RelayDirectory(
+                "relay-list absence was not authoritatively established".to_owned(),
+            ));
+        }
+        Ok(status)
     }
 
     pub async fn fetch_current_account_relay_list_status_for_account_id(

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -142,6 +142,46 @@ impl MarmotApp {
         Ok(status)
     }
 
+    /// Resolve an account's relay metadata through its advertised NIP-65
+    /// write relays before treating a kind-10050 inbox list as absent.
+    ///
+    /// The explicit fetch API above intentionally remains a one-hop diagnostic
+    /// primitive. Production account setup uses this target-aware wrapper so a
+    /// discovery relay (`D`) can point at an outbox (`W`) that owns the current
+    /// inbox declaration. If the second hop fails, already-observed positive
+    /// inbox metadata remains usable; an empty first hop is not promoted into
+    /// authoritative absence.
+    pub(crate) async fn resolve_account_relay_list_status_for_account_id(
+        &self,
+        account_id_hex: &str,
+        discovery_relays: Vec<TransportEndpoint>,
+    ) -> Result<AccountRelayListStatus, AppError> {
+        let first_hop = self
+            .fetch_account_relay_list_status_for_account_id(account_id_hex, discovery_relays)
+            .await?;
+        let outbox_relays = self.retain_safe_discovered_endpoints(
+            first_hop
+                .nip65
+                .relays
+                .iter()
+                .cloned()
+                .map(TransportEndpoint)
+                .collect(),
+            "account inbox outbox discovery",
+        );
+        if outbox_relays.is_empty() {
+            return Ok(first_hop);
+        }
+        match self
+            .fetch_account_relay_list_status_for_account_id(account_id_hex, outbox_relays)
+            .await
+        {
+            Ok(status) => Ok(status),
+            Err(_) if !first_hop.inbox.relays.is_empty() => Ok(first_hop),
+            Err(error) => Err(error),
+        }
+    }
+
     pub async fn fetch_current_account_relay_list_status_for_account_id(
         &self,
         account_id_hex: &str,

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -216,13 +216,13 @@ impl MarmotApp {
             || (status.inbox.created_at > 0 && status.inbox.relays.is_empty());
         let uncertain_absence =
             !complete && (status.nip65.relays.is_empty() || status.inbox.relays.is_empty());
-        if explicit_empty {
-            return Err(AppError::MissingRelayLists(status.missing.clone()));
-        }
         if uncertain_absence {
             return Err(AppError::RelayDirectory(
                 "relay-list absence was not authoritatively established".to_owned(),
             ));
+        }
+        if explicit_empty {
+            return Err(AppError::MissingRelayLists(status.missing.clone()));
         }
         Ok(status)
     }

--- a/crates/marmot-app/src/key_package_records.rs
+++ b/crates/marmot-app/src/key_package_records.rs
@@ -28,12 +28,39 @@ use crate::{
     push_unique_strings, relay_list_state_from_event, sort_directory_records,
 };
 
+pub(crate) fn merge_relay_list_status(
+    mut current: AccountRelayListStatus,
+    candidate: AccountRelayListStatus,
+) -> AccountRelayListStatus {
+    if candidate.nip65.created_at > current.nip65.created_at
+        || (candidate.nip65.created_at == 0
+            && current.nip65.created_at == 0
+            && current.nip65.relays.is_empty()
+            && !candidate.nip65.relays.is_empty())
+    {
+        current.nip65 = candidate.nip65;
+    }
+    if candidate.inbox.created_at > current.inbox.created_at
+        || (candidate.inbox.created_at == 0
+            && current.inbox.created_at == 0
+            && current.inbox.relays.is_empty()
+            && !candidate.inbox.relays.is_empty())
+    {
+        current.inbox = candidate.inbox;
+    }
+    push_unique_strings(&mut current.bootstrap_relays, candidate.bootstrap_relays);
+    current.refresh();
+    current
+}
+
 pub(crate) fn relay_list_status_from_records(
     account_id_hex: &str,
     mut records: Vec<RelayEventRecord>,
 ) -> AccountRelayListStatus {
     sort_directory_records(&mut records);
     let mut status = AccountRelayListStatus::empty();
+    let mut seen_nip65 = false;
+    let mut seen_inbox = false;
     for record in records {
         if record.event.pubkey != account_id_hex {
             continue;
@@ -42,8 +69,17 @@ pub(crate) fn relay_list_status_from_records(
             continue;
         };
         match record.event.kind {
-            KIND_NIP65_RELAY_LIST => status.nip65 = state,
-            KIND_MARMOT_INBOX_RELAY_LIST => status.inbox = state,
+            KIND_NIP65_RELAY_LIST if !seen_nip65 || state.created_at > status.nip65.created_at => {
+                status.nip65 = state;
+                seen_nip65 = true;
+            }
+            KIND_MARMOT_INBOX_RELAY_LIST
+                if !seen_inbox || state.created_at > status.inbox.created_at =>
+            {
+                status.inbox = state;
+                seen_inbox = true;
+            }
+            KIND_NIP65_RELAY_LIST | KIND_MARMOT_INBOX_RELAY_LIST => {}
             _ => continue,
         }
         push_unique_strings(
@@ -600,6 +636,45 @@ mod merge_tests {
             record("", "", false, true),
         ]);
         assert_eq!(records.len(), 2);
+    }
+
+    #[test]
+    fn relay_list_ties_choose_lexically_lower_event_id_in_any_input_order() {
+        let account_id = "11".repeat(32);
+        let make = |id: &str, kind: u64, relay: &str| RelayEventRecord {
+            endpoints: vec![TransportEndpoint("wss://source.example".to_owned())],
+            event: NostrTransportEvent {
+                id: id.repeat(64),
+                pubkey: account_id.clone(),
+                created_at: 42,
+                kind,
+                tags: vec![if kind == KIND_NIP65_RELAY_LIST {
+                    vec!["r".to_owned(), relay.to_owned(), "write".to_owned()]
+                } else {
+                    vec!["relay".to_owned(), relay.to_owned()]
+                }],
+                content: String::new(),
+                sig: None,
+            },
+        };
+        let lower_nip65 = make("0", KIND_NIP65_RELAY_LIST, "wss://lower-outbox.example");
+        let higher_nip65 = make("f", KIND_NIP65_RELAY_LIST, "wss://higher-outbox.example");
+        let lower_inbox = make(
+            "0",
+            KIND_MARMOT_INBOX_RELAY_LIST,
+            "wss://lower-inbox.example",
+        );
+        let higher_inbox = make(
+            "f",
+            KIND_MARMOT_INBOX_RELAY_LIST,
+            "wss://higher-inbox.example",
+        );
+        let input = vec![higher_inbox, lower_nip65, higher_nip65, lower_inbox];
+        for records in [input.clone(), input.into_iter().rev().collect()] {
+            let status = relay_list_status_from_records(&account_id, records);
+            assert_eq!(status.nip65.relays, vec!["wss://lower-outbox.example"]);
+            assert_eq!(status.inbox.relays, vec!["wss://lower-inbox.example"]);
+        }
     }
 
     #[test]

--- a/crates/marmot-app/src/relay_plane/directory.rs
+++ b/crates/marmot-app/src/relay_plane/directory.rs
@@ -4,7 +4,10 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use cgka_traits::TransportEndpoint;
-use nostr_sdk::prelude::{Client as NostrSdkClient, Event, Filter, Kind, PublicKey, RelayUrl};
+use nostr_sdk::prelude::{
+    Client as NostrSdkClient, Event, Filter, Kind, PublicKey, RelayMessage, RelayNotification,
+    RelayStatus, RelayUrl, SubscribeAutoCloseOptions, SubscribeOptions, SubscriptionId,
+};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, oneshot};
 use tokio::task::JoinSet;
@@ -112,6 +115,12 @@ pub(crate) struct DirectorySubscriptionSyncSummary {
     pub(crate) subscriptions_removed: usize,
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct DirectoryFetchOutcome {
+    pub(crate) records: Vec<DirectoryRelayEventRecord>,
+    pub(crate) complete: bool,
+}
+
 type DirectoryFetchResult = Result<Vec<DirectoryRelayEventRecord>, String>;
 
 #[async_trait]
@@ -120,6 +129,18 @@ pub(crate) trait DirectoryRelayFetcher: Send + Sync {
         &self,
         request: DirectoryFetchRequest,
     ) -> Result<Vec<DirectoryRelayEventRecord>, String>;
+
+    async fn fetch_directory_events_with_completion(
+        &self,
+        request: DirectoryFetchRequest,
+    ) -> Result<DirectoryFetchOutcome, String> {
+        self.fetch_directory_events(request)
+            .await
+            .map(|records| DirectoryFetchOutcome {
+                records,
+                complete: true,
+            })
+    }
 }
 
 #[derive(Clone)]
@@ -230,6 +251,27 @@ impl DirectoryRelayPlane {
 
         rx.await
             .map_err(|_| "directory fetch owner dropped before completing".to_owned())?
+    }
+
+    pub(crate) async fn fetch_events_with_completion(
+        &self,
+        request: DirectoryFetchRequest,
+    ) -> Result<DirectoryFetchOutcome, String> {
+        let fetcher = self.fetcher.clone();
+        let result = tokio::spawn(async move {
+            fetcher
+                .fetch_directory_events_with_completion(request)
+                .await
+        })
+        .await
+        .map_err(|_| "directory fetch task failed".to_owned())?;
+        let mut state = self.state.lock().await;
+        if result.is_ok() {
+            state.completed_fetches += 1;
+        } else {
+            state.failed_fetches += 1;
+        }
+        result
     }
 
     pub(crate) async fn stats(&self) -> DirectoryRelayStats {
@@ -490,6 +532,161 @@ impl DirectoryRelayFetcher for NostrSdkDirectoryRelayFetcher {
         }
         Ok(records)
     }
+
+    async fn fetch_directory_events_with_completion(
+        &self,
+        request: DirectoryFetchRequest,
+    ) -> Result<DirectoryFetchOutcome, String> {
+        let relay_urls = parsed_directory_relay_urls(&request.endpoints)?;
+        let mut tasks = JoinSet::new();
+        for relay_url in relay_urls.iter().cloned() {
+            let client = self.client.clone();
+            let queries = request.queries.clone();
+            tasks.spawn(async move { strict_fetch_endpoint(client, relay_url, queries).await });
+        }
+
+        let mut outcome = DirectoryFetchOutcome {
+            records: Vec::new(),
+            complete: true,
+        };
+        while let Some(result) = tasks.join_next().await {
+            match result {
+                Ok(endpoint) => {
+                    outcome.complete &= endpoint.complete;
+                    outcome.records.extend(endpoint.records);
+                }
+                Err(_) => outcome.complete = false,
+            }
+        }
+        if relay_urls.is_empty() {
+            outcome.complete = false;
+        }
+        Ok(outcome)
+    }
+}
+
+async fn strict_fetch_endpoint(
+    client: NostrSdkClient,
+    relay_url: RelayUrl,
+    queries: Vec<DirectoryEventQuery>,
+) -> DirectoryFetchOutcome {
+    let endpoint = TransportEndpoint(relay_url.to_string());
+    if client.relay(&relay_url).await.is_err() && client.add_relay(relay_url.clone()).await.is_err()
+    {
+        return DirectoryFetchOutcome::default();
+    }
+    if !matches!(
+        timeout(
+            DIRECTORY_RELAY_CONNECT_WAIT,
+            client.connect_relay(relay_url.clone()),
+        )
+        .await,
+        Ok(Ok(()))
+    ) {
+        return DirectoryFetchOutcome::default();
+    }
+    let Ok(relay) = client.relay(relay_url).await else {
+        return DirectoryFetchOutcome::default();
+    };
+    let mut filters = Vec::with_capacity(queries.len());
+    for query in &queries {
+        let Ok(kind) = u16::try_from(query.kind).map(Kind::from) else {
+            return DirectoryFetchOutcome::default();
+        };
+        let Ok(public_keys) = query
+            .authors
+            .iter()
+            .map(|author| PublicKey::parse(author))
+            .collect::<Result<Vec<_>, _>>()
+        else {
+            return DirectoryFetchOutcome::default();
+        };
+        filters.push(
+            Filter::new()
+                .authors(public_keys)
+                .kind(kind)
+                .limit(query.limit),
+        );
+    }
+
+    let max_records = queries.iter().map(|query| query.limit).sum::<usize>();
+    let subscription_id = SubscriptionId::generate();
+    let mut notifications = relay.notifications();
+    if relay
+        .subscribe_with_id(
+            subscription_id.clone(),
+            filters,
+            SubscribeOptions::default().close_on(Some(
+                SubscribeAutoCloseOptions::default()
+                    .timeout(Some(DIRECTORY_RELAY_FETCH_WAIT))
+                    .idle_timeout(Some(DIRECTORY_RELAY_FETCH_WAIT)),
+            )),
+        )
+        .await
+        .is_err()
+    {
+        return DirectoryFetchOutcome::default();
+    }
+
+    let mut records = Vec::new();
+    let mut seen_event_ids = HashSet::new();
+    let complete = timeout(DIRECTORY_RELAY_FETCH_WAIT, async {
+        loop {
+            let received = match notifications.recv().await {
+                Ok(RelayNotification::Event {
+                    subscription_id: received_id,
+                    event,
+                }) if received_id == subscription_id => Some(*event),
+                Ok(RelayNotification::Message {
+                    message:
+                        RelayMessage::Event {
+                            subscription_id: received_id,
+                            event,
+                        },
+                }) if received_id.as_ref() == &subscription_id => Some(event.into_owned()),
+                Ok(RelayNotification::Message {
+                    message: RelayMessage::EndOfStoredEvents(received_id),
+                }) if received_id.as_ref() == &subscription_id => break true,
+                Ok(RelayNotification::Message {
+                    message:
+                        RelayMessage::Closed {
+                            subscription_id: received_id,
+                            ..
+                        },
+                }) if received_id.as_ref() == &subscription_id => break false,
+                Ok(RelayNotification::AuthenticationFailed | RelayNotification::Shutdown) => {
+                    break false;
+                }
+                Ok(RelayNotification::RelayStatus {
+                    status:
+                        RelayStatus::Disconnected | RelayStatus::Terminated | RelayStatus::Banned,
+                }) => {
+                    break false;
+                }
+                Err(_) => break false,
+                _ => None,
+            };
+            if let Some(event) = received
+                && let Some(event) = queries
+                    .iter()
+                    .find_map(|query| validated_directory_event(&event, query))
+                && seen_event_ids.insert(event.id.clone())
+            {
+                if records.len() < max_records {
+                    records.push(DirectoryRelayEventRecord {
+                        endpoints: vec![endpoint.clone()],
+                        event,
+                    });
+                } else {
+                    break false;
+                }
+            }
+        }
+    })
+    .await
+    .unwrap_or(false);
+    let _ = relay.unsubscribe(&subscription_id).await;
+    DirectoryFetchOutcome { records, complete }
 }
 
 fn parsed_directory_relay_urls(endpoints: &[TransportEndpoint]) -> Result<Vec<RelayUrl>, String> {

--- a/crates/marmot-app/src/relay_plane/directory.rs
+++ b/crates/marmot-app/src/relay_plane/directory.rs
@@ -87,6 +87,8 @@ pub(crate) struct DirectoryRelayPlane {
 #[derive(Default)]
 struct DirectoryRelayPlaneState {
     inflight: HashMap<DirectoryFetchKey, Vec<oneshot::Sender<DirectoryFetchResult>>>,
+    inflight_completion:
+        HashMap<DirectoryFetchKey, Vec<oneshot::Sender<DirectoryCompletionResult>>>,
     active_subscriptions: HashMap<String, DirectorySubscriptionFilter>,
     completed_fetches: usize,
     coalesced_waiters: usize,
@@ -122,6 +124,7 @@ pub(crate) struct DirectoryFetchOutcome {
 }
 
 type DirectoryFetchResult = Result<Vec<DirectoryRelayEventRecord>, String>;
+type DirectoryCompletionResult = Result<DirectoryFetchOutcome, String>;
 
 #[async_trait]
 pub(crate) trait DirectoryRelayFetcher: Send + Sync {
@@ -138,7 +141,7 @@ pub(crate) trait DirectoryRelayFetcher: Send + Sync {
             .await
             .map(|records| DirectoryFetchOutcome {
                 records,
-                complete: true,
+                complete: false,
             })
     }
 }
@@ -257,27 +260,54 @@ impl DirectoryRelayPlane {
         &self,
         request: DirectoryFetchRequest,
     ) -> Result<DirectoryFetchOutcome, String> {
-        let fetcher = self.fetcher.clone();
-        let result = tokio::spawn(async move {
-            fetcher
-                .fetch_directory_events_with_completion(request)
+        let key = request.key();
+        let (tx, rx) = oneshot::channel();
+        let should_spawn = {
+            let mut state = self.state.lock().await;
+            if let Some(waiters) = state.inflight_completion.get_mut(&key) {
+                waiters.push(tx);
+                state.coalesced_waiters += 1;
+                false
+            } else {
+                state.inflight_completion.insert(key.clone(), vec![tx]);
+                true
+            }
+        };
+        if should_spawn {
+            let fetcher = self.fetcher.clone();
+            let state = self.state.clone();
+            tokio::spawn(async move {
+                let result = match tokio::spawn(async move {
+                    fetcher
+                        .fetch_directory_events_with_completion(request)
+                        .await
+                })
                 .await
-        })
-        .await
-        .map_err(|_| "directory fetch task failed".to_owned())?;
-        let mut state = self.state.lock().await;
-        if result.is_ok() {
-            state.completed_fetches += 1;
-        } else {
-            state.failed_fetches += 1;
+                {
+                    Ok(result) => result,
+                    Err(_) => Err("directory fetch task failed".to_owned()),
+                };
+                let mut state = state.lock().await;
+                if matches!(&result, Ok(outcome) if outcome.complete) {
+                    state.completed_fetches += 1;
+                } else {
+                    state.failed_fetches += 1;
+                }
+                if let Some(waiters) = state.inflight_completion.remove(&key) {
+                    for waiter in waiters {
+                        let _ = waiter.send(result.clone());
+                    }
+                }
+            });
         }
-        result
+        rx.await
+            .map_err(|_| "directory fetch owner dropped before completing".to_owned())?
     }
 
     pub(crate) async fn stats(&self) -> DirectoryRelayStats {
         let state = self.state.lock().await;
         DirectoryRelayStats {
-            inflight_fetches: state.inflight.len(),
+            inflight_fetches: state.inflight.len() + state.inflight_completion.len(),
             active_subscriptions: state.active_subscriptions.len(),
             completed_fetches: state.completed_fetches,
             coalesced_waiters: state.coalesced_waiters,
@@ -432,9 +462,8 @@ fn validated_directory_event(
     NostrTransportEvent::from_nostr_event(event).ok()
 }
 
-#[async_trait]
-impl DirectoryRelayFetcher for NostrSdkDirectoryRelayFetcher {
-    async fn fetch_directory_events(
+impl NostrSdkDirectoryRelayFetcher {
+    async fn fetch_request_events(
         &self,
         request: DirectoryFetchRequest,
     ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
@@ -532,15 +561,32 @@ impl DirectoryRelayFetcher for NostrSdkDirectoryRelayFetcher {
         }
         Ok(records)
     }
+}
+
+#[async_trait]
+impl DirectoryRelayFetcher for NostrSdkDirectoryRelayFetcher {
+    async fn fetch_directory_events(
+        &self,
+        request: DirectoryFetchRequest,
+    ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
+        let owned = Self::standalone();
+        let result = owned.fetch_request_events(request).await;
+        owned.client.shutdown().await;
+        result
+    }
 
     async fn fetch_directory_events_with_completion(
         &self,
         request: DirectoryFetchRequest,
     ) -> Result<DirectoryFetchOutcome, String> {
         let relay_urls = parsed_directory_relay_urls(&request.endpoints)?;
+        // Discovered targets belong to this bounded read, not the long-lived
+        // client pool. Closing the owned client also stops reconnects for
+        // failed relays without removing another caller's active relay.
+        let client = NostrSdkClient::builder().build();
         let mut tasks = JoinSet::new();
         for relay_url in relay_urls.iter().cloned() {
-            let client = self.client.clone();
+            let client = client.clone();
             let queries = request.queries.clone();
             tasks.spawn(async move { strict_fetch_endpoint(client, relay_url, queries).await });
         }
@@ -561,6 +607,7 @@ impl DirectoryRelayFetcher for NostrSdkDirectoryRelayFetcher {
         if relay_urls.is_empty() {
             outcome.complete = false;
         }
+        client.shutdown().await;
         Ok(outcome)
     }
 }
@@ -630,6 +677,7 @@ async fn strict_fetch_endpoint(
 
     let mut records = Vec::new();
     let mut seen_event_ids = HashSet::new();
+    let mut query_counts = vec![0usize; queries.len()];
     let complete = timeout(DIRECTORY_RELAY_FETCH_WAIT, async {
         loop {
             let received = match notifications.recv().await {
@@ -646,7 +694,15 @@ async fn strict_fetch_endpoint(
                 }) if received_id.as_ref() == &subscription_id => Some(event.into_owned()),
                 Ok(RelayNotification::Message {
                     message: RelayMessage::EndOfStoredEvents(received_id),
-                }) if received_id.as_ref() == &subscription_id => break true,
+                }) if received_id.as_ref() == &subscription_id => {
+                    // EOSE does not prove absence if any filter may have been
+                    // cut off at its requested limit, even below the combined
+                    // record cap. Positive records remain usable.
+                    break queries
+                        .iter()
+                        .zip(&query_counts)
+                        .all(|(query, count)| *count < query.limit);
+                }
                 Ok(RelayNotification::Message {
                     message:
                         RelayMessage::Closed {
@@ -663,6 +719,8 @@ async fn strict_fetch_endpoint(
                 }) => {
                     break false;
                 }
+                // Lag may have dropped an inbox EVENT immediately before
+                // EOSE. Continuing cannot establish absence safely.
                 Err(_) => break false,
                 _ => None,
             };
@@ -672,6 +730,11 @@ async fn strict_fetch_endpoint(
                     .find_map(|query| validated_directory_event(&event, query))
                 && seen_event_ids.insert(event.id.clone())
             {
+                for (query, count) in queries.iter().zip(&mut query_counts) {
+                    if query.kind == event.kind && query.authors.contains(&event.pubkey) {
+                        *count += 1;
+                    }
+                }
                 if records.len() < max_records {
                     records.push(DirectoryRelayEventRecord {
                         endpoints: vec![endpoint.clone()],
@@ -730,6 +793,41 @@ mod tests {
         let tampered = Event::from_json(tampered.to_string()).unwrap();
         assert!(tampered.verify().is_err());
         assert!(validated_directory_event(&tampered, &query).is_none());
+    }
+
+    #[tokio::test]
+    async fn strict_directory_exact_filter_limit_keeps_records_but_not_absence_proof() {
+        use nostr_relay_builder::MockRelay;
+        use nostr_sdk::prelude::{EventBuilder, Keys};
+
+        let relay = MockRelay::run().await.unwrap();
+        let url = relay.url().await;
+        let keys = Keys::generate();
+        let client = NostrSdkClient::builder().signer(keys.clone()).build();
+        client.add_relay(url.clone()).await.unwrap();
+        client.connect_relay(url.clone()).await.unwrap();
+        client
+            .send_event_builder(EventBuilder::new(Kind::Metadata, "{}"))
+            .await
+            .unwrap();
+        let request = DirectoryFetchRequest::new(
+            vec![TransportEndpoint(url.to_string())],
+            vec![
+                DirectoryEventQuery::new(0, vec![keys.public_key().to_hex()], 1),
+                DirectoryEventQuery::new(10050, vec![keys.public_key().to_hex()], 12),
+            ],
+        )
+        .unwrap();
+        let result = NostrSdkDirectoryRelayFetcher::standalone()
+            .fetch_directory_events_with_completion(request)
+            .await
+            .unwrap();
+        client.shutdown().await;
+        assert_eq!(result.records.len(), 1);
+        assert!(
+            !result.complete,
+            "one saturated filter must not be hidden by the combined limit"
+        );
     }
 
     #[tokio::test]

--- a/crates/marmot-app/src/relay_plane/mod.rs
+++ b/crates/marmot-app/src/relay_plane/mod.rs
@@ -43,8 +43,8 @@ pub use telemetry::{
 };
 
 pub(crate) use directory::{
-    DirectoryEventQuery, DirectoryFetchRequest, DirectoryRelayEventRecord, DirectoryRelayFetcher,
-    DirectoryRelayPlane, DirectoryRelayStats, DirectorySubscriptionFilter,
+    DirectoryEventQuery, DirectoryFetchOutcome, DirectoryFetchRequest, DirectoryRelayEventRecord,
+    DirectoryRelayFetcher, DirectoryRelayPlane, DirectoryRelayStats, DirectorySubscriptionFilter,
     DirectorySubscriptionSyncSummary, NostrSdkDirectoryRelayFetcher,
 };
 pub(crate) use safety::RelaySafetyPolicy;
@@ -918,6 +918,21 @@ impl MarmotRelayPlane {
         self.inner
             .directory
             .fetch_events(DirectoryFetchRequest::new(endpoints, queries)?)
+            .await
+    }
+
+    pub(crate) async fn fetch_directory_events_with_completion(
+        &self,
+        endpoints: Vec<TransportEndpoint>,
+        queries: Vec<DirectoryEventQuery>,
+    ) -> Result<DirectoryFetchOutcome, String> {
+        let endpoints = self
+            .inner
+            .relay_safety
+            .sanitize_endpoints(endpoints, "directory fetch")?;
+        self.inner
+            .directory
+            .fetch_events_with_completion(DirectoryFetchRequest::new(endpoints, queries)?)
             .await
     }
 

--- a/crates/marmot-app/src/relay_plane/tests.rs
+++ b/crates/marmot-app/src/relay_plane/tests.rs
@@ -1092,6 +1092,65 @@ async fn directory_fetches_coalesce_identical_inflight_requests() {
 }
 
 #[tokio::test]
+async fn directory_completion_coalesces_and_survives_waiter_cancellation() {
+    let fetcher = Arc::new(BlockingDirectoryFetcher {
+        fetch_count: AtomicUsize::new(0),
+        started: Notify::new(),
+        release: Notify::new(),
+        events: Vec::new(),
+    });
+    let plane = relay_plane_with_directory_fetcher(
+        Arc::new(RecordingRelayClient::default()),
+        fetcher.clone(),
+    );
+    let endpoints = vec![TransportEndpoint("wss://relay.example".into())];
+    let queries = vec![DirectoryEventQuery::new(0, vec!["11".repeat(32)], 12)];
+    let first_plane = plane.clone();
+    let first_endpoints = endpoints.clone();
+    let first_queries = queries.clone();
+    let first = tokio::spawn(async move {
+        first_plane
+            .fetch_directory_events_with_completion(first_endpoints, first_queries)
+            .await
+    });
+    let second_plane = plane.clone();
+    let second = tokio::spawn(async move {
+        second_plane
+            .fetch_directory_events_with_completion(endpoints, queries)
+            .await
+    });
+    timeout(Duration::from_secs(2), async {
+        loop {
+            if plane.relay_health().await.directory_coalesced_waiters == 1
+                && fetcher.fetch_count.load(Ordering::SeqCst) == 1
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(plane.relay_health().await.directory_inflight_fetches, 1);
+    first.abort();
+    let _ = first.await;
+    fetcher.release.notify_one();
+    let outcome = timeout(Duration::from_secs(2), second)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert!(
+        !outcome.complete,
+        "a legacy fetcher must not claim authoritative completion"
+    );
+    let health = plane.relay_health().await;
+    assert_eq!(health.directory_inflight_fetches, 0);
+    assert_eq!(health.directory_failed_fetches, 1);
+    assert_eq!(health.directory_completed_fetches, 0);
+}
+
+#[tokio::test]
 async fn directory_fetch_owner_cancellation_does_not_orphan_waiters() {
     let relay = Arc::new(RecordingRelayClient::default());
     let event = DirectoryRelayEventRecord {

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -200,6 +200,9 @@ struct GeneratedSetupTasks {
 }
 
 const GENERATED_SETUP_BACKGROUND_MAX_ATTEMPTS: usize = 3;
+// Existing-account discovery includes two relay-list hops and an advisory
+// profile read, each bounded by connection and fetch budgets (5s + 3s).
+const ACCOUNT_DIRECTORY_PREFLIGHT_WAIT: Duration = Duration::from_secs(26);
 const GENERATED_SETUP_BACKGROUND_RETRY_BASE_DELAY: Duration = Duration::from_millis(100);
 const ACCOUNT_CATCH_UP_TRANSIENT_RETRY_DELAYS: [Duration; 3] = [
     Duration::from_millis(250),
@@ -5392,7 +5395,7 @@ impl AccountManager {
                 // reactivation, exactly like the external-signer login path.
                 bounded_advisory_step(
                     &self.shared.app_performance_telemetry(),
-                    ACCOUNT_SETUP_ADVISORY_WAIT,
+                    ACCOUNT_DIRECTORY_PREFLIGHT_WAIT,
                     "import_directory_preflight",
                     self.preflight_existing_account_directory(
                         &account.account_id_hex,
@@ -5640,7 +5643,7 @@ impl AccountManager {
         // so a stalled indexer must not hold the whole login hostage.
         let recent_relay_lists = bounded_advisory_step(
             &self.shared.app_performance_telemetry(),
-            ACCOUNT_SETUP_ADVISORY_WAIT,
+            ACCOUNT_DIRECTORY_PREFLIGHT_WAIT,
             "login_directory_preflight",
             self.preflight_existing_account_directory(
                 &account.account_id_hex,
@@ -5706,7 +5709,7 @@ impl AccountManager {
             None
         };
 
-        // Advisory refresh, same bound as the preflight above.
+        // Single-hop advisory refresh keeps the shorter profile-refresh bound.
         let _ = bounded_advisory_step(
             &self.shared.app_performance_telemetry(),
             ACCOUNT_SETUP_ADVISORY_WAIT,
@@ -5953,7 +5956,7 @@ impl AccountManager {
                 } else {
                     match bounded_advisory_step(
                         &self.shared.app_performance_telemetry(),
-                        ACCOUNT_SETUP_ADVISORY_WAIT,
+                        ACCOUNT_DIRECTORY_PREFLIGHT_WAIT,
                         "import_relay_list_status",
                         self.app.resolve_account_relay_list_status_for_account_id(
                             &account.account_id_hex,
@@ -5970,10 +5973,18 @@ impl AccountManager {
                                 error_kind = error.privacy_safe_kind(),
                                 "import relay-list discovery failed; refusing to publish defaults"
                             );
-                            return self.complete_cached_relay_list_status(&account.label);
+                            return self
+                                .complete_cached_relay_list_status(&account.label)
+                                .or(Err(error));
                         }
                         None => {
-                            return self.complete_cached_relay_list_status(&account.label);
+                            return self
+                                .complete_cached_relay_list_status(&account.label)
+                                .map_err(|_| {
+                                    AppError::RelayDirectory(
+                                        "relay-list discovery timed out".to_owned(),
+                                    )
+                                });
                         }
                     }
                 };

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -5759,7 +5759,7 @@ impl AccountManager {
     ) -> Option<AccountRelayListStatus> {
         let status = match self
             .app
-            .fetch_account_relay_list_status_for_account_id(account_id_hex, discovery_relays)
+            .resolve_account_relay_list_status_for_account_id(account_id_hex, discovery_relays)
             .await
         {
             Ok(status) => status,
@@ -5955,7 +5955,7 @@ impl AccountManager {
                         &self.shared.app_performance_telemetry(),
                         ACCOUNT_SETUP_ADVISORY_WAIT,
                         "import_relay_list_status",
-                        self.app.fetch_account_relay_list_status_for_account_id(
+                        self.app.resolve_account_relay_list_status_for_account_id(
                             &account.account_id_hex,
                             bootstrap.bootstrap_relays.clone(),
                         ),
@@ -6018,7 +6018,7 @@ impl AccountManager {
                 return Err(AppError::MissingDefaultRelays);
             }
             self.app
-                .fetch_account_relay_list_status_for_account_id(
+                .resolve_account_relay_list_status_for_account_id(
                     &account.account_id_hex,
                     bootstrap_relays,
                 )

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -5957,7 +5957,7 @@ impl AccountManager {
                         "import_relay_list_status",
                         self.app.resolve_account_relay_list_status_for_account_id(
                             &account.account_id_hex,
-                            bootstrap.bootstrap_relays.clone(),
+                            directory_discovery_relays_for_setup(request),
                         ),
                     )
                     .await

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -236,15 +236,8 @@ async fn failed_import_relay_discovery_does_not_publish_default_lists() {
         .await
         .expect_err("failed discovery must not become a write of request defaults");
 
-    assert!(matches!(
-        error,
-        AppError::MissingRelayLists(missing)
-            if missing
-                == vec![
-                    crate::MissingRelayListKind::Nip65,
-                    crate::MissingRelayListKind::Inbox,
-                ]
-    ));
+    // A failed lookup is retryable uncertainty, not confirmed missing lists.
+    assert!(matches!(error, AppError::RelayDirectory(_)));
 }
 
 #[test]

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -7751,6 +7751,44 @@ async fn account_outbox_route_cap_without_inbox_remains_unknown() {
 }
 
 #[tokio::test]
+async fn account_signed_empty_inbox_with_incomplete_outbox_remains_unknown() {
+    let (_directory, app, accounts, fetcher) = member_resolution_fixture(1, false).await;
+    let id = &accounts[0].account_id_hex;
+    for event in fetcher.events.lock().unwrap().iter_mut() {
+        if event.kind == KIND_MARMOT_INBOX_RELAY_LIST {
+            event.tags.clear();
+        }
+    }
+    *fetcher.incomplete_endpoint.lock().unwrap() = Some("wss://shared.example".into());
+    let error = app
+        .resolve_account_relay_list_status_for_account_id(
+            id,
+            vec![TransportEndpoint("wss://directory.example".into())],
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(error, AppError::RelayDirectory(_)));
+    let cached = app.directory_entry_for_account_id(id).unwrap().unwrap();
+    assert!(cached.relay_lists.inbox.created_at > 0);
+    assert!(cached.relay_lists.inbox.relays.is_empty());
+    assert_eq!(fetcher.requests.lock().unwrap().len(), 2);
+
+    // The same signed empty declaration becomes actionable only when the
+    // outbox also completes; retaining it in the cache must not mask retries.
+    *fetcher.incomplete_endpoint.lock().unwrap() = None;
+    let error = app
+        .resolve_account_relay_list_status_for_account_id(
+            id,
+            vec![TransportEndpoint("wss://directory.example".into())],
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(error, AppError::MissingRelayLists(ref kinds) if kinds == &[MissingRelayListKind::Inbox])
+    );
+}
+
+#[tokio::test]
 async fn account_read_only_nip65_returns_typed_missing_write_routes() {
     let (_directory, app, accounts, fetcher) = member_resolution_fixture(1, false).await;
     let id = &accounts[0].account_id_hex;

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -297,14 +297,16 @@ pub(crate) struct ScriptedPushRelayClient {
 }
 
 #[derive(Default)]
-struct MemberResolutionDirectoryFetcher {
+pub(crate) struct MemberResolutionDirectoryFetcher {
     requests: std::sync::Mutex<Vec<crate::relay_plane::DirectoryFetchRequest>>,
     events: std::sync::Mutex<Vec<NostrTransportEvent>>,
     events_by_endpoint:
         std::sync::Mutex<std::collections::HashMap<String, Vec<NostrTransportEvent>>>,
     reject_multi_author: std::sync::atomic::AtomicBool,
+    reject_multi_author_incomplete: std::sync::atomic::AtomicBool,
     failing_single_author: std::sync::Mutex<Option<String>>,
     stalled_endpoint: std::sync::Mutex<Option<String>>,
+    incomplete_endpoint: std::sync::Mutex<Option<String>>,
 }
 
 #[async_trait]
@@ -362,6 +364,34 @@ impl crate::relay_plane::DirectoryRelayFetcher for MemberResolutionDirectoryFetc
                 event,
             })
             .collect())
+    }
+
+    async fn fetch_directory_events_with_completion(
+        &self,
+        request: crate::relay_plane::DirectoryFetchRequest,
+    ) -> Result<crate::relay_plane::DirectoryFetchOutcome, String> {
+        if self
+            .reject_multi_author_incomplete
+            .load(std::sync::atomic::Ordering::SeqCst)
+            && request.queries.iter().any(|query| query.authors.len() > 1)
+        {
+            self.requests.lock().unwrap().push(request);
+            return Ok(crate::relay_plane::DirectoryFetchOutcome::default());
+        }
+        let complete = !self
+            .incomplete_endpoint
+            .lock()
+            .unwrap()
+            .as_ref()
+            .is_some_and(|incomplete| {
+                request
+                    .endpoints
+                    .iter()
+                    .any(|endpoint| endpoint.0 == *incomplete)
+            });
+        self.fetch_directory_events(request)
+            .await
+            .map(|records| crate::relay_plane::DirectoryFetchOutcome { records, complete })
     }
 }
 
@@ -7453,7 +7483,7 @@ fn member_resolution_key_package_event(
     .unwrap()
 }
 
-async fn member_resolution_fixture(
+pub(crate) async fn member_resolution_fixture(
     count: usize,
     split_relays: bool,
 ) -> (
@@ -7577,6 +7607,211 @@ async fn member_inbox_is_resolved_on_discovered_outbox() {
                 .iter()
                 .any(|relay| relay == "wss://shared.example"))
     );
+}
+
+#[tokio::test]
+async fn account_outbox_route_cap_keeps_usable_first_hop_metadata() {
+    let (_directory, app, accounts, fetcher) = member_resolution_fixture(1, false).await;
+    let account_id = accounts[0].account_id_hex.clone();
+    let outboxes = (0..17)
+        .map(|index| format!("wss://outbox-{index}.example"))
+        .collect::<Vec<_>>();
+    let nip65_tags = outboxes
+        .iter()
+        .map(|relay| vec!["r".into(), relay.clone(), "write".into()])
+        .collect::<Vec<_>>();
+    let inbox = "wss://usable-inbox.example";
+    *fetcher.events.lock().unwrap() = vec![
+        NostrTransportEvent::new_unsigned(
+            account_id.clone(),
+            KIND_NIP65_RELAY_LIST,
+            nip65_tags,
+            String::new(),
+        ),
+        NostrTransportEvent::new_unsigned(
+            account_id.clone(),
+            KIND_MARMOT_INBOX_RELAY_LIST,
+            vec![vec!["relay".into(), inbox.into()]],
+            String::new(),
+        ),
+    ];
+
+    let status = app
+        .resolve_account_relay_list_status_for_account_id(
+            &account_id,
+            vec![TransportEndpoint("wss://directory.example".into())],
+        )
+        .await
+        .expect("the outbox route cap must not discard complete first-hop metadata");
+
+    assert_eq!(status.nip65.relays, outboxes);
+    assert_eq!(status.inbox.relays, vec![inbox]);
+    let cached = app
+        .directory_entry_for_account_id(&account_id)
+        .unwrap()
+        .expect("observed relay metadata must remain durable");
+    assert_eq!(cached.relay_lists.inbox.relays, vec![inbox]);
+    assert_eq!(
+        fetcher.requests.lock().unwrap().len(),
+        1,
+        "the oversized discovered route must fail closed before a second dial"
+    );
+}
+
+#[tokio::test]
+async fn incomplete_discovery_is_not_cleared_by_an_empty_cached_outbox() {
+    let (_directory, app, accounts, fetcher) = member_resolution_fixture(1, false).await;
+    let account_id = accounts[0].account_id_hex.clone();
+    let outbox = "wss://cached-outbox.example";
+    let mut entry = app
+        .directory_entry_for_account_id(&account_id)
+        .unwrap()
+        .unwrap_or_else(|| app.empty_directory_record(&account_id));
+    entry.relay_lists.nip65.created_at = 1;
+    entry.relay_lists.nip65.relays = vec![outbox.into()];
+    entry.relay_lists.refresh();
+    app.save_directory_entry(&entry).unwrap();
+    fetcher.events_by_endpoint.lock().unwrap().extend([
+        ("wss://directory.example".to_owned(), Vec::new()),
+        (outbox.to_owned(), Vec::new()),
+    ]);
+    *fetcher.incomplete_endpoint.lock().unwrap() = Some("wss://directory.example".into());
+
+    let error = app
+        .resolve_member_key_packages(&[account_id.as_str()])
+        .await
+        .expect_err("an empty outbox cannot prove absence after discovery failed");
+
+    assert!(
+        matches!(error, AppError::RelayDirectory(_)),
+        "unknown discovery must remain retryable instead of becoming a missing-route verdict: {error:?}"
+    );
+    assert!(fetcher.requests.lock().unwrap().iter().any(|request| {
+        request
+            .endpoints
+            .iter()
+            .any(|endpoint| endpoint.0 == outbox)
+    }));
+}
+
+#[tokio::test]
+async fn directory_relay_persistence_preserves_newer_signed_empty_lists() {
+    let (_directory, app, accounts, _fetcher) = member_resolution_fixture(1, false).await;
+    let id = &accounts[0].account_id_hex;
+    let mut older = AccountRelayListStatus::empty();
+    older.nip65.created_at = 10;
+    older.nip65.relays = vec!["wss://old-outbox.example".into()];
+    older.inbox.created_at = 10;
+    older.inbox.relays = vec!["wss://old-inbox.example".into()];
+    older.refresh();
+    let mut empty = AccountRelayListStatus::empty();
+    empty.nip65.created_at = 20;
+    empty.inbox.created_at = 20;
+    empty.refresh();
+    app.remember_directory_relay_lists(id, &older).unwrap();
+    app.remember_directory_relay_lists(id, &empty).unwrap();
+    app.remember_directory_relay_lists(id, &older).unwrap();
+    let persisted = app.directory_entry_for_account_id(id).unwrap().unwrap();
+    assert_eq!(persisted.relay_lists.nip65.created_at, 20);
+    assert_eq!(persisted.relay_lists.inbox.created_at, 20);
+    assert!(persisted.relay_lists.nip65.relays.is_empty());
+    assert!(persisted.relay_lists.inbox.relays.is_empty());
+}
+
+#[tokio::test]
+async fn account_outbox_route_cap_without_inbox_remains_unknown() {
+    let (_directory, app, accounts, fetcher) = member_resolution_fixture(1, false).await;
+    let id = &accounts[0].account_id_hex;
+    *fetcher.events.lock().unwrap() = vec![NostrTransportEvent::new_unsigned(
+        id.clone(),
+        KIND_NIP65_RELAY_LIST,
+        (0..17)
+            .map(|index| {
+                vec![
+                    "r".into(),
+                    format!("wss://outbox-{index}.example"),
+                    "write".into(),
+                ]
+            })
+            .collect(),
+        String::new(),
+    )];
+    let error = app
+        .resolve_account_relay_list_status_for_account_id(
+            id,
+            vec![TransportEndpoint("wss://directory.example".into())],
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(error, AppError::RelayDirectory(_)));
+    let cached = app.directory_entry_for_account_id(id).unwrap().unwrap();
+    assert_eq!(cached.relay_lists.nip65.relays.len(), 17);
+    assert!(cached.relay_lists.inbox.relays.is_empty());
+    assert_eq!(fetcher.requests.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn account_read_only_nip65_returns_typed_missing_write_routes() {
+    let (_directory, app, accounts, fetcher) = member_resolution_fixture(1, false).await;
+    let id = &accounts[0].account_id_hex;
+    *fetcher.events.lock().unwrap() = vec![
+        NostrTransportEvent::new_unsigned(
+            id.clone(),
+            KIND_NIP65_RELAY_LIST,
+            vec![vec![
+                "r".into(),
+                "wss://read-only.example".into(),
+                "read".into(),
+            ]],
+            String::new(),
+        ),
+        NostrTransportEvent::new_unsigned(
+            id.clone(),
+            KIND_MARMOT_INBOX_RELAY_LIST,
+            vec![vec!["relay".into(), "wss://inbox.example".into()]],
+            String::new(),
+        ),
+    ];
+    let error = app
+        .resolve_account_relay_list_status_for_account_id(
+            id,
+            vec![TransportEndpoint("wss://directory.example".into())],
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(error, AppError::MissingRelayLists(ref kinds) if kinds == &[MissingRelayListKind::Nip65])
+    );
+    let cached = app.directory_entry_for_account_id(id).unwrap().unwrap();
+    assert!(cached.relay_lists.nip65.relays.is_empty());
+    assert_eq!(
+        cached.relay_lists.nip65.read_relays,
+        vec!["wss://read-only.example"]
+    );
+}
+
+#[tokio::test]
+async fn future_dated_inbox_is_unknown_for_account_and_member_resolution() {
+    let (_directory, app, accounts, fetcher) = member_resolution_fixture(1, false).await;
+    let id = &accounts[0].account_id_hex;
+    for event in fetcher.events.lock().unwrap().iter_mut() {
+        if event.kind == KIND_MARMOT_INBOX_RELAY_LIST {
+            event.created_at = u64::MAX;
+        }
+    }
+    let account_error = app
+        .resolve_account_relay_list_status_for_account_id(
+            id,
+            vec![TransportEndpoint("wss://directory.example".into())],
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(account_error, AppError::RelayDirectory(_)));
+    let member_error = app
+        .resolve_member_key_packages(&[id.as_str()])
+        .await
+        .unwrap_err();
+    assert!(matches!(member_error, AppError::RelayDirectory(_)));
 }
 
 #[tokio::test]
@@ -8036,6 +8271,39 @@ async fn member_key_package_set_falls_back_when_multi_author_queries_are_rejecte
             .count(),
         6,
         "discovery, outbox, and KeyPackage batches must each fall back per member"
+    );
+}
+
+#[tokio::test]
+async fn member_key_package_set_falls_back_when_multi_author_queries_are_incomplete() {
+    let (_directory, app, accounts, fetcher) = member_resolution_fixture(2, false).await;
+    fetcher
+        .reject_multi_author_incomplete
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+    let members = accounts
+        .iter()
+        .map(|account| account.account_id_hex.as_str())
+        .collect::<Vec<_>>();
+
+    let summary = app
+        .prewarm_group_member_key_packages(&members)
+        .await
+        .expect("CLOSED-shaped incomplete batches must retry per author");
+
+    assert_eq!(summary.network_resolved_members, 2);
+    let requests = fetcher.requests.lock().unwrap();
+    assert!(
+        requests
+            .iter()
+            .any(|request| request.queries.iter().any(|query| query.authors.len() == 2))
+    );
+    assert_eq!(
+        requests
+            .iter()
+            .filter(|request| request.queries.iter().all(|query| query.authors.len() == 1))
+            .count(),
+        4,
+        "both relay-list hops must retry each member after an incomplete batch"
     );
 }
 

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -300,6 +300,8 @@ pub(crate) struct ScriptedPushRelayClient {
 struct MemberResolutionDirectoryFetcher {
     requests: std::sync::Mutex<Vec<crate::relay_plane::DirectoryFetchRequest>>,
     events: std::sync::Mutex<Vec<NostrTransportEvent>>,
+    events_by_endpoint:
+        std::sync::Mutex<std::collections::HashMap<String, Vec<NostrTransportEvent>>>,
     reject_multi_author: std::sync::atomic::AtomicBool,
     failing_single_author: std::sync::Mutex<Option<String>>,
     stalled_endpoint: std::sync::Mutex<Option<String>>,
@@ -335,7 +337,18 @@ impl crate::relay_plane::DirectoryRelayFetcher for MemberResolutionDirectoryFetc
         }) {
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
-        let events = self.events.lock().unwrap().clone();
+        let endpoint_events = self.events_by_endpoint.lock().unwrap();
+        let events = if endpoint_events.is_empty() {
+            self.events.lock().unwrap().clone()
+        } else {
+            request
+                .endpoints
+                .iter()
+                .filter_map(|endpoint| endpoint_events.get(&endpoint.0))
+                .flatten()
+                .cloned()
+                .collect()
+        };
         Ok(events
             .into_iter()
             .filter(|event| {
@@ -7495,6 +7508,75 @@ async fn member_resolution_fixture(
     }
     app.relay_plane = MarmotRelayPlane::new_with_directory_fetcher_for_test(relay, fetcher.clone());
     (directory, app, accounts, fetcher)
+}
+
+#[tokio::test]
+/// Relay-list resolution follows the target account's NIP-65 write relay for
+/// kind 10050 instead of treating a successful first-hop miss as absence.
+async fn member_inbox_is_resolved_on_discovered_outbox() {
+    let (_directory, app, accounts, fetcher) = member_resolution_fixture(1, false).await;
+    let account_id = accounts[0].account_id_hex.clone();
+    let events = fetcher.events.lock().unwrap().clone();
+    let mut first_hop = events
+        .iter()
+        .filter(|event| event.kind == KIND_MARMOT_KEY_PACKAGE)
+        .cloned()
+        .collect::<Vec<_>>();
+    first_hop.push(NostrTransportEvent::new_unsigned(
+        account_id.clone(),
+        KIND_NIP65_RELAY_LIST,
+        vec![vec![
+            "r".into(),
+            "wss://outbox.example".into(),
+            "write".into(),
+        ]],
+        String::new(),
+    ));
+    let outbox_events = events
+        .iter()
+        .filter(|event| {
+            matches!(
+                event.kind,
+                KIND_MARMOT_KEY_PACKAGE | KIND_MARMOT_INBOX_RELAY_LIST
+            )
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    fetcher.events_by_endpoint.lock().unwrap().extend([
+        ("wss://directory.example".to_owned(), first_hop.clone()),
+        ("wss://shared.example".to_owned(), first_hop),
+        ("wss://outbox.example".to_owned(), outbox_events),
+    ]);
+
+    let resolution = app
+        .resolve_member_key_packages(&[account_id.as_str()])
+        .await;
+    assert!(
+        resolution.is_ok(),
+        "member preflight must follow the advertised outbox: {resolution:?}; requests={:?}",
+        fetcher.requests.lock().unwrap()
+    );
+
+    let requests = fetcher.requests.lock().unwrap();
+    assert!(requests.iter().any(|request| {
+        request
+            .endpoints
+            .iter()
+            .any(|endpoint| endpoint.0 == "wss://outbox.example")
+            && request.queries.iter().any(|query| {
+                query.kind == KIND_MARMOT_INBOX_RELAY_LIST && query.authors.contains(&account_id)
+            })
+    }));
+    assert!(
+        app.directory_entry_for_account_id(&account_id)
+            .unwrap()
+            .is_some_and(|entry| entry
+                .relay_lists
+                .inbox
+                .relays
+                .iter()
+                .any(|relay| relay == "wss://shared.example"))
+    );
 }
 
 #[tokio::test]

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -7919,8 +7919,8 @@ async fn member_key_package_set_batches_shared_relay_and_reuses_prewarm() {
     let requests = fetcher.requests.lock().unwrap().clone();
     assert_eq!(
         requests.len(),
-        2,
-        "cold shared relays must use one relay-list batch and one KeyPackage batch"
+        3,
+        "cold shared outboxes need one discovery batch, one outbox batch, and one KeyPackage batch"
     );
     assert_eq!(requests[0].queries.len(), 2);
     assert!(
@@ -7929,10 +7929,21 @@ async fn member_key_package_set_batches_shared_relay_and_reuses_prewarm() {
             .iter()
             .all(|query| query.authors.len() == 8)
     );
-    assert_eq!(requests[1].queries.len(), 1);
-    assert_eq!(requests[1].queries[0].kind, KIND_MARMOT_KEY_PACKAGE);
-    assert_eq!(requests[1].queries[0].authors.len(), 8);
-    assert_eq!(requests[1].queries[0].limit, 8 * 12);
+    assert_eq!(
+        requests[1].endpoints,
+        vec![TransportEndpoint("wss://shared.example".into())]
+    );
+    assert_eq!(requests[1].queries.len(), 2);
+    assert!(
+        requests[1]
+            .queries
+            .iter()
+            .all(|query| query.authors.len() == 8)
+    );
+    assert_eq!(requests[2].queries.len(), 1);
+    assert_eq!(requests[2].queries[0].kind, KIND_MARMOT_KEY_PACKAGE);
+    assert_eq!(requests[2].queries[0].authors.len(), 8);
+    assert_eq!(requests[2].queries[0].limit, 8 * 12);
     drop(requests);
 
     for account in &accounts {
@@ -7949,8 +7960,49 @@ async fn member_key_package_set_batches_shared_relay_and_reuses_prewarm() {
     assert_eq!(resolved.len(), 8);
     assert_eq!(
         fetcher.requests.lock().unwrap().len(),
-        2,
+        3,
         "fresh prewarm entries must eliminate create-time relay requests"
+    );
+}
+
+#[tokio::test]
+async fn member_key_package_set_reuses_completed_discovery_when_it_is_the_outbox() {
+    let (_directory, app, accounts, fetcher) = member_resolution_fixture(2, false).await;
+    for event in fetcher.events.lock().unwrap().iter_mut() {
+        if event.kind == KIND_NIP65_RELAY_LIST {
+            event.tags = vec![vec![
+                "r".into(),
+                "wss://directory.example".into(),
+                "write".into(),
+            ]];
+        }
+    }
+    let members = accounts
+        .iter()
+        .map(|account| account.account_id_hex.as_str())
+        .collect::<Vec<_>>();
+    app.prewarm_group_member_key_packages(&members)
+        .await
+        .unwrap();
+    let requests = fetcher.requests.lock().unwrap().clone();
+    assert_eq!(
+        requests.len(),
+        2,
+        "the completed discovery query already covered the advertised outbox"
+    );
+    assert_eq!(requests[0].queries.len(), 2);
+    assert_eq!(requests[1].queries[0].kind, KIND_MARMOT_KEY_PACKAGE);
+    assert_eq!(
+        app.resolve_member_key_packages(&members)
+            .await
+            .unwrap()
+            .len(),
+        2
+    );
+    assert_eq!(
+        fetcher.requests.lock().unwrap().len(),
+        2,
+        "fresh prewarm must not repeat either query"
     );
 }
 
@@ -7982,8 +8034,8 @@ async fn member_key_package_set_falls_back_when_multi_author_queries_are_rejecte
             .iter()
             .filter(|request| request.queries.iter().all(|query| query.authors.len() == 1))
             .count(),
-        4,
-        "relay-list and KeyPackage batches must each fall back per member"
+        6,
+        "discovery, outbox, and KeyPackage batches must each fall back per member"
     );
 }
 

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -1058,7 +1058,25 @@ async fn import_with_stalled_discovery_endpoint_completes_within_the_advisory_ca
     });
 
     use nostr::prelude::ToBech32;
-    let secret = nostr::Keys::generate().secret_key().to_bech32().unwrap();
+    let keys = nostr::Keys::generate();
+    let secret = keys.secret_key().to_bech32().unwrap();
+    let relay_client =
+        NostrSdkRelayClient::new(NostrSdkClient::builder().signer(keys.clone()).build());
+    for (kind, tag) in [
+        (10002, vec!["r".to_owned(), url.clone(), "write".to_owned()]),
+        (10050, vec!["relay".to_owned(), url.clone()]),
+    ] {
+        let event = NostrTransportEvent::new_unsigned(
+            keys.public_key().to_hex(),
+            kind,
+            vec![tag],
+            String::new(),
+        );
+        relay_client
+            .publish_event(&[endpoint(&url)], &event, 1)
+            .await
+            .unwrap();
+    }
     let imported = timeout(
         Duration::from_secs(40),
         runtime.create_or_import_account(AccountSetupRequest {
@@ -11138,6 +11156,253 @@ async fn outbox_resolved_inbox_survives_restart_and_delivers_exact_welcome() {
     runtime.shutdown().await;
 }
 
+async fn independent_sender_outbox_invite_survives_restart(stale_discovery: bool) {
+    use nostr::prelude::ToBech32;
+
+    let sender_dir = tempfile::tempdir().unwrap();
+    let receiver_dir = tempfile::tempdir().unwrap();
+    let (_discovery, discovery_url) = mock_relay().await;
+    let (_outbox, outbox_url) = mock_relay().await;
+    let (_inbox, inbox_url) = mock_relay().await;
+    // R is receiver setup infrastructure, never a sender discovery source.
+    // This keeps the missing-D case free of setup-created kind 10050 on D.
+    let (_receiver_setup, receiver_setup_url) = mock_relay().await;
+    let config = || MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true);
+    let receiver =
+        MarmotApp::with_relay_and_config(receiver_dir.path(), receiver_setup_url.clone(), config());
+    let receiver_runtime = MarmotAppRuntime::new(receiver.clone());
+    let carol_keys = Keys::generate();
+    let carol_nsec = carol_keys.secret_key().to_bech32().unwrap();
+    let carol = receiver_runtime
+        .create_or_import_account(AccountSetupRequest {
+            import_nsec: Some(zeroize::Zeroizing::new(carol_nsec.clone())),
+            default_relays: vec![endpoint(&receiver_setup_url)],
+            bootstrap_relays: vec![endpoint(&receiver_setup_url)],
+            discovery_relays: vec![endpoint(&receiver_setup_url)],
+            publish_missing_relay_lists: true,
+            publish_initial_key_package: true,
+            ..AccountSetupRequest::default()
+        })
+        .await
+        .unwrap();
+    let carol_id = carol.account.account_id_hex.clone();
+    let carol_label = carol.account.label.clone();
+
+    // Publish metadata newer than the receiver's initial R-only setup.
+    sleep(Duration::from_secs(1)).await;
+    let created_at = test_unix_now_seconds();
+    let receiver_home = AccountHome::open(receiver_dir.path());
+    publish_nostr_event_at(
+        &receiver_home,
+        &carol_label,
+        &discovery_url,
+        10002,
+        vec![vec!["r".into(), outbox_url.clone(), "write".into()]],
+        String::new(),
+        created_at,
+    )
+    .await;
+    if stale_discovery {
+        publish_nostr_event_at(
+            &receiver_home,
+            &carol_label,
+            &discovery_url,
+            10050,
+            vec![vec!["relay".into(), receiver_setup_url]],
+            String::new(),
+            created_at.saturating_sub(60),
+        )
+        .await;
+    }
+    publish_nostr_event_at(
+        &receiver_home,
+        &carol_label,
+        &outbox_url,
+        10050,
+        vec![vec!["relay".into(), inbox_url.clone()]],
+        String::new(),
+        created_at,
+    )
+    .await;
+    receiver_runtime
+        .sign_out(
+            &carol_id,
+            SignOutOptions {
+                delete_key_packages: false,
+            },
+        )
+        .await
+        .unwrap();
+    receiver_runtime
+        .create_or_import_account(AccountSetupRequest {
+            import_nsec: Some(zeroize::Zeroizing::new(carol_nsec)),
+            default_relays: vec![endpoint(&discovery_url)],
+            bootstrap_relays: vec![endpoint(&discovery_url)],
+            discovery_relays: vec![endpoint(&discovery_url)],
+            publish_missing_relay_lists: true,
+            publish_initial_key_package: false,
+            ..AccountSetupRequest::default()
+        })
+        .await
+        .unwrap();
+    // Reuse the receiver-owned private MLS material and republish its public
+    // KeyPackage to the now-known W route; no lost-device recovery assumption.
+    receiver_runtime
+        .publish_key_package(&carol_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        receiver
+            .account_relay_list_status(&carol_label)
+            .unwrap()
+            .inbox
+            .relays,
+        vec![inbox_url.clone()]
+    );
+
+    let sender =
+        MarmotApp::with_relay_and_config(sender_dir.path(), discovery_url.clone(), config());
+    let sender_runtime = MarmotAppRuntime::new(sender.clone());
+    let sender_setup = AccountSetupRequest {
+        default_relays: vec![endpoint(&discovery_url)],
+        bootstrap_relays: vec![endpoint(&discovery_url)],
+        discovery_relays: vec![endpoint(&discovery_url)],
+        publish_missing_relay_lists: true,
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+    let alice =
+        create_network_ready_identity(&sender_runtime, sender_setup.relay_options_only()).await;
+    let bob = create_network_ready_identity(&sender_runtime, sender_setup).await;
+    let alice_id = alice.account.account_id_hex.clone();
+    let bob_id = bob.account.account_id_hex.clone();
+    let group_id = sender_runtime
+        .create_group(
+            &alice_id,
+            "independent outbox invitation",
+            std::slice::from_ref(&bob_id),
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(
+        sender
+            .directory_entry_for_account_id(&carol_id)
+            .unwrap()
+            .is_none_or(|entry| entry.relay_lists.inbox.relays.is_empty()),
+        "sender must not inherit the receiver's already-resolved inbox cache"
+    );
+    sender
+        .resolve_member_key_packages(&[carol_id.as_str()])
+        .await
+        .unwrap();
+    assert_eq!(
+        sender
+            .directory_entry_for_account_id(&carol_id)
+            .unwrap()
+            .unwrap()
+            .relay_lists
+            .inbox
+            .relays,
+        vec![inbox_url.clone()],
+        "fresh sender must resolve D -> W -> I before invitation"
+    );
+    sender_runtime.shutdown().await;
+    receiver_runtime.shutdown().await;
+    drop(sender_runtime);
+    drop(receiver_runtime);
+    drop(sender);
+    drop(receiver);
+    drop(receiver_home);
+
+    let sender =
+        MarmotApp::with_relay_and_config(sender_dir.path(), discovery_url.clone(), config());
+    let receiver =
+        MarmotApp::with_relay_and_config(receiver_dir.path(), discovery_url.clone(), config());
+    assert_eq!(
+        sender
+            .directory_entry_for_account_id(&carol_id)
+            .unwrap()
+            .unwrap()
+            .relay_lists
+            .inbox
+            .relays,
+        vec![inbox_url.clone()]
+    );
+    assert_eq!(
+        receiver
+            .account_relay_list_status(&carol_label)
+            .unwrap()
+            .inbox
+            .relays,
+        vec![inbox_url]
+    );
+    let sender_runtime = MarmotAppRuntime::new(sender.clone());
+    let receiver_runtime = MarmotAppRuntime::new(receiver.clone());
+    let mut receiver_events = receiver_runtime.subscribe();
+    receiver_runtime.reconcile_accounts().await.unwrap();
+    sender_runtime.reconcile_accounts().await.unwrap();
+    sender_runtime
+        .invite_members(&alice_id, &group_id, std::slice::from_ref(&carol_id))
+        .await
+        .unwrap();
+    wait_for_event(&mut receiver_events, |event| {
+        matches!(event, MarmotAppEvent::GroupJoined { account_id_hex, group_id: joined_group, .. }
+            if account_id_hex == &carol_id && joined_group == &group_id)
+    })
+    .await;
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let pending = receiver
+        .group(&carol_label, &group_id_hex)
+        .unwrap()
+        .unwrap();
+    assert!(pending.pending_confirmation && !pending.archived);
+    assert!(pending.via_welcome_message_id_hex.is_some());
+    assert_eq!(
+        pending.welcomer_account_id_hex.as_deref(),
+        Some(alice_id.as_str())
+    );
+    let members = sender_runtime
+        .group_members(&alice_id, &group_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        members
+            .iter()
+            .filter(|member| member.member_id_hex == carol_id)
+            .count(),
+        1
+    );
+    sender_runtime.shutdown().await;
+    receiver_runtime.shutdown().await;
+    drop(sender_runtime);
+    drop(receiver_runtime);
+    drop(sender);
+    drop(receiver);
+    // The invite must still be visible in the persisted projection after a
+    // second receiver restart, without an accept action or another Welcome.
+    let reopened = MarmotApp::with_relay_and_config(receiver_dir.path(), discovery_url, config());
+    let still_pending = reopened
+        .group(&carol_label, &group_id_hex)
+        .unwrap()
+        .unwrap();
+    assert!(still_pending.pending_confirmation && !still_pending.archived);
+    assert_eq!(
+        still_pending.via_welcome_message_id_hex,
+        pending.via_welcome_message_id_hex
+    );
+}
+
+#[tokio::test]
+async fn independent_sender_outbox_only_inbox_invite_survives_restart() {
+    independent_sender_outbox_invite_survives_restart(false).await;
+}
+
+#[tokio::test]
+async fn independent_sender_stale_discovery_inbox_invite_survives_restart() {
+    independent_sender_outbox_invite_survives_restart(true).await;
+}
+
 /// mdk#352 review follow-up: the welcome re-delivery surface is reachable end
 /// to end through the runtime worker. A create whose welcome delivered leaves
 /// nothing pending, and re-delivering an unknown welcome id is a clean error
@@ -11400,4 +11665,314 @@ async fn convergence_settles_across_generations_with_mid_window_queued_sends() {
     }
 
     runtime.shutdown().await;
+}
+
+#[derive(Clone, Debug)]
+struct CountUncertainSetupRelayListPublications(Arc<AtomicUsize>);
+
+impl WritePolicy for CountUncertainSetupRelayListPublications {
+    fn admit_event<'a>(
+        &'a self,
+        event: &'a nostr::Event,
+        _addr: &'a SocketAddr,
+    ) -> BoxedFuture<'a, PolicyResult> {
+        Box::pin(async move {
+            if event.kind == Kind::from(10002) || event.kind == Kind::from(10050) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+            PolicyResult::Accept
+        })
+    }
+}
+
+async fn assert_required_discovery_failure_does_not_publish_defaults(external_signer: bool) {
+    use nostr::prelude::ToBech32;
+
+    let dir = tempfile::tempdir().unwrap();
+    let publications = Arc::new(AtomicUsize::new(0));
+    let bootstrap = LocalRelay::new(RelayBuilder::default().write_policy(
+        CountUncertainSetupRelayListPublications(publications.clone()),
+    ));
+    bootstrap.run().await.unwrap();
+    let bootstrap_url = bootstrap.url().await.to_string();
+
+    // D accepts TCP but never completes the websocket handshake or discovery.
+    // B completes an empty query. Retrying B alone cannot settle what D knows.
+    let discovery = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let discovery_url = format!("ws://{}", discovery.local_addr().unwrap());
+    let held_discovery = tokio::spawn(async move {
+        let mut held = Vec::new();
+        while let Ok((socket, _)) = discovery.accept().await {
+            held.push(socket);
+        }
+    });
+    let app = MarmotApp::with_relay_and_config(
+        dir.path(),
+        bootstrap_url.clone(),
+        MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true),
+    );
+    let runtime = MarmotAppRuntime::new(app);
+    let keys = Keys::generate();
+    let request = AccountSetupRequest {
+        default_relays: vec![endpoint(&bootstrap_url)],
+        bootstrap_relays: vec![endpoint(&bootstrap_url)],
+        discovery_relays: vec![endpoint(&discovery_url)],
+        publish_missing_relay_lists: true,
+        publish_initial_key_package: false,
+        ..AccountSetupRequest::default()
+    };
+    let result = timeout(Duration::from_secs(40), async {
+        if external_signer {
+            runtime
+                .login_external_signer(
+                    keys.public_key().to_hex(),
+                    TestExternalAccountSigner { keys },
+                    request,
+                )
+                .await
+        } else {
+            runtime
+                .create_or_import_account(AccountSetupRequest {
+                    import_nsec: Some(zeroize::Zeroizing::new(
+                        keys.secret_key().to_bech32().unwrap(),
+                    )),
+                    ..request
+                })
+                .await
+        }
+    })
+    .await;
+    runtime.shutdown().await;
+    held_discovery.abort();
+    let _ = held_discovery.await;
+
+    let result = result.expect("uncertain discovery must retain the bounded setup deadline");
+    assert_eq!(
+        publications.load(Ordering::SeqCst),
+        0,
+        "an incomplete required discovery read must not publish replacement relay lists"
+    );
+    assert!(
+        result.is_err(),
+        "an uncached existing identity cannot become network-ready from unconfirmed absence"
+    );
+}
+
+#[tokio::test]
+async fn outbox_acceptance_import_required_discovery_failure_does_not_publish_defaults() {
+    assert_required_discovery_failure_does_not_publish_defaults(false).await;
+}
+
+#[tokio::test]
+async fn outbox_acceptance_external_signer_required_discovery_failure_does_not_publish_defaults() {
+    assert_required_discovery_failure_does_not_publish_defaults(true).await;
+}
+
+async fn newer_discovery_inbox_survives_older_outbox(external_signer: bool, empty_outbox: bool) {
+    use nostr::prelude::ToBech32;
+
+    let publisher_dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(publisher_dir.path());
+    let keys = Keys::generate();
+    home.import_account("publisher", &keys.secret_key().to_secret_hex())
+        .unwrap();
+    let (_discovery, discovery_url) = mock_relay().await;
+    let (_outbox, outbox_url) = mock_relay().await;
+    let (_inbox, inbox_url) = mock_relay().await;
+    let created_at = test_unix_now_seconds().saturating_sub(60);
+    publish_nostr_event_at(
+        &home,
+        "publisher",
+        &discovery_url,
+        10050,
+        vec![vec!["relay".into(), inbox_url.clone()]],
+        String::new(),
+        created_at,
+    )
+    .await;
+    publish_nostr_event_at(
+        &home,
+        "publisher",
+        &discovery_url,
+        10002,
+        vec![vec!["r".into(), outbox_url.clone(), "write".into()]],
+        String::new(),
+        created_at,
+    )
+    .await;
+    publish_nostr_event_at(
+        &home,
+        "publisher",
+        &outbox_url,
+        10050,
+        if empty_outbox {
+            Vec::new()
+        } else {
+            vec![vec!["relay".into(), outbox_url.clone()]]
+        },
+        String::new(),
+        created_at.saturating_sub(60),
+    )
+    .await;
+
+    let app_dir = tempfile::tempdir().unwrap();
+    let app = MarmotApp::with_relay_and_config(
+        app_dir.path(),
+        discovery_url.clone(),
+        MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true),
+    );
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let request = AccountSetupRequest {
+        default_relays: vec![endpoint(&discovery_url)],
+        bootstrap_relays: vec![endpoint(&discovery_url)],
+        discovery_relays: vec![endpoint(&discovery_url)],
+        publish_missing_relay_lists: true,
+        publish_initial_key_package: false,
+        ..AccountSetupRequest::default()
+    };
+    let result = if external_signer {
+        runtime
+            .login_external_signer(
+                keys.public_key().to_hex(),
+                TestExternalAccountSigner { keys },
+                request,
+            )
+            .await
+    } else {
+        runtime
+            .create_or_import_account(AccountSetupRequest {
+                import_nsec: Some(zeroize::Zeroizing::new(
+                    keys.secret_key().to_bech32().unwrap(),
+                )),
+                ..request
+            })
+            .await
+    };
+    runtime.shutdown().await;
+    let result = result.expect("existing account setup must resolve its advertised inbox");
+    assert_eq!(result.relay_lists.nip65.relays, vec![outbox_url]);
+    assert_eq!(
+        result.relay_lists.inbox.relays,
+        vec![inbox_url],
+        "an older outbox record, including explicit empty, must not replace the newer discovery inbox"
+    );
+    assert_eq!(
+        result.relay_lists.inbox.created_at, created_at,
+        "login must preserve the existing inbox advertisement timestamp"
+    );
+}
+
+#[tokio::test]
+async fn outbox_acceptance_import_newer_discovery_inbox_survives_older_outbox() {
+    newer_discovery_inbox_survives_older_outbox(false, false).await;
+}
+
+#[tokio::test]
+async fn outbox_acceptance_import_newer_discovery_inbox_survives_older_empty_outbox() {
+    newer_discovery_inbox_survives_older_outbox(false, true).await;
+}
+
+#[tokio::test]
+async fn outbox_acceptance_external_signer_newer_discovery_inbox_survives_older_outbox() {
+    newer_discovery_inbox_survives_older_outbox(true, false).await;
+}
+
+#[tokio::test]
+async fn outbox_acceptance_external_signer_newer_discovery_inbox_survives_older_empty_outbox() {
+    newer_discovery_inbox_survives_older_outbox(true, true).await;
+}
+
+async fn explicit_empty_outbox_metadata_never_publishes_defaults(external_signer: bool) {
+    use nostr::prelude::ToBech32;
+
+    for empty_kind in [10002, 10050] {
+        let dir = tempfile::tempdir().unwrap();
+        let publications = Arc::new(AtomicUsize::new(0));
+        let relay = LocalRelay::new(RelayBuilder::default().write_policy(
+            CountUncertainSetupRelayListPublications(publications.clone()),
+        ));
+        relay.run().await.unwrap();
+        let url = relay.url().await.to_string();
+        let keys = Keys::generate();
+        let publisher =
+            NostrSdkRelayClient::new(NostrSdkClient::builder().signer(keys.clone()).build());
+        for kind in [10002, 10050] {
+            let tags = if kind == empty_kind {
+                Vec::new()
+            } else if kind == 10002 {
+                vec![vec!["r".into(), url.clone(), "write".into()]]
+            } else {
+                vec![vec!["relay".into(), url.clone()]]
+            };
+            publisher
+                .publish_event(
+                    &[endpoint(&url)],
+                    &NostrTransportEvent::new_unsigned(
+                        keys.public_key().to_hex(),
+                        kind,
+                        tags,
+                        String::new(),
+                    ),
+                    1,
+                )
+                .await
+                .unwrap();
+        }
+        assert_eq!(publications.swap(0, Ordering::SeqCst), 2);
+        let runtime = MarmotAppRuntime::new(MarmotApp::with_relay_and_config(
+            dir.path(),
+            url.clone(),
+            MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true),
+        ));
+        let request = AccountSetupRequest {
+            default_relays: vec![endpoint(&url)],
+            bootstrap_relays: vec![endpoint(&url)],
+            discovery_relays: vec![endpoint(&url)],
+            publish_missing_relay_lists: true,
+            publish_initial_key_package: false,
+            ..AccountSetupRequest::default()
+        };
+        let result = timeout(Duration::from_secs(30), async {
+            if external_signer {
+                runtime
+                    .login_external_signer(
+                        keys.public_key().to_hex(),
+                        TestExternalAccountSigner { keys },
+                        request,
+                    )
+                    .await
+            } else {
+                runtime
+                    .create_or_import_account(AccountSetupRequest {
+                        import_nsec: Some(zeroize::Zeroizing::new(
+                            keys.secret_key().to_bech32().unwrap(),
+                        )),
+                        ..request
+                    })
+                    .await
+            }
+        })
+        .await
+        .expect("explicit-empty setup must remain bounded");
+        runtime.shutdown().await;
+        assert!(
+            result.is_err(),
+            "an intentionally empty relay list cannot become network-ready using app defaults"
+        );
+        assert_eq!(
+            publications.load(Ordering::SeqCst),
+            0,
+            "login must not replace a signed empty kind {empty_kind} list"
+        );
+    }
+}
+
+#[tokio::test]
+async fn outbox_acceptance_import_preserves_explicit_empty_metadata() {
+    explicit_empty_outbox_metadata_never_publishes_defaults(false).await;
+}
+
+#[tokio::test]
+async fn outbox_acceptance_external_signer_preserves_explicit_empty_metadata() {
+    explicit_empty_outbox_metadata_never_publishes_defaults(true).await;
 }

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -25,11 +25,11 @@ use marmot_app::{
 };
 use nostr::base64::Engine as _;
 use nostr::base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
-use nostr_relay_builder::prelude::{BoxedFuture, PolicyResult, WritePolicy};
+use nostr_relay_builder::prelude::{BoxedFuture, PolicyResult, QueryPolicy, WritePolicy};
 use nostr_relay_builder::{LocalRelay, MockRelay, RelayBuilder};
 use nostr_sdk::prelude::{
-    Alphabet, Client as NostrSdkClient, EventBuilder, Keys, Kind, SingleLetterTag, Tag, TagKind,
-    Timestamp as NostrTimestamp,
+    Alphabet, Client as NostrSdkClient, EventBuilder, Filter, Keys, Kind, SingleLetterTag, Tag,
+    TagKind, Timestamp as NostrTimestamp,
 };
 use sha2::{Digest, Sha256};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -188,6 +188,34 @@ impl WritePolicy for RejectKeyPackagesWhileArmed {
             {
                 PolicyResult::Reject("injected key package rejection".into())
             } else {
+                PolicyResult::Accept
+            }
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct RejectMultiAuthorQueries {
+    rejected: Arc<AtomicUsize>,
+    accepted: Arc<AtomicUsize>,
+}
+
+impl QueryPolicy for RejectMultiAuthorQueries {
+    fn admit_query<'a>(
+        &'a self,
+        query: &'a Filter,
+        _addr: &'a SocketAddr,
+    ) -> BoxedFuture<'a, PolicyResult> {
+        Box::pin(async move {
+            if query
+                .authors
+                .as_ref()
+                .is_some_and(|authors| authors.len() > 1)
+            {
+                self.rejected.fetch_add(1, Ordering::SeqCst);
+                PolicyResult::Reject("multi-author queries unsupported".into())
+            } else {
+                self.accepted.fetch_add(1, Ordering::SeqCst);
                 PolicyResult::Accept
             }
         })
@@ -1093,15 +1121,15 @@ async fn import_with_stalled_discovery_endpoint_completes_within_the_advisory_ca
     .expect("import must not hang on a stalled discovery endpoint")
     .expect("import should succeed without the advisory preflight");
     assert!(imported.account.local_signing);
-    assert_eq!(
+    assert!(
         runtime
             .shared_services()
             .relay_plane()
             .relay_health()
             .await
-            .directory_failed_fetches,
-        0,
-        "a stalled peer must not fail a directory fetch that has one connected relay"
+            .directory_failed_fetches
+            > 0,
+        "partial reads must remain visible even when known metadata permits login"
     );
     assert_eq!(
         runtime
@@ -11885,7 +11913,8 @@ async fn outbox_acceptance_external_signer_newer_discovery_inbox_survives_older_
 async fn explicit_empty_outbox_metadata_never_publishes_defaults(external_signer: bool) {
     use nostr::prelude::ToBech32;
 
-    for empty_kind in [10002, 10050] {
+    // A read-only NIP-65 declaration also must not be rewritten write-enabled.
+    for (empty_kind, read_only) in [(10002, false), (10050, false), (10002, true)] {
         let dir = tempfile::tempdir().unwrap();
         let publications = Arc::new(AtomicUsize::new(0));
         let relay = LocalRelay::new(RelayBuilder::default().write_policy(
@@ -11897,7 +11926,9 @@ async fn explicit_empty_outbox_metadata_never_publishes_defaults(external_signer
         let publisher =
             NostrSdkRelayClient::new(NostrSdkClient::builder().signer(keys.clone()).build());
         for kind in [10002, 10050] {
-            let tags = if kind == empty_kind {
+            let tags = if kind == 10002 && read_only {
+                vec![vec!["r".into(), url.clone(), "read".into()]]
+            } else if kind == empty_kind {
                 Vec::new()
             } else if kind == 10002 {
                 vec![vec!["r".into(), url.clone(), "write".into()]]
@@ -11956,7 +11987,7 @@ async fn explicit_empty_outbox_metadata_never_publishes_defaults(external_signer
         .expect("explicit-empty setup must remain bounded");
         runtime.shutdown().await;
         assert!(
-            result.is_err(),
+            matches!(result, Err(AppError::MissingRelayLists(_))),
             "an intentionally empty relay list cannot become network-ready using app defaults"
         );
         assert_eq!(
@@ -11975,4 +12006,89 @@ async fn outbox_acceptance_import_preserves_explicit_empty_metadata() {
 #[tokio::test]
 async fn outbox_acceptance_external_signer_preserves_explicit_empty_metadata() {
     explicit_empty_outbox_metadata_never_publishes_defaults(true).await;
+}
+
+#[tokio::test]
+async fn outbox_acceptance_closed_multi_author_queries_fall_back_per_member() {
+    use nostr::prelude::ToBech32;
+
+    let discovery_policy = RejectMultiAuthorQueries::default();
+    let discovery = LocalRelay::new(RelayBuilder::default().query_policy(discovery_policy.clone()));
+    discovery.run().await.unwrap();
+    let discovery_url = discovery.url().await.to_string();
+    let query_policy = RejectMultiAuthorQueries::default();
+    let outbox = LocalRelay::new(RelayBuilder::default().query_policy(query_policy.clone()));
+    outbox.run().await.unwrap();
+    let outbox_url = outbox.url().await.to_string();
+
+    let mut member_dirs = Vec::new();
+    let mut member_ids = Vec::new();
+    for _ in 0..2 {
+        let member_dir = tempfile::tempdir().unwrap();
+        let keys = Keys::generate();
+        let runtime = MarmotAppRuntime::new(MarmotApp::with_relay_and_config(
+            member_dir.path(),
+            outbox_url.clone(),
+            MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true),
+        ));
+        let setup = runtime
+            .create_or_import_account(AccountSetupRequest {
+                import_nsec: Some(zeroize::Zeroizing::new(
+                    keys.secret_key().to_bech32().unwrap(),
+                )),
+                default_relays: vec![endpoint(&outbox_url)],
+                bootstrap_relays: vec![endpoint(&outbox_url)],
+                discovery_relays: vec![endpoint(&outbox_url)],
+                publish_missing_relay_lists: true,
+                publish_initial_key_package: true,
+                ..AccountSetupRequest::default()
+            })
+            .await
+            .expect("member setup must publish relay metadata and a KeyPackage");
+        runtime.shutdown().await;
+
+        NostrSdkRelayClient::new(NostrSdkClient::builder().signer(keys.clone()).build())
+            .publish_event(
+                &[endpoint(&discovery_url)],
+                &NostrTransportEvent::new_unsigned(
+                    keys.public_key().to_hex(),
+                    KIND_NIP65_RELAY_LIST,
+                    vec![vec!["r".into(), outbox_url.clone(), "write".into()]],
+                    String::new(),
+                ),
+                1,
+            )
+            .await
+            .unwrap();
+        member_ids.push(setup.account.account_id_hex);
+        member_dirs.push(member_dir);
+    }
+
+    let reader_dir = tempfile::tempdir().unwrap();
+    discovery_policy.accepted.store(0, Ordering::SeqCst);
+    discovery_policy.rejected.store(0, Ordering::SeqCst);
+    query_policy.accepted.store(0, Ordering::SeqCst);
+    query_policy.rejected.store(0, Ordering::SeqCst);
+    let reader = MarmotApp::with_relay_and_config(
+        reader_dir.path(),
+        discovery_url,
+        MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true),
+    );
+    let member_refs = member_ids.iter().map(String::as_str).collect::<Vec<_>>();
+    let summary = reader
+        .prewarm_group_member_key_packages(&member_refs)
+        .await
+        .expect("CLOSED multi-author batches must fall back to routable single-author reads");
+
+    assert_eq!(summary.network_resolved_members, 2);
+    assert_eq!(discovery_policy.rejected.load(Ordering::SeqCst), 1);
+    assert_eq!(discovery_policy.accepted.load(Ordering::SeqCst), 4);
+    assert!(
+        query_policy.rejected.load(Ordering::SeqCst) >= 2,
+        "the real relay must reject both a relay-list and KeyPackage multi-author query"
+    );
+    assert!(
+        query_policy.accepted.load(Ordering::SeqCst) >= 6,
+        "the resolver must issue accepted single-author fallbacks for both members"
+    );
 }

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -8027,6 +8027,120 @@ async fn relay_list_fetch_only_uses_requested_bootstrap_relays_without_cache() {
     assert_eq!(missing_from_seed_b.bootstrap_relays, vec![seed_b_url]);
 }
 
+// Investigation-only regression: metadata is split across discovery and the
+// identity's advertised outbox, with a third relay owning Welcome delivery.
+async fn existing_login_preserves_outbox_only_inbox(external_signer: bool, stale_first_hop: bool) {
+    use nostr::prelude::ToBech32;
+
+    let publisher_dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(publisher_dir.path());
+    let keys = Keys::generate();
+    home.import_account("publisher", &keys.secret_key().to_secret_hex())
+        .unwrap();
+    let (_discovery, discovery_url) = mock_relay().await;
+    let (_outbox, outbox_url) = mock_relay().await;
+    let (_inbox, inbox_url) = mock_relay().await;
+    let created_at = test_unix_now_seconds().saturating_sub(60);
+    if stale_first_hop {
+        publish_nostr_event_at(
+            &home,
+            "publisher",
+            &discovery_url,
+            10050,
+            vec![vec!["relay".into(), discovery_url.clone()]],
+            String::new(),
+            created_at.saturating_sub(60),
+        )
+        .await;
+    }
+    publish_nostr_event_at(
+        &home,
+        "publisher",
+        &discovery_url,
+        10002,
+        vec![vec!["r".into(), outbox_url.clone(), "write".into()]],
+        String::new(),
+        created_at,
+    )
+    .await;
+    publish_nostr_event_at(
+        &home,
+        "publisher",
+        &outbox_url,
+        10050,
+        vec![vec!["relay".into(), inbox_url.clone()]],
+        String::new(),
+        created_at,
+    )
+    .await;
+
+    let app_dir = tempfile::tempdir().unwrap();
+    let app = MarmotApp::with_relay_and_config(
+        app_dir.path(),
+        discovery_url.clone(),
+        MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true),
+    );
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let request = AccountSetupRequest {
+        default_relays: vec![endpoint(&discovery_url)],
+        bootstrap_relays: vec![endpoint(&discovery_url)],
+        discovery_relays: vec![endpoint(&discovery_url)],
+        publish_missing_relay_lists: true,
+        publish_initial_key_package: false,
+        ..AccountSetupRequest::default()
+    };
+    let result = if external_signer {
+        runtime
+            .login_external_signer(
+                keys.public_key().to_hex(),
+                TestExternalAccountSigner { keys },
+                request,
+            )
+            .await
+    } else {
+        runtime
+            .create_or_import_account(AccountSetupRequest {
+                import_nsec: Some(zeroize::Zeroizing::new(
+                    keys.secret_key().to_bech32().unwrap(),
+                )),
+                ..request
+            })
+            .await
+    };
+    runtime.shutdown().await;
+    let result = result.expect("existing account setup must resolve its advertised inbox");
+    assert_eq!(result.relay_lists.nip65.relays, vec![outbox_url]);
+    assert_eq!(
+        result.relay_lists.inbox.relays,
+        vec![inbox_url],
+        "login must discover kind 10050 on the advertised outbox and preserve its inbox instead of publishing defaults"
+    );
+    assert_eq!(
+        result.relay_lists.inbox.created_at, created_at,
+        "login must preserve the existing inbox advertisement timestamp"
+    );
+}
+
+#[tokio::test]
+async fn import_preserves_inbox_metadata_only_on_discovered_outbox() {
+    existing_login_preserves_outbox_only_inbox(false, false).await;
+}
+
+#[tokio::test]
+async fn external_signer_preserves_inbox_metadata_only_on_discovered_outbox() {
+    existing_login_preserves_outbox_only_inbox(true, false).await;
+}
+
+#[tokio::test]
+async fn import_stale_first_hop_inbox_does_not_mask_newer_outbox_inbox() {
+    existing_login_preserves_outbox_only_inbox(false, true).await;
+}
+
+#[tokio::test]
+async fn external_signer_stale_first_hop_inbox_does_not_mask_newer_outbox_inbox() {
+    existing_login_preserves_outbox_only_inbox(true, true).await;
+}
+
 #[tokio::test]
 async fn relay_list_empty_fetch_keeps_cached_lists() {
     let dir = tempfile::tempdir().unwrap();
@@ -10863,6 +10977,163 @@ async fn resolved_inbox_route_survives_restart_and_delivers_exact_welcome() {
             .count(),
         1,
         "the persisted route must deliver one Welcome without staging a duplicate Add"
+    );
+    runtime.shutdown().await;
+}
+
+/// mdk#1703: the recipient's KeyPackage may be found on discovery while its
+/// current inbox declaration lives only on the advertised outbox. The resolved
+/// third-relay route must survive restart and deliver one Welcome.
+#[tokio::test]
+async fn outbox_resolved_inbox_survives_restart_and_delivers_exact_welcome() {
+    use nostr::prelude::ToBech32;
+
+    let dir = tempfile::tempdir().unwrap();
+    let (_discovery, discovery_url) = mock_relay().await;
+    let (_outbox, outbox_url) = mock_relay().await;
+    let (_inbox, inbox_url) = mock_relay().await;
+    let app = MarmotApp::with_relay_and_config(
+        dir.path(),
+        discovery_url.clone(),
+        MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true),
+    );
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let setup = AccountSetupRequest {
+        default_relays: vec![endpoint(&discovery_url)],
+        bootstrap_relays: vec![endpoint(&discovery_url)],
+        discovery_relays: vec![endpoint(&discovery_url)],
+        publish_missing_relay_lists: true,
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+    let alice = create_network_ready_identity(&runtime, setup.relay_options_only()).await;
+    let bob = create_network_ready_identity(&runtime, setup.relay_options_only()).await;
+    let carol_keys = Keys::generate();
+    let carol_nsec = carol_keys.secret_key().to_bech32().unwrap();
+    let carol = runtime
+        .create_or_import_account(AccountSetupRequest {
+            import_nsec: Some(zeroize::Zeroizing::new(carol_nsec.clone())),
+            ..setup
+        })
+        .await
+        .unwrap();
+    let alice_id = alice.account.account_id_hex.clone();
+    let bob_id = bob.account.account_id_hex.clone();
+    let carol_id = carol.account.account_id_hex.clone();
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let home = AccountHome::open(dir.path());
+    let created_at = test_unix_now_seconds();
+    publish_nostr_event_at(
+        &home,
+        &carol.account.label,
+        &discovery_url,
+        10002,
+        vec![vec!["r".into(), outbox_url.clone(), "write".into()]],
+        String::new(),
+        created_at,
+    )
+    .await;
+    publish_nostr_event_at(
+        &home,
+        &carol.account.label,
+        &outbox_url,
+        10050,
+        vec![vec!["relay".into(), inbox_url.clone()]],
+        String::new(),
+        created_at,
+    )
+    .await;
+
+    runtime
+        .sign_out(
+            &carol_id,
+            SignOutOptions {
+                delete_key_packages: false,
+            },
+        )
+        .await
+        .unwrap();
+    runtime
+        .create_or_import_account(AccountSetupRequest {
+            import_nsec: Some(zeroize::Zeroizing::new(carol_nsec)),
+            default_relays: vec![endpoint(&discovery_url)],
+            bootstrap_relays: vec![endpoint(&discovery_url)],
+            discovery_relays: vec![endpoint(&discovery_url)],
+            publish_missing_relay_lists: true,
+            publish_initial_key_package: false,
+            ..AccountSetupRequest::default()
+        })
+        .await
+        .expect("reactivation must resolve kind 10050 from the advertised outbox");
+
+    let mut events = runtime.subscribe();
+    let group_id = runtime
+        .create_group(
+            &alice_id,
+            "outbox persisted invite route",
+            std::slice::from_ref(&bob_id),
+            None,
+        )
+        .await
+        .unwrap();
+    wait_for_event(&mut events, |event| {
+        matches!(
+            event,
+            MarmotAppEvent::GroupJoined { account_id_hex, group_id: joined_group, .. }
+                if account_id_hex == &bob_id && joined_group == &group_id
+        )
+    })
+    .await;
+
+    app.resolve_member_key_packages(&[carol_id.as_str()])
+        .await
+        .expect("KeyPackage and outbox-hosted inbox route should resolve before restart");
+    assert!(
+        app.directory_entry_for_account_id(&carol_id)
+            .unwrap()
+            .is_some_and(|entry| entry.relay_lists.inbox.relays.contains(&inbox_url))
+    );
+    runtime.shutdown().await;
+    drop(runtime);
+    drop(app);
+
+    let app = MarmotApp::with_relay_and_config(
+        dir.path(),
+        discovery_url,
+        MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true),
+    );
+    assert!(
+        app.directory_entry_for_account_id(&carol_id)
+            .unwrap()
+            .is_some_and(|entry| entry.relay_lists.inbox.relays.contains(&inbox_url)),
+        "the outbox-resolved inbox route must survive process restart"
+    );
+    let runtime = MarmotAppRuntime::new(app);
+    let mut restarted_events = runtime.subscribe();
+    runtime.reconcile_accounts().await.unwrap();
+    runtime
+        .invite_members(&alice_id, &group_id, std::slice::from_ref(&carol_id))
+        .await
+        .unwrap();
+    wait_for_event(&mut restarted_events, |event| {
+        matches!(
+            event,
+            MarmotAppEvent::GroupJoined { account_id_hex, group_id: joined_group, .. }
+                if account_id_hex == &carol_id && joined_group == &group_id
+        )
+    })
+    .await;
+
+    let members = runtime.group_members(&alice_id, &group_id).await.unwrap();
+    assert_eq!(members.len(), 3);
+    assert_eq!(
+        members
+            .iter()
+            .filter(|member| member.member_id_hex == carol_id)
+            .count(),
+        1,
+        "the persisted outbox-resolved route must deliver exactly one Welcome"
     );
     runtime.shutdown().await;
 }

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -11796,6 +11796,109 @@ async fn outbox_acceptance_external_signer_required_discovery_failure_does_not_p
     assert_required_discovery_failure_does_not_publish_defaults(true).await;
 }
 
+async fn partial_outbox_failure_does_not_publish_defaults(external_signer: bool) {
+    use nostr::prelude::ToBech32;
+
+    let dir = tempfile::tempdir().unwrap();
+    let publications = Arc::new(AtomicUsize::new(0));
+    let discovery = LocalRelay::new(RelayBuilder::default().write_policy(
+        CountUncertainSetupRelayListPublications(publications.clone()),
+    ));
+    discovery.run().await.unwrap();
+    let discovery_url = discovery.url().await.to_string();
+    let healthy = LocalRelay::new(RelayBuilder::default().write_policy(
+        CountUncertainSetupRelayListPublications(publications.clone()),
+    ));
+    healthy.run().await.unwrap();
+    let healthy_url = healthy.url().await.to_string();
+    // W1 reaches EOSE with no inbox declaration. W2 never completes its
+    // handshake: W1's absence cannot establish what W2 may hold.
+    let unavailable = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let unavailable_url = format!("ws://{}", unavailable.local_addr().unwrap());
+    let held_outbox = tokio::spawn(async move {
+        let mut held = Vec::new();
+        while let Ok((socket, _)) = unavailable.accept().await {
+            held.push(socket);
+        }
+    });
+    let keys = Keys::generate();
+    let publisher =
+        NostrSdkRelayClient::new(NostrSdkClient::builder().signer(keys.clone()).build());
+    publisher
+        .publish_event(
+            &[endpoint(&discovery_url)],
+            &NostrTransportEvent::new_unsigned(
+                keys.public_key().to_hex(),
+                10002,
+                vec![
+                    vec!["r".into(), healthy_url.clone(), "write".into()],
+                    vec!["r".into(), unavailable_url, "write".into()],
+                ],
+                String::new(),
+            ),
+            1,
+        )
+        .await
+        .unwrap();
+    assert_eq!(publications.swap(0, Ordering::SeqCst), 1);
+    let runtime = MarmotAppRuntime::new(MarmotApp::with_relay_and_config(
+        dir.path(),
+        discovery_url.clone(),
+        MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true),
+    ));
+    let request = AccountSetupRequest {
+        default_relays: vec![endpoint(&healthy_url)],
+        bootstrap_relays: vec![endpoint(&discovery_url)],
+        discovery_relays: vec![endpoint(&discovery_url)],
+        publish_missing_relay_lists: true,
+        publish_initial_key_package: false,
+        ..AccountSetupRequest::default()
+    };
+    let result = timeout(Duration::from_secs(40), async {
+        if external_signer {
+            runtime
+                .login_external_signer(
+                    keys.public_key().to_hex(),
+                    TestExternalAccountSigner { keys },
+                    request,
+                )
+                .await
+        } else {
+            runtime
+                .create_or_import_account(AccountSetupRequest {
+                    import_nsec: Some(zeroize::Zeroizing::new(
+                        keys.secret_key().to_bech32().unwrap(),
+                    )),
+                    ..request
+                })
+                .await
+        }
+    })
+    .await;
+    runtime.shutdown().await;
+    held_outbox.abort();
+    let _ = held_outbox.await;
+    assert!(matches!(
+        result.expect("partial outbox discovery must remain bounded"),
+        Err(AppError::RelayDirectory(_))
+    ));
+    assert_eq!(
+        publications.load(Ordering::SeqCst),
+        0,
+        "a healthy-empty outbox must not authorize overwriting an unavailable sibling's metadata"
+    );
+}
+
+#[tokio::test]
+async fn outbox_acceptance_import_partial_outbox_failure_does_not_publish_defaults() {
+    partial_outbox_failure_does_not_publish_defaults(false).await;
+}
+
+#[tokio::test]
+async fn outbox_acceptance_external_signer_partial_outbox_failure_does_not_publish_defaults() {
+    partial_outbox_failure_does_not_publish_defaults(true).await;
+}
+
 async fn newer_discovery_inbox_survives_older_outbox(external_signer: bool, empty_outbox: bool) {
     use nostr::prelude::ToBech32;
 


### PR DESCRIPTION
Existing-account login and invite preparation could miss an inbox when discovery relays advertised a NIP-65 write relay but the kind `10050` metadata lived on that outbox. This change follows the advertised safe outboxes and preserves the newest target-authored relay lists across both hops and cached state.

## Resolution and preservation

- Both member metadata hops share bounded endpoint-set batching and single-author fallback, including real `CLOSED` multi-author rejection. Partial positive records survive fallback and route-cap failures; first-hop uncertainty cannot be cleared by an empty second hop.
- Account setup distinguishes signed missing/empty routes (`MissingRelayLists`) from unknown lookup (`RelayDirectory`). Timeouts, incomplete reads, saturated filters and future-rejected records cannot authorize default publication. Existing usable positive metadata remains usable during partial discovery.
- Prewarm stays process-local without adding strangers to durable directory subscriptions. Reuse preserves its original five-minute expiry. Commit-mode persistence and other relay/KeyPackage cache writers cannot overwrite newer relay metadata with older records.
- Completion-aware reads coalesce and remain safe when callers cancel. Inflight/failure telemetry includes these reads. Request-scoped SDK clients prevent discovered relays from accumulating in the live subscription client.

## Deliberate behavior changes

An incomplete lookup with no usable inbox now stays retryable instead of silently publishing defaults. A signed empty or read-only declaration is preserved and returns an actionable missing-route error; this PR does not silently convert read relays into write relays. A healthy-empty relay does not prove that an unavailable sibling has no inbox declaration. Setup gets a dedicated 26-second directory preflight budget, and member resolution retains a bounded 50-second overall deadline.

Replaceable records with equal timestamps now use NIP-01's lexically lower event ID when comparing fetched records. An already accepted cached value is retained on an equal timestamp because that projection does not retain the event ID.

Clients should explain broken setup and offer a simple, explicitly explained, non-destructive repair rather than overwrite existing lists without notice. Typed durable readiness/resume is owned by [MDK issue #1679](https://github.com/marmot-protocol/mdk/issues/1679); client warning/repair UI is a separate follow-up, not implemented here.

Client recovery follow-ups: [iOS #937](https://github.com/marmot-protocol/whitenoise-ios/issues/937) and [macOS #854](https://github.com/marmot-protocol/whitenoise-mac/issues/854).

## Verification

Focused regressions cover both signing login modes, route caps with and without usable metadata, signed empty/read-only preservation with zero replacement publications, cache expiry, future-dated metadata, strict filter saturation, coalescing/cancellation, production `CLOSED` fallback, and actual invites between independent runtimes that remain pending across restart. `just fast-ci` passed, as did both additional healthy-empty W1 / unavailable W2 login regressions. The latest follow-up also passed five account regressions and the failed-import runtime unit test. [Exact-head GitHub CI](https://github.com/marmot-protocol/mdk/actions/runs/34034206362) passed, including all four Rust shards, relay-runtime, CLI, bindings, Clippy and simulator checks. [All platform binary builds](https://github.com/marmot-protocol/mdk/actions/runs/34034206290) passed too.

The combined focused run passed 50 tests before an existing startup member-read timing assertion failed under concurrent testing (15 tests were not run after fail-fast). A serial run then passed all 20 selected relay-runtime tests, including that exact assertion and the remaining outbox acceptance cases. No assertion was weakened. Exact-head CI remains the full-suite gate.

The previous CI revision caught an outdated failed-import unit expectation: it still expected confirmed missing lists for a failed lookup. The follow-up requires the intended retryable `RelayDirectory` error and also covers signed-empty metadata overlapping an incomplete outbox query. Observed metadata remains durable and neither error permits replacement publication.

Addresses [MDK issue #1703](https://github.com/marmot-protocol/mdk/issues/1703). [White Noise Android issue #2452](https://github.com/marmot-protocol/whitenoise-android/issues/2452) tracks related invite failure presentation and downstream verification. No shipped-app fix, release or merge is claimed by this PR.
