### PR TITLE
fix(storage): version the shared store schema

### DIFF
--- a/crates/storage-sqlite/AGENTS.md
+++ b/crates/storage-sqlite/AGENTS.md
@@ -23,6 +23,7 @@ not "fix" it into the per-account database.
 | `src/chat_list.rs` | Chat-list projection, including avatar URLs. |
 | `src/timeline.rs` | Materialized message-timeline aggregation. |
 | `src/encrypted_media_secrets.rs` | Per-group encrypted-media secret storage. |
+| `src/shared/error.rs` | Shared-store redacting SQLite error mapper and result extension. |
 | `src/shared/migrations.rs`, `src/shared/v1.sql`, `src/shared/legacy.sql` | Independent `shared_schema_migrations` runner, frozen v1 schema and recognized retired columns. |
 | `src/shared/migration_tests.rs`, `src/shared/assurance_tests.rs`, `src/shared/fixtures/` | Shared migration contract, populated historical upgrades and bounded interrupted-transaction recovery. |
 | `src/shared.rs` | `SqliteSharedStorage`: a separate non-account-scoped database for cross-identity state (public-directory cache, relay-telemetry/audit-log settings, telemetry install id). |

--- a/crates/storage-sqlite/AGENTS.md
+++ b/crates/storage-sqlite/AGENTS.md
@@ -23,6 +23,8 @@ not "fix" it into the per-account database.
 | `src/chat_list.rs` | Chat-list projection, including avatar URLs. |
 | `src/timeline.rs` | Materialized message-timeline aggregation. |
 | `src/encrypted_media_secrets.rs` | Per-group encrypted-media secret storage. |
+| `src/shared/migrations.rs`, `src/shared/v1.sql`, `src/shared/legacy.sql` | Independent `shared_schema_migrations` runner, frozen v1 schema and recognized retired columns. |
+| `src/shared/migration_tests.rs`, `src/shared/assurance_tests.rs`, `src/shared/fixtures/` | Shared migration contract, populated historical upgrades and bounded interrupted-transaction recovery. |
 | `src/shared.rs` | `SqliteSharedStorage`: a separate non-account-scoped database for cross-identity state (public-directory cache, relay-telemetry/audit-log settings, telemetry install id). |
 
 ## Invariants

--- a/crates/storage-sqlite/README.md
+++ b/crates/storage-sqlite/README.md
@@ -25,7 +25,7 @@ The crate is split around storage concerns:
 - `migrations.rs` owns the account/session migration runner and migration tests.
 - `shared/migrations.rs` owns the independent shared-store runner; `shared/v1.sql` freezes its initial schema,
   `shared/legacy.sql` defines recognized compatibility columns, and `shared/fixtures/` plus the migration and assurance
-  tests cover adoption and recovery.
+  tests cover adoption and recovery. `shared/error.rs` owns the privacy-safe error mapper and result extension.
 
 ## Migrations
 
@@ -51,8 +51,8 @@ Unversioned shared tables must match frozen current or verified historical defin
 covers columns, types, nullability, defaults, primary keys, foreign keys, CHECK expressions, collations and indexes.
 Conservative DDL comparison can refuse equivalent but unrecognized SQL; incompatible shapes fail with static errors
 and no version row. Missing tables are created. Public users, ordered follows, live settings, timestamps, installation
-identity and rowids are preserved. Existing unused directory tables remain untouched. The recognized nullable
-`otlp_endpoint` column is retained but non-NULL values are cleared transactionally; retained audit `data_mode` columns
+identity and rowids are preserved. Existing unused directory tables remain untouched; their pre-existing orphaned rows do not gate live-store adoption. The recognized nullable
+`otlp_endpoint` column (inline or appended) is retained but non-NULL values are cleared transactionally; retained audit `data_mode` columns
 (inline or historically appended) remain inert and unchanged by subsequent settings writes. No full-data audit mode
 is reintroduced. SQLite errors retain extended result codes and transient BUSY/LOCKED classification without
 SQLite's database-controlled message.

--- a/crates/storage-sqlite/README.md
+++ b/crates/storage-sqlite/README.md
@@ -22,11 +22,14 @@ The crate is split around storage concerns:
   and SQLite error mapping; `shared.rs` owns `SqliteSharedStorage`, a separate (non-account-scoped) database for
   cross-identity state: the public-directory user cache, relay-telemetry settings, audit-log settings, and the telemetry
   install id.
-- `migrations.rs` owns the migration runner and migration tests.
+- `migrations.rs` owns the account/session migration runner and migration tests.
+- `shared/migrations.rs` owns the independent shared-store runner; `shared/v1.sql` freezes its initial schema,
+  `shared/legacy.sql` defines recognized compatibility columns, and `shared/fixtures/` plus the migration and assurance
+  tests cover adoption and recovery.
 
 ## Migrations
 
-Schema changes go through Rust migrations, not external SQL files. The runner and ordered registry live in
+Account/session schema changes go through Rust migrations. The runner and ordered registry live in
 `src/migrations.rs`; migration bodies live in numbered files like `src/migrations/0001_initial_schema.rs`. Each
 migration has a monotonically increasing integer version, a matching padded name, and an `apply` function that runs
 inside a SQLite transaction. That function can execute DDL, rewrite rows, or perform more complex data-shape changes
@@ -34,6 +37,30 @@ when storage semantics evolve.
 
 Applied migrations are recorded in `cgka_schema_migrations`. Opening an encrypted database applies any missing
 migrations after SQLCipher keying and before storage handles are exposed.
+
+The three current app database categories have independent histories: `session.sqlite` uses
+`cgka_schema_migrations`, the per-account `app-cache.sqlite3` uses marmot-app's `app_cache_schema_migrations`, and
+installation-wide `shared.sqlite3` uses `shared_schema_migrations`. No runner reads another store's ledger.
+
+Shared version `1 / 0001_shared_store` establishes the five live tables. Each migration body and its ledger row commit
+in the same immediate transaction; failure rolls back both. Recorded versions and names must be an exact prefix of
+the compiled registry. Future versions return `StorageError::UnsupportedSchemaVersion`. A pending opener rechecks the
+prefix under the write lock; an already-current opener validates history using reads only.
+
+Unversioned shared tables must match frozen current or verified historical definitions before adoption. Validation
+covers columns, types, nullability, defaults, primary keys, foreign keys, CHECK expressions, collations and indexes.
+Conservative DDL comparison can refuse equivalent but unrecognized SQL; incompatible shapes fail with static errors
+and no version row. Missing tables are created. Public users, ordered follows, live settings, timestamps, installation
+identity and rowids are preserved. Existing unused directory tables remain untouched. The recognized nullable
+`otlp_endpoint` column is retained but non-NULL values are cleared transactionally; retained audit `data_mode` columns
+(inline or historically appended) remain inert and unchanged by subsequent settings writes. No full-data audit mode
+is reintroduced. SQLite errors retain extended result codes and transient BUSY/LOCKED classification without
+SQLite's database-controlled message.
+
+The shared store remains unencrypted and owner-only, with WAL, synchronous NORMAL, a 5-second busy timeout,
+foreign keys ON, trusted_schema OFF, temp_store MEMORY and terminal close behavior. Its fixture provenance and
+assurance limits are documented in [shared/fixtures/README.md](src/shared/fixtures/README.md) and the
+[app storage boundaries](../../docs/marmot-architecture/further-context/app-sqlite-storage-boundaries.md).
 
 ## Operational boundary
 

--- a/crates/storage-sqlite/src/shared.rs
+++ b/crates/storage-sqlite/src/shared.rs
@@ -1,3 +1,5 @@
+mod migrations;
+
 use crate::connection::CachedSql;
 use std::path::Path;
 use std::sync::Arc;
@@ -5,8 +7,7 @@ use std::time::Duration;
 
 use crate::connection::{CloseableConnection, ConnectionGuard};
 use crate::{
-    SqliteResultExt, bool_i64, connection::retry_on_busy, optional_u64_to_i64, u64_to_i64,
-    unix_now_ms, usize_to_i64,
+    bool_i64, connection::retry_on_busy, optional_u64_to_i64, u64_to_i64, unix_now_ms, usize_to_i64,
 };
 use cgka_traits::storage::{StorageError, StorageResult};
 use rusqlite::{OptionalExtension, TransactionBehavior, params};
@@ -68,12 +69,14 @@ impl SqliteSharedStorage {
         // The shared cache is unencrypted, so file-level 0600 (including
         // sidecars) is the only thing keeping it from other local users.
         crate::connection::ensure_private_db_files(path)?;
-        let conn = rusqlite::Connection::open(path).storage()?;
+        let conn = rusqlite::Connection::open(path).map_err(migrations::sqlite_error)?;
         Self::from_connection(conn)
     }
 
     pub fn in_memory() -> StorageResult<Self> {
-        Self::from_connection(rusqlite::Connection::open_in_memory().storage()?)
+        Self::from_connection(
+            rusqlite::Connection::open_in_memory().map_err(migrations::sqlite_error)?,
+        )
     }
 
     /// Checkpoint the WAL and close this shared database, releasing its file
@@ -91,58 +94,20 @@ impl SqliteSharedStorage {
         self.conn.is_closed()
     }
 
-    fn from_connection(conn: rusqlite::Connection) -> StorageResult<Self> {
+    fn from_connection(mut conn: rusqlite::Connection) -> StorageResult<Self> {
         conn.busy_timeout(Duration::from_millis(SHARED_BUSY_TIMEOUT_MS))
-            .storage()?;
-        conn.pragma_update(None, "foreign_keys", true).storage()?;
+            .map_err(migrations::sqlite_error)?;
+        conn.pragma_update(None, "foreign_keys", true)
+            .map_err(migrations::sqlite_error)?;
         conn.pragma_update(None, "trusted_schema", false)
-            .storage()?;
+            .map_err(migrations::sqlite_error)?;
         conn.execute_batch(
             "PRAGMA journal_mode = WAL;
              PRAGMA synchronous = NORMAL;
              PRAGMA temp_store = MEMORY;",
         )
-        .storage()?;
-        conn.execute_batch(
-            r#"
-CREATE TABLE IF NOT EXISTS directory_users (
-    account_id_hex TEXT PRIMARY KEY NOT NULL,
-    npub TEXT NOT NULL,
-    profile_json TEXT,
-    relay_lists_json TEXT NOT NULL,
-    key_package_json TEXT,
-    event_id_hex TEXT,
-    event_kind INTEGER,
-    event_created_at INTEGER
-);
-CREATE TABLE IF NOT EXISTS directory_user_follows (
-    account_id_hex TEXT NOT NULL REFERENCES directory_users(account_id_hex) ON DELETE CASCADE,
-    follow_account_id_hex TEXT NOT NULL,
-    position INTEGER NOT NULL,
-    event_id_hex TEXT,
-    event_created_at INTEGER,
-    PRIMARY KEY (account_id_hex, follow_account_id_hex)
-);
-	CREATE TABLE IF NOT EXISTS relay_telemetry_settings (
-	    id INTEGER PRIMARY KEY CHECK (id = 1),
-	    export_enabled INTEGER NOT NULL DEFAULT 0,
-	    export_interval_seconds INTEGER NOT NULL DEFAULT 60,
-	    updated_at_ms INTEGER NOT NULL
-	);
-		CREATE TABLE IF NOT EXISTS audit_log_settings (
-		    id INTEGER PRIMARY KEY CHECK (id = 1),
-		    enabled INTEGER NOT NULL DEFAULT 0,
-		    updated_at_ms INTEGER NOT NULL
-		);
-		CREATE TABLE IF NOT EXISTS telemetry_install (
-		    id INTEGER PRIMARY KEY CHECK (id = 1),
-		    install_id TEXT NOT NULL,
-		    updated_at_ms INTEGER NOT NULL
-		);
-		"#,
-        )
-        .storage()?;
-        Self::clear_legacy_relay_telemetry_endpoint(&conn)?;
+        .map_err(migrations::sqlite_error)?;
+        migrations::run_all(&mut conn)?;
         Ok(Self {
             conn: Arc::new(CloseableConnection::new(conn, CLOSED_DETAIL)),
         })
@@ -156,7 +121,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
             let mut conn = self.lock()?;
             let tx = conn
                 .transaction_with_behavior(TransactionBehavior::Immediate)
-                .storage()?;
+                .map_err(migrations::sqlite_error)?;
             tx.execute_cached(
                 "INSERT INTO directory_users (
                 account_id_hex, npub, profile_json, relay_lists_json, key_package_json,
@@ -182,12 +147,12 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
                     optional_u64_to_i64(record.event_created_at)?,
                 ],
             )
-            .storage()?;
+            .map_err(migrations::sqlite_error)?;
             tx.execute_cached(
                 "DELETE FROM directory_user_follows WHERE account_id_hex = ?1",
                 params![&record.account_id_hex],
             )
-            .storage()?;
+            .map_err(migrations::sqlite_error)?;
             for (position, follow) in record.follows.iter().enumerate() {
                 tx.execute_cached(
                     "INSERT OR IGNORE INTO directory_user_follows (
@@ -202,9 +167,9 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
                         optional_u64_to_i64(record.event_created_at)?,
                     ],
                 )
-                .storage()?;
+                .map_err(migrations::sqlite_error)?;
             }
-            tx.commit().storage()
+            tx.commit().map_err(migrations::sqlite_error)
         })
     }
 
@@ -213,7 +178,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
         account_id_hex: &str,
     ) -> StorageResult<Option<PublicDirectoryUserRecord>> {
         let mut conn = self.lock()?;
-        let tx = conn.transaction().storage()?;
+        let tx = conn.transaction().map_err(migrations::sqlite_error)?;
         let Some(mut record) = tx
             .query_row_cached(
                 "SELECT account_id_hex, npub, profile_json, relay_lists_json,
@@ -236,9 +201,9 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
                 },
             )
             .optional()
-            .storage()?
+            .map_err(migrations::sqlite_error)?
         else {
-            tx.commit().storage()?;
+            tx.commit().map_err(migrations::sqlite_error)?;
             return Ok(None);
         };
         let mut stmt = tx
@@ -247,14 +212,14 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
                  WHERE account_id_hex = ?1
                  ORDER BY position, follow_account_id_hex",
             )
-            .storage()?;
+            .map_err(migrations::sqlite_error)?;
         record.follows = stmt
             .query_map(params![account_id_hex], |row| row.get::<_, String>(0))
-            .storage()?
+            .map_err(migrations::sqlite_error)?
             .collect::<Result<Vec<_>, _>>()
-            .storage()?;
+            .map_err(migrations::sqlite_error)?;
         drop(stmt);
-        tx.commit().storage()?;
+        tx.commit().map_err(migrations::sqlite_error)?;
         Ok(Some(record))
     }
 
@@ -277,7 +242,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
         // each user's follows by position then follow id).
         let cap = i64::try_from(max).unwrap_or(i64::MAX);
         let mut conn = self.lock()?;
-        let tx = conn.transaction().storage()?;
+        let tx = conn.transaction().map_err(migrations::sqlite_error)?;
         let mut follows_by_account: std::collections::HashMap<String, Vec<String>> =
             std::collections::HashMap::new();
         {
@@ -290,14 +255,14 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
                      )
                      ORDER BY account_id_hex, position, follow_account_id_hex",
                 )
-                .storage()?;
+                .map_err(migrations::sqlite_error)?;
             let rows = stmt
                 .query_map(params![cap], |row| {
                     Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
                 })
-                .storage()?;
+                .map_err(migrations::sqlite_error)?;
             for row in rows {
-                let (account_id_hex, follow) = row.storage()?;
+                let (account_id_hex, follow) = row.map_err(migrations::sqlite_error)?;
                 follows_by_account
                     .entry(account_id_hex)
                     .or_default()
@@ -312,7 +277,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
                  ORDER BY account_id_hex
                  LIMIT ?1",
             )
-            .storage()?;
+            .map_err(migrations::sqlite_error)?;
         let records = stmt
             .query_map(params![cap], |row| {
                 Ok(PublicDirectoryUserRecord {
@@ -327,11 +292,11 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
                     follows: Vec::new(),
                 })
             })
-            .storage()?
+            .map_err(migrations::sqlite_error)?
             .collect::<Result<Vec<_>, _>>()
-            .storage()?;
+            .map_err(migrations::sqlite_error)?;
         drop(stmt);
-        tx.commit().storage()?;
+        tx.commit().map_err(migrations::sqlite_error)?;
         if records.len() >= max {
             // no silent caps: surface (aggregate count only, privacy-safe) that
             // the listing was truncated so an operator can tell the bound bit.
@@ -369,7 +334,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
                     })
                 },
             )
-            .storage()
+            .map_err(migrations::sqlite_error)
     }
 
     pub fn set_relay_telemetry_settings(
@@ -393,7 +358,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
                         unix_now_ms(),
                     ],
                 )
-                .storage()?;
+                .map_err(migrations::sqlite_error)?;
             Ok(())
         })
     }
@@ -408,7 +373,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
                 |row| row.get(0),
             )
             .optional()
-            .storage()
+            .map_err(migrations::sqlite_error)
     }
 
     pub fn set_telemetry_install_id(&self, install_id: &str) -> StorageResult<()> {
@@ -422,7 +387,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
                     updated_at_ms = excluded.updated_at_ms",
                     params![install_id, unix_now_ms()],
                 )
-                .storage()?;
+                .map_err(migrations::sqlite_error)?;
             Ok(())
         })
     }
@@ -441,7 +406,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
                     })
                 },
             )
-            .storage()
+            .map_err(migrations::sqlite_error)
     }
 
     pub fn set_audit_log_settings(&self, settings: &StoredAuditLogSettings) -> StorageResult<()> {
@@ -455,7 +420,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
                     updated_at_ms = excluded.updated_at_ms",
                     params![bool_i64(settings.enabled), unix_now_ms()],
                 )
-                .storage()?;
+                .map_err(migrations::sqlite_error)?;
             Ok(())
         })
     }
@@ -487,29 +452,9 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
                  ON CONFLICT(id) DO NOTHING",
                     params![unix_now_ms()],
                 )
-                .storage()?;
+                .map_err(migrations::sqlite_error)?;
             Ok(())
         })
-    }
-
-    fn clear_legacy_relay_telemetry_endpoint(conn: &rusqlite::Connection) -> StorageResult<()> {
-        let columns = {
-            let mut stmt = conn
-                .prepare_cached("PRAGMA table_info(relay_telemetry_settings)")
-                .storage()?;
-            stmt.query_map([], |row| row.get::<_, String>(1))
-                .storage()?
-                .collect::<Result<Vec<_>, _>>()
-                .storage()?
-        };
-        if columns.iter().any(|column| column == "otlp_endpoint") {
-            conn.execute_cached(
-                "UPDATE relay_telemetry_settings SET otlp_endpoint = NULL",
-                [],
-            )
-            .storage()?;
-        }
-        Ok(())
     }
 
     fn ensure_audit_log_settings(&self) -> StorageResult<()> {
@@ -523,7 +468,7 @@ CREATE TABLE IF NOT EXISTS directory_user_follows (
                  ON CONFLICT(id) DO NOTHING",
                     params![unix_now_ms()],
                 )
-                .storage()?;
+                .map_err(migrations::sqlite_error)?;
             Ok(())
         })
     }
@@ -847,5 +792,33 @@ mod tests {
             )
             .unwrap();
         assert_eq!(legacy_mode, "full_data");
+    }
+}
+
+#[cfg(test)]
+mod migration_contract_tests {
+    use super::*;
+
+    #[test]
+    fn fresh_shared_storage_records_version_one() {
+        let storage = SqliteSharedStorage::in_memory().unwrap();
+        let row: (i64, String) = storage
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT version, name FROM shared_schema_migrations",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(row, (1, "0001_shared_store".into()));
+    }
+
+    #[test]
+    fn shared_storage_refuses_malformed_unversioned_table() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE directory_users (account_id_hex TEXT)")
+            .unwrap();
+        assert!(SqliteSharedStorage::from_connection(conn).is_err());
     }
 }

--- a/crates/storage-sqlite/src/shared.rs
+++ b/crates/storage-sqlite/src/shared.rs
@@ -1,4 +1,7 @@
+mod error;
 mod migrations;
+
+use error::SharedSqliteResultExt;
 
 use crate::connection::CachedSql;
 use std::path::Path;
@@ -69,14 +72,12 @@ impl SqliteSharedStorage {
         // The shared cache is unencrypted, so file-level 0600 (including
         // sidecars) is the only thing keeping it from other local users.
         crate::connection::ensure_private_db_files(path)?;
-        let conn = rusqlite::Connection::open(path).map_err(migrations::sqlite_error)?;
+        let conn = rusqlite::Connection::open(path).storage()?;
         Self::from_connection(conn)
     }
 
     pub fn in_memory() -> StorageResult<Self> {
-        Self::from_connection(
-            rusqlite::Connection::open_in_memory().map_err(migrations::sqlite_error)?,
-        )
+        Self::from_connection(rusqlite::Connection::open_in_memory().storage()?)
     }
 
     /// Checkpoint the WAL and close this shared database, releasing its file
@@ -96,17 +97,16 @@ impl SqliteSharedStorage {
 
     fn from_connection(mut conn: rusqlite::Connection) -> StorageResult<Self> {
         conn.busy_timeout(Duration::from_millis(SHARED_BUSY_TIMEOUT_MS))
-            .map_err(migrations::sqlite_error)?;
-        conn.pragma_update(None, "foreign_keys", true)
-            .map_err(migrations::sqlite_error)?;
+            .storage()?;
+        conn.pragma_update(None, "foreign_keys", true).storage()?;
         conn.pragma_update(None, "trusted_schema", false)
-            .map_err(migrations::sqlite_error)?;
+            .storage()?;
         conn.execute_batch(
             "PRAGMA journal_mode = WAL;
              PRAGMA synchronous = NORMAL;
              PRAGMA temp_store = MEMORY;",
         )
-        .map_err(migrations::sqlite_error)?;
+        .storage()?;
         migrations::run_all(&mut conn)?;
         Ok(Self {
             conn: Arc::new(CloseableConnection::new(conn, CLOSED_DETAIL)),
@@ -121,7 +121,7 @@ impl SqliteSharedStorage {
             let mut conn = self.lock()?;
             let tx = conn
                 .transaction_with_behavior(TransactionBehavior::Immediate)
-                .map_err(migrations::sqlite_error)?;
+                .storage()?;
             tx.execute_cached(
                 "INSERT INTO directory_users (
                 account_id_hex, npub, profile_json, relay_lists_json, key_package_json,
@@ -147,12 +147,12 @@ impl SqliteSharedStorage {
                     optional_u64_to_i64(record.event_created_at)?,
                 ],
             )
-            .map_err(migrations::sqlite_error)?;
+            .storage()?;
             tx.execute_cached(
                 "DELETE FROM directory_user_follows WHERE account_id_hex = ?1",
                 params![&record.account_id_hex],
             )
-            .map_err(migrations::sqlite_error)?;
+            .storage()?;
             for (position, follow) in record.follows.iter().enumerate() {
                 tx.execute_cached(
                     "INSERT OR IGNORE INTO directory_user_follows (
@@ -167,9 +167,9 @@ impl SqliteSharedStorage {
                         optional_u64_to_i64(record.event_created_at)?,
                     ],
                 )
-                .map_err(migrations::sqlite_error)?;
+                .storage()?;
             }
-            tx.commit().map_err(migrations::sqlite_error)
+            tx.commit().storage()
         })
     }
 
@@ -178,7 +178,7 @@ impl SqliteSharedStorage {
         account_id_hex: &str,
     ) -> StorageResult<Option<PublicDirectoryUserRecord>> {
         let mut conn = self.lock()?;
-        let tx = conn.transaction().map_err(migrations::sqlite_error)?;
+        let tx = conn.transaction().storage()?;
         let Some(mut record) = tx
             .query_row_cached(
                 "SELECT account_id_hex, npub, profile_json, relay_lists_json,
@@ -201,9 +201,9 @@ impl SqliteSharedStorage {
                 },
             )
             .optional()
-            .map_err(migrations::sqlite_error)?
+            .storage()?
         else {
-            tx.commit().map_err(migrations::sqlite_error)?;
+            tx.commit().storage()?;
             return Ok(None);
         };
         let mut stmt = tx
@@ -212,14 +212,14 @@ impl SqliteSharedStorage {
                  WHERE account_id_hex = ?1
                  ORDER BY position, follow_account_id_hex",
             )
-            .map_err(migrations::sqlite_error)?;
+            .storage()?;
         record.follows = stmt
             .query_map(params![account_id_hex], |row| row.get::<_, String>(0))
-            .map_err(migrations::sqlite_error)?
+            .storage()?
             .collect::<Result<Vec<_>, _>>()
-            .map_err(migrations::sqlite_error)?;
+            .storage()?;
         drop(stmt);
-        tx.commit().map_err(migrations::sqlite_error)?;
+        tx.commit().storage()?;
         Ok(Some(record))
     }
 
@@ -242,7 +242,7 @@ impl SqliteSharedStorage {
         // each user's follows by position then follow id).
         let cap = i64::try_from(max).unwrap_or(i64::MAX);
         let mut conn = self.lock()?;
-        let tx = conn.transaction().map_err(migrations::sqlite_error)?;
+        let tx = conn.transaction().storage()?;
         let mut follows_by_account: std::collections::HashMap<String, Vec<String>> =
             std::collections::HashMap::new();
         {
@@ -255,14 +255,14 @@ impl SqliteSharedStorage {
                      )
                      ORDER BY account_id_hex, position, follow_account_id_hex",
                 )
-                .map_err(migrations::sqlite_error)?;
+                .storage()?;
             let rows = stmt
                 .query_map(params![cap], |row| {
                     Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
                 })
-                .map_err(migrations::sqlite_error)?;
+                .storage()?;
             for row in rows {
-                let (account_id_hex, follow) = row.map_err(migrations::sqlite_error)?;
+                let (account_id_hex, follow) = row.storage()?;
                 follows_by_account
                     .entry(account_id_hex)
                     .or_default()
@@ -277,7 +277,7 @@ impl SqliteSharedStorage {
                  ORDER BY account_id_hex
                  LIMIT ?1",
             )
-            .map_err(migrations::sqlite_error)?;
+            .storage()?;
         let records = stmt
             .query_map(params![cap], |row| {
                 Ok(PublicDirectoryUserRecord {
@@ -292,11 +292,11 @@ impl SqliteSharedStorage {
                     follows: Vec::new(),
                 })
             })
-            .map_err(migrations::sqlite_error)?
+            .storage()?
             .collect::<Result<Vec<_>, _>>()
-            .map_err(migrations::sqlite_error)?;
+            .storage()?;
         drop(stmt);
-        tx.commit().map_err(migrations::sqlite_error)?;
+        tx.commit().storage()?;
         if records.len() >= max {
             // no silent caps: surface (aggregate count only, privacy-safe) that
             // the listing was truncated so an operator can tell the bound bit.
@@ -334,7 +334,7 @@ impl SqliteSharedStorage {
                     })
                 },
             )
-            .map_err(migrations::sqlite_error)
+            .storage()
     }
 
     pub fn set_relay_telemetry_settings(
@@ -358,7 +358,7 @@ impl SqliteSharedStorage {
                         unix_now_ms(),
                     ],
                 )
-                .map_err(migrations::sqlite_error)?;
+                .storage()?;
             Ok(())
         })
     }
@@ -373,7 +373,7 @@ impl SqliteSharedStorage {
                 |row| row.get(0),
             )
             .optional()
-            .map_err(migrations::sqlite_error)
+            .storage()
     }
 
     pub fn set_telemetry_install_id(&self, install_id: &str) -> StorageResult<()> {
@@ -387,7 +387,7 @@ impl SqliteSharedStorage {
                     updated_at_ms = excluded.updated_at_ms",
                     params![install_id, unix_now_ms()],
                 )
-                .map_err(migrations::sqlite_error)?;
+                .storage()?;
             Ok(())
         })
     }
@@ -406,7 +406,7 @@ impl SqliteSharedStorage {
                     })
                 },
             )
-            .map_err(migrations::sqlite_error)
+            .storage()
     }
 
     pub fn set_audit_log_settings(&self, settings: &StoredAuditLogSettings) -> StorageResult<()> {
@@ -420,7 +420,7 @@ impl SqliteSharedStorage {
                     updated_at_ms = excluded.updated_at_ms",
                     params![bool_i64(settings.enabled), unix_now_ms()],
                 )
-                .map_err(migrations::sqlite_error)?;
+                .storage()?;
             Ok(())
         })
     }
@@ -452,7 +452,7 @@ impl SqliteSharedStorage {
                  ON CONFLICT(id) DO NOTHING",
                     params![unix_now_ms()],
                 )
-                .map_err(migrations::sqlite_error)?;
+                .storage()?;
             Ok(())
         })
     }
@@ -468,7 +468,7 @@ impl SqliteSharedStorage {
                  ON CONFLICT(id) DO NOTHING",
                     params![unix_now_ms()],
                 )
-                .map_err(migrations::sqlite_error)?;
+                .storage()?;
             Ok(())
         })
     }

--- a/crates/storage-sqlite/src/shared/assurance_tests.rs
+++ b/crates/storage-sqlite/src/shared/assurance_tests.rs
@@ -1,0 +1,311 @@
+//! Deterministic synthetic upgrades from independently extracted historical DDL.
+//! Abrupt process exit exercises SQLite recovery, not physical power loss.
+use super::super::{SqliteSharedStorage, StoredAuditLogSettings, StoredRelayTelemetrySettings};
+use super::*;
+use rusqlite::types::Value;
+
+const ORIGINAL: &str = include_str!("fixtures/original.sql");
+const FIVE_TABLES: &str = include_str!("fixtures/five_tables_audit_mode.sql");
+const PRE_LEDGER: &str = include_str!("fixtures/pre_ledger.sql");
+const REPAIRS: &str = include_str!("fixtures/legacy_repairs.sql");
+
+fn snapshot(conn: &Connection, tables: &[&str]) -> Vec<Vec<Vec<Value>>> {
+    tables
+        .iter()
+        .map(|table| {
+            let mut stmt = conn
+                .prepare(&format!("SELECT rowid, * FROM {table} ORDER BY rowid"))
+                .unwrap();
+            let columns = stmt.column_count();
+            stmt.query_map([], |row| {
+                (0..columns).map(|column| row.get(column)).collect()
+            })
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap()
+        })
+        .collect()
+}
+
+fn seed(conn: &mut Connection, users: i64) {
+    let tx = conn.transaction().unwrap();
+    tx.execute(
+        r#"WITH RECURSIVE seq(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM seq WHERE n < ?1)
+        INSERT INTO directory_users
+        SELECT printf('%064x',n), 'npub-'||n,
+            CASE n % 3 WHEN 0 THEN NULL WHEN 1 THEN '{invalid cached JSON'
+            ELSE '{"name":"日本語 🦫","unknown":[1,null]}' END,
+            '{}', NULL, 'event-'||n, n % 4, n FROM seq"#,
+        [users],
+    )
+    .unwrap();
+    tx.execute_batch("INSERT INTO directory_user_follows SELECT account_id_hex, 'z-friend', 0, event_id_hex, event_created_at FROM directory_users;
+        INSERT INTO directory_user_follows SELECT account_id_hex, 'a-friend', 1, NULL, NULL FROM directory_users;
+        INSERT INTO relay_telemetry_settings (id, export_enabled, export_interval_seconds, updated_at_ms) VALUES (1, 1, 37, 1234);
+        INSERT INTO audit_log_settings (id, enabled, updated_at_ms) VALUES (1, 1, 1235);
+        INSERT INTO telemetry_install VALUES (1, 'synthetic-install-identity-🦫', 1236);").unwrap();
+    tx.commit().unwrap();
+}
+
+fn assert_integrity(conn: &Connection) {
+    let result: String = conn
+        .query_row("PRAGMA integrity_check", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(result, "ok");
+    assert!(
+        conn.prepare("PRAGMA foreign_key_check")
+            .unwrap()
+            .query([])
+            .unwrap()
+            .next()
+            .unwrap()
+            .is_none()
+    );
+}
+
+fn assert_live_api(storage: &SqliteSharedStorage) {
+    let record = storage
+        .public_directory_user(&format!("{:064x}", 1))
+        .unwrap()
+        .unwrap();
+    assert_eq!(record.follows, ["z-friend", "a-friend"]);
+    assert_eq!(
+        storage.relay_telemetry_settings().unwrap(),
+        StoredRelayTelemetrySettings {
+            export_enabled: true,
+            export_interval_seconds: 37
+        }
+    );
+    assert_eq!(
+        storage.audit_log_settings().unwrap(),
+        StoredAuditLogSettings { enabled: true }
+    );
+    assert_eq!(
+        storage.telemetry_install_id().unwrap().as_deref(),
+        Some("synthetic-install-identity-🦫")
+    );
+}
+
+#[test]
+fn populated_current_shape_adoption_preserves_every_value_and_rowid() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("shared.sqlite3");
+    let mut conn = Connection::open(&path).unwrap();
+    conn.execute_batch(PRE_LEDGER).unwrap();
+    conn.pragma_update(None, "foreign_keys", true).unwrap();
+    seed(&mut conn, 10_000); // 30,003 rows, all values and rowids compared.
+    let before = snapshot(&conn, TABLES);
+    let storage = SqliteSharedStorage::open(&path).unwrap();
+    assert_eq!(snapshot(&storage.lock().unwrap(), TABLES), before);
+    assert_live_api(&storage);
+    assert_integrity(&storage.lock().unwrap());
+    storage.close().unwrap();
+    let storage = SqliteSharedStorage::open(&path).unwrap();
+    assert_eq!(snapshot(&storage.lock().unwrap(), TABLES), before);
+}
+
+#[test]
+fn every_verified_schema_generation_preserves_live_and_retired_rows() {
+    for fixture in [ORIGINAL, FIVE_TABLES, PRE_LEDGER] {
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(fixture).unwrap();
+        conn.pragma_update(None, "foreign_keys", true).unwrap();
+        seed(&mut conn, 100);
+        let mut tables = TABLES.to_vec();
+        if fixture == ORIGINAL {
+            conn.execute_batch("INSERT INTO directory_events VALUES ('old-event', 'author', 0, 99);
+                INSERT INTO directory_key_packages VALUES (printf('%064x', 1), NULL, NULL, 'old key package', 99);
+                INSERT INTO directory_search_graph_users VALUES ('old-user', 'npub', NULL, NULL, NULL, NULL, NULL, NULL);
+                INSERT INTO directory_search_graph_follows VALUES ('old-user', 'friend', 0, NULL, NULL)").unwrap();
+            tables.extend([
+                "directory_events",
+                "directory_key_packages",
+                "directory_search_graph_users",
+                "directory_search_graph_follows",
+            ]);
+        }
+        if fixture != PRE_LEDGER {
+            conn.execute_batch("UPDATE audit_log_settings SET data_mode = 'full_data'")
+                .unwrap();
+        }
+        let before = snapshot(&conn, &tables);
+        let storage = SqliteSharedStorage::from_connection(conn).unwrap();
+        assert_eq!(snapshot(&storage.lock().unwrap(), &tables), before);
+        assert_live_api(&storage);
+        assert_integrity(&storage.lock().unwrap());
+        storage
+            .set_audit_log_settings(&StoredAuditLogSettings { enabled: false })
+            .unwrap();
+        if fixture != PRE_LEDGER {
+            let mode: String = storage
+                .lock()
+                .unwrap()
+                .query_row("SELECT data_mode FROM audit_log_settings", [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(mode, "full_data");
+        }
+    }
+}
+
+#[test]
+fn legacy_endpoint_and_appended_audit_column_remain_inert() {
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(REPAIRS).unwrap();
+    conn.execute_batch("ALTER TABLE audit_log_settings ADD COLUMN data_mode TEXT NOT NULL DEFAULT 'obfuscated_sensitive_data';
+        INSERT INTO audit_log_settings VALUES (1, 1, 1235, 'full_data');
+        INSERT INTO relay_telemetry_settings VALUES (1, 1, 'https://collector.example/v1/metrics?token=secret', 37, 1234)").unwrap();
+    let before = snapshot(&conn, &["audit_log_settings"]);
+    let storage = SqliteSharedStorage::from_connection(conn).unwrap();
+    assert_eq!(
+        snapshot(&storage.lock().unwrap(), &["audit_log_settings"]),
+        before
+    );
+    assert_eq!(
+        storage
+            .relay_telemetry_settings()
+            .unwrap()
+            .export_interval_seconds,
+        37
+    );
+    assert_eq!(
+        storage.audit_log_settings().unwrap(),
+        StoredAuditLogSettings { enabled: true }
+    );
+    storage
+        .set_audit_log_settings(&StoredAuditLogSettings { enabled: false })
+        .unwrap();
+    storage
+        .set_relay_telemetry_settings(&StoredRelayTelemetrySettings {
+            export_enabled: false,
+            export_interval_seconds: 90,
+        })
+        .unwrap();
+    let mut conn = storage.lock().unwrap();
+    let endpoint: Option<String> = conn
+        .query_row(
+            "SELECT otlp_endpoint FROM relay_telemetry_settings",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(endpoint, None);
+    assert_eq!(
+        conn.query_row("SELECT data_mode FROM audit_log_settings", [], |r| r
+            .get::<_, String>(0))
+            .unwrap(),
+        "full_data"
+    );
+    conn.pragma_update(None, "query_only", true).unwrap();
+    run_all(&mut conn).unwrap();
+    assert_integrity(&conn);
+}
+
+#[test]
+fn endpoint_neutralization_rolls_back_when_ledger_insert_fails() {
+    let mut conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(REPAIRS).unwrap();
+    conn.execute_batch("INSERT INTO relay_telemetry_settings VALUES (1, 1, 'https://collector.example/?token=secret', 37, 1234)").unwrap();
+    conn.execute_batch(LEDGER_SQL).unwrap();
+    conn.execute_batch("CREATE TRIGGER reject BEFORE INSERT ON shared_schema_migrations BEGIN SELECT RAISE(ABORT, 'private trigger payload'); END").unwrap();
+    let before = snapshot(&conn, &["relay_telemetry_settings", "audit_log_settings"]);
+    let error = run_all(&mut conn).unwrap_err();
+    assert!(!format!("{error} {error:?}").contains("private trigger payload"));
+    assert_eq!(
+        snapshot(&conn, &["relay_telemetry_settings", "audit_log_settings"]),
+        before
+    );
+    assert!(!table_exists(&conn, "directory_users").unwrap());
+    conn.execute_batch("DROP TRIGGER reject").unwrap();
+    run_all(&mut conn).unwrap();
+    assert_integrity(&conn);
+}
+
+#[test]
+fn orphaned_foreign_key_data_is_refused_without_changes() {
+    let mut conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(PRE_LEDGER).unwrap();
+    conn.pragma_update(None, "foreign_keys", false).unwrap();
+    conn.execute_batch(
+        "INSERT INTO directory_user_follows VALUES ('missing', 'friend', 0, NULL, NULL)",
+    )
+    .unwrap();
+    let before = snapshot(&conn, TABLES);
+    assert_eq!(
+        run_all(&mut conn).unwrap_err().to_string(),
+        "backend failure: invalid shared store schema shape"
+    );
+    assert!(!table_exists(&conn, LEDGER).unwrap());
+    assert_eq!(snapshot(&conn, TABLES), before);
+}
+
+#[test]
+fn interrupted_shared_upgrade_recovers_in_delete_and_wal_modes() {
+    const CHILD_PATH: &str = "MDK_SHARED_UPGRADE_CRASH_TEST_PATH";
+    if let Some(path) = std::env::var_os(CHILD_PATH) {
+        let mut conn = Connection::open(path).unwrap();
+        let interrupted = [Migration {
+            version: 1,
+            name: MIGRATIONS[0].name,
+            apply: |tx| {
+                version_1(tx)?;
+                // Force dirty pages to the journal/WAL before leaving without any
+                // Rust or SQLite destructor. Exit occurs before ledger insertion.
+                tx.execute_batch(
+                    "PRAGMA cache_size = 1; CREATE TABLE crash_probe (data BLOB);
+                INSERT INTO crash_probe VALUES (zeroblob(262144));",
+                )
+                .map_err(sqlite_error)?;
+                std::process::exit(77);
+            },
+        }];
+        run(&mut conn, &interrupted).unwrap();
+        panic!("child must exit in the transaction");
+    }
+    for journal in ["DELETE", "WAL"] {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shared.sqlite3");
+        let conn = Connection::open(&path).unwrap();
+        conn.pragma_update(None, "journal_mode", journal).unwrap();
+        conn.execute_batch(REPAIRS).unwrap();
+        conn.execute_batch("INSERT INTO relay_telemetry_settings VALUES (1, 1, 'synthetic-private-endpoint', 37, 1234);
+            INSERT INTO audit_log_settings VALUES (1, 1, 1235)").unwrap();
+        let before = snapshot(&conn, &["relay_telemetry_settings", "audit_log_settings"]);
+        drop(conn);
+        let mut child = std::process::Command::new(std::env::current_exe().unwrap())
+            .args(["--exact", "shared::migrations::assurance_tests::interrupted_shared_upgrade_recovers_in_delete_and_wal_modes", "--nocapture"])
+            .env(CHILD_PATH, &path).spawn().unwrap();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+        let status = loop {
+            if let Some(status) = child.try_wait().unwrap() {
+                break status;
+            }
+            if std::time::Instant::now() >= deadline {
+                child.kill().unwrap();
+                child.wait().unwrap();
+                panic!("interrupted-upgrade child exceeded its deadline");
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        };
+        assert_eq!(status.code(), Some(77), "{journal}");
+        let mut conn = Connection::open(&path).unwrap();
+        assert_eq!(
+            snapshot(&conn, &["relay_telemetry_settings", "audit_log_settings"]),
+            before,
+            "{journal}"
+        );
+        assert!(!table_exists(&conn, LEDGER).unwrap());
+        assert!(!table_exists(&conn, "directory_users").unwrap());
+        assert!(!table_exists(&conn, "crash_probe").unwrap());
+        assert_integrity(&conn);
+        run_all(&mut conn).unwrap();
+        assert_integrity(&conn);
+        let endpoint: Option<String> = conn
+            .query_row(
+                "SELECT otlp_endpoint FROM relay_telemetry_settings",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(endpoint, None);
+    }
+}

--- a/crates/storage-sqlite/src/shared/assurance_tests.rs
+++ b/crates/storage-sqlite/src/shared/assurance_tests.rs
@@ -309,3 +309,69 @@ fn interrupted_shared_upgrade_recovers_in_delete_and_wal_modes() {
         assert_eq!(endpoint, None);
     }
 }
+
+#[test]
+fn appended_endpoint_is_neutralized_without_rewriting_live_settings() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("shared.sqlite3");
+    let conn = Connection::open(&path).unwrap();
+    conn.execute_batch(PRE_LEDGER).unwrap();
+    // Defensive compatibility case from review, not a claimed historical build.
+    conn.execute_batch("ALTER TABLE relay_telemetry_settings ADD COLUMN otlp_endpoint TEXT;
+        INSERT INTO relay_telemetry_settings VALUES (1, 1, 37, 1234, 'https://collector.example/?token=secret')").unwrap();
+    let before = snapshot(&conn, &["relay_telemetry_settings"]);
+    let storage = SqliteSharedStorage::open(&path).unwrap();
+    let mut expected = before;
+    *expected[0][0].last_mut().unwrap() = Value::Null;
+    assert_eq!(
+        snapshot(&storage.lock().unwrap(), &["relay_telemetry_settings"]),
+        expected
+    );
+    assert_integrity(&storage.lock().unwrap());
+    storage.close().unwrap();
+    let storage = SqliteSharedStorage::open(&path).unwrap();
+    let mut conn = storage.lock().unwrap();
+    conn.pragma_update(None, "query_only", true).unwrap();
+    run_all(&mut conn).unwrap();
+    assert_eq!(snapshot(&conn, &["relay_telemetry_settings"]), expected);
+}
+
+#[test]
+fn retired_orphans_do_not_gate_live_store_adoption() {
+    let mut conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(ORIGINAL).unwrap();
+    seed(&mut conn, 3);
+    conn.pragma_update(None, "foreign_keys", false).unwrap();
+    conn.execute_batch(
+        "INSERT INTO directory_key_packages VALUES ('retired-orphan', NULL, NULL, 'unused', 99)",
+    )
+    .unwrap();
+    let before = snapshot(&conn, &["directory_key_packages"]);
+    conn.pragma_update(None, "foreign_keys", true).unwrap();
+    run_all(&mut conn).unwrap();
+    assert_eq!(snapshot(&conn, &["directory_key_packages"]), before);
+    assert!(
+        conn.prepare("PRAGMA foreign_key_check(directory_user_follows)")
+            .unwrap()
+            .query([])
+            .unwrap()
+            .next()
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        conn.query_row("PRAGMA integrity_check", [], |r| r.get::<_, String>(0))
+            .unwrap(),
+        "ok"
+    );
+    // Retired data remains untouched, including the pre-existing violation.
+    assert!(
+        conn.prepare("PRAGMA foreign_key_check(directory_key_packages)")
+            .unwrap()
+            .query([])
+            .unwrap()
+            .next()
+            .unwrap()
+            .is_some()
+    );
+}

--- a/crates/storage-sqlite/src/shared/error.rs
+++ b/crates/storage-sqlite/src/shared/error.rs
@@ -1,0 +1,38 @@
+//! Privacy-safe SQLite diagnostics for every shared-store operation.
+use cgka_traits::storage::{StorageError, StorageResult};
+
+/// Shared queries use this instead of the crate-wide unredacted conversion.
+pub(super) trait SharedSqliteResultExt<T> {
+    fn storage(self) -> StorageResult<T>;
+}
+
+impl<T> SharedSqliteResultExt<T> for rusqlite::Result<T> {
+    fn storage(self) -> StorageResult<T> {
+        self.map_err(sqlite_error)
+    }
+}
+
+/// Preserve SQLite codes/transience and useful conversion categories, but never
+/// display database-controlled messages, column names, stored values or causes.
+pub(super) fn sqlite_error(error: rusqlite::Error) -> StorageError {
+    use rusqlite::Error;
+    let detail = match error {
+        Error::SqliteFailure(code, _) => {
+            return crate::codec::map_sqlite_error(Error::SqliteFailure(code, None));
+        }
+        Error::InvalidColumnType(index, _, kind) => {
+            format!("shared store invalid column type at index {index}: {kind:?}")
+        }
+        Error::FromSqlConversionFailure(index, kind, _) => {
+            format!("shared store conversion failed at column index {index}: {kind:?}")
+        }
+        Error::IntegralValueOutOfRange(index, _) => {
+            format!("shared store integer out of range at column index {index}")
+        }
+        Error::QueryReturnedNoRows => "shared store query returned no rows".into(),
+        Error::QueryReturnedMoreThanOneRow => "shared store query returned multiple rows".into(),
+        Error::InvalidColumnIndex(index) => format!("shared store invalid column index {index}"),
+        _ => "shared store SQLite operation failed".into(),
+    };
+    StorageError::Backend(detail)
+}

--- a/crates/storage-sqlite/src/shared/fixtures/README.md
+++ b/crates/storage-sqlite/src/shared/fixtures/README.md
@@ -19,11 +19,15 @@ by executing that historical ALTER against the independently extracted pre-mode 
 only the older settings tables are supported by the historical tests; missing live tables are created during adoption.
 
 Repository history does not establish which shapes shipped to which devices. In particular, the endpoint and pre-mode
-audit shapes are compatibility-test evidence, not a claim about an identified deployed build.
+audit shapes are compatibility-test evidence, not a claim about an identified deployed build. The review-added
+appended-endpoint test executes `ALTER TABLE relay_telemetry_settings ADD COLUMN otlp_endpoint TEXT` against
+`pre_ledger.sql`. This is defensive compatibility coverage, not an invented historical fixture or deployment claim.
 
 Adoption retains retired columns: endpoints are set to NULL transactionally, while data_mode remains unread and
 unchanged by current writes. This avoids rebuilding tables or changing rowids. Retired directory tables are preserved,
-including populated synthetic rows, and are neither recreated nor used by the current API.
+including populated synthetic rows, and are neither recreated nor used by the current API. Adoption checks only the
+live schema foreign key. A separate retired-orphan regression intentionally retains a pre-existing FK violation in
+`directory_key_packages` while verifying live FK integrity and successful adoption.
 
 Normal CI assurance includes 30,003 populated rows with exact typed-value/rowid comparison, all fixture upgrades,
 foreign-key and integrity checks, rollback on body/ledger failure, and bounded (20-second child deadline) process-exit

--- a/crates/storage-sqlite/src/shared/fixtures/README.md
+++ b/crates/storage-sqlite/src/shared/fixtures/README.md
@@ -1,0 +1,32 @@
+# Shared-store historical fixtures
+
+These SQL files were extracted from repository revisions, independently of the new `../v1.sql`.
+They contain synthetic schema only. No installed databases were read.
+
+| Fixture | Evidence |
+| --- | --- |
+| `original.sql` | `9db9dbc092d52eb7b2d5bc6dcfb1f9beb3125464`, `shared.rs::from_connection`: nine tables, including four now-unused directory tables and inline audit `data_mode`. |
+| `five_tables_audit_mode.sql` | `5464b34eb019716b1cbf92bb2864206516477744`: stops creating unused tables, but does not drop existing ones; five live tables with inline audit `data_mode`. |
+| `pre_ledger.sql` | `fe133b82f0c2ed29c18861013d56d6dfb3a5e9f1`: removes audit data-mode creation and its additive repair; existing columns remain inert. |
+| `legacy_repairs.sql` | Tests `clears_legacy_plaintext_relay_telemetry_endpoint` and `audit_log_settings_data_mode_column_is_added_to_legacy_table` at `9db9dbc092d52eb7b2d5bc6dcfb1f9beb3125464`: nullable endpoint between enabled and interval, and pre-mode audit table. |
+
+History inspection used `git log -p origin/master -- crates/storage-sqlite/src/shared.rs` and `git show <commit>:<path>`.
+All six master-lineage revisions touching that file through `6b2b041b` form three identical-DDL pairs:
+`9db9dbc0`/`1dfe1907`, `5464b34e`/`dcf27f22`, and `fe133b82`/`6b2b041b`.
+The first revision already includes `ensure_audit_log_data_mode_column`; its `ALTER TABLE ... ADD COLUMN` explains
+why recognized audit tables can have data_mode either before or after updated_at_ms. The appended variant is tested
+by executing that historical ALTER against the independently extracted pre-mode fixture. Partial stores containing
+only the older settings tables are supported by the historical tests; missing live tables are created during adoption.
+
+Repository history does not establish which shapes shipped to which devices. In particular, the endpoint and pre-mode
+audit shapes are compatibility-test evidence, not a claim about an identified deployed build.
+
+Adoption retains retired columns: endpoints are set to NULL transactionally, while data_mode remains unread and
+unchanged by current writes. This avoids rebuilding tables or changing rowids. Retired directory tables are preserved,
+including populated synthetic rows, and are neither recreated nor used by the current API.
+
+Normal CI assurance includes 30,003 populated rows with exact typed-value/rowid comparison, all fixture upgrades,
+foreign-key and integrity checks, rollback on body/ledger failure, and bounded (20-second child deadline) process-exit
+recovery with dirty-page spill under DELETE and WAL journaling. Process exit is not power loss. These tests do not
+cover every OS I/O fault, deployment cohort, malicious out-of-band mutation, or prove a numerical failure rate.
+Conservative frozen-DDL recognition can refuse equivalent hand-edited schemas; no rows are discarded to repair them.

--- a/crates/storage-sqlite/src/shared/fixtures/five_tables_audit_mode.sql
+++ b/crates/storage-sqlite/src/shared/fixtures/five_tables_audit_mode.sql
@@ -1,0 +1,37 @@
+-- Extracted from 5464b34eb019716b1cbf92bb2864206516477744
+-- crates/storage-sqlite/src/shared.rs, from_connection.
+CREATE TABLE IF NOT EXISTS directory_users (
+    account_id_hex TEXT PRIMARY KEY NOT NULL,
+    npub TEXT NOT NULL,
+    profile_json TEXT,
+    relay_lists_json TEXT NOT NULL,
+    key_package_json TEXT,
+    event_id_hex TEXT,
+    event_kind INTEGER,
+    event_created_at INTEGER
+);
+CREATE TABLE IF NOT EXISTS directory_user_follows (
+    account_id_hex TEXT NOT NULL REFERENCES directory_users(account_id_hex) ON DELETE CASCADE,
+    follow_account_id_hex TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    event_id_hex TEXT,
+    event_created_at INTEGER,
+    PRIMARY KEY (account_id_hex, follow_account_id_hex)
+);
+	CREATE TABLE IF NOT EXISTS relay_telemetry_settings (
+	    id INTEGER PRIMARY KEY CHECK (id = 1),
+	    export_enabled INTEGER NOT NULL DEFAULT 0,
+	    export_interval_seconds INTEGER NOT NULL DEFAULT 60,
+	    updated_at_ms INTEGER NOT NULL
+	);
+		CREATE TABLE IF NOT EXISTS audit_log_settings (
+		    id INTEGER PRIMARY KEY CHECK (id = 1),
+		    enabled INTEGER NOT NULL DEFAULT 0,
+		    data_mode TEXT NOT NULL DEFAULT 'obfuscated_sensitive_data',
+		    updated_at_ms INTEGER NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS telemetry_install (
+		    id INTEGER PRIMARY KEY CHECK (id = 1),
+		    install_id TEXT NOT NULL,
+		    updated_at_ms INTEGER NOT NULL
+		);

--- a/crates/storage-sqlite/src/shared/fixtures/legacy_repairs.sql
+++ b/crates/storage-sqlite/src/shared/fixtures/legacy_repairs.sql
@@ -1,0 +1,16 @@
+-- Extracted independently from 9db9dbc092d52eb7b2d5bc6dcfb1f9beb3125464 shared.rs tests:
+-- clears_legacy_plaintext_relay_telemetry_endpoint and
+-- audit_log_settings_data_mode_column_is_added_to_legacy_table.
+-- This is compatibility-test evidence, not a verified deployed build.
+CREATE TABLE relay_telemetry_settings (
+                    id INTEGER PRIMARY KEY CHECK (id = 1),
+                    export_enabled INTEGER NOT NULL DEFAULT 0,
+                    otlp_endpoint TEXT,
+                    export_interval_seconds INTEGER NOT NULL DEFAULT 60,
+                    updated_at_ms INTEGER NOT NULL
+                );
+CREATE TABLE audit_log_settings (
+                    id INTEGER PRIMARY KEY CHECK (id = 1),
+                    enabled INTEGER NOT NULL DEFAULT 0,
+                    updated_at_ms INTEGER NOT NULL
+                 );

--- a/crates/storage-sqlite/src/shared/fixtures/original.sql
+++ b/crates/storage-sqlite/src/shared/fixtures/original.sql
@@ -1,0 +1,68 @@
+-- Extracted from 9db9dbc092d52eb7b2d5bc6dcfb1f9beb3125464
+-- crates/storage-sqlite/src/shared.rs, from_connection.
+CREATE TABLE IF NOT EXISTS directory_users (
+    account_id_hex TEXT PRIMARY KEY NOT NULL,
+    npub TEXT NOT NULL,
+    profile_json TEXT,
+    relay_lists_json TEXT NOT NULL,
+    key_package_json TEXT,
+    event_id_hex TEXT,
+    event_kind INTEGER,
+    event_created_at INTEGER
+);
+CREATE TABLE IF NOT EXISTS directory_user_follows (
+    account_id_hex TEXT NOT NULL REFERENCES directory_users(account_id_hex) ON DELETE CASCADE,
+    follow_account_id_hex TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    event_id_hex TEXT,
+    event_created_at INTEGER,
+    PRIMARY KEY (account_id_hex, follow_account_id_hex)
+);
+CREATE TABLE IF NOT EXISTS directory_events (
+    event_id_hex TEXT PRIMARY KEY NOT NULL,
+    author_account_id_hex TEXT NOT NULL,
+    kind INTEGER NOT NULL,
+    created_at INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS directory_key_packages (
+    account_id_hex TEXT PRIMARY KEY NOT NULL REFERENCES directory_users(account_id_hex) ON DELETE CASCADE,
+    key_package_ref_hex TEXT,
+    key_package_event_id_hex TEXT,
+    key_package_json TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS directory_search_graph_users (
+    account_id_hex TEXT PRIMARY KEY NOT NULL,
+    npub TEXT NOT NULL,
+    profile_json TEXT,
+    relay_lists_json TEXT,
+    key_package_json TEXT,
+    event_id_hex TEXT,
+    event_kind INTEGER,
+    event_created_at INTEGER
+);
+CREATE TABLE IF NOT EXISTS directory_search_graph_follows (
+    account_id_hex TEXT NOT NULL,
+    follow_account_id_hex TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    event_id_hex TEXT,
+    event_created_at INTEGER,
+    PRIMARY KEY (account_id_hex, follow_account_id_hex)
+);
+	CREATE TABLE IF NOT EXISTS relay_telemetry_settings (
+	    id INTEGER PRIMARY KEY CHECK (id = 1),
+	    export_enabled INTEGER NOT NULL DEFAULT 0,
+	    export_interval_seconds INTEGER NOT NULL DEFAULT 60,
+	    updated_at_ms INTEGER NOT NULL
+	);
+		CREATE TABLE IF NOT EXISTS audit_log_settings (
+		    id INTEGER PRIMARY KEY CHECK (id = 1),
+		    enabled INTEGER NOT NULL DEFAULT 0,
+		    data_mode TEXT NOT NULL DEFAULT 'obfuscated_sensitive_data',
+		    updated_at_ms INTEGER NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS telemetry_install (
+		    id INTEGER PRIMARY KEY CHECK (id = 1),
+		    install_id TEXT NOT NULL,
+		    updated_at_ms INTEGER NOT NULL
+		);

--- a/crates/storage-sqlite/src/shared/fixtures/pre_ledger.sql
+++ b/crates/storage-sqlite/src/shared/fixtures/pre_ledger.sql
@@ -1,0 +1,36 @@
+-- Extracted from fe133b82f0c2ed29c18861013d56d6dfb3a5e9f1
+-- crates/storage-sqlite/src/shared.rs, from_connection.
+CREATE TABLE IF NOT EXISTS directory_users (
+    account_id_hex TEXT PRIMARY KEY NOT NULL,
+    npub TEXT NOT NULL,
+    profile_json TEXT,
+    relay_lists_json TEXT NOT NULL,
+    key_package_json TEXT,
+    event_id_hex TEXT,
+    event_kind INTEGER,
+    event_created_at INTEGER
+);
+CREATE TABLE IF NOT EXISTS directory_user_follows (
+    account_id_hex TEXT NOT NULL REFERENCES directory_users(account_id_hex) ON DELETE CASCADE,
+    follow_account_id_hex TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    event_id_hex TEXT,
+    event_created_at INTEGER,
+    PRIMARY KEY (account_id_hex, follow_account_id_hex)
+);
+	CREATE TABLE IF NOT EXISTS relay_telemetry_settings (
+	    id INTEGER PRIMARY KEY CHECK (id = 1),
+	    export_enabled INTEGER NOT NULL DEFAULT 0,
+	    export_interval_seconds INTEGER NOT NULL DEFAULT 60,
+	    updated_at_ms INTEGER NOT NULL
+	);
+		CREATE TABLE IF NOT EXISTS audit_log_settings (
+		    id INTEGER PRIMARY KEY CHECK (id = 1),
+		    enabled INTEGER NOT NULL DEFAULT 0,
+		    updated_at_ms INTEGER NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS telemetry_install (
+		    id INTEGER PRIMARY KEY CHECK (id = 1),
+		    install_id TEXT NOT NULL,
+		    updated_at_ms INTEGER NOT NULL
+		);

--- a/crates/storage-sqlite/src/shared/legacy.sql
+++ b/crates/storage-sqlite/src/shared/legacy.sql
@@ -1,0 +1,15 @@
+-- Recognized compatibility columns, evidenced by shared.rs at 9db9dbc092d52eb7b2d5bc6dcfb1f9beb3125464:
+-- clears_legacy_plaintext_relay_telemetry_endpoint and from_connection respectively.
+CREATE TABLE relay_telemetry_settings (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    export_enabled INTEGER NOT NULL DEFAULT 0,
+    otlp_endpoint TEXT,
+    export_interval_seconds INTEGER NOT NULL DEFAULT 60,
+    updated_at_ms INTEGER NOT NULL
+);
+CREATE TABLE audit_log_settings (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    enabled INTEGER NOT NULL DEFAULT 0,
+    data_mode TEXT NOT NULL DEFAULT 'obfuscated_sensitive_data',
+    updated_at_ms INTEGER NOT NULL
+);

--- a/crates/storage-sqlite/src/shared/migration_tests.rs
+++ b/crates/storage-sqlite/src/shared/migration_tests.rs
@@ -1,0 +1,412 @@
+use super::super::*;
+use super::*;
+use rusqlite::Connection;
+
+fn count(conn: &Connection) -> i64 {
+    conn.query_row("SELECT count(*) FROM shared_schema_migrations", [], |r| {
+        r.get(0)
+    })
+    .unwrap()
+}
+
+#[test]
+fn fresh_file_preserves_pragmas_permissions_and_close() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("shared.sqlite3");
+    let storage = SqliteSharedStorage::open(&path).unwrap();
+    {
+        let conn = storage.lock().unwrap();
+        assert_eq!(count(&conn), 1);
+        for (pragma, expected) in [
+            ("busy_timeout", 5000),
+            ("synchronous", 1),
+            ("foreign_keys", 1),
+            ("trusted_schema", 0),
+            ("temp_store", 2),
+        ] {
+            assert_eq!(
+                conn.query_row(&format!("PRAGMA {pragma}"), [], |r| r.get::<_, i64>(0))
+                    .unwrap(),
+                expected
+            );
+        }
+        assert_eq!(
+            conn.query_row("PRAGMA journal_mode", [], |r| r.get::<_, String>(0))
+                .unwrap(),
+            "wal"
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            for suffix in ["", "-wal", "-shm"] {
+                let file = dir.path().join(format!("shared.sqlite3{suffix}"));
+                assert_eq!(
+                    std::fs::metadata(file).unwrap().permissions().mode() & 0o777,
+                    0o600
+                );
+            }
+        }
+    }
+    let clone = storage.clone();
+    storage.close().unwrap();
+    assert!(matches!(
+        clone.telemetry_install_id(),
+        Err(StorageError::Closed(_))
+    ));
+    let bytes = std::fs::read(&path).unwrap();
+    assert!(bytes.starts_with(b"SQLite format 3\0"));
+}
+
+#[test]
+fn current_open_is_read_only_and_idempotent_while_writer_holds_lock() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("shared.sqlite3");
+    let first = SqliteSharedStorage::open(&path).unwrap();
+    let before: i64 = first
+        .lock()
+        .unwrap()
+        .query_row(
+            "SELECT applied_at_unix_seconds FROM shared_schema_migrations",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let writer = Connection::open(&path).unwrap();
+    writer
+        .execute_batch(
+            "BEGIN IMMEDIATE; UPDATE shared_schema_migrations SET applied_at_unix_seconds = 0",
+        )
+        .unwrap();
+    let second = SqliteSharedStorage::open(&path).unwrap();
+    let conn = second.lock().unwrap();
+    assert_eq!(count(&conn), 1);
+    assert_eq!(
+        conn.query_row(
+            "SELECT applied_at_unix_seconds FROM shared_schema_migrations",
+            [],
+            |r| r.get::<_, i64>(0)
+        )
+        .unwrap(),
+        before
+    );
+    conn.execute_batch("PRAGMA query_only = ON").unwrap();
+    drop(conn);
+    run_all(&mut second.lock().unwrap()).unwrap();
+    writer.execute_batch("ROLLBACK").unwrap();
+}
+
+#[test]
+fn concurrent_openers_record_once() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("shared.sqlite3");
+    // Establish WAL independently so this tests migration serialization, not a
+    // racing journal-mode transition. Both openers start with no ledger.
+    let conn = Connection::open(&path).unwrap();
+    conn.execute_batch("PRAGMA journal_mode = WAL").unwrap();
+    let barrier = std::sync::Barrier::new(2);
+    std::thread::scope(|scope| {
+        let handles: Vec<_> = (0..2)
+            .map(|_| {
+                scope.spawn(|| {
+                    barrier.wait();
+                    let storage = SqliteSharedStorage::open(&path).unwrap();
+                    assert_eq!(count(&storage.lock().unwrap()), 1);
+                })
+            })
+            .collect();
+        for handle in handles {
+            handle.join().unwrap();
+        }
+    });
+    assert_eq!(count(&conn), 1);
+}
+
+#[test]
+fn pending_migration_busy_remains_transient() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("shared.sqlite3");
+    let writer = Connection::open(&path).unwrap();
+    writer
+        .execute_batch("PRAGMA journal_mode = WAL; BEGIN IMMEDIATE")
+        .unwrap();
+    let mut conn = Connection::open(&path).unwrap();
+    conn.busy_timeout(Duration::ZERO).unwrap();
+    assert!(matches!(run_all(&mut conn), Err(StorageError::Busy(_))));
+}
+
+#[test]
+fn invalid_schema_shapes_are_refused_without_ledger() {
+    for sql in [
+        VERSION_1_SQL.replace("    profile_json TEXT,", ""),
+        VERSION_1_SQL.replace("npub TEXT NOT NULL", "npub BLOB NOT NULL"),
+        VERSION_1_SQL.replace("npub TEXT NOT NULL", "npub TEXT"),
+        VERSION_1_SQL.replace(
+            "PRIMARY KEY (account_id_hex, follow_account_id_hex)",
+            "PRIMARY KEY (account_id_hex, position)",
+        ),
+        VERSION_1_SQL.replace(
+            "REFERENCES directory_users(account_id_hex) ON DELETE CASCADE",
+            "",
+        ),
+        VERSION_1_SQL.replace("ON DELETE CASCADE", "ON DELETE RESTRICT"),
+        VERSION_1_SQL.replace("DEFAULT 60", "DEFAULT 30"),
+        VERSION_1_SQL.replace("CHECK (id = 1)", "CHECK (id > 0)"),
+        VERSION_1_SQL.replace("CHECK (id = 1)", "CHECK (id = 1 OR 1)"),
+        VERSION_1_SQL.replace(
+            "account_id_hex TEXT PRIMARY KEY",
+            "account_id_hex TEXT COLLATE NOCASE PRIMARY KEY",
+        ),
+        format!("{VERSION_1_SQL} CREATE UNIQUE INDEX wrong ON directory_users(npub)"),
+        format!("{VERSION_1_SQL} CREATE INDEX wrong ON directory_user_follows(position DESC)"),
+        format!(
+            "{VERSION_1_SQL} CREATE TRIGGER unexpected AFTER UPDATE ON relay_telemetry_settings BEGIN DELETE FROM directory_users; END"
+        ),
+        VERSION_1_SQL.replace(
+            "CREATE TABLE IF NOT EXISTS telemetry_install",
+            "CREATE TABLE IF NOT EXISTS wrong_install",
+        ) + "; CREATE VIEW telemetry_install AS SELECT * FROM wrong_install;",
+    ] {
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(&sql).unwrap();
+        assert_eq!(
+            run_all(&mut conn).unwrap_err().to_string(),
+            "backend failure: invalid shared store schema shape"
+        );
+        assert!(!table_exists(&conn, "shared_schema_migrations").unwrap());
+    }
+}
+
+#[test]
+fn invalid_history_and_future_versions_fail_before_body() {
+    for rows in [
+        "(1, 'private name', 0)",
+        "(0, '0001_shared_store', 0)",
+        "(-1, '0001_shared_store', 0), (1, '0001_shared_store', 0)",
+        "(2, 'future private name', 0)",
+    ] {
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(LEDGER_SQL).unwrap();
+        conn.execute_batch(&format!(
+            "INSERT INTO shared_schema_migrations VALUES {rows}"
+        ))
+        .unwrap();
+        let error = run_all(&mut conn).unwrap_err();
+        if rows.starts_with("(2") {
+            assert!(matches!(
+                error,
+                StorageError::UnsupportedSchemaVersion {
+                    found: 2,
+                    latest_supported: 1
+                }
+            ));
+        } else {
+            assert_eq!(
+                error.to_string(),
+                "backend failure: invalid shared store migration history"
+            );
+        }
+        assert!(!table_exists(&conn, "directory_users").unwrap());
+    }
+}
+
+#[test]
+fn malformed_ledger_and_gapped_test_registry_are_refused() {
+    for ddl in [
+        "CREATE TABLE shared_schema_migrations (version INTEGER, name TEXT, applied_at_unix_seconds INTEGER)",
+        "CREATE TABLE shared_schema_migrations (private TEXT)",
+        "CREATE VIEW shared_schema_migrations AS SELECT 1 AS version, '0001_shared_store' AS name",
+    ] {
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(ddl).unwrap();
+        assert_eq!(
+            run_all(&mut conn).unwrap_err().to_string(),
+            "backend failure: invalid shared store migration history"
+        );
+    }
+    let mut conn = Connection::open_in_memory().unwrap();
+    for versions in [[1, 1], [2, 1], [1, 3]] {
+        let registry = versions.map(|version| Migration {
+            version,
+            name: "test",
+            apply: version_1,
+        });
+        assert!(run(&mut conn, &registry).is_err());
+        assert!(!table_exists(&conn, "directory_users").unwrap());
+    }
+}
+
+#[test]
+fn body_and_ledger_failures_roll_back_and_redact_sqlite_messages() {
+    let mut conn = Connection::open_in_memory().unwrap();
+    let failing = [Migration {
+        version: 1,
+        name: "test",
+        apply: |tx| {
+            tx.execute_batch(
+                "CREATE TABLE probe (value TEXT); INSERT INTO probe VALUES ('private');",
+            )
+            .map_err(sqlite_error)?;
+            tx.execute_batch("INSERT INTO missing VALUES (1)")
+                .map_err(sqlite_error)?;
+            Ok(())
+        },
+    }];
+    assert!(run(&mut conn, &failing).is_err());
+    assert!(!table_exists(&conn, "probe").unwrap());
+    assert!(!table_exists(&conn, "shared_schema_migrations").unwrap());
+
+    conn.execute_batch(LEDGER_SQL).unwrap();
+    conn.execute_batch("CREATE TRIGGER reject BEFORE INSERT ON shared_schema_migrations BEGIN SELECT RAISE(ABORT, 'https://collector.example/?token=secret'); END").unwrap();
+    let error = run_all(&mut conn).unwrap_err();
+    let message = format!("{error:?} {error}");
+    assert!(!message.contains("collector"));
+    assert!(!message.contains("secret"));
+    assert!(
+        message.contains("1811"),
+        "extended SQLITE_CONSTRAINT_TRIGGER code retained"
+    );
+    assert_eq!(count(&conn), 0);
+    assert!(!table_exists(&conn, "directory_users").unwrap());
+    conn.execute_batch("DROP TRIGGER reject").unwrap();
+    run_all(&mut conn).unwrap();
+    assert_eq!(count(&conn), 1);
+}
+
+#[test]
+fn ignored_ledger_insert_cannot_commit_body() {
+    let mut conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(LEDGER_SQL).unwrap();
+    conn.execute_batch("CREATE TRIGGER skip BEFORE INSERT ON shared_schema_migrations BEGIN SELECT RAISE(IGNORE); END").unwrap();
+    assert!(run_all(&mut conn).is_err());
+    assert_eq!(count(&conn), 0);
+    assert!(!table_exists(&conn, "directory_users").unwrap());
+}
+
+#[test]
+fn fresh_schema_matches_frozen_contract_and_has_independent_ledger() {
+    let storage = SqliteSharedStorage::in_memory().unwrap();
+    let conn = storage.lock().unwrap();
+    let reference = Connection::open_in_memory().unwrap();
+    reference.execute_batch(VERSION_1_SQL).unwrap();
+    for table in TABLES {
+        assert!(table_matches(&conn, &reference, table).unwrap());
+    }
+    for other in ["cgka_schema_migrations", "app_cache_schema_migrations"] {
+        assert!(!table_exists(&conn, other).unwrap());
+    }
+}
+
+#[test]
+fn recorded_gap_and_duplicate_rows_cannot_bless_a_schema() {
+    let mut conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(LEDGER_SQL).unwrap();
+    conn.execute_batch("INSERT INTO shared_schema_migrations VALUES (2, 'second', 0)")
+        .unwrap();
+    let registry = [
+        Migration {
+            version: 1,
+            name: "first",
+            apply: |_| panic!("gap must fail before body"),
+        },
+        Migration {
+            version: 2,
+            name: "second",
+            apply: |_| panic!("gap must fail before body"),
+        },
+    ];
+    assert_eq!(
+        run(&mut conn, &registry).unwrap_err().to_string(),
+        "backend failure: invalid shared store migration history"
+    );
+    conn.execute_batch("DROP TABLE shared_schema_migrations;
+        CREATE TABLE shared_schema_migrations (version INTEGER, name TEXT NOT NULL, applied_at_unix_seconds INTEGER NOT NULL);
+        INSERT INTO shared_schema_migrations VALUES (1, '0001_shared_store', 0), (1, '0001_shared_store', 0)").unwrap();
+    assert_eq!(
+        run_all(&mut conn).unwrap_err().to_string(),
+        "backend failure: invalid shared store migration history"
+    );
+    assert!(!table_exists(&conn, "directory_users").unwrap());
+}
+
+#[test]
+fn retired_column_defaults_and_types_are_not_wildcards() {
+    for sql in [
+        LEGACY_SQL.replace("otlp_endpoint TEXT", "otlp_endpoint BLOB"),
+        LEGACY_SQL.replace("otlp_endpoint TEXT", "otlp_endpoint TEXT NOT NULL"),
+        LEGACY_SQL.replace("'obfuscated_sensitive_data'", "'full_data'"),
+        LEGACY_SQL.replace(
+            "'obfuscated_sensitive_data'",
+            "'obfuscated_ sensitive_data'",
+        ),
+    ] {
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(&sql).unwrap();
+        assert_eq!(
+            run_all(&mut conn).unwrap_err().to_string(),
+            "backend failure: invalid shared store schema shape"
+        );
+        assert!(!table_exists(&conn, LEDGER).unwrap());
+    }
+}
+
+#[test]
+fn extended_busy_and_locked_errors_remain_transient_and_redacted() {
+    for code in [
+        rusqlite::ffi::SQLITE_BUSY,
+        rusqlite::ffi::SQLITE_BUSY_RECOVERY,
+        rusqlite::ffi::SQLITE_LOCKED,
+        rusqlite::ffi::SQLITE_LOCKED_SHAREDCACHE,
+    ] {
+        let error = sqlite_error(rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(code),
+            Some("private database value".into()),
+        ));
+        assert!(error.is_transient());
+        assert!(error.to_string().contains(&code.to_string()));
+        assert!(!format!("{error} {error:?}").contains("private database value"));
+    }
+}
+
+#[test]
+fn migration_and_settings_errors_never_log_or_return_private_trigger_text() {
+    #[derive(Clone)]
+    struct Capture(Arc<std::sync::Mutex<Vec<u8>>>);
+    impl std::io::Write for Capture {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    let output = Capture(Arc::new(std::sync::Mutex::new(Vec::new())));
+    let writer = output.clone();
+    let subscriber = tracing_subscriber::fmt()
+        .without_time()
+        .with_ansi(false)
+        .with_max_level(tracing::Level::TRACE)
+        .with_writer(move || writer.clone())
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+    let mut conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(include_str!("fixtures/legacy_repairs.sql"))
+        .unwrap();
+    conn.execute_batch("INSERT INTO relay_telemetry_settings VALUES (1, 1, 'https://collector.example/?token=secret', 37, 0)").unwrap();
+    run_all(&mut conn).unwrap();
+    let storage = SqliteSharedStorage::from_connection(conn).unwrap();
+    storage.lock().unwrap().execute_batch("CREATE TRIGGER reject_settings BEFORE UPDATE ON relay_telemetry_settings BEGIN SELECT RAISE(ABORT, 'https://collector.example/?token=secret'); END").unwrap();
+    let error = storage
+        .set_relay_telemetry_settings(&StoredRelayTelemetrySettings {
+            export_enabled: false,
+            export_interval_seconds: 90,
+        })
+        .unwrap_err();
+    let messages = format!(
+        "{error} {error:?} {}",
+        String::from_utf8(output.0.lock().unwrap().clone()).unwrap()
+    );
+    for private in ["collector", "token", "secret"] {
+        assert!(!messages.contains(private));
+    }
+}

--- a/crates/storage-sqlite/src/shared/migration_tests.rs
+++ b/crates/storage-sqlite/src/shared/migration_tests.rs
@@ -410,3 +410,51 @@ fn migration_and_settings_errors_never_log_or_return_private_trigger_text() {
         assert!(!messages.contains(private));
     }
 }
+
+#[test]
+fn conversion_errors_keep_categories_without_names_values_or_causes() {
+    use rusqlite::types::Type;
+    for (error, category) in [
+        (
+            rusqlite::Error::InvalidColumnType(2, "private-column-name".into(), Type::Text),
+            "column type",
+        ),
+        (
+            rusqlite::Error::FromSqlConversionFailure(
+                3,
+                Type::Text,
+                Box::new(std::io::Error::other("private-conversion-value")),
+            ),
+            "conversion",
+        ),
+        (
+            rusqlite::Error::IntegralValueOutOfRange(4, 918273645),
+            "out of range",
+        ),
+        (rusqlite::Error::QueryReturnedNoRows, "no rows"),
+    ] {
+        let message = sqlite_error(error).to_string();
+        assert!(message.contains(category), "{message}");
+        assert!(!message.contains("private"));
+        assert!(!message.contains("918273645"));
+    }
+}
+
+#[test]
+fn ledger_integer_primary_key_rejects_text_and_bad_name_is_invalid_history() {
+    let mut conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(LEDGER_SQL).unwrap();
+    assert!(
+        conn.execute(
+            "INSERT INTO shared_schema_migrations VALUES ('not-integer', 'test', 0)",
+            []
+        )
+        .is_err()
+    );
+    conn.execute_batch("INSERT INTO shared_schema_migrations VALUES (1, x'ff', 0)")
+        .unwrap();
+    assert_eq!(
+        run_all(&mut conn).unwrap_err().to_string(),
+        "backend failure: invalid shared store migration history"
+    );
+}

--- a/crates/storage-sqlite/src/shared/migrations.rs
+++ b/crates/storage-sqlite/src/shared/migrations.rs
@@ -1,5 +1,6 @@
 //! Installation-wide shared.sqlite3 migration domain. Independent of account
 //! and app-cache ledgers; never copies their histories or application records.
+use super::error::sqlite_error;
 use cgka_traits::storage::{StorageError, StorageResult};
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 
@@ -29,18 +30,6 @@ const TABLES: &[&str] = &[
     "audit_log_settings",
     "telemetry_install",
 ];
-
-/// Drop SQLite's optional database-controlled message before mapping the error.
-/// Existing StorageError variants retain the extended code in their safe text
-/// and classify BUSY/LOCKED (including extended codes) as transient.
-pub(super) fn sqlite_error(error: rusqlite::Error) -> StorageError {
-    match error {
-        rusqlite::Error::SqliteFailure(code, _) => {
-            crate::codec::map_sqlite_error(rusqlite::Error::SqliteFailure(code, None))
-        }
-        _ => StorageError::Backend("shared store SQLite operation failed".into()),
-    }
-}
 
 pub(super) fn run_all(conn: &mut Connection) -> StorageResult<()> {
     run(conn, MIGRATIONS)
@@ -104,7 +93,10 @@ fn applied_count(conn: &Connection, migrations: &[Migration]) -> StorageResult<u
             [],
             |row| row.get(0),
         )
-        .map_err(sqlite_error)?;
+        .map_err(|error| match error {
+            rusqlite::Error::SqliteFailure(..) => sqlite_error(error),
+            _ => invalid_history(),
+        })?;
     if let Some(found) = found
         && found > latest_supported
     {
@@ -166,6 +158,12 @@ fn version_1(tx: &Transaction<'_>) -> StorageResult<()> {
     appended.execute_batch("ALTER TABLE audit_log_settings ADD COLUMN data_mode TEXT NOT NULL DEFAULT 'obfuscated_sensitive_data'")
         .map_err(sqlite_error)?;
 
+    // Accept the review's additive endpoint layout defensively. History proves
+    // the inline layout only; this is not evidence of an additional shipped build.
+    appended
+        .execute_batch("ALTER TABLE relay_telemetry_settings ADD COLUMN otlp_endpoint TEXT")
+        .map_err(sqlite_error)?;
+
     let mut legacy_endpoint = false;
     for table in TABLES {
         if !table_exists(tx, table)? {
@@ -176,20 +174,28 @@ fn version_1(tx: &Transaction<'_>) -> StorageResult<()> {
             [table], |r| r.get(0),
         ).map_err(sqlite_error)?;
         // No historical shared-table triggers exist. Refuse side effects that
-        // could alter live rows during the endpoint update or later writes.
+        // could alter live rows during adoption. Current opens do not recheck triggers.
         if has_trigger {
             return Err(invalid_shape());
         }
         if table_matches(tx, &reference, table)? {
             continue;
         }
-        if *table == "relay_telemetry_settings" && table_matches(tx, &legacy, table)? {
-            legacy_endpoint = true;
-        } else if !(*table == "audit_log_settings"
-            && (table_matches(tx, &legacy, table)? || table_matches(tx, &appended, table)?))
-        {
+        let alternatives: &[&Connection] = match *table {
+            "relay_telemetry_settings" | "audit_log_settings" => &[&legacy, &appended],
+            _ => &[],
+        };
+        let mut recognized = false;
+        for alternative in alternatives {
+            if table_matches(tx, alternative, table)? {
+                recognized = true;
+                break;
+            }
+        }
+        if !recognized {
             return Err(invalid_shape());
         }
+        legacy_endpoint |= *table == "relay_telemetry_settings";
     }
     // Missing tables are safe to create only after existing ones are recognized.
     // Leave old unused directory tables and all their rows untouched.
@@ -198,9 +204,11 @@ fn version_1(tx: &Transaction<'_>) -> StorageResult<()> {
         tx.execute("UPDATE relay_telemetry_settings SET otlp_endpoint = NULL WHERE otlp_endpoint IS NOT NULL", [])
             .map_err(sqlite_error)?;
     }
-    // A ledger never blesses pre-existing orphaned rows; this check is read-only.
+    // Validate the only FK in the live v1 contract. Retired tables are outside
+    // this migration's authority; existing orphaned rows there remain untouched
+    // and must not make live settings or the installation identity unavailable.
     let mut check = tx
-        .prepare("PRAGMA foreign_key_check")
+        .prepare("PRAGMA foreign_key_check(directory_user_follows)")
         .map_err(sqlite_error)?;
     if check
         .query([])

--- a/crates/storage-sqlite/src/shared/migrations.rs
+++ b/crates/storage-sqlite/src/shared/migrations.rs
@@ -1,0 +1,306 @@
+//! Installation-wide shared.sqlite3 migration domain. Independent of account
+//! and app-cache ledgers; never copies their histories or application records.
+use cgka_traits::storage::{StorageError, StorageResult};
+use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
+
+struct Migration {
+    version: i64,
+    name: &'static str,
+    apply: fn(&Transaction<'_>) -> StorageResult<()>,
+}
+
+const MIGRATIONS: &[Migration] = &[Migration {
+    version: 1,
+    name: "0001_shared_store",
+    apply: version_1,
+}];
+const VERSION_1_SQL: &str = include_str!("v1.sql");
+const LEGACY_SQL: &str = include_str!("legacy.sql");
+const LEDGER: &str = "shared_schema_migrations";
+const LEDGER_SQL: &str = "CREATE TABLE IF NOT EXISTS shared_schema_migrations (
+    version INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    applied_at_unix_seconds INTEGER NOT NULL
+);";
+const TABLES: &[&str] = &[
+    "directory_users",
+    "directory_user_follows",
+    "relay_telemetry_settings",
+    "audit_log_settings",
+    "telemetry_install",
+];
+
+/// Drop SQLite's optional database-controlled message before mapping the error.
+/// Existing StorageError variants retain the extended code in their safe text
+/// and classify BUSY/LOCKED (including extended codes) as transient.
+pub(super) fn sqlite_error(error: rusqlite::Error) -> StorageError {
+    match error {
+        rusqlite::Error::SqliteFailure(code, _) => {
+            crate::codec::map_sqlite_error(rusqlite::Error::SqliteFailure(code, None))
+        }
+        _ => StorageError::Backend("shared store SQLite operation failed".into()),
+    }
+}
+
+pub(super) fn run_all(conn: &mut Connection) -> StorageResult<()> {
+    run(conn, MIGRATIONS)
+}
+
+fn run(conn: &mut Connection, migrations: &[Migration]) -> StorageResult<()> {
+    for (index, migration) in migrations.iter().enumerate() {
+        if migration.version != index as i64 + 1 {
+            return Err(invalid_history());
+        }
+    }
+    // Already-current opens acquire no write lock. Pending opens recheck the
+    // entire prefix after BEGIN IMMEDIATE, not just before waiting for a writer.
+    let applied = applied_count(conn, migrations)?;
+    for (index, migration) in migrations.iter().enumerate().skip(applied) {
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(sqlite_error)?;
+        let applied = applied_count(&tx, migrations)?;
+        if applied > index {
+            tx.commit().map_err(sqlite_error)?;
+            continue;
+        }
+        if applied != index {
+            return Err(invalid_history());
+        }
+        tx.execute_batch(LEDGER_SQL).map_err(sqlite_error)?;
+        (migration.apply)(&tx)?;
+        let inserted = tx
+            .execute(
+                "INSERT INTO shared_schema_migrations (version, name, applied_at_unix_seconds)
+             VALUES (?1, ?2, CAST(strftime('%s', 'now') AS INTEGER))",
+                params![migration.version, migration.name],
+            )
+            .map_err(sqlite_error)?;
+        // A trigger using RAISE(IGNORE), or changing/deleting the inserted row,
+        // must not let an unrecorded migration commit.
+        if inserted != 1 || applied_count(&tx, migrations)? != index + 1 {
+            return Err(invalid_history());
+        }
+        tx.commit().map_err(sqlite_error)?;
+    }
+    Ok(())
+}
+
+fn applied_count(conn: &Connection, migrations: &[Migration]) -> StorageResult<usize> {
+    if !table_exists(conn, LEDGER)? {
+        return Ok(0);
+    }
+    let reference = Connection::open_in_memory().map_err(sqlite_error)?;
+    reference.execute_batch(LEDGER_SQL).map_err(sqlite_error)?;
+    if !table_matches(conn, &reference, LEDGER)? {
+        return Err(invalid_history());
+    }
+    let latest_supported = migrations.last().map_or(0, |m| m.version);
+    // Inspect numeric versions first, so a future version refuses before any
+    // body runs even if its name has an unfamiliar SQLite storage type.
+    let found: Option<i64> = conn
+        .query_row(
+            "SELECT max(version) FROM shared_schema_migrations",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(sqlite_error)?;
+    if let Some(found) = found
+        && found > latest_supported
+    {
+        return Err(StorageError::UnsupportedSchemaVersion {
+            found,
+            latest_supported,
+        });
+    }
+    let mut statement = conn
+        .prepare("SELECT version, name FROM shared_schema_migrations ORDER BY version")
+        .map_err(sqlite_error)?;
+    let mut rows = statement.query([]).map_err(sqlite_error)?;
+    let mut count = 0;
+    while let Some(row) = rows.next().map_err(sqlite_error)? {
+        let version: i64 = row.get(0).map_err(|_| invalid_history())?;
+        let name: String = row.get(1).map_err(|_| invalid_history())?;
+        let Some(expected) = migrations.get(count) else {
+            return Err(invalid_history());
+        };
+        if version != expected.version || name != expected.name {
+            return Err(invalid_history());
+        }
+        count += 1;
+    }
+    Ok(count)
+}
+
+// Views and other objects with a reserved name must be validated, not treated
+// as a missing table. The caller checks that their type/DDL is a real table.
+fn table_exists(conn: &Connection, name: &str) -> StorageResult<bool> {
+    conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE name = ?1)",
+        [name],
+        |r| r.get(0),
+    )
+    .map_err(sqlite_error)
+}
+
+fn invalid_history() -> StorageError {
+    StorageError::Backend("invalid shared store migration history".into())
+}
+
+fn invalid_shape() -> StorageError {
+    StorageError::Backend("invalid shared store schema shape".into())
+}
+
+fn version_1(tx: &Transaction<'_>) -> StorageResult<()> {
+    let reference = Connection::open_in_memory().map_err(sqlite_error)?;
+    reference
+        .execute_batch(VERSION_1_SQL)
+        .map_err(sqlite_error)?;
+    let legacy = Connection::open_in_memory().map_err(sqlite_error)?;
+    legacy.execute_batch(LEGACY_SQL).map_err(sqlite_error)?;
+    let appended = Connection::open_in_memory().map_err(sqlite_error)?;
+    appended
+        .execute_batch(VERSION_1_SQL)
+        .map_err(sqlite_error)?;
+    // The additive repair in 9db9dbc0 put this column AFTER updated_at_ms.
+    appended.execute_batch("ALTER TABLE audit_log_settings ADD COLUMN data_mode TEXT NOT NULL DEFAULT 'obfuscated_sensitive_data'")
+        .map_err(sqlite_error)?;
+
+    let mut legacy_endpoint = false;
+    for table in TABLES {
+        if !table_exists(tx, table)? {
+            continue;
+        }
+        let has_trigger: bool = tx.query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'trigger' AND tbl_name = ?1)",
+            [table], |r| r.get(0),
+        ).map_err(sqlite_error)?;
+        // No historical shared-table triggers exist. Refuse side effects that
+        // could alter live rows during the endpoint update or later writes.
+        if has_trigger {
+            return Err(invalid_shape());
+        }
+        if table_matches(tx, &reference, table)? {
+            continue;
+        }
+        if *table == "relay_telemetry_settings" && table_matches(tx, &legacy, table)? {
+            legacy_endpoint = true;
+        } else if !(*table == "audit_log_settings"
+            && (table_matches(tx, &legacy, table)? || table_matches(tx, &appended, table)?))
+        {
+            return Err(invalid_shape());
+        }
+    }
+    // Missing tables are safe to create only after existing ones are recognized.
+    // Leave old unused directory tables and all their rows untouched.
+    tx.execute_batch(VERSION_1_SQL).map_err(sqlite_error)?;
+    if legacy_endpoint {
+        tx.execute("UPDATE relay_telemetry_settings SET otlp_endpoint = NULL WHERE otlp_endpoint IS NOT NULL", [])
+            .map_err(sqlite_error)?;
+    }
+    // A ledger never blesses pre-existing orphaned rows; this check is read-only.
+    let mut check = tx
+        .prepare("PRAGMA foreign_key_check")
+        .map_err(sqlite_error)?;
+    if check
+        .query([])
+        .map_err(sqlite_error)?
+        .next()
+        .map_err(sqlite_error)?
+        .is_some()
+    {
+        return Err(invalid_shape());
+    }
+    Ok(())
+}
+
+/// Compare introspected structure AND conservative frozen DDL. PRAGMAs cover
+/// all columns (including hidden/generated), keys, FKs and index definitions;
+/// DDL additionally pins CHECK expressions, collations, conflict policies,
+/// deferrability and table options. Unknown equivalent SQL may fail closed.
+fn table_matches(conn: &Connection, reference: &Connection, name: &str) -> StorageResult<bool> {
+    let ddl = |db: &Connection| -> StorageResult<Option<String>> {
+        db.query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?1",
+            [name],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(sqlite_error)
+    };
+    let (Some(actual), Some(expected)) = (ddl(conn)?, ddl(reference)?) else {
+        return Ok(false);
+    };
+    if normalized_ddl(&actual) != normalized_ddl(&expected) {
+        return Ok(false);
+    }
+    for query in [
+        "SELECT * FROM pragma_table_xinfo(?1) ORDER BY cid",
+        "SELECT * FROM pragma_foreign_key_list(?1) ORDER BY id, seq",
+        "SELECT name, \"unique\", origin, partial FROM pragma_index_list(?1) ORDER BY name",
+    ] {
+        if structure(conn, query, name)? != structure(reference, query, name)? {
+            return Ok(false);
+        }
+    }
+    let indexes = structure(
+        reference,
+        "SELECT name FROM pragma_index_list(?1) ORDER BY name",
+        name,
+    )?;
+    for row in indexes {
+        let rusqlite::types::Value::Text(index) = &row[0] else {
+            return Err(invalid_shape());
+        };
+        let query = "SELECT * FROM pragma_index_xinfo(?1) ORDER BY seqno";
+        if structure(conn, query, index)? != structure(reference, query, index)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn structure(
+    conn: &Connection,
+    query: &str,
+    name: &str,
+) -> StorageResult<Vec<Vec<rusqlite::types::Value>>> {
+    let mut statement = conn.prepare(query).map_err(sqlite_error)?;
+    let columns = statement.column_count();
+    statement
+        .query_map([name], |row| {
+            (0..columns).map(|column| row.get(column)).collect()
+        })
+        .map_err(sqlite_error)?
+        .collect::<rusqlite::Result<_>>()
+        .map_err(sqlite_error)
+}
+
+/// Ignore formatting outside quoted tokens only. Do not normalize literals:
+/// defaults and CHECK text are contract, including whitespace and letter case.
+fn normalized_ddl(sql: &str) -> String {
+    let mut quoted = None;
+    let mut result = String::new();
+    for ch in sql.chars() {
+        if let Some(end) = quoted {
+            result.push(ch);
+            if ch == end {
+                quoted = None;
+            }
+        } else if matches!(ch, '\'' | '"' | '`' | '[') {
+            quoted = Some(if ch == '[' { ']' } else { ch });
+            result.push(ch);
+        } else if !ch.is_ascii_whitespace() {
+            result.push(ch.to_ascii_lowercase());
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+#[path = "migration_tests.rs"]
+mod tests;
+
+#[cfg(test)]
+#[path = "assurance_tests.rs"]
+mod assurance_tests;

--- a/crates/storage-sqlite/src/shared/v1.sql
+++ b/crates/storage-sqlite/src/shared/v1.sql
@@ -1,0 +1,35 @@
+-- Frozen shared-store version 1. Change only by adding a numbered migration.
+CREATE TABLE IF NOT EXISTS directory_users (
+    account_id_hex TEXT PRIMARY KEY NOT NULL,
+    npub TEXT NOT NULL,
+    profile_json TEXT,
+    relay_lists_json TEXT NOT NULL,
+    key_package_json TEXT,
+    event_id_hex TEXT,
+    event_kind INTEGER,
+    event_created_at INTEGER
+);
+CREATE TABLE IF NOT EXISTS directory_user_follows (
+    account_id_hex TEXT NOT NULL REFERENCES directory_users(account_id_hex) ON DELETE CASCADE,
+    follow_account_id_hex TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    event_id_hex TEXT,
+    event_created_at INTEGER,
+    PRIMARY KEY (account_id_hex, follow_account_id_hex)
+);
+CREATE TABLE IF NOT EXISTS relay_telemetry_settings (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    export_enabled INTEGER NOT NULL DEFAULT 0,
+    export_interval_seconds INTEGER NOT NULL DEFAULT 60,
+    updated_at_ms INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS audit_log_settings (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    enabled INTEGER NOT NULL DEFAULT 0,
+    updated_at_ms INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS telemetry_install (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    install_id TEXT NOT NULL,
+    updated_at_ms INTEGER NOT NULL
+);

--- a/docs/marmot-architecture/further-context/app-sqlite-storage-boundaries.md
+++ b/docs/marmot-architecture/further-context/app-sqlite-storage-boundaries.md
@@ -1,7 +1,7 @@
 ---
 title: "App SQLite Storage Boundaries"
 created: 2026-09-04
-updated: 2026-09-05
+updated: 2026-09-06
 tags: [marmot, app-core, sqlite, storage, migrations]
 status: current-implementation
 ---
@@ -42,9 +42,9 @@ current store.
 
 ## Migration Domains
 
-Both `session.sqlite` and the per-account `app-cache.sqlite3` have independent numbered migration histories and
-future-schema refusal. The directory cache uses `app_cache_schema_migrations`; it never reads or updates
-`cgka_schema_migrations`.
+All three current database categories have independent numbered migration histories and future-schema refusal:
+`session.sqlite` uses `cgka_schema_migrations`, per-account `app-cache.sqlite3` uses `app_cache_schema_migrations`, and
+installation-wide `shared.sqlite3` uses `shared_schema_migrations`. Each runner reads and updates only its own ledger.
 
 Cache version 1 creates the six directory/search tables and indexes. Existing unversioned tables are adopted only
 after their columns, types, nullability, defaults, primary keys and index columns match the version-1 shape. Missing
@@ -60,9 +60,29 @@ returns `UnsupportedSchemaVersion` before a migration body runs. This refuses do
 not reverse committed migrations. SQLCipher hardening, owner-only files, terminal close behavior, and the legacy
 plaintext directory import remain in place.
 
-`shared.sqlite3` still initializes its tables without a numbered ledger or future-schema refusal. Versioning that store
-is a separate follow-up; its changes must remain additive and compatible with existing databases in the meantime.
-Directory mirroring/reconciliation, session storage, and the retired app-projection import are unchanged.
+Shared version `1 / 0001_shared_store` establishes `directory_users`, `directory_user_follows`,
+`relay_telemetry_settings`, `audit_log_settings`, and `telemetry_install`. It uses the same body-plus-ledger transaction,
+exact-prefix/name validation, read-only current-open path, write-lock recheck and typed future-version refusal contract
+within its own storage-sqlite module. Shared-store SQLite errors preserve extended result codes, with BUSY/LOCKED
+remaining transient, while omitting database-controlled messages (including trigger payloads).
+
+Before creating missing tables or recording version 1, the shared runner recognizes existing tables against frozen
+current and historical definitions. Introspection checks columns, types, nullability, defaults, primary keys, foreign
+keys, index columns/collations/order and uniqueness. Conservative DDL comparison also pins CHECK expressions, conflict
+policies and table options. Unknown definitions, extra indexes or triggers on live tables, and foreign-key violations
+fail closed with stable static errors. Equivalent but unrecognized hand-edited SQL can also be refused. No user data
+is deleted to recover an unknown layout.
+
+Adoption preserves public-directory users, follow ordering, telemetry enabled/interval values, audit enabled values,
+timestamps and installation identity, including rowids. Recognized retired columns are retained to avoid table rebuilds:
+nullable `relay_telemetry_settings.otlp_endpoint` values become NULL within the migration transaction, while audit
+`data_mode` (inline or appended by the historical repair) stays inert and unchanged. Subsequent settings writes do not
+reactivate either field. Already-current opens do not repeat endpoint writes. Old unused directory tables and their
+rows remain untouched; new databases do not create them.
+
+The shared store remains unencrypted and owner-only with its existing 5-second busy timeout, WAL, synchronous NORMAL,
+foreign keys ON, trusted_schema OFF, temp_store MEMORY and terminal close semantics. Directory mirroring/reconciliation,
+session storage, app-cache migrations, and the retired app-projection import are unchanged.
 
 Each store needs an independent schema identity because its release cadence, rollback behavior, and durability
 contract can diverge. A session migration version must never be treated as the version of either cache.
@@ -88,3 +108,20 @@ These tests do not establish a numerical field failure rate or guarantee zero ri
 upgrade testing, representative deployed-cache copies and rollout monitoring remain additional evidence. A refused
 malformed schema preserves the file but can still make directory operations unavailable until repaired; preserving data
 and preserving availability are separate requirements.
+
+
+Shared-store fixtures independently extract the three master-lineage DDL generations from `9db9dbc0` (original nine
+tables), `5464b34e` (five tables with audit data mode), and `fe133b82` (five current tables). All six master-lineage
+revisions touching shared.rs through `6b2b041b` fall into these generations. The original revision's tests and additive
+repair independently establish the legacy endpoint layout and both audit-column positions. These compatibility tests
+are evidence of supported input, not proof of a particular deployed release. See the
+[fixture provenance](../../../crates/storage-sqlite/src/shared/fixtures/README.md).
+
+Shared assurance compares every typed value and rowid across 30,003 populated current-shape rows, checks all historical
+fixtures (including retained unused tables), and verifies integrity and foreign keys after upgrades. Failure injection
+covers migration-body and ledger-insert rollback, including rollback of endpoint neutralization. A bounded child process
+exits without destructors after schema and endpoint changes and forced dirty-page spill, before ledger insertion;
+rollback-journal and WAL recovery preserve the original rows and allow retry. This proves transaction recovery under
+process interruption, not power-loss safety, deployment coverage or every disk-full/I/O failure. Future schemas and
+unknown malformed layouts are refused without a migration body; refusal preserves data but can make the shared store
+unavailable until a compatible binary or explicit repair is supplied.

--- a/docs/marmot-architecture/further-context/app-sqlite-storage-boundaries.md
+++ b/docs/marmot-architecture/further-context/app-sqlite-storage-boundaries.md
@@ -69,19 +69,21 @@ remaining transient, while omitting database-controlled messages (including trig
 Before creating missing tables or recording version 1, the shared runner recognizes existing tables against frozen
 current and historical definitions. Introspection checks columns, types, nullability, defaults, primary keys, foreign
 keys, index columns/collations/order and uniqueness. Conservative DDL comparison also pins CHECK expressions, conflict
-policies and table options. Unknown definitions, extra indexes or triggers on live tables, and foreign-key violations
-fail closed with stable static errors. Equivalent but unrecognized hand-edited SQL can also be refused. No user data
+policies and table options. At adoption time, unknown definitions, extra indexes or triggers on live tables, and live
+foreign-key violations fail closed with stable static errors. Already-current opens validate history without rechecking
+triggers or table shapes. Retired-table foreign-key violations remain untouched and do not gate the live store. Equivalent but unrecognized hand-edited SQL can also be refused. No user data
 is deleted to recover an unknown layout.
 
 Adoption preserves public-directory users, follow ordering, telemetry enabled/interval values, audit enabled values,
 timestamps and installation identity, including rowids. Recognized retired columns are retained to avoid table rebuilds:
-nullable `relay_telemetry_settings.otlp_endpoint` values become NULL within the migration transaction, while audit
+nullable `relay_telemetry_settings.otlp_endpoint` values (inline or appended) become NULL within the migration
+transaction, while audit
 `data_mode` (inline or appended by the historical repair) stays inert and unchanged. Subsequent settings writes do not
 reactivate either field. Already-current opens do not repeat endpoint writes. Old unused directory tables and their
 rows remain untouched; new databases do not create them.
 
-The shared store remains unencrypted and owner-only with its existing 5-second busy timeout, WAL, synchronous NORMAL,
-foreign keys ON, trusted_schema OFF, temp_store MEMORY and terminal close semantics. Directory mirroring/reconciliation,
+The shared store retains the unencrypted, owner-only operational posture documented in
+[storage-sqlite migrations](../../../crates/storage-sqlite/README.md#migrations). Directory mirroring/reconciliation,
 session storage, app-cache migrations, and the retired app-projection import are unchanged.
 
 Each store needs an independent schema identity because its release cadence, rollback behavior, and durability
@@ -114,11 +116,13 @@ Shared-store fixtures independently extract the three master-lineage DDL generat
 tables), `5464b34e` (five tables with audit data mode), and `fe133b82` (five current tables). All six master-lineage
 revisions touching shared.rs through `6b2b041b` fall into these generations. The original revision's tests and additive
 repair independently establish the legacy endpoint layout and both audit-column positions. These compatibility tests
-are evidence of supported input, not proof of a particular deployed release. See the
+are evidence of supported input, not proof of a particular deployed release. Review also prompted defensive acceptance
+of an endpoint appended to the current relay-settings schema; history does not establish that variant was deployed. See the
 [fixture provenance](../../../crates/storage-sqlite/src/shared/fixtures/README.md).
 
 Shared assurance compares every typed value and rowid across 30,003 populated current-shape rows, checks all historical
-fixtures (including retained unused tables), and verifies integrity and foreign keys after upgrades. Failure injection
+fixtures (including retained unused tables), and verifies integrity and foreign keys after upgrades. An additional
+retired-orphan fixture verifies live foreign keys while deliberately preserving the pre-existing retired-table violation. Failure injection
 covers migration-body and ledger-insert rollback, including rollback of endpoint neutralization. A bounded child process
 exits without destructors after schema and endpoint changes and forced dirty-page spill, before ledger insertion;
 rollback-journal and WAL recovery preserve the original rows and allow retry. This proves transaction recovery under

--- a/docs/marmot-architecture/overview/current-state.md
+++ b/docs/marmot-architecture/overview/current-state.md
@@ -1,7 +1,7 @@
 ---
 title: "Current State — Implementations & Spec"
 created: 2026-04-19
-updated: 2026-09-05
+updated: 2026-09-06
 tags: [marmot, overview, current-state, implementations]
 status: overview
 ---
@@ -113,7 +113,8 @@ This repository now has the main engine candidate:
   group/message/member methods. Detailed group creation returns the exact chat-list row committed with the local
   projection; founding Welcome fanout stays post-response and its app repair index is reconstructed from
   engine-authoritative retained obligations. Its per-account directory cache has an independent numbered migration
-  ledger and future-version refusal; `shared.sqlite3` remains unversioned. See
+  ledger and future-version refusal; installation-wide `shared.sqlite3` now has its own independent
+  `shared_schema_migrations` history with transactional adoption of recognized unversioned layouts. See
   [App SQLite Storage Boundaries](../further-context/app-sqlite-storage-boundaries.md).
 - `crates/cli` — first real CLI, daemon, and TUI surface over `marmot-app`. It is intentionally product-facing rather
   than a lab harness, and its JSON envelope is shaped for daemon/TUI/testing callers.


### PR DESCRIPTION
`shared.sqlite3` previously initialized tables with unversioned `CREATE TABLE IF NOT EXISTS` and cleared retired telemetry endpoints in a separate repair. A malformed existing table could be accepted, and schema changes had no shared-store version or downgrade boundary.

This adds independent `shared_schema_migrations`, starting at `1 / 0001_shared_store`. Each numbered body and ledger insertion commit in one immediate transaction. Failures roll back both, including endpoint neutralization; ignored or altered ledger insertions cannot confirm a migration. History must match the exact compiled version/name prefix, and newer versions return `StorageError::UnsupportedSchemaVersion`. Current opens use reads only; pending openers recheck history under the write lock.

Unversioned tables are recognized against frozen current and historical definitions before missing tables are created. Validation covers columns/types/nullability/defaults, primary keys, foreign keys, CHECK expressions, collations, table options, and index structure/uniqueness. Unrecognized definitions, live-table triggers, and live-schema foreign-key violations fail closed without recording v1. Public-directory users, ordered follows, live settings, timestamps, telemetry installation identity, and rowids are preserved.

Historical fixtures were independently extracted from:

- `9db9dbc0`: original nine-table schema, including four now-unused directory tables and inline audit data mode.
- `5464b34e`: five live tables with inline audit data mode; existing unused tables were never dropped.
- `fe133b82`: five current tables after retirement of audit data-mode creation.
- Compatibility tests at `9db9dbc0`: nullable legacy `otlp_endpoint` and pre-mode audit schema. The historical additive repair establishes the appended audit-column variant.

The appended endpoint layout is defensive compatibility coverage requested during review, not a claim about another historical or deployed schema.

These cover all three DDL generations across six master-lineage revisions touching shared.rs through `6b2b041b`. Fixture documentation separates repository/compatibility evidence from unknown deployed-build coverage.

Recognized retired columns remain in place to avoid table rebuilds: non-NULL endpoints in either the inline or defensively supported appended layout become NULL transactionally, while inline/appended audit `data_mode` stays inert and unchanged by later writes. Old unused directory tables and their rows remain untouched; pre-existing orphaned rows in those retired tables do not gate live-store adoption. SQLite errors retain extended result codes and transient BUSY/LOCKED classification while stripping database-controlled messages, including trigger text and stored values. Conversion errors retain safe categories, column indices and SQLite types without database-controlled names, values or nested causes; a shared-store result extension applies this mapper uniformly.

Non-goals: no session or app-cache migration changes, ledger coupling, directory movement, mirroring/reconciliation changes, encryption changes, crate split, error-enum redesign, telemetry/audit product change, data deletion to recover unknown schemas, or version bumps. Owner-only creation, WAL, synchronous NORMAL, 5-second busy timeout, foreign keys, trusted_schema, temp_store, and terminal close behavior are preserved.

Validation:

- TDD baseline: both initial contract tests failed against the old initializer (missing ledger; malformed table accepted).
- `cargo test -p storage-sqlite shared:: -- --nocapture`: 38 passed, including migration and upgrade assurance tests.
- `cargo test -p storage-sqlite`: 486 unit tests and 2 integration tests passed; 4 existing ignored tests; no failures.
- `cargo clippy -p storage-sqlite --all-targets -- -D warnings`: passed.
- `just fast-ci`: passed (including workspace default/OTLP check and clippy plus 5 convergence-policy tests).
- `cargo test -p cgka-conformance-simulator --test tracing_audit --locked`: 4 passed.
- Required docs stale-marker scan: both matches inspected (the scan command itself and the still-present engine Nostr-layering TODO); no stale migration guidance.
- `git diff --check`: passed.
- `cargo test -p marmot-app --test relay_runtime --features test-policy-overrides --locked app_runtime_readd_after_remove_resurfaces_removed_member_group -- --exact --nocapture`: 1 passed.
- `cargo test -p marmot-app --test relay_runtime --features test-policy-overrides --locked removed_member_triggers_local_push_token_cleanup -- --exact --nocapture`: 1 passed.

Assurance compares every typed value and rowid across 30,003 populated rows, exercises all historical fixtures, verifies integrity and foreign keys after upgrades, and covers body/ledger rollback plus bounded process-exit recovery with dirty-page spill under DELETE and WAL journaling. Process interruption is not power loss. These tests do not establish deployed-schema coverage, a field failure rate, or every disk-full/OS I/O failure. Conservative DDL recognition can refuse equivalent hand-edited schemas; refusal preserves data but can make the store unavailable pending a compatible binary or explicit repair. Full GitHub CI passed on `5f0dc400` ([run 34028647553](https://github.com/marmot-protocol/mdk/actions/runs/34028647553)), including Required CI, all Rust test shards, simulator/vector tests and the full relay-runtime suite. All platform binary builds also passed. The original head failed two relay-runtime tests; both passed focused local reruns using CI feature flags, and the token-cleanup assertion also failed identically on master run 33724316503. The updated head passed the full remote suite without weakening assertions or changing CI gates. This does not claim to eliminate the pre-existing relay-test flake.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved shared database upgrades with transactional migrations, schema validation, rollback protection, and recovery from interrupted upgrades.
  - Preserved compatible existing data and identifiers while handling legacy database layouts more safely.
  - Improved error handling for malformed, unsupported, or incomplete database schemas.

- **Documentation**
  - Documented shared database migration history, compatibility behavior, schema adoption, validation rules, and recovery guarantees.
  - Added reference fixtures covering historical database layouts and migration scenarios.

- **Tests**
  - Expanded coverage for upgrades, concurrent access, read-only databases, permissions, foreign-key validation, and migration failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
