### PR TITLE
feat: add durable interactive account onboarding

### DIFF
--- a/crates/cgka-conformance-simulator/src/app_runtime.rs
+++ b/crates/cgka-conformance-simulator/src/app_runtime.rs
@@ -1498,6 +1498,8 @@ fn app_error(error: AppError) -> SubjectError {
         | AppError::NotificationsDisabled
         | AppError::AccountSetupRecoveryRequired
         | AppError::AccountSetupRetryRequired
+        | AppError::OnboardingActionUnavailable
+        | AppError::OnboardingRequired
         | AppError::AccountSetupResetNotApplicable
         | AppError::AccountSetupKeyPackageRecoveryAvailable
         | AppError::ReactionNotFound => SubjectFailureCategory::ExpectedRefusal,

--- a/crates/marmot-account/src/home.rs
+++ b/crates/marmot-account/src/home.rs
@@ -122,6 +122,8 @@ pub enum AccountSetupKind {
     GeneratedIdentity,
     PublicIdentity,
     ExternalSigner,
+    /// Host-driven setup must remain gated until its app checkpoint completes.
+    InteractiveIdentity,
 }
 
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -411,6 +413,24 @@ impl AccountHome {
         &self,
         secret_key: &str,
     ) -> AccountHomeResult<NostrAccountImport> {
+        self.import_nostr_account_with_setup_kind(secret_key, AccountSetupKind::ImportedIdentity)
+    }
+
+    /// Persist the interactive setup provenance before making a new identity
+    /// visible. A crash before the app writes its detailed checkpoint remains
+    /// distinguishable from a completed or legacy account.
+    pub fn import_nostr_account_for_onboarding(
+        &self,
+        secret_key: &str,
+    ) -> AccountHomeResult<NostrAccountImport> {
+        self.import_nostr_account_with_setup_kind(secret_key, AccountSetupKind::InteractiveIdentity)
+    }
+
+    fn import_nostr_account_with_setup_kind(
+        &self,
+        secret_key: &str,
+        kind: AccountSetupKind,
+    ) -> AccountHomeResult<NostrAccountImport> {
         let keys =
             nostr::Keys::parse(secret_key).map_err(|_| AccountHomeError::InvalidSecretKey)?;
         let account_id_hex = keys.public_key().to_hex();
@@ -445,9 +465,7 @@ impl AccountHome {
             signed_out: false,
         };
         if let Some(setup) = self.raw_account_setup_state(&account.label)? {
-            if setup.account_id_hex != account.account_id_hex
-                || setup.kind != AccountSetupKind::ImportedIdentity
-            {
+            if setup.account_id_hex != account.account_id_hex || setup.kind != kind {
                 return Err(AccountHomeError::AccountExists(account.label));
             }
             match self.secret_store.load_secret(&account) {
@@ -481,7 +499,7 @@ impl AccountHome {
         let setup = AccountSetupState {
             account_id_hex: account.account_id_hex.clone(),
             reused_account_id_credential,
-            kind: AccountSetupKind::ImportedIdentity,
+            kind,
             phase: AccountSetupPhase::LocalStateCreated,
         };
         self.write_account_setup_state(&account.label, &setup)?;
@@ -617,6 +635,27 @@ impl AccountHome {
     pub fn account_setup_context(&self, account_ref: &str) -> AccountHomeResult<Option<Vec<u8>>> {
         let account = self.account(account_ref)?;
         match fs::read(self.account_setup_context_path(&account.label)) {
+            Ok(bytes) => Ok(Some(bytes)),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    /// App-owned onboarding checkpoint. Unlike setup context, this survives
+    /// setup completion so a host can distinguish checked from legacy accounts.
+    /// Bytes are private and atomically replaced; this layer assigns no meaning
+    /// to their schema or to the onboarding policy.
+    pub fn set_account_onboarding(&self, account_ref: &str, bytes: &[u8]) -> AccountHomeResult<()> {
+        let account = self.account(account_ref)?;
+        write_secret_bytes(
+            self.account_dir(&account.label).join("onboarding.json"),
+            bytes,
+        )
+    }
+
+    pub fn account_onboarding(&self, account_ref: &str) -> AccountHomeResult<Option<Vec<u8>>> {
+        let account = self.account(account_ref)?;
+        match fs::read(self.account_dir(&account.label).join("onboarding.json")) {
             Ok(bytes) => Ok(Some(bytes)),
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
             Err(err) => Err(err.into()),

--- a/crates/marmot-account/src/home.rs
+++ b/crates/marmot-account/src/home.rs
@@ -662,6 +662,44 @@ impl AccountHome {
         }
     }
 
+    /// Retain the last cancelled checkpoint while removing its active gate.
+    /// The caller must first durably sign out and retain any setup journal.
+    pub fn archive_account_onboarding(&self, account_ref: &str) -> AccountHomeResult<()> {
+        let _guard = self.mutation_lock.lock().unwrap_or_else(|p| p.into_inner());
+        let account = self.account(account_ref)?;
+        if !account.signed_out {
+            return Err(AccountHomeError::AccountExists(account.label));
+        }
+        let directory = self.account_dir(&account.label);
+        match fs::rename(
+            directory.join("onboarding.json"),
+            directory.join("onboarding-cancelled.json"),
+        ) {
+            Ok(()) => {
+                fs::File::open(directory)?.sync_all()?;
+                Ok(())
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Read the retained cancellation record for an explicit onboarding restart.
+    pub fn cancelled_account_onboarding(
+        &self,
+        account_ref: &str,
+    ) -> AccountHomeResult<Option<Vec<u8>>> {
+        let account = self.account(account_ref)?;
+        match fs::read(
+            self.account_dir(&account.label)
+                .join("onboarding-cancelled.json"),
+        ) {
+            Ok(bytes) => Ok(Some(bytes)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
     /// Remove an explicitly-authorized legacy incomplete setup while retaining
     /// the matching account-id-keyed credential for the immediate retry.
     pub fn reset_incomplete_setup_preserving_credential(

--- a/crates/marmot-app/AGENTS.md
+++ b/crates/marmot-app/AGENTS.md
@@ -12,7 +12,7 @@ App runtime bridge for the first real Marmot app surfaces.
   `account_worker.rs` (the per-account worker: command enum, worker loop, reconnect backoff, runtime-event publishers),
   `subscriptions.rs` (the `Runtime*Subscription` handles and the materialized-timeline window), `commands.rs` (the
   `AccountManager` command-RPC wrappers that send a worker command and await its oneshot reply), `agent_stream_watch.rs`
-  (agent-text-stream discovery and the brokered-QUIC watch machinery), `audit_tracker.rs` (the forensic audit-log
+  (agent-text-stream discovery and the brokered-QUIC watch machinery), `onboarding.rs` and `onboarding/` (durable preflight, cancellation, and advisory installation detection), `audit_tracker.rs` (the forensic audit-log
   tracker upload worker), and `event_routing.rs` (pure `MarmotAppEvent` classification/routing helpers). Keep `mod.rs`
   re-exporting the moved public types so `crate::runtime::Item` and the `marmot_app::...` paths stay stable.
 - Keep app-client commands and query methods in the `src/client/` module; the crate root should construct clients but

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -1161,6 +1161,8 @@ fn read_marker_error_code(error: &AppError) -> &'static str {
         AppError::AccountSetupRecoveryRequired => {
             "read_marker_failed:account_setup_recovery_required"
         }
+        AppError::OnboardingActionUnavailable => "read_marker_failed:onboarding_action_unavailable",
+        AppError::OnboardingRequired => "read_marker_failed:onboarding_required",
         AppError::AccountSetupRetryRequired => "read_marker_failed:account_setup_retry_required",
         AppError::AccountSetupResetNotApplicable => {
             "read_marker_failed:account_setup_reset_not_applicable"

--- a/crates/marmot-app/src/error.rs
+++ b/crates/marmot-app/src/error.rs
@@ -211,6 +211,10 @@ pub enum AppError {
     AccountSetupRecoveryRequired,
     #[error("durable account setup can be resumed by retrying the original operation")]
     AccountSetupRetryRequired,
+    #[error("onboarding action is unavailable or stale")]
+    OnboardingActionUnavailable,
+    #[error("account must complete interactive onboarding")]
+    OnboardingRequired,
     #[error("account is not in the legacy incomplete-setup reset state")]
     AccountSetupResetNotApplicable,
     #[error("recoverable KeyPackage setup state exists; retry instead of resetting")]
@@ -310,6 +314,8 @@ impl AppError {
             Self::AccountWorkerBusy => "account_worker_busy",
             Self::AccountWorkerResponseTimedOut => "account_worker_response_timed_out",
             Self::AccountSetupRecoveryRequired => "account_setup_recovery_required",
+            Self::OnboardingActionUnavailable => "onboarding_action_unavailable",
+            Self::OnboardingRequired => "onboarding_required",
             Self::AccountSetupRetryRequired => "account_setup_retry_required",
             Self::AccountSetupResetNotApplicable => "account_setup_reset_not_applicable",
             Self::AccountSetupKeyPackageRecoveryAvailable => {

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -83,9 +83,10 @@ mod drafts;
 mod error;
 mod external_signer;
 pub use runtime::{
-    OnboardingAction, OnboardingFinding, OnboardingIssue, OnboardingOptions,
-    OnboardingRepairProposal, OnboardingSnapshot, OnboardingStatus, OnboardingStep,
-    OnboardingStepState, OnboardingSubscription,
+    OnboardingAction, OnboardingDeviceDiscovery, OnboardingDevicePackage, OnboardingFinding,
+    OnboardingIssue, OnboardingOptions, OnboardingRepairProposal, OnboardingSingleDeviceNotice,
+    OnboardingSnapshot, OnboardingStatus, OnboardingStep, OnboardingStepState,
+    OnboardingSubscription,
 };
 mod groups;
 mod ids;

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -82,6 +82,11 @@ mod directory;
 mod drafts;
 mod error;
 mod external_signer;
+pub use runtime::{
+    OnboardingAction, OnboardingFinding, OnboardingIssue, OnboardingOptions,
+    OnboardingRepairProposal, OnboardingSnapshot, OnboardingStatus, OnboardingStep,
+    OnboardingStepState, OnboardingSubscription,
+};
 mod groups;
 mod ids;
 mod key_package_records;

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -82,12 +82,6 @@ mod directory;
 mod drafts;
 mod error;
 mod external_signer;
-pub use runtime::{
-    OnboardingAction, OnboardingDeviceDiscovery, OnboardingDevicePackage, OnboardingFinding,
-    OnboardingIssue, OnboardingOptions, OnboardingRepairProposal, OnboardingSingleDeviceNotice,
-    OnboardingSnapshot, OnboardingStatus, OnboardingStep, OnboardingStepState,
-    OnboardingSubscription,
-};
 mod groups;
 mod ids;
 mod key_package_records;
@@ -117,13 +111,17 @@ pub use runtime::{
     AccountManager, AccountSetupReadiness, AccountSetupRequest, AccountSetupResult,
     AgentStreamWatchOptions, AgentTextStreamCryptoContext, CatchUpAccountsSummary,
     ChatListUpdateTrigger, GroupLeaveFailure, LocalCleanupReport, ManagedAccount, MarmotAppEvent,
-    MarmotAppRuntime, RelayFailure, RuntimeAccountError, RuntimeAgentStreamMessage,
-    RuntimeAgentStreamUpdate, RuntimeAgentStreamWatch, RuntimeChatListSubscription,
-    RuntimeChatListUpdate, RuntimeChatsSubscription, RuntimeEventsSubscription, RuntimeGroupEvent,
-    RuntimeGroupStateSubscription, RuntimeMessageReceived, RuntimeMessageUpdate,
-    RuntimeMessagesSubscription, RuntimeNotificationsSubscription, RuntimeProjectionUpdate,
-    RuntimeSharedServices, RuntimeTimelineMessageUpdate, RuntimeTimelineMessagesSubscription,
-    SignOutOptions, SignOutOutcome, StreamStartView, TimelineWindowHandle, WipeOutcome,
+    MarmotAppRuntime, OnboardingAction, OnboardingDeviceDiscovery, OnboardingDevicePackage,
+    OnboardingFinding, OnboardingIssue, OnboardingOptions, OnboardingRepairProposal,
+    OnboardingSingleDeviceNotice, OnboardingSnapshot, OnboardingStatus, OnboardingStep,
+    OnboardingStepState, OnboardingSubscription, RelayFailure, RuntimeAccountError,
+    RuntimeAgentStreamMessage, RuntimeAgentStreamUpdate, RuntimeAgentStreamWatch,
+    RuntimeChatListSubscription, RuntimeChatListUpdate, RuntimeChatsSubscription,
+    RuntimeEventsSubscription, RuntimeGroupEvent, RuntimeGroupStateSubscription,
+    RuntimeMessageReceived, RuntimeMessageUpdate, RuntimeMessagesSubscription,
+    RuntimeNotificationsSubscription, RuntimeProjectionUpdate, RuntimeSharedServices,
+    RuntimeTimelineMessageUpdate, RuntimeTimelineMessagesSubscription, SignOutOptions,
+    SignOutOutcome, StreamStartView, TimelineWindowHandle, WipeOutcome,
     default_directory_discovery_relays,
 };
 pub(crate) use sqlcipher::{SqlcipherDatabaseKind, remove_sqlite_file_set};

--- a/crates/marmot-app/src/relay_plane/directory.rs
+++ b/crates/marmot-app/src/relay_plane/directory.rs
@@ -18,6 +18,17 @@ use super::DIRECTORY_RELAY_CONNECT_WAIT;
 
 const DIRECTORY_RELAY_FETCH_WAIT: Duration = Duration::from_secs(3);
 
+/// Stable errors for a bounded, isolated relay inspection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DirectoryInspectionError {
+    Unreachable,
+    TimedOut,
+    AuthenticationRequired,
+    PaymentRequired,
+    Restricted,
+    InvalidRequest,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DirectoryRelayConnectOutcome {
     Connected,
@@ -151,8 +162,8 @@ pub(crate) trait DirectoryRelayFetcher: Send + Sync {
         &self,
         _request: DirectoryFetchRequest,
         _signer: Option<Arc<dyn nostr::NostrSigner>>,
-    ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
-        Err("inspection unavailable".into())
+    ) -> Result<Vec<DirectoryRelayEventRecord>, DirectoryInspectionError> {
+        Err(DirectoryInspectionError::Unreachable)
     }
 }
 
@@ -224,7 +235,7 @@ impl DirectoryRelayPlane {
         &self,
         request: DirectoryFetchRequest,
         signer: Option<Arc<dyn nostr::NostrSigner>>,
-    ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
+    ) -> Result<Vec<DirectoryRelayEventRecord>, DirectoryInspectionError> {
         self.fetcher.inspect_directory_events(request, signer).await
     }
     pub(crate) fn new(fetcher: Arc<dyn DirectoryRelayFetcher>) -> Self {
@@ -598,30 +609,34 @@ impl DirectoryRelayFetcher for NostrSdkDirectoryRelayFetcher {
         &self,
         request: DirectoryFetchRequest,
         signer: Option<Arc<dyn nostr::NostrSigner>>,
-    ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
+    ) -> Result<Vec<DirectoryRelayEventRecord>, DirectoryInspectionError> {
+        use DirectoryInspectionError::*;
         use nostr_sdk::prelude::ReqExitPolicy;
         // The signer belongs to this request only, never to a shared mutable
         // directory client that could authenticate as another account.
-        let scoped = signer
-            .map(|signer| ScopedInspectionClient(NostrSdkClient::builder().signer(signer).build()));
-        let client = scoped.as_ref().map_or(&self.client, |scoped| &scoped.0);
-        let urls = parsed_directory_relay_urls(&request.endpoints)?;
+        let builder = NostrSdkClient::builder();
+        let client = ScopedInspectionClient(match signer {
+            Some(signer) => builder.signer(signer).build(),
+            None => builder.build(),
+        });
+        let client = &client.0;
+        let urls = parsed_directory_relay_urls(&request.endpoints).map_err(|_| InvalidRequest)?;
         if urls.len() != 1 {
-            return Err("inspection requires one relay".into());
+            return Err(InvalidRequest);
         }
         let url = urls[0].clone();
         client
             .add_relay(url.clone())
             .await
-            .map_err(|_| "unreachable")?;
+            .map_err(|_| Unreachable)?;
         timeout(
             DIRECTORY_RELAY_CONNECT_WAIT,
             client.connect_relay(url.clone()),
         )
         .await
-        .map_err(|_| "timeout")?
-        .map_err(|_| "unreachable")?;
-        let relay = client.relay(url).await.map_err(|_| "unreachable")?;
+        .map_err(|_| TimedOut)?
+        .map_err(|_| Unreachable)?;
+        let relay = client.relay(url).await.map_err(|_| Unreachable)?;
         let mut records = Vec::new();
         for query in request.queries {
             let keys = query
@@ -629,8 +644,8 @@ impl DirectoryRelayFetcher for NostrSdkDirectoryRelayFetcher {
                 .iter()
                 .map(|key| PublicKey::parse(key))
                 .collect::<Result<Vec<_>, _>>()
-                .map_err(|_| "invalid author")?;
-            let kind = u16::try_from(query.kind).map_err(|_| "invalid kind")?;
+                .map_err(|_| InvalidRequest)?;
+            let kind = u16::try_from(query.kind).map_err(|_| InvalidRequest)?;
             let filter = if query.kind == 1059 {
                 Filter::new().pubkeys(keys)
             } else {
@@ -648,22 +663,21 @@ impl DirectoryRelayFetcher for NostrSdkDirectoryRelayFetcher {
                 .map_err(|error| {
                     use nostr_sdk::pool::relay::Error;
                     match error {
-                        Error::Timeout => "timeout",
-                        Error::AuthenticationFailed => "auth-required",
+                        Error::Timeout => TimedOut,
+                        Error::AuthenticationFailed => AuthenticationRequired,
                         Error::RelayMessage(message) if message.starts_with("auth-required:") => {
-                            "auth-required"
+                            AuthenticationRequired
                         }
                         Error::RelayMessage(message)
                             if message.starts_with("payment-required:") =>
                         {
-                            "payment-required"
+                            PaymentRequired
                         }
                         Error::RelayMessage(_)
                         | Error::ReadDisabled
-                        | Error::ConnectionRejected { .. } => "restricted",
-                        _ => "unreachable",
+                        | Error::ConnectionRejected { .. } => Restricted,
+                        _ => Unreachable,
                     }
-                    .to_owned()
                 })?;
             if query.kind == 1059 {
                 continue;
@@ -885,6 +899,28 @@ fn parsed_directory_relay_urls(endpoints: &[TransportEndpoint]) -> Result<Vec<Re
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn signerless_inspection_never_retains_relays_in_the_shared_client() {
+        let relay = nostr_relay_builder::MockRelay::run().await.unwrap();
+        let endpoint = TransportEndpoint(relay.url().await.to_string());
+        let fetcher = NostrSdkDirectoryRelayFetcher::standalone();
+        let author = nostr::Keys::generate().public_key().to_hex();
+        for (author, succeeds) in [(author, true), ("invalid-author".into(), false)] {
+            let result = fetcher
+                .inspect_directory_events(
+                    DirectoryFetchRequest::new(
+                        vec![endpoint.clone()],
+                        vec![DirectoryEventQuery::new(0, vec![author], 1)],
+                    )
+                    .unwrap(),
+                    None,
+                )
+                .await;
+            assert_eq!(result.is_ok(), succeeds);
+            assert!(fetcher.client.relays().await.is_empty());
+        }
+    }
 
     #[test]
     fn directory_event_validation_rejects_invalid_signatures_and_wrong_authors() {

--- a/crates/marmot-app/src/relay_plane/directory.rs
+++ b/crates/marmot-app/src/relay_plane/directory.rs
@@ -144,11 +144,33 @@ pub(crate) trait DirectoryRelayFetcher: Send + Sync {
                 complete: false,
             })
     }
+
+    /// A single-relay read that must reach EOSE. Pool fetches may silently
+    /// aggregate partial results and cannot establish absence for onboarding.
+    async fn inspect_directory_events(
+        &self,
+        _request: DirectoryFetchRequest,
+        _signer: Option<Arc<dyn nostr::NostrSigner>>,
+    ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
+        Err("inspection unavailable".into())
+    }
 }
 
 #[derive(Clone)]
 pub(crate) struct NostrSdkDirectoryRelayFetcher {
     client: NostrSdkClient,
+}
+
+struct ScopedInspectionClient(NostrSdkClient);
+impl Drop for ScopedInspectionClient {
+    fn drop(&mut self) {
+        let client = self.0.clone();
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            runtime.spawn(async move {
+                let _ = client.shutdown().await;
+            });
+        }
+    }
 }
 
 impl DirectoryEventQuery {
@@ -198,6 +220,13 @@ impl DirectoryFetchRequest {
 }
 
 impl DirectoryRelayPlane {
+    pub(crate) async fn inspect_events(
+        &self,
+        request: DirectoryFetchRequest,
+        signer: Option<Arc<dyn nostr::NostrSigner>>,
+    ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
+        self.fetcher.inspect_directory_events(request, signer).await
+    }
     pub(crate) fn new(fetcher: Arc<dyn DirectoryRelayFetcher>) -> Self {
         Self {
             fetcher,
@@ -565,6 +594,92 @@ impl NostrSdkDirectoryRelayFetcher {
 
 #[async_trait]
 impl DirectoryRelayFetcher for NostrSdkDirectoryRelayFetcher {
+    async fn inspect_directory_events(
+        &self,
+        request: DirectoryFetchRequest,
+        signer: Option<Arc<dyn nostr::NostrSigner>>,
+    ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
+        use nostr_sdk::prelude::ReqExitPolicy;
+        // The signer belongs to this request only, never to a shared mutable
+        // directory client that could authenticate as another account.
+        let scoped = signer
+            .map(|signer| ScopedInspectionClient(NostrSdkClient::builder().signer(signer).build()));
+        let client = scoped.as_ref().map_or(&self.client, |scoped| &scoped.0);
+        let urls = parsed_directory_relay_urls(&request.endpoints)?;
+        if urls.len() != 1 {
+            return Err("inspection requires one relay".into());
+        }
+        let url = urls[0].clone();
+        client
+            .add_relay(url.clone())
+            .await
+            .map_err(|_| "unreachable")?;
+        timeout(
+            DIRECTORY_RELAY_CONNECT_WAIT,
+            client.connect_relay(url.clone()),
+        )
+        .await
+        .map_err(|_| "timeout")?
+        .map_err(|_| "unreachable")?;
+        let relay = client.relay(url).await.map_err(|_| "unreachable")?;
+        let mut records = Vec::new();
+        for query in request.queries {
+            let keys = query
+                .authors
+                .iter()
+                .map(|key| PublicKey::parse(key))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| "invalid author")?;
+            let kind = u16::try_from(query.kind).map_err(|_| "invalid kind")?;
+            let filter = if query.kind == 1059 {
+                Filter::new().pubkeys(keys)
+            } else {
+                Filter::new().authors(keys)
+            }
+            .kind(Kind::from(kind))
+            .limit(query.limit);
+            let events = relay
+                .fetch_events(
+                    filter,
+                    DIRECTORY_RELAY_FETCH_WAIT,
+                    ReqExitPolicy::ExitOnEOSE,
+                )
+                .await
+                .map_err(|error| {
+                    use nostr_sdk::pool::relay::Error;
+                    match error {
+                        Error::Timeout => "timeout",
+                        Error::AuthenticationFailed => "auth-required",
+                        Error::RelayMessage(message) if message.starts_with("auth-required:") => {
+                            "auth-required"
+                        }
+                        Error::RelayMessage(message)
+                            if message.starts_with("payment-required:") =>
+                        {
+                            "payment-required"
+                        }
+                        Error::RelayMessage(_)
+                        | Error::ReadDisabled
+                        | Error::ConnectionRejected { .. } => "restricted",
+                        _ => "unreachable",
+                    }
+                    .to_owned()
+                })?;
+            if query.kind == 1059 {
+                continue;
+            } // Read probe only; do not retain inbox payloads.
+            for event in events {
+                if let Some(event) = validated_directory_event(&event, &query) {
+                    records.push(DirectoryRelayEventRecord {
+                        endpoints: request.endpoints.clone(),
+                        event,
+                    });
+                }
+            }
+        }
+        Ok(records)
+    }
+
     async fn fetch_directory_events(
         &self,
         request: DirectoryFetchRequest,

--- a/crates/marmot-app/src/relay_plane/mod.rs
+++ b/crates/marmot-app/src/relay_plane/mod.rs
@@ -936,6 +936,22 @@ impl MarmotRelayPlane {
             .await
     }
 
+    pub(crate) async fn inspect_directory_events(
+        &self,
+        endpoint: TransportEndpoint,
+        query: DirectoryEventQuery,
+        signer: Option<Arc<dyn nostr::NostrSigner>>,
+    ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
+        let endpoints = self
+            .inner
+            .relay_safety
+            .sanitize_endpoints(vec![endpoint], "onboarding inspection")?;
+        self.inner
+            .directory
+            .inspect_events(DirectoryFetchRequest::new(endpoints, vec![query])?, signer)
+            .await
+    }
+
     /// Narrow discovered relay endpoints to the safe ones, dropping the rest.
     ///
     /// Unlike the fail-closed sanitize on the dial path, this is for endpoints

--- a/crates/marmot-app/src/relay_plane/mod.rs
+++ b/crates/marmot-app/src/relay_plane/mod.rs
@@ -43,9 +43,9 @@ pub use telemetry::{
 };
 
 pub(crate) use directory::{
-    DirectoryEventQuery, DirectoryFetchOutcome, DirectoryFetchRequest, DirectoryRelayEventRecord,
-    DirectoryRelayFetcher, DirectoryRelayPlane, DirectoryRelayStats, DirectorySubscriptionFilter,
-    DirectorySubscriptionSyncSummary, NostrSdkDirectoryRelayFetcher,
+    DirectoryEventQuery, DirectoryFetchOutcome, DirectoryFetchRequest, DirectoryInspectionError,
+    DirectoryRelayEventRecord, DirectoryRelayFetcher, DirectoryRelayPlane, DirectoryRelayStats,
+    DirectorySubscriptionFilter, DirectorySubscriptionSyncSummary, NostrSdkDirectoryRelayFetcher,
 };
 pub(crate) use safety::RelaySafetyPolicy;
 pub(crate) use telemetry::rollup_from_snapshots;
@@ -941,14 +941,19 @@ impl MarmotRelayPlane {
         endpoint: TransportEndpoint,
         query: DirectoryEventQuery,
         signer: Option<Arc<dyn nostr::NostrSigner>>,
-    ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
+    ) -> Result<Vec<DirectoryRelayEventRecord>, directory::DirectoryInspectionError> {
         let endpoints = self
             .inner
             .relay_safety
-            .sanitize_endpoints(vec![endpoint], "onboarding inspection")?;
+            .sanitize_endpoints(vec![endpoint], "onboarding inspection")
+            .map_err(|_| directory::DirectoryInspectionError::InvalidRequest)?;
         self.inner
             .directory
-            .inspect_events(DirectoryFetchRequest::new(endpoints, vec![query])?, signer)
+            .inspect_events(
+                DirectoryFetchRequest::new(endpoints, vec![query])
+                    .map_err(|_| directory::DirectoryInspectionError::InvalidRequest)?,
+                signer,
+            )
             .await
     }
 

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -695,6 +695,13 @@ async fn run_app_runtime_account_worker(
     let startup_stage_telemetry = shared.app_performance_telemetry();
     let startup_sync_result = {
         let mut initial_sync = std::pin::pin!(async {
+            #[cfg(any(test, feature = "test-policy-overrides"))]
+            if let Some(barrier) = shared.take_next_startup_sync_barrier() {
+                // First acknowledge entry, then hold sync until the test has
+                // exercised the command loop below.
+                barrier.wait().await;
+                barrier.wait().await;
+            }
             let summary = client
                 .sync_with_stage_telemetry(&startup_stage_telemetry)
                 .await?;

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -1702,7 +1702,7 @@ impl AccountManager {
         &self,
         account_ref: &str,
     ) -> Result<usize, AppError> {
-        let command = self.worker_commands(account_ref).await?;
+        let command = self.worker_commands_for_setup(account_ref).await?;
         let (respond, response) = oneshot::channel();
         command
             .send(AccountWorkerCommand::PublishSetupKeyPackage { respond })

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -230,6 +230,8 @@ pub struct RuntimeSharedServices {
     /// scheduler timing. Consulted only with the `test-policy-overrides`
     /// feature; always `None` in production.
     create_group_catch_up_barrier: Arc<StdMutex<Option<Arc<tokio::sync::Notify>>>>,
+    #[cfg(any(test, feature = "test-policy-overrides"))]
+    next_startup_sync_barrier: Arc<StdMutex<Option<Arc<tokio::sync::Barrier>>>>,
 }
 
 const MESSAGE_SUBSCRIPTION_SEEN_ID_LIMIT: usize = MAX_SEEN_EVENT_IDS;
@@ -308,6 +310,8 @@ impl Default for RuntimeSharedServices {
             service_endpoints: MarmotServiceEndpoints::default(),
             audit_log_tracker_uploader: None,
             create_group_catch_up_barrier: Arc::new(StdMutex::new(None)),
+            #[cfg(any(test, feature = "test-policy-overrides"))]
+            next_startup_sync_barrier: Arc::new(StdMutex::new(None)),
         }
     }
 }
@@ -334,6 +338,8 @@ impl RuntimeSharedServices {
             service_endpoints: app.service_endpoints().clone(),
             audit_log_tracker_uploader: Some(audit_log_tracker_uploader),
             create_group_catch_up_barrier: Arc::new(StdMutex::new(None)),
+            #[cfg(any(test, feature = "test-policy-overrides"))]
+            next_startup_sync_barrier: Arc::new(StdMutex::new(None)),
         }
     }
 
@@ -360,6 +366,20 @@ impl RuntimeSharedServices {
 
     fn create_group_catch_up_barrier(&self) -> Option<Arc<tokio::sync::Notify>> {
         self.create_group_catch_up_barrier.lock().unwrap().clone()
+    }
+
+    /// Test-only hook: rendezvous once when the next worker reaches initial
+    /// sync, then again to release it after read assertions. Consumed once so
+    /// later restarts cannot inherit it.
+    #[cfg(any(test, feature = "test-policy-overrides"))]
+    #[doc(hidden)]
+    pub fn set_next_startup_sync_barrier(&self, barrier: Arc<tokio::sync::Barrier>) {
+        *self.next_startup_sync_barrier.lock().unwrap() = Some(barrier);
+    }
+
+    #[cfg(any(test, feature = "test-policy-overrides"))]
+    fn take_next_startup_sync_barrier(&self) -> Option<Arc<tokio::sync::Barrier>> {
+        self.next_startup_sync_barrier.lock().unwrap().take()
     }
 
     pub(crate) fn lifecycle(&self) -> RuntimeLifecycle {

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -3985,12 +3985,12 @@ impl MarmotAppRuntime {
         account_ref: &str,
     ) -> Result<AccountSetupReadiness, AppError> {
         let account = self.accounts.resolve(account_ref)?;
-        if let Some(onboarding) = self.accounts.onboarding_snapshot(account_ref)? {
-            return Ok(if onboarding.ready {
-                AccountSetupReadiness::NetworkReady
-            } else {
-                AccountSetupReadiness::Initializing
-            });
+        if self
+            .accounts
+            .onboarding_snapshot(account_ref)?
+            .is_some_and(|s| !s.ready)
+        {
+            return Ok(AccountSetupReadiness::Initializing);
         }
         if self
             .accounts
@@ -5022,13 +5022,17 @@ impl AccountManager {
                 .collect::<Vec<_>>();
             let accounts = accounts
                 .into_iter()
-                .map(|account| {
-                    self.onboarding_worker_allowed(&account.label)
-                        .map(|allowed| allowed.then_some(account))
-                })
-                .collect::<Result<Vec<_>, _>>()?
-                .into_iter()
-                .flatten()
+                .filter(
+                    |account| match self.onboarding_worker_allowed(&account.label) {
+                        Ok(allowed) => allowed,
+                        Err(error) => {
+                            tracing::warn!(target: "marmot_app::runtime", method = "reconcile",
+                                error_kind = error.privacy_safe_kind(),
+                                "gated one account with an unreadable onboarding checkpoint");
+                            false
+                        }
+                    },
+                )
                 .collect::<Vec<_>>();
             let active_account_ids = accounts
                 .iter()
@@ -5365,8 +5369,9 @@ impl AccountManager {
         account_ref: &str,
     ) -> Result<mpsc::Sender<AccountWorkerCommand>, AppError> {
         self.shared.lifecycle().ensure_running()?;
-        self.require_onboarding_complete(account_ref)?;
-        self.worker_commands_for_setup(account_ref).await
+        let account = self.resolve(account_ref)?;
+        self.require_onboarding_complete_for(&account)?;
+        self.worker_commands_for_account(account).await
     }
 
     async fn worker_commands_for_setup(
@@ -5375,6 +5380,12 @@ impl AccountManager {
     ) -> Result<mpsc::Sender<AccountWorkerCommand>, AppError> {
         self.shared.lifecycle().ensure_running()?;
         let account = self.resolve(account_ref)?;
+        self.worker_commands_for_account(account).await
+    }
+    async fn worker_commands_for_account(
+        &self,
+        account: AccountSummary,
+    ) -> Result<mpsc::Sender<AccountWorkerCommand>, AppError> {
         if !account.can_sign() {
             return Err(AccountHomeError::SecretNotFound(account.account_id_hex).into());
         }
@@ -5413,6 +5424,16 @@ impl AccountManager {
             .map(|value| value.as_str())
             .or(request.identity.as_deref());
         let (mut account, private_key_import) = if let Some(identity) = identity_key {
+            let account_id = if crate::is_nostr_secret(identity) {
+                AccountHome::account_id_for_secret(identity)?
+            } else {
+                AccountHome::account_id_for_public_key(identity)?
+            };
+            match self.app.account_home().account(&account_id) {
+                Ok(account) => self.require_onboarding_complete(&account.label)?,
+                Err(AccountHomeError::UnknownAccount(_)) => {}
+                Err(error) => return Err(error.into()),
+            }
             match self.signed_out_account_for_identity(identity)? {
                 Some(account) => (account, None),
                 None => self.create_nostr_account_from_setup(&request)?,
@@ -5420,7 +5441,6 @@ impl AccountManager {
         } else {
             self.create_nostr_account_from_setup(&request)?
         };
-        self.require_onboarding_complete(&account.label)?;
         let reactivating_existing = account.signed_out;
         let recent_relay_lists =
             if imports_private_key || reactivating_existing || !account.local_signing {
@@ -5633,10 +5653,10 @@ impl AccountManager {
         if signer_public_key.to_hex() != account_id_hex {
             return Err(AppError::ExternalSignerMismatch);
         }
-        if let Ok(account) = self.app.account_home().account(&account_id_hex) {
+        let existing_account = self.app.account_home().account(&account_id_hex).ok();
+        if let Some(account) = existing_account.as_ref() {
             self.require_onboarding_complete(&account.label)?;
         }
-        let existing_account = self.app.account_home().account(&account_id_hex).ok();
         let created_account = existing_account.is_none();
         // add_external_signer_account below promotes a pre-existing tracked
         // (public) account to external_signing, so a later setup failure must

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -62,6 +62,8 @@ mod agent_stream_watch;
 mod audit_tracker;
 mod commands;
 mod event_routing;
+mod onboarding;
+pub use onboarding::*;
 mod subscriptions;
 
 // Re-export the public surface so `crate::runtime::Item` and the
@@ -182,6 +184,8 @@ pub struct AccountManager {
     tearing_down: Arc<StdMutex<HashSet<String>>>,
     worker_transactions: Arc<Mutex<()>>,
     generated_setup_local_transaction: Arc<Mutex<()>>,
+    onboarding_transactions: Arc<StdMutex<HashMap<String, std::sync::Weak<Mutex<()>>>>>,
+    onboarding_updates: Arc<StdMutex<HashMap<String, watch::Sender<OnboardingSnapshot>>>>,
     #[cfg(test)]
     reconcile_rollback_waiters: Arc<StdMutex<Vec<std::sync::mpsc::Sender<()>>>>,
     invite_catch_up_tasks: Arc<StdMutex<InviteCatchUpTasks>>,
@@ -3981,6 +3985,13 @@ impl MarmotAppRuntime {
         account_ref: &str,
     ) -> Result<AccountSetupReadiness, AppError> {
         let account = self.accounts.resolve(account_ref)?;
+        if let Some(onboarding) = self.accounts.onboarding_snapshot(account_ref)? {
+            return Ok(if onboarding.ready {
+                AccountSetupReadiness::NetworkReady
+            } else {
+                AccountSetupReadiness::Initializing
+            });
+        }
         if self
             .accounts
             .app
@@ -4702,6 +4713,8 @@ impl AccountManager {
             tearing_down: Arc::new(StdMutex::new(HashSet::new())),
             worker_transactions: Arc::new(Mutex::new(())),
             generated_setup_local_transaction: Arc::new(Mutex::new(())),
+            onboarding_transactions: Arc::new(StdMutex::new(HashMap::new())),
+            onboarding_updates: Arc::new(StdMutex::new(HashMap::new())),
             #[cfg(test)]
             reconcile_rollback_waiters: Arc::new(StdMutex::new(Vec::new())),
             invite_catch_up_tasks: Arc::new(StdMutex::new(InviteCatchUpTasks {
@@ -4830,6 +4843,10 @@ impl AccountManager {
             // account live, and a live external-signer account still needs its
             // signer to reconcile.
             self.app.forget_external_signer(&account.account_id_hex);
+            self.onboarding_updates
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .remove(&account.account_id_hex);
             Ok(())
         }
         .await;
@@ -5002,6 +5019,16 @@ impl AccountManager {
                                 && !account.signed_out
                                 && self.app.has_external_signer(&account.account_id_hex)))
                 })
+                .collect::<Vec<_>>();
+            let accounts = accounts
+                .into_iter()
+                .map(|account| {
+                    self.onboarding_worker_allowed(&account.label)
+                        .map(|allowed| allowed.then_some(account))
+                })
+                .collect::<Result<Vec<_>, _>>()?
+                .into_iter()
+                .flatten()
                 .collect::<Vec<_>>();
             let active_account_ids = accounts
                 .iter()
@@ -5338,6 +5365,15 @@ impl AccountManager {
         account_ref: &str,
     ) -> Result<mpsc::Sender<AccountWorkerCommand>, AppError> {
         self.shared.lifecycle().ensure_running()?;
+        self.require_onboarding_complete(account_ref)?;
+        self.worker_commands_for_setup(account_ref).await
+    }
+
+    async fn worker_commands_for_setup(
+        &self,
+        account_ref: &str,
+    ) -> Result<mpsc::Sender<AccountWorkerCommand>, AppError> {
+        self.shared.lifecycle().ensure_running()?;
         let account = self.resolve(account_ref)?;
         if !account.can_sign() {
             return Err(AccountHomeError::SecretNotFound(account.account_id_hex).into());
@@ -5384,6 +5420,7 @@ impl AccountManager {
         } else {
             self.create_nostr_account_from_setup(&request)?
         };
+        self.require_onboarding_complete(&account.label)?;
         let reactivating_existing = account.signed_out;
         let recent_relay_lists =
             if imports_private_key || reactivating_existing || !account.local_signing {
@@ -5595,6 +5632,9 @@ impl AccountManager {
         let account_id_hex = AccountHome::account_id_for_public_key(&public_key)?;
         if signer_public_key.to_hex() != account_id_hex {
             return Err(AppError::ExternalSignerMismatch);
+        }
+        if let Ok(account) = self.app.account_home().account(&account_id_hex) {
+            self.require_onboarding_complete(&account.label)?;
         }
         let existing_account = self.app.account_home().account(&account_id_hex).ok();
         let created_account = existing_account.is_none();
@@ -6355,6 +6395,10 @@ impl AccountManager {
 
     pub async fn shutdown(&self) {
         self.shared.lifecycle().begin_shutdown();
+        self.onboarding_updates
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clear();
         let generated_setup_tasks = {
             let mut tasks = self
                 .generated_setup_tasks

--- a/crates/marmot-app/src/runtime/onboarding.rs
+++ b/crates/marmot-app/src/runtime/onboarding.rs
@@ -91,6 +91,7 @@ pub struct OnboardingDevicePackage {
     /// Original event timestamp, not a last-active timestamp.
     pub published_at: u64,
     pub expires_at: Option<u64>,
+    #[serde(default)]
     pub usable: bool,
 }
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -400,6 +401,20 @@ impl AccountManager {
         for (index, step) in checkpoint.snapshot.steps.iter().enumerate() {
             if step.step.index() != index {
                 return Err(onboarding_error());
+            }
+        }
+        // Older checkpoints did not offer rechecks of finished steps. Refresh
+        // these derived hints before exposing or validating the snapshot, while
+        // retaining the offered-action contract and cancellation's sole exit.
+        if !checkpoint.snapshot.cancellation_pending {
+            for step in &mut checkpoint.snapshot.steps {
+                if matches!(
+                    step.status,
+                    OnboardingStatus::Passed | OnboardingStatus::Skipped
+                ) && !step.actions.contains(&OnboardingAction::Retry)
+                {
+                    step.actions.push(OnboardingAction::Retry);
+                }
             }
         }
         Ok(Some(checkpoint))

--- a/crates/marmot-app/src/runtime/onboarding.rs
+++ b/crates/marmot-app/src/runtime/onboarding.rs
@@ -6,7 +6,10 @@ use crate::relay_plane::{DirectoryEventQuery, DirectoryRelayEventRecord, RelayEn
 use nostr::{EventBuilder, Kind, PublicKey, Tag, Timestamp};
 use transport_nostr_peeler::NostrTransportEvent;
 
-const ONBOARDING_VERSION: u32 = 1;
+mod single_device;
+
+const ONBOARDING_VERSION: u32 = 2;
+const STEP_COUNT: usize = 6;
 const MAX_RELAYS: usize = 16;
 const CHECK_WAIT: Duration = Duration::from_secs(15);
 const CHECK_MAX_AGE: u64 = 300;
@@ -18,6 +21,7 @@ pub enum OnboardingStep {
     Relays,
     InboxRelays,
     KeyPackage,
+    SingleDevice,
 }
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum OnboardingStatus {
@@ -49,6 +53,9 @@ pub enum OnboardingIssue {
     RecordChanged,
     Interrupted,
     TooManyRelays,
+    MultiDeviceUnsupported,
+    OtherInstallationPossible,
+    DiscoveryIncomplete,
 }
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum OnboardingAction {
@@ -62,6 +69,31 @@ pub enum OnboardingAction {
     CancelRepair,
     ReconnectSigner,
     EditDiscoveryRelays,
+    ContinueAnyway,
+    CancelOnboarding,
+}
+/// Evidence from the queried relays, never a claim that multi-device use is safe.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum OnboardingDeviceDiscovery {
+    NoneFound,
+    OtherInstallationPossible,
+    Unknown,
+}
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OnboardingDevicePackage {
+    pub slot_id: String,
+    pub key_package_ref_hex: String,
+    pub event_id_hex: String,
+    /// Original event timestamp, not a last-active timestamp.
+    pub published_at: u64,
+    pub expires_at: u64,
+}
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OnboardingSingleDeviceNotice {
+    pub discovery: OnboardingDeviceDiscovery,
+    pub other_packages: Vec<OnboardingDevicePackage>,
+    pub discovery_complete: bool,
+    pub acknowledged_at: Option<u64>,
 }
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OnboardingFinding {
@@ -95,6 +127,8 @@ pub struct OnboardingSnapshot {
     pub ready: bool,
     pub steps: Vec<OnboardingStepState>,
     pub proposal: Option<OnboardingRepairProposal>,
+    #[serde(default)]
+    pub single_device_notice: Option<OnboardingSingleDeviceNotice>,
 }
 /// Hosts pass the same default relay set used by account creation. Discovery
 /// relays are independent indexers and are never implicitly published.
@@ -113,6 +147,8 @@ struct OnboardingCheckpoint {
     // a retry republishes precisely the same event once signed.
     approved: bool,
     signed_repair: Option<NostrTransportEvent>,
+    #[serde(default)]
+    single_device_acknowledged: bool,
 }
 
 pub struct OnboardingSubscription {
@@ -132,7 +168,8 @@ impl OnboardingStep {
             Self::Follows => 1,
             Self::Relays => 2,
             Self::InboxRelays => 3,
-            Self::KeyPackage => 4,
+            Self::SingleDevice => 4,
+            Self::KeyPackage => 5,
         }
     }
     fn kind(self) -> u64 {
@@ -141,7 +178,7 @@ impl OnboardingStep {
             Self::Follows => 3,
             Self::Relays => 10002,
             Self::InboxRelays => 10050,
-            Self::KeyPackage => 30443,
+            Self::KeyPackage | Self::SingleDevice => 30443,
         }
     }
     fn optional(self) -> bool {
@@ -158,6 +195,7 @@ impl OnboardingCheckpoint {
             OnboardingStep::Follows,
             OnboardingStep::Relays,
             OnboardingStep::InboxRelays,
+            OnboardingStep::SingleDevice,
             OnboardingStep::KeyPackage,
         ]
         .into_iter()
@@ -177,11 +215,13 @@ impl OnboardingCheckpoint {
                 ready: false,
                 steps,
                 proposal: None,
+                single_device_notice: None,
             },
             options,
-            records: vec![None; 5],
+            records: vec![None; STEP_COUNT],
             approved: false,
             signed_repair: None,
+            single_device_acknowledged: false,
         }
     }
     fn set(
@@ -191,6 +231,12 @@ impl OnboardingCheckpoint {
         findings: Vec<OnboardingFinding>,
     ) {
         let actions = match status {
+            OnboardingStatus::NeedsInput if step == OnboardingStep::SingleDevice => vec![
+                OnboardingAction::ContinueAnyway,
+                OnboardingAction::CancelOnboarding,
+                OnboardingAction::Retry,
+                OnboardingAction::EditDiscoveryRelays,
+            ],
             OnboardingStatus::NeedsInput | OnboardingStatus::RetryableFailure => {
                 let mut actions = vec![
                     OnboardingAction::Retry,
@@ -266,12 +312,50 @@ impl AccountManager {
         let Some(bytes) = self.app.account_home().account_onboarding(account_ref)? else {
             return Ok(None);
         };
-        let checkpoint: OnboardingCheckpoint = serde_json::from_slice(&bytes)?;
+        let mut checkpoint: OnboardingCheckpoint = serde_json::from_slice(&bytes)?;
         let account = self.resolve(account_ref)?;
+        // Upgrade the pre-notice checkpoint without activating an unfinished
+        // account. Completed accounts are not retroactively gated; a new sign-in
+        // resets every step and requires the notice then.
+        if checkpoint.version == 1
+            && checkpoint.snapshot.steps.len() == 5
+            && checkpoint.records.len() == 5
+            && checkpoint.snapshot.steps.iter().map(|s| s.step).eq([
+                OnboardingStep::Profile,
+                OnboardingStep::Follows,
+                OnboardingStep::Relays,
+                OnboardingStep::InboxRelays,
+                OnboardingStep::KeyPackage,
+            ])
+        {
+            checkpoint.snapshot.steps.insert(
+                4,
+                OnboardingStepState {
+                    step: OnboardingStep::SingleDevice,
+                    status: if checkpoint.snapshot.ready {
+                        OnboardingStatus::Skipped
+                    } else {
+                        OnboardingStatus::Pending
+                    },
+                    findings: Vec::new(),
+                    actions: Vec::new(),
+                    checked_at: None,
+                },
+            );
+            checkpoint.records.insert(4, None);
+            if !checkpoint.snapshot.ready {
+                checkpoint.set(
+                    OnboardingStep::KeyPackage,
+                    OnboardingStatus::Pending,
+                    Vec::new(),
+                );
+            }
+            checkpoint.version = ONBOARDING_VERSION;
+        }
         if checkpoint.version != ONBOARDING_VERSION
             || checkpoint.snapshot.account_id_hex != account.account_id_hex
-            || checkpoint.snapshot.steps.len() != 5
-            || checkpoint.records.len() != 5
+            || checkpoint.snapshot.steps.len() != STEP_COUNT
+            || checkpoint.records.len() != STEP_COUNT
         {
             return Err(onboarding_error());
         }
@@ -369,7 +453,7 @@ impl AccountManager {
         Ok(checkpoint.is_none_or(|c| {
             c.snapshot.ready
                 || matches!(
-                    c.snapshot.steps[4].status,
+                    c.snapshot.steps[OnboardingStep::KeyPackage.index()].status,
                     OnboardingStatus::Checking
                         | OnboardingStatus::WaitingForSigner
                         | OnboardingStatus::Passed
@@ -399,7 +483,9 @@ impl AccountManager {
     ) -> Result<OnboardingSnapshot, AppError> {
         if let Some(mut existing) = self.onboarding_checkpoint(&account.label)? {
             if account.signed_out && existing.snapshot.ready {
-                for index in 0..5 {
+                existing.single_device_acknowledged = false;
+                existing.snapshot.single_device_notice = None;
+                for index in 0..STEP_COUNT {
                     let step = existing.snapshot.steps[index].step;
                     existing.set(step, OnboardingStatus::Pending, Vec::new());
                 }
@@ -424,21 +510,28 @@ impl AccountManager {
         let transaction = self.onboarding_transaction(&id);
         let _transaction = transaction.lock().await;
         let _workers = self.worker_transactions.lock().await;
-        let account = match self.app.account_home().account(&id) {
-            Ok(account) if account.local_signing => self
-                .app
-                .account_home()
-                .import_account_idempotent(&account.label, &nsec)?,
+        let snapshot = match self.app.account_home().account(&id) {
+            Ok(account) if account.local_signing => {
+                // Reset a completed checkpoint before import clears signed_out.
+                // A crash between the two writes must leave the account gated.
+                let snapshot = self.initialize_onboarding(&account, options)?;
+                self.app
+                    .account_home()
+                    .import_account_idempotent(&account.label, &nsec)?;
+                snapshot
+            }
             Ok(_) => return Err(onboarding_error()),
-            Err(AccountHomeError::UnknownAccount(_)) => self
-                .app
-                .account_home()
-                .import_nostr_account_for_onboarding(&nsec)?
-                .account()
-                .clone(),
+            Err(AccountHomeError::UnknownAccount(_)) => {
+                let account = self
+                    .app
+                    .account_home()
+                    .import_nostr_account_for_onboarding(&nsec)?
+                    .account()
+                    .clone();
+                self.initialize_onboarding(&account, options)?
+            }
             Err(error) => return Err(error.into()),
         };
-        let snapshot = self.initialize_onboarding(&account, options)?;
         self.reconcile_locked().await?;
         Ok(snapshot)
     }
@@ -463,12 +556,25 @@ impl AccountManager {
         let transaction = self.onboarding_transaction(&id);
         let _transaction = transaction.lock().await;
         let _workers = self.worker_transactions.lock().await;
-        let account = self
-            .app
-            .account_home()
-            .add_external_signer_account(&public_key)?;
-        // Gate the account before registering a signer can make it runnable.
-        let snapshot = self.initialize_onboarding(&account, options)?;
+        // Existing identities must be gated before promotion can clear their
+        // signed-out state, and before signer registration makes them runnable.
+        let snapshot = match self.app.account_home().account(&id) {
+            Ok(account) => {
+                let snapshot = self.initialize_onboarding(&account, options)?;
+                self.app
+                    .account_home()
+                    .add_external_signer_account(&public_key)?;
+                snapshot
+            }
+            Err(AccountHomeError::UnknownAccount(_)) => {
+                let account = self
+                    .app
+                    .account_home()
+                    .add_external_signer_account(&public_key)?;
+                self.initialize_onboarding(&account, options)?
+            }
+            Err(error) => return Err(error.into()),
+        };
         self.reconcile_locked().await?;
         drop(_workers);
         self.app.register_external_signer(&id, signer).await?;
@@ -522,7 +628,7 @@ impl AccountManager {
         } else if c.snapshot.proposal.is_some() {
             return Ok(());
         }
-        for index in 0..5 {
+        for index in 0..STEP_COUNT {
             let step = c.snapshot.steps[index].step;
             match c.snapshot.steps[index].status {
                 OnboardingStatus::Passed | OnboardingStatus::Skipped => continue,
@@ -533,7 +639,13 @@ impl AccountManager {
             }
             c.set(step, OnboardingStatus::Checking, Vec::new());
             self.save_onboarding(c)?;
-            if step == OnboardingStep::KeyPackage {
+            if step == OnboardingStep::SingleDevice {
+                if c.single_device_acknowledged {
+                    c.set(step, OnboardingStatus::Passed, Vec::new());
+                } else {
+                    self.check_onboarding_single_device(c).await?;
+                }
+            } else if step == OnboardingStep::KeyPackage {
                 let account = self.resolve(&c.snapshot.account_id_hex)?;
                 if account.external_signing
                     && !self.app.has_external_signer(&account.account_id_hex)
@@ -633,7 +745,11 @@ impl AccountManager {
         } else {
             c.snapshot.proposal = None;
             // Rechecking earlier prerequisites invalidates publication readiness.
-            for index in step.index()..5 {
+            if step == OnboardingStep::SingleDevice {
+                c.single_device_acknowledged = false;
+                c.snapshot.single_device_notice = None;
+            }
+            for index in step.index()..STEP_COUNT {
                 let next = c.snapshot.steps[index].step;
                 c.set(next, OnboardingStatus::Pending, Vec::new());
             }
@@ -665,7 +781,7 @@ impl AccountManager {
         self.validate_onboarding_options(&options)?;
         c.options = options;
         c.snapshot.proposal = None;
-        for index in 0..5 {
+        for index in 0..STEP_COUNT {
             if c.snapshot.steps[index].status != OnboardingStatus::Skipped {
                 let step = c.snapshot.steps[index].step;
                 c.set(step, OnboardingStatus::Pending, Vec::new());
@@ -784,6 +900,10 @@ impl AccountManager {
             match result {
                 Ok((_, Ok(events))) => {
                     completed += 1;
+                    // A full bounded page may omit another installation's slot.
+                    if kind == 30443 && events.len() >= 32 {
+                        failures.push(finding(OnboardingIssue::DiscoveryIncomplete));
+                    }
                     records.extend(events.into_iter().map(|r| r.event));
                 }
                 Ok((endpoint, Err(error))) => {
@@ -805,9 +925,13 @@ impl AccountManager {
         // Enforce the event boundary even for injected fetchers. Never let an
         // older valid event hide a newer signed but malformed declaration.
         records.retain(|event| {
-            event.kind == kind
+            let valid = event.kind == kind
                 && event.pubkey == account_id
-                && event.to_verified_nostr_event().is_ok()
+                && event.to_verified_nostr_event().is_ok();
+            if kind == 30443 && !valid {
+                failures.push(finding(OnboardingIssue::Malformed));
+            }
+            valid
         });
         records.sort_by(|a, b| b.created_at.cmp(&a.created_at).then(a.id.cmp(&b.id)));
         records.dedup_by(|a, b| a.id == b.id);

--- a/crates/marmot-app/src/runtime/onboarding.rs
+++ b/crates/marmot-app/src/runtime/onboarding.rs
@@ -6,6 +6,7 @@ use crate::relay_plane::{DirectoryEventQuery, DirectoryRelayEventRecord, RelayEn
 use nostr::{EventBuilder, Kind, PublicKey, Tag, Timestamp};
 use transport_nostr_peeler::NostrTransportEvent;
 
+mod cancellation;
 mod single_device;
 
 const ONBOARDING_VERSION: u32 = 2;
@@ -13,6 +14,9 @@ const STEP_COUNT: usize = 6;
 const MAX_RELAYS: usize = 16;
 const CHECK_WAIT: Duration = Duration::from_secs(15);
 const CHECK_MAX_AGE: u64 = 300;
+const FUTURE_CLOCK_SKEW: u64 = 300;
+const DISCOVERY_PAGE_LIMIT: usize = 32;
+const MAX_FOLLOWS: usize = 10_000;
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum OnboardingStep {
@@ -20,8 +24,8 @@ pub enum OnboardingStep {
     Follows,
     Relays,
     InboxRelays,
-    KeyPackage,
     SingleDevice,
+    KeyPackage,
 }
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum OnboardingStatus {
@@ -82,11 +86,12 @@ pub enum OnboardingDeviceDiscovery {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OnboardingDevicePackage {
     pub slot_id: String,
-    pub key_package_ref_hex: String,
+    pub key_package_ref_hex: Option<String>,
     pub event_id_hex: String,
     /// Original event timestamp, not a last-active timestamp.
     pub published_at: u64,
-    pub expires_at: u64,
+    pub expires_at: Option<u64>,
+    pub usable: bool,
 }
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OnboardingSingleDeviceNotice {
@@ -129,6 +134,8 @@ pub struct OnboardingSnapshot {
     pub proposal: Option<OnboardingRepairProposal>,
     #[serde(default)]
     pub single_device_notice: Option<OnboardingSingleDeviceNotice>,
+    #[serde(default)]
+    pub cancellation_pending: bool,
 }
 /// Hosts pass the same default relay set used by account creation. Discovery
 /// relays are independent indexers and are never implicitly published.
@@ -149,6 +156,8 @@ struct OnboardingCheckpoint {
     signed_repair: Option<NostrTransportEvent>,
     #[serde(default)]
     single_device_acknowledged: bool,
+    #[serde(default)]
+    setup_cleanup_pending: bool,
 }
 
 pub struct OnboardingSubscription {
@@ -189,6 +198,17 @@ impl OnboardingStep {
     }
 }
 impl OnboardingCheckpoint {
+    fn reset_step(&mut self, step: OnboardingStep) {
+        if step.optional() && self.snapshot.steps[step.index()].status == OnboardingStatus::Skipped
+        {
+            return;
+        }
+        if step == OnboardingStep::SingleDevice {
+            self.single_device_acknowledged = false;
+            self.snapshot.single_device_notice = None;
+        }
+        self.set(step, OnboardingStatus::Pending, Vec::new());
+    }
     fn new(account: &AccountSummary, options: OnboardingOptions) -> Self {
         let steps = [
             OnboardingStep::Profile,
@@ -216,12 +236,14 @@ impl OnboardingCheckpoint {
                 steps,
                 proposal: None,
                 single_device_notice: None,
+                cancellation_pending: false,
             },
             options,
             records: vec![None; STEP_COUNT],
             approved: false,
             signed_repair: None,
             single_device_acknowledged: false,
+            setup_cleanup_pending: false,
         }
     }
     fn set(
@@ -264,6 +286,7 @@ impl OnboardingCheckpoint {
             OnboardingStatus::WaitingForSigner => {
                 vec![OnboardingAction::ReconnectSigner, OnboardingAction::Retry]
             }
+            OnboardingStatus::Passed | OnboardingStatus::Skipped => vec![OnboardingAction::Retry],
             _ => Vec::new(),
         };
         self.snapshot.steps[step.index()] = OnboardingStepState {
@@ -309,11 +332,26 @@ impl AccountManager {
         &self,
         account_ref: &str,
     ) -> Result<Option<OnboardingCheckpoint>, AppError> {
-        let Some(bytes) = self.app.account_home().account_onboarding(account_ref)? else {
+        let c = self.read_onboarding_checkpoint(account_ref)?;
+        if c.as_ref().is_some_and(|c| c.snapshot.cancellation_pending) {
+            return Err(onboarding_error());
+        }
+        Ok(c)
+    }
+    fn read_onboarding_checkpoint(
+        &self,
+        account_ref: &str,
+    ) -> Result<Option<OnboardingCheckpoint>, AppError> {
+        self.read_onboarding_checkpoint_for(&self.resolve(account_ref)?)
+    }
+    fn read_onboarding_checkpoint_for(
+        &self,
+        account: &AccountSummary,
+    ) -> Result<Option<OnboardingCheckpoint>, AppError> {
+        let Some(bytes) = self.app.account_home().account_onboarding(&account.label)? else {
             return Ok(None);
         };
         let mut checkpoint: OnboardingCheckpoint = serde_json::from_slice(&bytes)?;
-        let account = self.resolve(account_ref)?;
         // Upgrade the pre-notice checkpoint without activating an unfinished
         // account. Completed accounts are not retroactively gated; a new sign-in
         // resets every step and requires the notice then.
@@ -368,6 +406,19 @@ impl AccountManager {
     }
     fn save_onboarding(&self, checkpoint: &mut OnboardingCheckpoint) -> Result<(), AppError> {
         self.shared.lifecycle().ensure_running()?;
+        if !checkpoint.approved && !checkpoint.snapshot.ready {
+            for state in &mut checkpoint.snapshot.steps {
+                if !state.actions.contains(&OnboardingAction::CancelOnboarding) {
+                    state.actions.push(OnboardingAction::CancelOnboarding);
+                }
+            }
+        } else {
+            for state in &mut checkpoint.snapshot.steps {
+                state
+                    .actions
+                    .retain(|a| *a != OnboardingAction::CancelOnboarding);
+            }
+        }
         if checkpoint.approved
             && let Some(proposal) = &checkpoint.snapshot.proposal
         {
@@ -385,6 +436,11 @@ impl AccountManager {
             &checkpoint.snapshot.account_id_hex,
             &serde_json::to_vec(checkpoint)?,
         )?;
+        tracing::debug!(target: "marmot_app::onboarding", method = "save_onboarding",
+            ready = checkpoint.snapshot.ready, cancellation_pending = checkpoint.snapshot.cancellation_pending,
+            passed_count = checkpoint.snapshot.steps.iter().filter(|s| s.status == OnboardingStatus::Passed).count(),
+            decision_count = checkpoint.snapshot.steps.iter().filter(|s| s.status == OnboardingStatus::NeedsInput).count(),
+            "persisted onboarding progress");
         if let Some(sender) = self
             .onboarding_updates
             .lock()
@@ -399,7 +455,9 @@ impl AccountManager {
         &self,
         account_ref: &str,
     ) -> Result<Option<OnboardingSnapshot>, AppError> {
-        Ok(self.onboarding_checkpoint(account_ref)?.map(|c| c.snapshot))
+        Ok(self
+            .read_onboarding_checkpoint(account_ref)?
+            .map(|c| c.snapshot))
     }
     pub fn subscribe_onboarding(
         &self,
@@ -426,12 +484,18 @@ impl AccountManager {
         })
     }
     pub(super) fn require_onboarding_complete(&self, account_ref: &str) -> Result<(), AppError> {
-        let required = match self.onboarding_snapshot(account_ref)? {
-            Some(snapshot) => !snapshot.ready,
+        self.require_onboarding_complete_for(&self.resolve(account_ref)?)
+    }
+    pub(super) fn require_onboarding_complete_for(
+        &self,
+        account: &AccountSummary,
+    ) -> Result<(), AppError> {
+        let required = match self.read_onboarding_checkpoint_for(account)? {
+            Some(c) => !c.snapshot.ready || c.snapshot.cancellation_pending,
             None => self
                 .app
                 .account_home()
-                .account_setup_state(account_ref)?
+                .account_setup_state(&account.label)?
                 .is_some_and(|s| s.kind == AccountSetupKind::InteractiveIdentity),
         };
         if required {
@@ -482,6 +546,19 @@ impl AccountManager {
         options: OnboardingOptions,
     ) -> Result<OnboardingSnapshot, AppError> {
         if let Some(mut existing) = self.onboarding_checkpoint(&account.label)? {
+            if existing.snapshot.ready
+                && self
+                    .app
+                    .account_home()
+                    .account_setup_state(&account.label)?
+                    .is_some_and(|s| {
+                        s.kind != AccountSetupKind::InteractiveIdentity
+                            && !(existing.setup_cleanup_pending
+                                && s.phase == AccountSetupPhase::KeyPackagePublicationConfirmed)
+                    })
+            {
+                return Err(onboarding_error());
+            }
             if account.signed_out && existing.snapshot.ready {
                 existing.single_device_acknowledged = false;
                 existing.snapshot.single_device_notice = None;
@@ -492,6 +569,30 @@ impl AccountManager {
                 self.save_onboarding(&mut existing)?;
             }
             return Ok(existing.snapshot);
+        }
+        let setup = self
+            .app
+            .account_home()
+            .account_setup_state(&account.label)?;
+        let cancelled = self
+            .app
+            .account_home()
+            .cancelled_account_onboarding(&account.label)?
+            .and_then(|bytes| serde_json::from_slice::<OnboardingCheckpoint>(&bytes).ok())
+            .is_some_and(|c| {
+                c.version == ONBOARDING_VERSION
+                    && c.snapshot.account_id_hex == account.account_id_hex
+                    && c.snapshot.cancellation_pending
+                    && !c.approved
+                    && account.signed_out
+            });
+        if (setup
+            .as_ref()
+            .is_some_and(|s| s.kind != AccountSetupKind::InteractiveIdentity)
+            && !cancelled)
+            || (setup.is_none() && !account.signed_out)
+        {
+            return Err(onboarding_error());
         }
         let mut checkpoint = OnboardingCheckpoint::new(account, options);
         self.save_onboarding(&mut checkpoint)?;
@@ -567,6 +668,21 @@ impl AccountManager {
                 snapshot
             }
             Err(AccountHomeError::UnknownAccount(_)) => {
+                // Record ownership of this setup before making the external
+                // account visible, just as the nsec import path does.
+                let pending = AccountSummary {
+                    label: id.clone(),
+                    account_id_hex: id.clone(),
+                    local_signing: false,
+                    external_signing: true,
+                    signed_out: false,
+                };
+                self.app.account_home().begin_account_setup_with(
+                    &pending,
+                    false,
+                    AccountSetupKind::InteractiveIdentity,
+                    AccountSetupPhase::LocalStateCreated,
+                )?;
                 let account = self
                     .app
                     .account_home()
@@ -596,27 +712,34 @@ impl AccountManager {
         if c.snapshot.ready {
             // Completion is checkpointed before journal cleanup; a crash in
             // between must leave only idempotent housekeeping to resume.
-            self.app
-                .account_home()
-                .complete_account_setup(&c.snapshot.account_id_hex)?;
+            if c.setup_cleanup_pending {
+                let home = self.app.account_home();
+                // A later legacy sign-in may have started after completion was
+                // persisted. Never clear its unfinished setup as housekeeping.
+                if home
+                    .account_setup_state(&c.snapshot.account_id_hex)?
+                    .is_none_or(|s| s.phase == AccountSetupPhase::KeyPackagePublicationConfirmed)
+                {
+                    home.complete_account_setup(&c.snapshot.account_id_hex)?;
+                }
+                c.setup_cleanup_pending = false;
+                self.save_onboarding(c)?;
+            }
             return Ok(());
         }
         if !c.approved && c.snapshot.proposal.is_none() {
             // A long pause cannot turn a historical reachability check into
             // evidence for today's publication route.
-            for index in 0..4 {
+            for index in 0..OnboardingStep::SingleDevice.index() {
                 if c.snapshot.steps[index].status == OnboardingStatus::Passed
                     && c.snapshot.steps[index]
                         .checked_at
                         .is_none_or(|at| unix_now_seconds().saturating_sub(at) > CHECK_MAX_AGE)
                 {
                     let step = c.snapshot.steps[index].step;
-                    c.set(step, OnboardingStatus::Pending, Vec::new());
-                    c.set(
-                        OnboardingStep::KeyPackage,
-                        OnboardingStatus::Pending,
-                        Vec::new(),
-                    );
+                    c.reset_step(step);
+                    c.reset_step(OnboardingStep::SingleDevice);
+                    c.reset_step(OnboardingStep::KeyPackage);
                 }
             }
             self.save_onboarding(c)?;
@@ -640,11 +763,7 @@ impl AccountManager {
             c.set(step, OnboardingStatus::Checking, Vec::new());
             self.save_onboarding(c)?;
             if step == OnboardingStep::SingleDevice {
-                if c.single_device_acknowledged {
-                    c.set(step, OnboardingStatus::Passed, Vec::new());
-                } else {
-                    self.check_onboarding_single_device(c).await?;
-                }
+                self.check_onboarding_single_device(c).await?;
             } else if step == OnboardingStep::KeyPackage {
                 let account = self.resolve(&c.snapshot.account_id_hex)?;
                 if account.external_signing
@@ -717,6 +836,9 @@ impl AccountManager {
                 }
                 c.set(step, status, findings);
             }
+            if c.snapshot.ready {
+                c.setup_cleanup_pending = true;
+            }
             self.save_onboarding(c)?;
             if c.snapshot.steps[index].status != OnboardingStatus::Passed {
                 self.reconcile().await?;
@@ -727,6 +849,8 @@ impl AccountManager {
             self.app
                 .account_home()
                 .complete_account_setup(&c.snapshot.account_id_hex)?;
+            c.setup_cleanup_pending = false;
+            self.save_onboarding(c)?;
         }
         Ok(())
     }
@@ -740,18 +864,23 @@ impl AccountManager {
         let mut c = self
             .onboarding_checkpoint(account_ref)?
             .ok_or_else(onboarding_error)?;
+        if !c.snapshot.steps[step.index()]
+            .actions
+            .contains(&OnboardingAction::Retry)
+        {
+            return Err(onboarding_error());
+        }
         if c.approved {
             self.run_onboarding_locked(&mut c).await?;
         } else {
             c.snapshot.proposal = None;
             // Rechecking earlier prerequisites invalidates publication readiness.
-            if step == OnboardingStep::SingleDevice {
-                c.single_device_acknowledged = false;
-                c.snapshot.single_device_notice = None;
+            // Only explicitly retrying a skipped step revokes that skip.
+            if c.snapshot.steps[step.index()].status == OnboardingStatus::Skipped {
+                c.set(step, OnboardingStatus::Pending, Vec::new());
             }
             for index in step.index()..STEP_COUNT {
-                let next = c.snapshot.steps[index].step;
-                c.set(next, OnboardingStatus::Pending, Vec::new());
+                c.reset_step(c.snapshot.steps[index].step);
             }
             self.save_onboarding(&mut c)?;
             self.reconcile().await?;
@@ -784,7 +913,7 @@ impl AccountManager {
         for index in 0..STEP_COUNT {
             if c.snapshot.steps[index].status != OnboardingStatus::Skipped {
                 let step = c.snapshot.steps[index].step;
-                c.set(step, OnboardingStatus::Pending, Vec::new());
+                c.reset_step(step);
             }
         }
         self.save_onboarding(&mut c)?;
@@ -866,7 +995,13 @@ impl AccountManager {
                 continue;
             }
             let endpoint = c.normalized_endpoint.unwrap_or(c.endpoint);
-            let url = nostr::RelayUrl::parse(&endpoint).expect("classified relay");
+            let Ok(url) = nostr::RelayUrl::parse(&endpoint) else {
+                failures.push(OnboardingFinding {
+                    issue: OnboardingIssue::InvalidRelay,
+                    endpoint: Some(endpoint),
+                });
+                continue;
+            };
             if !seen.insert(url) {
                 continue;
             }
@@ -876,7 +1011,8 @@ impl AccountManager {
             }
             let plane = self.app.relay_plane.clone();
             let signer = signer.clone();
-            let query = DirectoryEventQuery::new(kind, vec![account_id.to_owned()], 32);
+            let query =
+                DirectoryEventQuery::new(kind, vec![account_id.to_owned()], DISCOVERY_PAGE_LIMIT);
             tasks.spawn(async move {
                 let result = timeout(
                     CHECK_WAIT,
@@ -889,7 +1025,7 @@ impl AccountManager {
                 .await;
                 let result = match result {
                     Ok(result) => result,
-                    Err(_) => Err("timeout".into()),
+                    Err(_) => Err(crate::relay_plane::DirectoryInspectionError::TimedOut),
                 };
                 (endpoint, result)
             });
@@ -901,18 +1037,26 @@ impl AccountManager {
                 Ok((_, Ok(events))) => {
                     completed += 1;
                     // A full bounded page may omit another installation's slot.
-                    if kind == 30443 && events.len() >= 32 {
+                    if kind == 30443
+                        && events
+                            .iter()
+                            .filter(|r| r.event.kind == kind && r.event.pubkey == account_id)
+                            .count()
+                            >= DISCOVERY_PAGE_LIMIT
+                    {
                         failures.push(finding(OnboardingIssue::DiscoveryIncomplete));
                     }
                     records.extend(events.into_iter().map(|r| r.event));
                 }
                 Ok((endpoint, Err(error))) => {
-                    let issue = match error.as_str() {
-                        "timeout" => OnboardingIssue::TimedOut,
-                        "auth-required" => OnboardingIssue::AuthenticationRequired,
-                        "payment-required" => OnboardingIssue::PaymentRequired,
-                        "restricted" => OnboardingIssue::AccessRestricted,
-                        _ => OnboardingIssue::Unreachable,
+                    use crate::relay_plane::DirectoryInspectionError::*;
+                    let issue = match error {
+                        TimedOut => OnboardingIssue::TimedOut,
+                        AuthenticationRequired => OnboardingIssue::AuthenticationRequired,
+                        PaymentRequired => OnboardingIssue::PaymentRequired,
+                        Restricted => OnboardingIssue::AccessRestricted,
+                        Unreachable => OnboardingIssue::Unreachable,
+                        InvalidRequest => OnboardingIssue::InvalidRelay,
                     };
                     failures.push(OnboardingFinding {
                         issue,
@@ -928,7 +1072,7 @@ impl AccountManager {
             let valid = event.kind == kind
                 && event.pubkey == account_id
                 && event.to_verified_nostr_event().is_ok();
-            if kind == 30443 && !valid {
+            if kind == 30443 && event.kind == kind && event.pubkey == account_id && !valid {
                 failures.push(finding(OnboardingIssue::Malformed));
             }
             valid
@@ -954,7 +1098,7 @@ impl AccountManager {
         } else {
             None
         };
-        if let Some(event) = list.filter(|e| e.created_at <= unix_now_seconds() + CHECK_MAX_AGE)
+        if let Some(event) = list.filter(|e| e.created_at <= unix_now_seconds() + FUTURE_CLOCK_SKEW)
             && let Some(state) = crate::relay_list_state_from_event(&event)
         {
             let safe = self.app.relay_plane.retain_safe_discovered_endpoints(
@@ -1015,7 +1159,7 @@ impl AccountManager {
                 )
             };
         };
-        if event.created_at > unix_now_seconds() + CHECK_MAX_AGE {
+        if event.created_at > unix_now_seconds() + FUTURE_CLOCK_SKEW {
             return (
                 OnboardingStatus::RetryableFailure,
                 vec![finding(OnboardingIssue::FutureDated)],
@@ -1088,6 +1232,10 @@ impl AccountManager {
         } else {
             OnboardingStatus::NeedsInput
         };
+        if !failures.is_empty() {
+            findings.push(finding(OnboardingIssue::DiscoveryIncomplete));
+            findings.extend(failures);
+        }
         (status, findings, Some(event))
     }
     /// Prepare a relay replacement without signing or publishing it. Passing
@@ -1167,7 +1315,7 @@ impl AccountManager {
         account_ref: &str,
         follows: Vec<String>,
     ) -> Result<OnboardingSnapshot, AppError> {
-        if follows.len() > 10000
+        if follows.len() > MAX_FOLLOWS
             || follows
                 .iter()
                 .any(|key| key.len() != 64 || PublicKey::from_hex(key).is_err())
@@ -1358,7 +1506,9 @@ impl AccountManager {
                 c.approved = false;
                 c.signed_repair = None;
                 c.snapshot.proposal = None;
-                c.set(proposal.step, OnboardingStatus::Pending, Vec::new());
+                c.reset_step(proposal.step);
+                c.reset_step(OnboardingStep::SingleDevice);
+                c.reset_step(OnboardingStep::KeyPackage);
                 if proposal.step == OnboardingStep::Relays {
                     c.set(
                         OnboardingStep::InboxRelays,
@@ -1367,7 +1517,7 @@ impl AccountManager {
                     );
                     for step in [OnboardingStep::Profile, OnboardingStep::Follows] {
                         if c.snapshot.steps[step.index()].status != OnboardingStatus::Skipped {
-                            c.set(step, OnboardingStatus::Pending, Vec::new());
+                            c.reset_step(step);
                         }
                     }
                 }

--- a/crates/marmot-app/src/runtime/onboarding.rs
+++ b/crates/marmot-app/src/runtime/onboarding.rs
@@ -1,0 +1,1435 @@
+//! Durable, host-driven onboarding. Discovery never authorizes publication.
+//! A repair is a separate proposal and revision-checked approval; its signed
+//! bytes are checkpointed before they can reach a relay.
+use super::*;
+use crate::relay_plane::{DirectoryEventQuery, DirectoryRelayEventRecord, RelayEndpointPolicy};
+use nostr::{EventBuilder, Kind, PublicKey, Tag, Timestamp};
+use transport_nostr_peeler::NostrTransportEvent;
+
+const ONBOARDING_VERSION: u32 = 1;
+const MAX_RELAYS: usize = 16;
+const CHECK_WAIT: Duration = Duration::from_secs(15);
+const CHECK_MAX_AGE: u64 = 300;
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum OnboardingStep {
+    Profile,
+    Follows,
+    Relays,
+    InboxRelays,
+    KeyPackage,
+}
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum OnboardingStatus {
+    Pending,
+    Checking,
+    Passed,
+    NeedsInput,
+    RetryableFailure,
+    WaitingForSigner,
+    Skipped,
+}
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum OnboardingIssue {
+    Missing,
+    Malformed,
+    FutureDated,
+    InvalidRelay,
+    RetiredRelay,
+    UnsafeRelay,
+    Unreachable,
+    TimedOut,
+    AuthenticationRequired,
+    PaymentRequired,
+    AccessRestricted,
+    NoUsableRoute,
+    PublicationFailed,
+    SignerUnavailable,
+    SignerRejected,
+    RecordChanged,
+    Interrupted,
+    TooManyRelays,
+}
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum OnboardingAction {
+    Retry,
+    ContinueWithout,
+    UseRecommendedRelays,
+    EditRelays,
+    EditProfile,
+    EditFollows,
+    ApproveRepair,
+    CancelRepair,
+    ReconnectSigner,
+    EditDiscoveryRelays,
+}
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OnboardingFinding {
+    pub issue: OnboardingIssue,
+    pub endpoint: Option<String>,
+}
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OnboardingStepState {
+    pub step: OnboardingStep,
+    pub status: OnboardingStatus,
+    pub findings: Vec<OnboardingFinding>,
+    pub actions: Vec<OnboardingAction>,
+    pub checked_at: Option<u64>,
+}
+/// The relay declarations that approval will publish. Unknown non-relay tags
+/// and the original event content are retained internally.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OnboardingRepairProposal {
+    pub step: OnboardingStep,
+    pub revision: u64,
+    pub previous_event_id: Option<String>,
+    pub read_relays: Vec<String>,
+    pub write_relays: Vec<String>,
+    pub profile: Option<UserProfileMetadata>,
+    pub follows: Option<Vec<String>>,
+}
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OnboardingSnapshot {
+    pub account_id_hex: String,
+    pub revision: u64,
+    pub ready: bool,
+    pub steps: Vec<OnboardingStepState>,
+    pub proposal: Option<OnboardingRepairProposal>,
+}
+/// Hosts pass the same default relay set used by account creation. Discovery
+/// relays are independent indexers and are never implicitly published.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OnboardingOptions {
+    pub default_relays: Vec<String>,
+    pub discovery_relays: Vec<String>,
+}
+#[derive(Clone, Serialize, Deserialize)]
+struct OnboardingCheckpoint {
+    version: u32,
+    snapshot: OnboardingSnapshot,
+    options: OnboardingOptions,
+    records: Vec<Option<NostrTransportEvent>>,
+    // Persisted before signing/publication. Approval survives cancellation;
+    // a retry republishes precisely the same event once signed.
+    approved: bool,
+    signed_repair: Option<NostrTransportEvent>,
+}
+
+pub struct OnboardingSubscription {
+    pub snapshot: OnboardingSnapshot,
+    receiver: watch::Receiver<OnboardingSnapshot>,
+}
+impl OnboardingSubscription {
+    pub async fn recv(&mut self) -> Option<OnboardingSnapshot> {
+        self.receiver.changed().await.ok()?;
+        Some(self.receiver.borrow_and_update().clone())
+    }
+}
+impl OnboardingStep {
+    fn index(self) -> usize {
+        match self {
+            Self::Profile => 0,
+            Self::Follows => 1,
+            Self::Relays => 2,
+            Self::InboxRelays => 3,
+            Self::KeyPackage => 4,
+        }
+    }
+    fn kind(self) -> u64 {
+        match self {
+            Self::Profile => 0,
+            Self::Follows => 3,
+            Self::Relays => 10002,
+            Self::InboxRelays => 10050,
+            Self::KeyPackage => 30443,
+        }
+    }
+    fn optional(self) -> bool {
+        matches!(self, Self::Profile | Self::Follows)
+    }
+    fn relay(self) -> bool {
+        matches!(self, Self::Relays | Self::InboxRelays)
+    }
+}
+impl OnboardingCheckpoint {
+    fn new(account: &AccountSummary, options: OnboardingOptions) -> Self {
+        let steps = [
+            OnboardingStep::Profile,
+            OnboardingStep::Follows,
+            OnboardingStep::Relays,
+            OnboardingStep::InboxRelays,
+            OnboardingStep::KeyPackage,
+        ]
+        .into_iter()
+        .map(|step| OnboardingStepState {
+            step,
+            status: OnboardingStatus::Pending,
+            findings: Vec::new(),
+            actions: Vec::new(),
+            checked_at: None,
+        })
+        .collect();
+        Self {
+            version: ONBOARDING_VERSION,
+            snapshot: OnboardingSnapshot {
+                account_id_hex: account.account_id_hex.clone(),
+                revision: 0,
+                ready: false,
+                steps,
+                proposal: None,
+            },
+            options,
+            records: vec![None; 5],
+            approved: false,
+            signed_repair: None,
+        }
+    }
+    fn set(
+        &mut self,
+        step: OnboardingStep,
+        status: OnboardingStatus,
+        findings: Vec<OnboardingFinding>,
+    ) {
+        let actions = match status {
+            OnboardingStatus::NeedsInput | OnboardingStatus::RetryableFailure => {
+                let mut actions = vec![
+                    OnboardingAction::Retry,
+                    OnboardingAction::EditDiscoveryRelays,
+                ];
+                if step.optional() {
+                    actions.push(OnboardingAction::ContinueWithout);
+                    if status == OnboardingStatus::NeedsInput {
+                        actions.push(if step == OnboardingStep::Profile {
+                            OnboardingAction::EditProfile
+                        } else {
+                            OnboardingAction::EditFollows
+                        });
+                    }
+                }
+                // No replacement may be proposed from inconclusive discovery.
+                if step.relay() && status == OnboardingStatus::NeedsInput {
+                    actions.extend([
+                        OnboardingAction::UseRecommendedRelays,
+                        OnboardingAction::EditRelays,
+                    ]);
+                }
+                actions
+            }
+            OnboardingStatus::WaitingForSigner => {
+                vec![OnboardingAction::ReconnectSigner, OnboardingAction::Retry]
+            }
+            _ => Vec::new(),
+        };
+        self.snapshot.steps[step.index()] = OnboardingStepState {
+            step,
+            status,
+            findings,
+            actions,
+            checked_at: Some(unix_now_seconds()),
+        };
+        self.snapshot.ready = self.snapshot.steps.iter().all(|s| {
+            matches!(
+                s.status,
+                OnboardingStatus::Passed | OnboardingStatus::Skipped
+            )
+        });
+    }
+}
+fn finding(issue: OnboardingIssue) -> OnboardingFinding {
+    OnboardingFinding {
+        issue,
+        endpoint: None,
+    }
+}
+fn onboarding_error() -> AppError {
+    AppError::OnboardingActionUnavailable
+}
+
+impl AccountManager {
+    fn onboarding_transaction(&self, id: &str) -> Arc<Mutex<()>> {
+        let mut locks = self
+            .onboarding_transactions
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        locks.retain(|_, lock| lock.strong_count() > 0);
+        if let Some(lock) = locks.get(id).and_then(std::sync::Weak::upgrade) {
+            return lock;
+        }
+        let lock = Arc::new(Mutex::new(()));
+        locks.insert(id.to_owned(), Arc::downgrade(&lock));
+        lock
+    }
+    fn onboarding_checkpoint(
+        &self,
+        account_ref: &str,
+    ) -> Result<Option<OnboardingCheckpoint>, AppError> {
+        let Some(bytes) = self.app.account_home().account_onboarding(account_ref)? else {
+            return Ok(None);
+        };
+        let checkpoint: OnboardingCheckpoint = serde_json::from_slice(&bytes)?;
+        let account = self.resolve(account_ref)?;
+        if checkpoint.version != ONBOARDING_VERSION
+            || checkpoint.snapshot.account_id_hex != account.account_id_hex
+            || checkpoint.snapshot.steps.len() != 5
+            || checkpoint.records.len() != 5
+        {
+            return Err(onboarding_error());
+        }
+        for (index, step) in checkpoint.snapshot.steps.iter().enumerate() {
+            if step.step.index() != index {
+                return Err(onboarding_error());
+            }
+        }
+        Ok(Some(checkpoint))
+    }
+    fn save_onboarding(&self, checkpoint: &mut OnboardingCheckpoint) -> Result<(), AppError> {
+        self.shared.lifecycle().ensure_running()?;
+        if checkpoint.approved
+            && let Some(proposal) = &checkpoint.snapshot.proposal
+        {
+            let state = &mut checkpoint.snapshot.steps[proposal.step.index()];
+            state.actions = match state.status {
+                OnboardingStatus::WaitingForSigner => {
+                    vec![OnboardingAction::ReconnectSigner, OnboardingAction::Retry]
+                }
+                OnboardingStatus::RetryableFailure => vec![OnboardingAction::Retry],
+                _ => Vec::new(),
+            };
+        }
+        checkpoint.snapshot.revision += 1;
+        self.app.account_home().set_account_onboarding(
+            &checkpoint.snapshot.account_id_hex,
+            &serde_json::to_vec(checkpoint)?,
+        )?;
+        if let Some(sender) = self
+            .onboarding_updates
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .get(&checkpoint.snapshot.account_id_hex)
+        {
+            sender.send_replace(checkpoint.snapshot.clone());
+        }
+        Ok(())
+    }
+    pub fn onboarding_snapshot(
+        &self,
+        account_ref: &str,
+    ) -> Result<Option<OnboardingSnapshot>, AppError> {
+        Ok(self.onboarding_checkpoint(account_ref)?.map(|c| c.snapshot))
+    }
+    pub fn subscribe_onboarding(
+        &self,
+        account_ref: &str,
+    ) -> Result<OnboardingSubscription, AppError> {
+        // Lock before reading disk so a concurrent persisted update cannot be
+        // lost between snapshot acquisition and receiver registration.
+        let mut updates = self
+            .onboarding_updates
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        self.shared.lifecycle().ensure_running()?;
+        updates.retain(|_, sender| sender.receiver_count() > 0);
+        let snapshot = self
+            .onboarding_snapshot(account_ref)?
+            .ok_or_else(onboarding_error)?;
+        let sender = updates
+            .entry(snapshot.account_id_hex.clone())
+            .or_insert_with(|| watch::channel(snapshot.clone()).0);
+        sender.send_replace(snapshot.clone());
+        Ok(OnboardingSubscription {
+            snapshot,
+            receiver: sender.subscribe(),
+        })
+    }
+    pub(super) fn require_onboarding_complete(&self, account_ref: &str) -> Result<(), AppError> {
+        let required = match self.onboarding_snapshot(account_ref)? {
+            Some(snapshot) => !snapshot.ready,
+            None => self
+                .app
+                .account_home()
+                .account_setup_state(account_ref)?
+                .is_some_and(|s| s.kind == AccountSetupKind::InteractiveIdentity),
+        };
+        if required {
+            return Err(AppError::OnboardingRequired);
+        }
+        Ok(())
+    }
+    pub(super) fn onboarding_worker_allowed(&self, account_ref: &str) -> Result<bool, AppError> {
+        let checkpoint = self.onboarding_checkpoint(account_ref)?;
+        if checkpoint.is_none()
+            && self
+                .app
+                .account_home()
+                .account_setup_state(account_ref)?
+                .is_some_and(|s| s.kind == AccountSetupKind::InteractiveIdentity)
+        {
+            return Ok(false);
+        }
+        Ok(checkpoint.is_none_or(|c| {
+            c.snapshot.ready
+                || matches!(
+                    c.snapshot.steps[4].status,
+                    OnboardingStatus::Checking
+                        | OnboardingStatus::WaitingForSigner
+                        | OnboardingStatus::Passed
+                )
+        }))
+    }
+    fn validate_onboarding_options(&self, options: &OnboardingOptions) -> Result<(), AppError> {
+        for endpoints in [&options.default_relays, &options.discovery_relays] {
+            if endpoints.is_empty()
+                || endpoints.len() > MAX_RELAYS
+                || self
+                    .app
+                    .relay_plane
+                    .classify_relay_endpoints(endpoints.clone())
+                    .iter()
+                    .any(|c| c.policy != RelayEndpointPolicy::Allowed)
+            {
+                return Err(onboarding_error());
+            }
+        }
+        Ok(())
+    }
+    fn initialize_onboarding(
+        &self,
+        account: &AccountSummary,
+        options: OnboardingOptions,
+    ) -> Result<OnboardingSnapshot, AppError> {
+        if let Some(mut existing) = self.onboarding_checkpoint(&account.label)? {
+            if account.signed_out && existing.snapshot.ready {
+                for index in 0..5 {
+                    let step = existing.snapshot.steps[index].step;
+                    existing.set(step, OnboardingStatus::Pending, Vec::new());
+                }
+                self.save_onboarding(&mut existing)?;
+            }
+            return Ok(existing.snapshot);
+        }
+        let mut checkpoint = OnboardingCheckpoint::new(account, options);
+        self.save_onboarding(&mut checkpoint)?;
+        Ok(checkpoint.snapshot)
+    }
+    /// Import only the identity. No relay records or KeyPackages are published.
+    /// A retained account/checkpoint is returned even if later checks fail.
+    pub async fn begin_onboarding(
+        &self,
+        nsec: Zeroizing<String>,
+        options: OnboardingOptions,
+    ) -> Result<OnboardingSnapshot, AppError> {
+        self.shared.lifecycle().ensure_running()?;
+        self.validate_onboarding_options(&options)?;
+        let id = AccountHome::account_id_for_secret(&nsec)?;
+        let transaction = self.onboarding_transaction(&id);
+        let _transaction = transaction.lock().await;
+        let _workers = self.worker_transactions.lock().await;
+        let account = match self.app.account_home().account(&id) {
+            Ok(account) if account.local_signing => self
+                .app
+                .account_home()
+                .import_account_idempotent(&account.label, &nsec)?,
+            Ok(_) => return Err(onboarding_error()),
+            Err(AccountHomeError::UnknownAccount(_)) => self
+                .app
+                .account_home()
+                .import_nostr_account_for_onboarding(&nsec)?
+                .account()
+                .clone(),
+            Err(error) => return Err(error.into()),
+        };
+        let snapshot = self.initialize_onboarding(&account, options)?;
+        self.reconcile_locked().await?;
+        Ok(snapshot)
+    }
+    pub async fn begin_external_signer_onboarding<S: crate::ExternalAccountSigner + 'static>(
+        &self,
+        public_key: String,
+        signer: S,
+        options: OnboardingOptions,
+    ) -> Result<OnboardingSnapshot, AppError> {
+        self.shared.lifecycle().ensure_running()?;
+        self.validate_onboarding_options(&options)?;
+        let id = AccountHome::account_id_for_public_key(&public_key)?;
+        if signer
+            .get_public_key()
+            .await
+            .map_err(crate::external_signer_public_key_error)?
+            .to_hex()
+            != id
+        {
+            return Err(AppError::ExternalSignerMismatch);
+        }
+        let transaction = self.onboarding_transaction(&id);
+        let _transaction = transaction.lock().await;
+        let _workers = self.worker_transactions.lock().await;
+        let account = self
+            .app
+            .account_home()
+            .add_external_signer_account(&public_key)?;
+        // Gate the account before registering a signer can make it runnable.
+        let snapshot = self.initialize_onboarding(&account, options)?;
+        self.reconcile_locked().await?;
+        drop(_workers);
+        self.app.register_external_signer(&id, signer).await?;
+        Ok(snapshot)
+    }
+    /// Run pending checks until a decision or retry is needed. Cancelling this
+    /// future is safe: the next call retries its last checkpointed operation.
+    pub async fn run_onboarding(&self, account_ref: &str) -> Result<OnboardingSnapshot, AppError> {
+        let transaction = self.onboarding_transaction(&self.resolve(account_ref)?.account_id_hex);
+        let _transaction = transaction.lock().await;
+        let mut c = self
+            .onboarding_checkpoint(account_ref)?
+            .ok_or_else(onboarding_error)?;
+        self.run_onboarding_locked(&mut c).await?;
+        Ok(c.snapshot)
+    }
+    async fn run_onboarding_locked(&self, c: &mut OnboardingCheckpoint) -> Result<(), AppError> {
+        self.shared.lifecycle().ensure_running()?;
+        if c.snapshot.ready {
+            // Completion is checkpointed before journal cleanup; a crash in
+            // between must leave only idempotent housekeeping to resume.
+            self.app
+                .account_home()
+                .complete_account_setup(&c.snapshot.account_id_hex)?;
+            return Ok(());
+        }
+        if !c.approved && c.snapshot.proposal.is_none() {
+            // A long pause cannot turn a historical reachability check into
+            // evidence for today's publication route.
+            for index in 0..4 {
+                if c.snapshot.steps[index].status == OnboardingStatus::Passed
+                    && c.snapshot.steps[index]
+                        .checked_at
+                        .is_none_or(|at| unix_now_seconds().saturating_sub(at) > CHECK_MAX_AGE)
+                {
+                    let step = c.snapshot.steps[index].step;
+                    c.set(step, OnboardingStatus::Pending, Vec::new());
+                    c.set(
+                        OnboardingStep::KeyPackage,
+                        OnboardingStatus::Pending,
+                        Vec::new(),
+                    );
+                }
+            }
+            self.save_onboarding(c)?;
+        }
+        if c.approved {
+            if !self.publish_onboarding_repair(c).await? {
+                return Ok(());
+            }
+        } else if c.snapshot.proposal.is_some() {
+            return Ok(());
+        }
+        for index in 0..5 {
+            let step = c.snapshot.steps[index].step;
+            match c.snapshot.steps[index].status {
+                OnboardingStatus::Passed | OnboardingStatus::Skipped => continue,
+                OnboardingStatus::NeedsInput
+                | OnboardingStatus::RetryableFailure
+                | OnboardingStatus::WaitingForSigner => return Ok(()),
+                _ => {}
+            }
+            c.set(step, OnboardingStatus::Checking, Vec::new());
+            self.save_onboarding(c)?;
+            if step == OnboardingStep::KeyPackage {
+                let account = self.resolve(&c.snapshot.account_id_hex)?;
+                if account.external_signing
+                    && !self.app.has_external_signer(&account.account_id_hex)
+                {
+                    c.set(
+                        step,
+                        OnboardingStatus::WaitingForSigner,
+                        vec![finding(OnboardingIssue::SignerUnavailable)],
+                    );
+                } else {
+                    if self
+                        .app
+                        .account_home()
+                        .account_setup_state(&account.label)?
+                        .is_none()
+                    {
+                        self.app.account_home().begin_account_setup_with(
+                            &account,
+                            false,
+                            if account.external_signing {
+                                AccountSetupKind::ExternalSigner
+                            } else {
+                                AccountSetupKind::ImportedIdentity
+                            },
+                            AccountSetupPhase::KeyPackagePublicationStarted,
+                        )?;
+                    } else {
+                        self.app.account_home().set_account_setup_phase(
+                            &account.label,
+                            AccountSetupPhase::KeyPackagePublicationStarted,
+                        )?;
+                    }
+                    if account.external_signing {
+                        c.set(step, OnboardingStatus::WaitingForSigner, Vec::new());
+                        self.save_onboarding(c)?;
+                    }
+                    let account = self
+                        .app
+                        .account_home()
+                        .set_account_signed_out(&account.label, false)?;
+                    match self.publish_initial_key_package_for_account(&account).await {
+                        Ok(_) => {
+                            self.app.account_home().set_account_setup_phase(
+                                &account.label,
+                                AccountSetupPhase::KeyPackagePublicationConfirmed,
+                            )?;
+                            c.set(step, OnboardingStatus::Passed, Vec::new());
+                        }
+                        Err(error) => set_operation_error(c, step, &error),
+                    }
+                }
+            } else {
+                let (status, findings, event) = self.check_onboarding_step(c, step).await;
+                c.records[index] = event.clone();
+                // Cache even imperfect signed data for settings visibility;
+                // routing still filters it through the relay safety chokepoint.
+                if let Some(event) = event {
+                    self.app
+                        .ingest_directory_relay_event(DirectoryRelayEventRecord {
+                            endpoints: c
+                                .options
+                                .discovery_relays
+                                .iter()
+                                .cloned()
+                                .map(TransportEndpoint)
+                                .collect(),
+                            event,
+                        })?;
+                }
+                c.set(step, status, findings);
+            }
+            self.save_onboarding(c)?;
+            if c.snapshot.steps[index].status != OnboardingStatus::Passed {
+                self.reconcile().await?;
+                return Ok(());
+            }
+        }
+        if c.snapshot.ready {
+            self.app
+                .account_home()
+                .complete_account_setup(&c.snapshot.account_id_hex)?;
+        }
+        Ok(())
+    }
+    pub async fn retry_onboarding_step(
+        &self,
+        account_ref: &str,
+        step: OnboardingStep,
+    ) -> Result<OnboardingSnapshot, AppError> {
+        let transaction = self.onboarding_transaction(&self.resolve(account_ref)?.account_id_hex);
+        let _transaction = transaction.lock().await;
+        let mut c = self
+            .onboarding_checkpoint(account_ref)?
+            .ok_or_else(onboarding_error)?;
+        if c.approved {
+            self.run_onboarding_locked(&mut c).await?;
+        } else {
+            c.snapshot.proposal = None;
+            // Rechecking earlier prerequisites invalidates publication readiness.
+            for index in step.index()..5 {
+                let next = c.snapshot.steps[index].step;
+                c.set(next, OnboardingStatus::Pending, Vec::new());
+            }
+            self.save_onboarding(&mut c)?;
+            self.reconcile().await?;
+            self.run_onboarding_locked(&mut c).await?;
+        }
+        Ok(c.snapshot)
+    }
+    /// Retry discovery through an explicitly selected source set. This never
+    /// changes published relay declarations or publishes defaults.
+    pub async fn set_onboarding_discovery_relays(
+        &self,
+        account_ref: &str,
+        discovery_relays: Vec<String>,
+    ) -> Result<OnboardingSnapshot, AppError> {
+        let transaction = self.onboarding_transaction(&self.resolve(account_ref)?.account_id_hex);
+        let _transaction = transaction.lock().await;
+        let mut c = self
+            .onboarding_checkpoint(account_ref)?
+            .ok_or_else(onboarding_error)?;
+        if c.approved {
+            return Err(onboarding_error());
+        }
+        let options = OnboardingOptions {
+            default_relays: c.options.default_relays.clone(),
+            discovery_relays,
+        };
+        self.validate_onboarding_options(&options)?;
+        c.options = options;
+        c.snapshot.proposal = None;
+        for index in 0..5 {
+            if c.snapshot.steps[index].status != OnboardingStatus::Skipped {
+                let step = c.snapshot.steps[index].step;
+                c.set(step, OnboardingStatus::Pending, Vec::new());
+            }
+        }
+        self.save_onboarding(&mut c)?;
+        self.reconcile().await?;
+        self.run_onboarding_locked(&mut c).await?;
+        Ok(c.snapshot)
+    }
+    pub async fn continue_onboarding_without(
+        &self,
+        account_ref: &str,
+        step: OnboardingStep,
+    ) -> Result<OnboardingSnapshot, AppError> {
+        let transaction = self.onboarding_transaction(&self.resolve(account_ref)?.account_id_hex);
+        let _transaction = transaction.lock().await;
+        let mut c = self
+            .onboarding_checkpoint(account_ref)?
+            .ok_or_else(onboarding_error)?;
+        if c.approved
+            || !step.optional()
+            || !c.snapshot.steps[step.index()]
+                .actions
+                .contains(&OnboardingAction::ContinueWithout)
+        {
+            return Err(onboarding_error());
+        }
+        c.set(step, OnboardingStatus::Skipped, Vec::new());
+        self.save_onboarding(&mut c)?;
+        self.run_onboarding_locked(&mut c).await?;
+        Ok(c.snapshot)
+    }
+}
+
+fn set_operation_error(c: &mut OnboardingCheckpoint, step: OnboardingStep, error: &AppError) {
+    let (status, issue) = match error {
+        AppError::ExternalSignerUnavailable(_) => (
+            OnboardingStatus::WaitingForSigner,
+            OnboardingIssue::SignerUnavailable,
+        ),
+        AppError::ExternalSignerRejected => (
+            OnboardingStatus::WaitingForSigner,
+            OnboardingIssue::SignerRejected,
+        ),
+        _ => (
+            OnboardingStatus::RetryableFailure,
+            OnboardingIssue::PublicationFailed,
+        ),
+    };
+    c.set(step, status, vec![finding(issue)]);
+}
+
+impl AccountManager {
+    async fn inspect_onboarding_relays(
+        &self,
+        account_id: &str,
+        kind: u64,
+        endpoints: Vec<String>,
+    ) -> (Vec<NostrTransportEvent>, Vec<OnboardingFinding>, usize) {
+        let signer = self
+            .resolve(account_id)
+            .ok()
+            .and_then(|account| self.app.account_signer_for_summary(&account).ok())
+            .map(|signer| signer.as_nostr_signer());
+        let mut tasks = JoinSet::new();
+        let classifications = self.app.relay_plane.classify_relay_endpoints(endpoints);
+        let mut failures = Vec::new();
+        let mut seen = HashSet::new();
+        for c in classifications {
+            let issue = match c.policy {
+                RelayEndpointPolicy::Allowed => None,
+                RelayEndpointPolicy::Retired => Some(OnboardingIssue::RetiredRelay),
+                RelayEndpointPolicy::Unsafe => Some(OnboardingIssue::UnsafeRelay),
+                RelayEndpointPolicy::Invalid => Some(OnboardingIssue::InvalidRelay),
+            };
+            if let Some(issue) = issue {
+                failures.push(OnboardingFinding {
+                    issue,
+                    endpoint: Some(c.endpoint),
+                });
+                continue;
+            }
+            let endpoint = c.normalized_endpoint.unwrap_or(c.endpoint);
+            let url = nostr::RelayUrl::parse(&endpoint).expect("classified relay");
+            if !seen.insert(url) {
+                continue;
+            }
+            if seen.len() > MAX_RELAYS {
+                failures.push(finding(OnboardingIssue::TooManyRelays));
+                break;
+            }
+            let plane = self.app.relay_plane.clone();
+            let signer = signer.clone();
+            let query = DirectoryEventQuery::new(kind, vec![account_id.to_owned()], 32);
+            tasks.spawn(async move {
+                let result = timeout(
+                    CHECK_WAIT,
+                    plane.inspect_directory_events(
+                        TransportEndpoint(endpoint.clone()),
+                        query,
+                        signer,
+                    ),
+                )
+                .await;
+                let result = match result {
+                    Ok(result) => result,
+                    Err(_) => Err("timeout".into()),
+                };
+                (endpoint, result)
+            });
+        }
+        let mut records = Vec::new();
+        let mut completed = 0;
+        while let Some(result) = tasks.join_next().await {
+            match result {
+                Ok((_, Ok(events))) => {
+                    completed += 1;
+                    records.extend(events.into_iter().map(|r| r.event));
+                }
+                Ok((endpoint, Err(error))) => {
+                    let issue = match error.as_str() {
+                        "timeout" => OnboardingIssue::TimedOut,
+                        "auth-required" => OnboardingIssue::AuthenticationRequired,
+                        "payment-required" => OnboardingIssue::PaymentRequired,
+                        "restricted" => OnboardingIssue::AccessRestricted,
+                        _ => OnboardingIssue::Unreachable,
+                    };
+                    failures.push(OnboardingFinding {
+                        issue,
+                        endpoint: Some(endpoint),
+                    });
+                }
+                Err(_) => failures.push(finding(OnboardingIssue::Interrupted)),
+            }
+        }
+        // Enforce the event boundary even for injected fetchers. Never let an
+        // older valid event hide a newer signed but malformed declaration.
+        records.retain(|event| {
+            event.kind == kind
+                && event.pubkey == account_id
+                && event.to_verified_nostr_event().is_ok()
+        });
+        records.sort_by(|a, b| b.created_at.cmp(&a.created_at).then(a.id.cmp(&b.id)));
+        records.dedup_by(|a, b| a.id == b.id);
+        (records, failures, completed)
+    }
+    async fn onboarding_sources(
+        &self,
+        c: &OnboardingCheckpoint,
+        step: OnboardingStep,
+    ) -> Vec<String> {
+        let mut sources = c.options.discovery_relays.clone();
+        let list = if let Some(event) = &c.records[OnboardingStep::Relays.index()] {
+            Some(event.clone())
+        } else if step.optional() {
+            self.inspect_onboarding_relays(&c.snapshot.account_id_hex, 10002, sources.clone())
+                .await
+                .0
+                .into_iter()
+                .next()
+        } else {
+            None
+        };
+        if let Some(event) = list.filter(|e| e.created_at <= unix_now_seconds() + CHECK_MAX_AGE)
+            && let Some(state) = crate::relay_list_state_from_event(&event)
+        {
+            let safe = self.app.relay_plane.retain_safe_discovered_endpoints(
+                state.relays.into_iter().map(TransportEndpoint).collect(),
+                "onboarding discovery",
+            );
+            for endpoint in safe {
+                if !sources.contains(&endpoint.0) {
+                    sources.push(endpoint.0);
+                }
+            }
+        }
+        sources
+    }
+    async fn check_onboarding_step(
+        &self,
+        c: &OnboardingCheckpoint,
+        step: OnboardingStep,
+    ) -> (
+        OnboardingStatus,
+        Vec<OnboardingFinding>,
+        Option<NostrTransportEvent>,
+    ) {
+        if step == OnboardingStep::InboxRelays
+            && self
+                .resolve(&c.snapshot.account_id_hex)
+                .is_ok_and(|account| {
+                    account.external_signing
+                        && !self.app.has_external_signer(&account.account_id_hex)
+                })
+        {
+            return (
+                OnboardingStatus::WaitingForSigner,
+                vec![finding(OnboardingIssue::SignerUnavailable)],
+                c.records[step.index()].clone(),
+            );
+        }
+        let sources = self.onboarding_sources(c, step).await;
+        let (records, failures, completed) = self
+            .inspect_onboarding_relays(&c.snapshot.account_id_hex, step.kind(), sources)
+            .await;
+        let Some(event) = records.into_iter().next() else {
+            return if completed == 0 || !failures.is_empty() {
+                (
+                    OnboardingStatus::RetryableFailure,
+                    if failures.is_empty() {
+                        vec![finding(OnboardingIssue::Unreachable)]
+                    } else {
+                        failures
+                    },
+                    None,
+                )
+            } else {
+                (
+                    OnboardingStatus::NeedsInput,
+                    vec![finding(OnboardingIssue::Missing)],
+                    None,
+                )
+            };
+        };
+        if event.created_at > unix_now_seconds() + CHECK_MAX_AGE {
+            return (
+                OnboardingStatus::RetryableFailure,
+                vec![finding(OnboardingIssue::FutureDated)],
+                Some(event),
+            );
+        }
+        let mut findings = validate_onboarding_record(&event);
+        if step.relay() {
+            let name = if step == OnboardingStep::Relays {
+                "r"
+            } else {
+                "relay"
+            };
+            let raw = event
+                .tags
+                .iter()
+                .filter(|t| t.first().is_some_and(|v| v == name))
+                .filter_map(|t| t.get(1).cloned())
+                .collect();
+            for classified in self.app.relay_plane.classify_relay_endpoints(raw) {
+                let issue = match classified.policy {
+                    RelayEndpointPolicy::Allowed => continue,
+                    RelayEndpointPolicy::Invalid => OnboardingIssue::InvalidRelay,
+                    RelayEndpointPolicy::Retired => OnboardingIssue::RetiredRelay,
+                    RelayEndpointPolicy::Unsafe => OnboardingIssue::UnsafeRelay,
+                };
+                findings.push(OnboardingFinding {
+                    issue,
+                    endpoint: Some(classified.endpoint),
+                });
+            }
+            let state = crate::relay_list_state_from_event(&event);
+            if let Some(state) = state {
+                let mut endpoints = state.relays.clone();
+                if step == OnboardingStep::Relays {
+                    for endpoint in state.read_relays {
+                        if !endpoints.contains(&endpoint) {
+                            endpoints.push(endpoint);
+                        }
+                    }
+                }
+                if endpoints.is_empty() {
+                    findings.push(finding(OnboardingIssue::NoUsableRoute));
+                } else {
+                    // EOSE proves an actual query completed, not merely a TCP
+                    // connection. Publication is independently confirmed below.
+                    let (_, failures, completed) = self
+                        .inspect_onboarding_relays(
+                            &c.snapshot.account_id_hex,
+                            if step == OnboardingStep::InboxRelays {
+                                1059
+                            } else {
+                                10002
+                            },
+                            endpoints,
+                        )
+                        .await;
+                    findings.extend(failures);
+                    if completed == 0 || (step == OnboardingStep::Relays && state.relays.is_empty())
+                    {
+                        findings.push(finding(OnboardingIssue::NoUsableRoute));
+                    }
+                }
+            } else {
+                findings.push(finding(OnboardingIssue::Malformed));
+            }
+        }
+        let status = if findings.is_empty() {
+            OnboardingStatus::Passed
+        } else {
+            OnboardingStatus::NeedsInput
+        };
+        (status, findings, Some(event))
+    }
+    /// Prepare a relay replacement without signing or publishing it. Passing
+    /// None uses the same recommended defaults supplied at identity creation.
+    /// For inbox lists use read_relays; write_relays must be empty.
+    pub async fn propose_onboarding_relays(
+        &self,
+        account_ref: &str,
+        step: OnboardingStep,
+        selection: Option<(Vec<String>, Vec<String>)>,
+    ) -> Result<OnboardingSnapshot, AppError> {
+        let transaction = self.onboarding_transaction(&self.resolve(account_ref)?.account_id_hex);
+        let _transaction = transaction.lock().await;
+        let mut c = self
+            .onboarding_checkpoint(account_ref)?
+            .ok_or_else(onboarding_error)?;
+        if !step.relay()
+            || c.approved
+            || c.snapshot.steps[step.index()].status != OnboardingStatus::NeedsInput
+        {
+            return Err(onboarding_error());
+        }
+        let (read_relays, write_relays) = selection.unwrap_or_else(|| {
+            (
+                c.options.default_relays.clone(),
+                if step == OnboardingStep::Relays {
+                    c.options.default_relays.clone()
+                } else {
+                    Vec::new()
+                },
+            )
+        });
+        let all = read_relays
+            .iter()
+            .chain(&write_relays)
+            .cloned()
+            .collect::<Vec<_>>();
+        if all.is_empty()
+            || all.iter().collect::<HashSet<_>>().len() > MAX_RELAYS
+            || (step == OnboardingStep::Relays && write_relays.is_empty())
+            || (step == OnboardingStep::InboxRelays && !write_relays.is_empty())
+            || self
+                .app
+                .relay_plane
+                .classify_relay_endpoints(all)
+                .iter()
+                .any(|v| v.policy != RelayEndpointPolicy::Allowed)
+        {
+            return Err(onboarding_error());
+        }
+        c.snapshot.proposal = Some(OnboardingRepairProposal {
+            step,
+            revision: c.snapshot.revision + 1,
+            previous_event_id: c.records[step.index()].as_ref().map(|e| e.id.clone()),
+            read_relays,
+            write_relays,
+            profile: None,
+            follows: None,
+        });
+        c.snapshot.steps[step.index()].actions = vec![
+            OnboardingAction::ApproveRepair,
+            OnboardingAction::CancelRepair,
+        ];
+        self.save_onboarding(&mut c)?;
+        Ok(c.snapshot)
+    }
+    pub async fn propose_onboarding_profile(
+        &self,
+        account_ref: &str,
+        profile: UserProfileMetadata,
+    ) -> Result<OnboardingSnapshot, AppError> {
+        self.propose_onboarding_optional(account_ref, Some(profile), None)
+            .await
+    }
+    pub async fn propose_onboarding_follows(
+        &self,
+        account_ref: &str,
+        follows: Vec<String>,
+    ) -> Result<OnboardingSnapshot, AppError> {
+        if follows.len() > 10000
+            || follows
+                .iter()
+                .any(|key| key.len() != 64 || PublicKey::from_hex(key).is_err())
+        {
+            return Err(onboarding_error());
+        }
+        self.propose_onboarding_optional(account_ref, None, Some(follows))
+            .await
+    }
+    async fn propose_onboarding_optional(
+        &self,
+        account_ref: &str,
+        profile: Option<UserProfileMetadata>,
+        follows: Option<Vec<String>>,
+    ) -> Result<OnboardingSnapshot, AppError> {
+        let transaction = self.onboarding_transaction(&self.resolve(account_ref)?.account_id_hex);
+        let _transaction = transaction.lock().await;
+        let mut c = self
+            .onboarding_checkpoint(account_ref)?
+            .ok_or_else(onboarding_error)?;
+        let step = if profile.is_some() {
+            OnboardingStep::Profile
+        } else {
+            OnboardingStep::Follows
+        };
+        if c.approved || c.snapshot.steps[step.index()].status != OnboardingStatus::NeedsInput {
+            return Err(onboarding_error());
+        }
+        c.snapshot.proposal = Some(OnboardingRepairProposal {
+            step,
+            revision: c.snapshot.revision + 1,
+            previous_event_id: c.records[step.index()].as_ref().map(|e| e.id.clone()),
+            read_relays: Vec::new(),
+            write_relays: Vec::new(),
+            profile,
+            follows,
+        });
+        c.snapshot.steps[step.index()].actions = vec![
+            OnboardingAction::ApproveRepair,
+            OnboardingAction::CancelRepair,
+        ];
+        self.save_onboarding(&mut c)?;
+        Ok(c.snapshot)
+    }
+    pub async fn cancel_onboarding_repair(
+        &self,
+        account_ref: &str,
+    ) -> Result<OnboardingSnapshot, AppError> {
+        let transaction = self.onboarding_transaction(&self.resolve(account_ref)?.account_id_hex);
+        let _transaction = transaction.lock().await;
+        let mut c = self
+            .onboarding_checkpoint(account_ref)?
+            .ok_or_else(onboarding_error)?;
+        if c.approved {
+            return Err(onboarding_error());
+        }
+        let proposal = c.snapshot.proposal.take().ok_or_else(onboarding_error)?;
+        let findings = c.snapshot.steps[proposal.step.index()].findings.clone();
+        c.set(proposal.step, OnboardingStatus::NeedsInput, findings);
+        self.save_onboarding(&mut c)?;
+        Ok(c.snapshot)
+    }
+    pub async fn approve_onboarding_repair(
+        &self,
+        account_ref: &str,
+        revision: u64,
+    ) -> Result<OnboardingSnapshot, AppError> {
+        let transaction = self.onboarding_transaction(&self.resolve(account_ref)?.account_id_hex);
+        let _transaction = transaction.lock().await;
+        let mut c = self
+            .onboarding_checkpoint(account_ref)?
+            .ok_or_else(onboarding_error)?;
+        let proposal = c.snapshot.proposal.clone().ok_or_else(onboarding_error)?;
+        if c.approved || c.snapshot.revision != revision || proposal.revision != revision {
+            return Err(onboarding_error());
+        }
+        let sources = self.onboarding_sources(&c, proposal.step).await;
+        let (records, failures, completed) = self
+            .inspect_onboarding_relays(&c.snapshot.account_id_hex, proposal.step.kind(), sources)
+            .await;
+        if completed == 0 || !failures.is_empty() {
+            c.set(proposal.step, OnboardingStatus::RetryableFailure, failures);
+            c.snapshot.proposal = None;
+        } else if records.first().map(|e| &e.id) != proposal.previous_event_id.as_ref() {
+            c.records[proposal.step.index()] = records.first().cloned();
+            c.snapshot.proposal = None;
+            c.set(
+                proposal.step,
+                OnboardingStatus::RetryableFailure,
+                vec![finding(OnboardingIssue::RecordChanged)],
+            );
+        } else {
+            c.approved = true;
+            c.set(proposal.step, OnboardingStatus::Checking, Vec::new());
+            // All route-dependent checks must be repeated after publication.
+            c.set(
+                OnboardingStep::KeyPackage,
+                OnboardingStatus::Pending,
+                Vec::new(),
+            );
+        }
+        self.save_onboarding(&mut c)?;
+        if c.approved {
+            self.run_onboarding_locked(&mut c).await?;
+        }
+        Ok(c.snapshot)
+    }
+    async fn publish_onboarding_repair(
+        &self,
+        c: &mut OnboardingCheckpoint,
+    ) -> Result<bool, AppError> {
+        let proposal = c.snapshot.proposal.clone().ok_or_else(onboarding_error)?;
+        let account = self.resolve(&c.snapshot.account_id_hex)?;
+        let signer = match self.app.account_signer_for_summary(&account) {
+            Ok(signer) => signer.as_nostr_signer(),
+            Err(error) => {
+                set_operation_error(c, proposal.step, &error);
+                self.save_onboarding(c)?;
+                return Ok(false);
+            }
+        };
+        if c.signed_repair.is_none() {
+            if account.external_signing {
+                c.set(
+                    proposal.step,
+                    OnboardingStatus::WaitingForSigner,
+                    Vec::new(),
+                );
+                self.save_onboarding(c)?;
+            }
+            let (tags, content, created_at) = relay_repair_event(c, &proposal);
+            let tags = tags
+                .into_iter()
+                .map(Tag::parse)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| onboarding_error())?;
+            let unsigned = EventBuilder::new(Kind::from(proposal.step.kind() as u16), content)
+                .tags(tags)
+                .custom_created_at(Timestamp::from(created_at))
+                .build(
+                    PublicKey::parse(&account.account_id_hex)
+                        .map_err(|_| AppError::InvalidPublicKey)?,
+                );
+            let signed = match signer.sign_event(unsigned).await {
+                Ok(event) => event,
+                Err(error) => {
+                    set_operation_error(
+                        c,
+                        proposal.step,
+                        &crate::external_signer_error(error, "onboarding repair"),
+                    );
+                    self.save_onboarding(c)?;
+                    return Ok(false);
+                }
+            };
+            c.signed_repair = Some(
+                NostrTransportEvent::from_nostr_event(&signed).map_err(|_| onboarding_error())?,
+            );
+            c.set(proposal.step, OnboardingStatus::Checking, Vec::new());
+            self.save_onboarding(c)?;
+        }
+        let event = c.signed_repair.clone().ok_or_else(onboarding_error)?;
+        let mut endpoints = self.onboarding_sources(c, proposal.step).await;
+        endpoints.extend(
+            proposal
+                .read_relays
+                .iter()
+                .chain(&proposal.write_relays)
+                .cloned(),
+        );
+        let endpoints = self.app.relay_plane.retain_safe_discovered_endpoints(
+            endpoints.into_iter().map(TransportEndpoint).collect(),
+            "onboarding repair",
+        );
+        let outcome = self
+            .app
+            .relay_client_for_account_id(&account.account_id_hex, signer)
+            .publish_event(&endpoints, &event, 1)
+            .await;
+        match outcome {
+            Ok(outcome) if !outcome.accepted.is_empty() => {
+                self.app
+                    .ingest_directory_relay_event(DirectoryRelayEventRecord {
+                        endpoints,
+                        event: event.clone(),
+                    })?;
+                c.records[proposal.step.index()] = Some(event);
+                c.approved = false;
+                c.signed_repair = None;
+                c.snapshot.proposal = None;
+                c.set(proposal.step, OnboardingStatus::Pending, Vec::new());
+                if proposal.step == OnboardingStep::Relays {
+                    c.set(
+                        OnboardingStep::InboxRelays,
+                        OnboardingStatus::Pending,
+                        Vec::new(),
+                    );
+                    for step in [OnboardingStep::Profile, OnboardingStep::Follows] {
+                        if c.snapshot.steps[step.index()].status != OnboardingStatus::Skipped {
+                            c.set(step, OnboardingStatus::Pending, Vec::new());
+                        }
+                    }
+                }
+                self.save_onboarding(c)?;
+                Ok(true)
+            }
+            _ => {
+                c.set(
+                    proposal.step,
+                    OnboardingStatus::RetryableFailure,
+                    vec![finding(OnboardingIssue::PublicationFailed)],
+                );
+                self.save_onboarding(c)?;
+                Ok(false)
+            }
+        }
+    }
+}
+
+fn validate_onboarding_record(event: &NostrTransportEvent) -> Vec<OnboardingFinding> {
+    let malformed = match event.kind {
+        0 => match serde_json::from_str::<serde_json::Value>(&event.content) {
+            Ok(serde_json::Value::Object(map)) => {
+                [
+                    "name",
+                    "display_name",
+                    "about",
+                    "picture",
+                    "banner",
+                    "website",
+                    "nip05",
+                    "lud06",
+                    "lud16",
+                ]
+                .iter()
+                .any(|key| {
+                    map.get(*key)
+                        .is_some_and(|v| !v.is_string() && !v.is_null())
+                }) || ["picture", "banner", "website"].iter().any(|key| {
+                    map.get(*key)
+                        .and_then(serde_json::Value::as_str)
+                        .filter(|value| !value.is_empty())
+                        .is_some_and(|value| {
+                            url::Url::parse(value).map_or(true, |url| {
+                                !matches!(url.scheme(), "https" | "http")
+                                    || url.host_str().is_none()
+                                    || !url.username().is_empty()
+                                    || url.password().is_some()
+                            })
+                        })
+                })
+            }
+            _ => true,
+        },
+        3 => event
+            .tags
+            .iter()
+            .filter(|t| t.first().is_some_and(|v| v == "p"))
+            .any(|tag| {
+                tag.get(1)
+                    .is_none_or(|key| key.len() != 64 || PublicKey::from_hex(key).is_err())
+            }),
+        10002 => event
+            .tags
+            .iter()
+            .filter(|t| t.first().is_some_and(|v| v == "r"))
+            .any(|tag| {
+                tag.get(1).is_none_or(String::is_empty)
+                    || tag
+                        .get(2)
+                        .is_some_and(|role| !matches!(role.as_str(), "read" | "write"))
+            }),
+        10050 => event
+            .tags
+            .iter()
+            .filter(|t| t.first().is_some_and(|v| v == "relay"))
+            .any(|tag| tag.get(1).is_none_or(String::is_empty)),
+        _ => false,
+    };
+    if malformed {
+        vec![finding(OnboardingIssue::Malformed)]
+    } else {
+        Vec::new()
+    }
+}
+fn relay_repair_event(
+    c: &OnboardingCheckpoint,
+    proposal: &OnboardingRepairProposal,
+) -> (Vec<Vec<String>>, String, u64) {
+    let previous = c.records[proposal.step.index()].as_ref();
+    if let Some(profile) = &proposal.profile {
+        let mut content = previous
+            .and_then(|e| serde_json::from_str::<serde_json::Value>(&e.content).ok())
+            .and_then(|v| v.as_object().cloned())
+            .unwrap_or_default();
+        if let Some(patch) = crate::directory::records::profile_content_json(profile).as_object() {
+            content.extend(patch.clone());
+        }
+        // None means preserve; an explicitly supplied empty string clears a
+        // field, including one whose remote value had the wrong JSON type.
+        for (name, value) in [
+            ("name", &profile.name),
+            ("display_name", &profile.display_name),
+            ("about", &profile.about),
+            ("picture", &profile.picture),
+            ("banner", &profile.banner),
+            ("nip05", &profile.nip05),
+            ("lud16", &profile.lud16),
+        ] {
+            if value.as_ref().is_some_and(String::is_empty) {
+                content.remove(name);
+            }
+        }
+        return (
+            previous.map(|e| e.tags.clone()).unwrap_or_default(),
+            serde_json::Value::Object(content).to_string(),
+            unix_now_seconds().max(previous.map_or(0, |e| e.created_at.saturating_add(1))),
+        );
+    }
+    if let Some(follows) = &proposal.follows {
+        let mut tags = previous
+            .map(|e| {
+                e.tags
+                    .iter()
+                    .filter(|t| {
+                        t.first().is_none_or(|v| v != "p")
+                            || t.get(1).is_some_and(|key| follows.contains(key))
+                    })
+                    .cloned()
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        for key in follows {
+            if !tags
+                .iter()
+                .any(|t| t.first().is_some_and(|v| v == "p") && t.get(1) == Some(key))
+            {
+                tags.push(vec!["p".into(), key.clone()]);
+            }
+        }
+        return (
+            tags,
+            previous.map(|e| e.content.clone()).unwrap_or_default(),
+            unix_now_seconds().max(previous.map_or(0, |e| e.created_at.saturating_add(1))),
+        );
+    }
+    let tag_name = if proposal.step == OnboardingStep::Relays {
+        "r"
+    } else {
+        "relay"
+    };
+    let mut tags = previous
+        .map(|e| {
+            e.tags
+                .iter()
+                .filter(|t| t.first().is_none_or(|v| v != tag_name))
+                .cloned()
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let mut relays = proposal.read_relays.clone();
+    for relay in &proposal.write_relays {
+        if !relays.contains(relay) {
+            relays.push(relay.clone());
+        }
+    }
+    for relay in relays {
+        let mut tag = vec![tag_name.to_owned(), relay.clone()];
+        if proposal.step == OnboardingStep::Relays {
+            match (
+                proposal.read_relays.contains(&relay),
+                proposal.write_relays.contains(&relay),
+            ) {
+                (true, false) => tag.push("read".into()),
+                (false, true) => tag.push("write".into()),
+                _ => {}
+            }
+        }
+        tags.push(tag);
+    }
+    (
+        tags,
+        previous.map(|e| e.content.clone()).unwrap_or_default(),
+        unix_now_seconds().max(previous.map_or(0, |e| e.created_at.saturating_add(1))),
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/marmot-app/src/runtime/onboarding/cancellation.rs
+++ b/crates/marmot-app/src/runtime/onboarding/cancellation.rs
@@ -1,0 +1,65 @@
+//! Reversible exit from onboarding; no relay deletions or local identity wipe.
+use super::*;
+
+impl AccountManager {
+    /// Cancel an unfinished workflow and retain the identity signed out.
+    /// Completed repairs are not undone. An approved, unfinished repair must
+    /// first be resumed, since its exact publication may already be exposed.
+    /// Retrying cancellation after interruption finishes the same local intent.
+    pub async fn cancel_onboarding(&self, account_ref: &str) -> Result<(), AppError> {
+        self.shared.lifecycle().ensure_running()?;
+        let account = self.resolve(account_ref)?;
+        let transaction = self.onboarding_transaction(&account.account_id_hex);
+        let _transaction = transaction.lock().await;
+        let Some(mut checkpoint) = self.read_onboarding_checkpoint(&account.label)? else {
+            return Ok(());
+        };
+        if checkpoint.approved || checkpoint.snapshot.ready {
+            return Err(onboarding_error());
+        }
+        let setup = self
+            .app
+            .account_home()
+            .account_setup_state(&account.label)?;
+        if setup
+            .as_ref()
+            .is_some_and(|s| s.account_id_hex != account.account_id_hex)
+        {
+            return Err(onboarding_error());
+        }
+        let _workers = self.worker_transactions.lock().await;
+        checkpoint.snapshot.cancellation_pending = true;
+        for state in &mut checkpoint.snapshot.steps {
+            state.actions = vec![OnboardingAction::CancelOnboarding];
+        }
+        self.save_onboarding(&mut checkpoint)?;
+        self.app
+            .account_home()
+            .set_account_signed_out(&account.label, true)?;
+        self.reconcile_locked().await?;
+        self.app.forget_external_signer(&account.account_id_hex);
+        // Keep the setup phase and private KeyPackage journal intact so a later
+        // legacy sign-in can resume it. Only relinquish interactive ownership.
+        if let Some(setup) = setup.filter(|s| s.kind == AccountSetupKind::InteractiveIdentity) {
+            self.app.account_home().begin_account_setup_with(
+                &account,
+                setup.reused_account_id_credential,
+                if account.local_signing {
+                    AccountSetupKind::ImportedIdentity
+                } else {
+                    AccountSetupKind::ExternalSigner
+                },
+                setup.phase,
+            )?;
+        }
+        self.app
+            .account_home()
+            .archive_account_onboarding(&account.label)?;
+        self.onboarding_updates
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .remove(&account.account_id_hex);
+        tracing::debug!(target: "marmot_app::onboarding", method = "cancel_onboarding", "cancelled onboarding and retained the signed-out identity");
+        Ok(())
+    }
+}

--- a/crates/marmot-app/src/runtime/onboarding/cancellation.rs
+++ b/crates/marmot-app/src/runtime/onboarding/cancellation.rs
@@ -37,7 +37,8 @@ impl AccountManager {
             .account_home()
             .set_account_signed_out(&account.label, true)?;
         self.reconcile_locked().await?;
-        self.app.forget_external_signer(&account.account_id_hex);
+        // Cancellation is reversible, like sign-out. Keep the host's signer
+        // attached so explicit sign-in can reuse it; removal owns detachment.
         // Keep the setup phase and private KeyPackage journal intact so a later
         // legacy sign-in can resume it. Only relinquish interactive ownership.
         if let Some(setup) = setup.filter(|s| s.kind == AccountSetupKind::InteractiveIdentity) {

--- a/crates/marmot-app/src/runtime/onboarding/single_device.rs
+++ b/crates/marmot-app/src/runtime/onboarding/single_device.rs
@@ -44,9 +44,8 @@ impl AccountManager {
             if !seen_slots.insert(slot.clone()) {
                 continue;
             }
-            let future = event.created_at > now + FUTURE_CLOCK_SKEW;
-            if future {
-                findings.push(finding(OnboardingIssue::FutureDated));
+            if slots.contains(&slot) {
+                continue;
             }
             let event_id_hex = event.id.clone();
             let published_at = event.created_at;
@@ -59,12 +58,16 @@ impl AccountManager {
             let metadata = parsed
                 .as_ref()
                 .and_then(|f| crate::key_package_metadata(&f.key_package).ok());
+            let reference = metadata.as_ref().map(|m| m.key_package_ref_hex.clone());
+            if reference.as_ref().is_some_and(|r| refs.contains(r)) {
+                continue;
+            }
+            let future = published_at > now + FUTURE_CLOCK_SKEW;
+            if future {
+                findings.push(finding(OnboardingIssue::FutureDated));
+            }
             if metadata.is_none() {
                 findings.push(finding(OnboardingIssue::Malformed));
-            }
-            let reference = metadata.as_ref().map(|m| m.key_package_ref_hex.clone());
-            if slots.contains(&slot) || reference.as_ref().is_some_and(|r| refs.contains(r)) {
-                continue;
             }
             // A verified account-authored foreign slot is evidence even when
             // its payload is unusable. Package validity is a separate property.

--- a/crates/marmot-app/src/runtime/onboarding/single_device.rs
+++ b/crates/marmot-app/src/runtime/onboarding/single_device.rs
@@ -44,42 +44,43 @@ impl AccountManager {
             if !seen_slots.insert(slot.clone()) {
                 continue;
             }
-            if event.created_at > now + CHECK_MAX_AGE {
+            let future = event.created_at > now + FUTURE_CLOCK_SKEW;
+            if future {
                 findings.push(finding(OnboardingIssue::FutureDated));
-                continue;
             }
-            let Ok(fetched) =
+            let event_id_hex = event.id.clone();
+            let published_at = event.created_at;
+            let parsed =
                 crate::key_package_records::key_package_from_record(DirectoryRelayEventRecord {
                     endpoints: Vec::new(),
                     event,
                 })
-            else {
+                .ok();
+            let metadata = parsed
+                .as_ref()
+                .and_then(|f| crate::key_package_metadata(&f.key_package).ok());
+            if metadata.is_none() {
                 findings.push(finding(OnboardingIssue::Malformed));
-                continue;
-            };
-            let metadata = crate::key_package_metadata(&fetched.key_package)
-                .map_err(|_| onboarding_error())?;
-            if metadata.not_after <= now {
+            }
+            let reference = metadata.as_ref().map(|m| m.key_package_ref_hex.clone());
+            if slots.contains(&slot) || reference.as_ref().is_some_and(|r| refs.contains(r)) {
                 continue;
             }
-            if metadata.not_before > now + CHECK_MAX_AGE {
-                findings.push(finding(OnboardingIssue::FutureDated));
-                continue;
-            }
-            // A stable local slot survives rotation and expiry of the old
-            // private bundle. A matching reference also recognizes relay echoes
-            // of locally owned material advertised under a different event/slot.
-            if slots.contains(&slot) || refs.contains(&fetched.key_package_ref_hex) {
-                continue;
-            }
+            // A verified account-authored foreign slot is evidence even when
+            // its payload is unusable. Package validity is a separate property.
             packages.push(OnboardingDevicePackage {
                 slot_id: slot,
-                key_package_ref_hex: fetched.key_package_ref_hex,
-                event_id_hex: fetched.key_package_event_id,
-                published_at: fetched.created_at,
-                expires_at: metadata.not_after,
+                key_package_ref_hex: reference,
+                event_id_hex,
+                published_at,
+                expires_at: metadata.as_ref().map(|m| m.not_after),
+                usable: !future
+                    && metadata
+                        .as_ref()
+                        .is_some_and(|m| m.not_before <= now && m.not_after > now),
             });
         }
+        // Missing any selected source remains inconclusive even if others reached EOSE.
         let discovery_complete = completed > 0 && findings.is_empty();
         let discovery = if !packages.is_empty() {
             findings.push(finding(OnboardingIssue::OtherInstallationPossible));

--- a/crates/marmot-app/src/runtime/onboarding/single_device.rs
+++ b/crates/marmot-app/src/runtime/onboarding/single_device.rs
@@ -1,0 +1,155 @@
+//! Advisory installation detection without opening a worker or publishing.
+use super::*;
+
+impl AccountManager {
+    pub(super) async fn check_onboarding_single_device(
+        &self,
+        checkpoint: &mut OnboardingCheckpoint,
+    ) -> Result<(), AppError> {
+        let id = &checkpoint.snapshot.account_id_hex;
+        let account = self.resolve(id)?;
+        let storage = self.app.account_storage(&account.label)?;
+        let owned = cgka_engine::key_package::durably_owned_key_packages(
+            &storage,
+            cgka_traits::group::ProtocolProfile::Current,
+        )
+        .map_err(cgka_session::SessionError::from)?;
+        let local = self.app.local_key_package_records(&account.label, owned)?;
+        let mut slots: HashSet<String> = local.iter().map(|p| p.key_package_id.clone()).collect();
+        if let Some(lifecycle) = storage.key_package_lifecycle()? {
+            slots.insert(lifecycle.stable_slot_id);
+        }
+        slots.remove("");
+        let refs: HashSet<String> = local.into_iter().map(|p| p.key_package_ref_hex).collect();
+        let sources = self
+            .onboarding_sources(checkpoint, OnboardingStep::SingleDevice)
+            .await;
+        let (events, mut findings, completed) =
+            self.inspect_onboarding_relays(id, 30443, sources).await;
+        let now = unix_now_seconds();
+        let mut packages = Vec::new();
+        let mut seen_slots = HashSet::new();
+        for event in events {
+            // The inspector verifies authors/signatures and sorts newest first,
+            // including Nostr's event-id tie break. Inspect only each slot's
+            // newest record; a malformed replacement must not revive an old one.
+            let Some(slot) = event
+                .tag_value("d")
+                .filter(|s| !s.is_empty())
+                .map(str::to_owned)
+            else {
+                findings.push(finding(OnboardingIssue::Malformed));
+                continue;
+            };
+            if !seen_slots.insert(slot.clone()) {
+                continue;
+            }
+            if event.created_at > now + CHECK_MAX_AGE {
+                findings.push(finding(OnboardingIssue::FutureDated));
+                continue;
+            }
+            let Ok(fetched) =
+                crate::key_package_records::key_package_from_record(DirectoryRelayEventRecord {
+                    endpoints: Vec::new(),
+                    event,
+                })
+            else {
+                findings.push(finding(OnboardingIssue::Malformed));
+                continue;
+            };
+            let metadata = crate::key_package_metadata(&fetched.key_package)
+                .map_err(|_| onboarding_error())?;
+            if metadata.not_after <= now {
+                continue;
+            }
+            if metadata.not_before > now + CHECK_MAX_AGE {
+                findings.push(finding(OnboardingIssue::FutureDated));
+                continue;
+            }
+            // A stable local slot survives rotation and expiry of the old
+            // private bundle. A matching reference also recognizes relay echoes
+            // of locally owned material advertised under a different event/slot.
+            if slots.contains(&slot) || refs.contains(&fetched.key_package_ref_hex) {
+                continue;
+            }
+            packages.push(OnboardingDevicePackage {
+                slot_id: slot,
+                key_package_ref_hex: fetched.key_package_ref_hex,
+                event_id_hex: fetched.key_package_event_id,
+                published_at: fetched.created_at,
+                expires_at: metadata.not_after,
+            });
+        }
+        let discovery_complete = completed > 0 && findings.is_empty();
+        let discovery = if !packages.is_empty() {
+            findings.push(finding(OnboardingIssue::OtherInstallationPossible));
+            OnboardingDeviceDiscovery::OtherInstallationPossible
+        } else if discovery_complete {
+            OnboardingDeviceDiscovery::NoneFound
+        } else {
+            OnboardingDeviceDiscovery::Unknown
+        };
+        findings.insert(0, finding(OnboardingIssue::MultiDeviceUnsupported));
+        checkpoint.snapshot.single_device_notice = Some(OnboardingSingleDeviceNotice {
+            discovery,
+            other_packages: packages,
+            discovery_complete,
+            acknowledged_at: None,
+        });
+        checkpoint.set(
+            OnboardingStep::SingleDevice,
+            OnboardingStatus::NeedsInput,
+            findings,
+        );
+        Ok(())
+    }
+
+    /// Acknowledge the one-device limitation for this onboarding attempt. This
+    /// authorizes normal setup publication, never deletion of another slot.
+    /// Persist before resuming so cancellation/restart cannot lose the choice.
+    pub async fn acknowledge_onboarding_single_device(
+        &self,
+        account_ref: &str,
+        revision: u64,
+    ) -> Result<OnboardingSnapshot, AppError> {
+        let transaction = self.onboarding_transaction(&self.resolve(account_ref)?.account_id_hex);
+        let _transaction = transaction.lock().await;
+        let mut checkpoint = self
+            .onboarding_checkpoint(account_ref)?
+            .ok_or_else(onboarding_error)?;
+        let step = &checkpoint.snapshot.steps[OnboardingStep::SingleDevice.index()];
+        if checkpoint.snapshot.revision != revision
+            || checkpoint.approved
+            || checkpoint.snapshot.proposal.is_some()
+            || checkpoint.single_device_acknowledged
+            || checkpoint.snapshot.steps[..OnboardingStep::SingleDevice.index()]
+                .iter()
+                .any(|s| {
+                    !matches!(
+                        s.status,
+                        OnboardingStatus::Passed | OnboardingStatus::Skipped
+                    )
+                })
+            || step.status != OnboardingStatus::NeedsInput
+            || !step.actions.contains(&OnboardingAction::ContinueAnyway)
+        {
+            return Err(onboarding_error());
+        }
+        let notice = checkpoint
+            .snapshot
+            .single_device_notice
+            .as_mut()
+            .ok_or_else(onboarding_error)?;
+        notice.acknowledged_at = Some(unix_now_seconds());
+        checkpoint.single_device_acknowledged = true;
+        let findings = step.findings.clone();
+        checkpoint.set(
+            OnboardingStep::SingleDevice,
+            OnboardingStatus::Passed,
+            findings,
+        );
+        self.save_onboarding(&mut checkpoint)?;
+        self.run_onboarding_locked(&mut checkpoint).await?;
+        Ok(checkpoint.snapshot)
+    }
+}

--- a/crates/marmot-app/src/runtime/onboarding/tests.rs
+++ b/crates/marmot-app/src/runtime/onboarding/tests.rs
@@ -65,6 +65,113 @@ impl DirectoryRelayFetcher for Network {
 }
 
 #[tokio::test]
+async fn onboarding_older_checkpoint_restores_retry_hints_and_conservative_package_validity() {
+    let (directory, first, network, _keys, id) = fixture().await;
+    let manager = first.accounts();
+    let mut c = manager.onboarding_checkpoint(&id).unwrap().unwrap();
+    c.set(OnboardingStep::Profile, OnboardingStatus::Passed, vec![]);
+    c.set(OnboardingStep::Follows, OnboardingStatus::Skipped, vec![]);
+    c.snapshot.single_device_notice = Some(OnboardingSingleDeviceNotice {
+        discovery: OnboardingDeviceDiscovery::OtherInstallationPossible,
+        other_packages: vec![OnboardingDevicePackage {
+            slot_id: "foreign".into(),
+            key_package_ref_hex: Some("ref".into()),
+            event_id_hex: "event".into(),
+            published_at: 1,
+            expires_at: Some(2),
+            usable: true,
+        }],
+        discovery_complete: true,
+        acknowledged_at: None,
+    });
+    let mut old = serde_json::to_value(&c).unwrap();
+    for index in 0..2 {
+        old["snapshot"]["steps"][index]["actions"] = serde_json::json!([]);
+    }
+    old["snapshot"]["single_device_notice"]["other_packages"][0]
+        .as_object_mut()
+        .unwrap()
+        .remove("usable");
+    manager
+        .app
+        .account_home()
+        .set_account_onboarding(&id, &serde_json::to_vec(&old).unwrap())
+        .unwrap();
+    first.shutdown_and_close().await.unwrap();
+    let reopened = runtime(directory.path(), network);
+    let manager = reopened.accounts();
+    let snapshot = manager.onboarding_snapshot(&id).unwrap().unwrap();
+    assert!(!snapshot.single_device_notice.unwrap().other_packages[0].usable);
+    for step in &snapshot.steps[..2] {
+        assert!(step.actions.contains(&OnboardingAction::Retry));
+    }
+    let retried = manager
+        .retry_onboarding_step(&id, OnboardingStep::Profile)
+        .await
+        .unwrap();
+    assert_eq!(
+        retried.steps[OnboardingStep::Follows.index()].status,
+        OnboardingStatus::Skipped
+    );
+    manager.cancel_onboarding(&id).await.unwrap();
+    assert!(manager.onboarding_snapshot(&id).unwrap().is_none());
+    reopened.shutdown_and_close().await.unwrap();
+}
+
+#[tokio::test]
+async fn single_device_ignores_unusable_owned_slots_but_preserves_foreign_evidence() {
+    let (_directory, runtime, network, keys, id) = fixture().await;
+    let manager = runtime.accounts();
+    manager
+        .app
+        .account_storage(&id)
+        .unwrap()
+        .put_key_package_lifecycle(&cgka_traits::KeyPackageLifecycleState::slot_only(
+            "owned-slot".into(),
+        ))
+        .unwrap();
+    let mut c = manager.onboarding_checkpoint(&id).unwrap().unwrap();
+    for published_at in [
+        unix_now_seconds(),
+        unix_now_seconds() + FUTURE_CLOCK_SKEW + 1,
+    ] {
+        *network.events.lock().unwrap() = vec![signed(
+            &keys,
+            30443,
+            vec![vec!["d".into(), "owned-slot".into()]],
+            "malformed",
+            published_at,
+        )];
+        manager
+            .check_onboarding_single_device(&mut c)
+            .await
+            .unwrap();
+        let notice = c.snapshot.single_device_notice.as_ref().unwrap();
+        assert_eq!(notice.discovery, OnboardingDeviceDiscovery::NoneFound);
+        assert!(notice.discovery_complete && notice.other_packages.is_empty());
+        network.events.lock().unwrap().push(signed(
+            &keys,
+            30443,
+            vec![vec!["d".into(), "foreign-slot".into()]],
+            "malformed",
+            published_at,
+        ));
+        manager
+            .check_onboarding_single_device(&mut c)
+            .await
+            .unwrap();
+        let notice = c.snapshot.single_device_notice.as_ref().unwrap();
+        assert_eq!(
+            notice.discovery,
+            OnboardingDeviceDiscovery::OtherInstallationPossible
+        );
+        assert_eq!(notice.other_packages.len(), 1);
+        assert!(!notice.other_packages[0].usable);
+    }
+    runtime.shutdown_and_close().await.unwrap();
+}
+
+#[tokio::test]
 async fn onboarding_legacy_setup_admission_does_not_mutate_account() {
     let directory = tempfile::tempdir().unwrap();
     let network = Arc::new(Network::default());

--- a/crates/marmot-app/src/runtime/onboarding/tests.rs
+++ b/crates/marmot-app/src/runtime/onboarding/tests.rs
@@ -246,7 +246,10 @@ async fn zero_ack_repair_survives_restart_and_retries_exact_signed_bytes() {
             .unwrap()
     );
     assert_eq!(network.attempts.lock().unwrap()[1], expected);
-    assert!(c.snapshot.steps[4].status == OnboardingStatus::Pending && !c.snapshot.ready);
+    assert!(
+        c.snapshot.steps[OnboardingStep::KeyPackage.index()].status == OnboardingStatus::Pending
+            && !c.snapshot.ready
+    );
     second.shutdown_and_close().await.unwrap();
 }
 #[tokio::test]
@@ -403,6 +406,7 @@ async fn completed_checkpoint_resumes_interrupted_journal_cleanup() {
         OnboardingStep::Follows,
         OnboardingStep::Relays,
         OnboardingStep::InboxRelays,
+        OnboardingStep::SingleDevice,
         OnboardingStep::KeyPackage,
     ] {
         c.set(step, OnboardingStatus::Passed, Vec::new());
@@ -468,5 +472,118 @@ async fn profile_url_validation_and_explicit_clear_preserve_unrelated_fields() {
     let json: serde_json::Value = serde_json::from_str(&content).unwrap();
     assert!(json.get("picture").is_none());
     assert_eq!(json["custom"], true);
+    runtime.shutdown_and_close().await.unwrap();
+}
+
+#[tokio::test]
+async fn single_device_notice_distinguishes_empty_failed_and_invalid_discovery_without_publishing()
+{
+    let (_directory, runtime, network, keys, id) = fixture().await;
+    let manager = runtime.accounts();
+    let mut c = manager.onboarding_checkpoint(&id).unwrap().unwrap();
+    manager
+        .check_onboarding_single_device(&mut c)
+        .await
+        .unwrap();
+    let notice = c.snapshot.single_device_notice.as_ref().unwrap();
+    assert_eq!(notice.discovery, OnboardingDeviceDiscovery::NoneFound);
+    assert!(notice.discovery_complete);
+    assert_eq!(c.snapshot.steps[4].status, OnboardingStatus::NeedsInput);
+    assert!(
+        c.snapshot.steps[4]
+            .actions
+            .contains(&OnboardingAction::CancelOnboarding)
+    );
+    network.fail_reads.store(true, Ordering::SeqCst);
+    manager
+        .check_onboarding_single_device(&mut c)
+        .await
+        .unwrap();
+    let notice = c.snapshot.single_device_notice.as_ref().unwrap();
+    assert_eq!(notice.discovery, OnboardingDeviceDiscovery::Unknown);
+    assert!(!notice.discovery_complete);
+    network.fail_reads.store(false, Ordering::SeqCst);
+    network.events.lock().unwrap().push(signed(
+        &keys,
+        30443,
+        vec![vec!["d".into(), "foreign".into()]],
+        "malformed",
+        unix_now_seconds(),
+    ));
+    manager
+        .check_onboarding_single_device(&mut c)
+        .await
+        .unwrap();
+    assert_eq!(
+        c.snapshot.single_device_notice.as_ref().unwrap().discovery,
+        OnboardingDeviceDiscovery::Unknown
+    );
+    assert!(
+        c.snapshot.steps[4]
+            .findings
+            .iter()
+            .any(|f| f.issue == OnboardingIssue::Malformed)
+    );
+    network.events.lock().unwrap().clear();
+    network.events.lock().unwrap().push(signed(
+        &keys,
+        30443,
+        vec![vec!["d".into(), "future".into()]],
+        "ignored",
+        unix_now_seconds() + 600,
+    ));
+    manager
+        .check_onboarding_single_device(&mut c)
+        .await
+        .unwrap();
+    assert_eq!(
+        c.snapshot.single_device_notice.as_ref().unwrap().discovery,
+        OnboardingDeviceDiscovery::Unknown
+    );
+    assert!(
+        c.snapshot.steps[4]
+            .findings
+            .iter()
+            .any(|f| f.issue == OnboardingIssue::FutureDated)
+    );
+    assert!(network.attempts.lock().unwrap().is_empty());
+    runtime.shutdown_and_close().await.unwrap();
+}
+
+#[tokio::test]
+async fn pre_notice_checkpoint_upgrade_gates_incomplete_publication_and_preserves_completed_accounts()
+ {
+    let (_directory, runtime, _network, _keys, id) = fixture().await;
+    let manager = runtime.accounts();
+    let mut c = manager.onboarding_checkpoint(&id).unwrap().unwrap();
+    c.version = 1;
+    c.snapshot.steps.remove(4);
+    c.records.remove(4);
+    for step in &mut c.snapshot.steps {
+        step.status = OnboardingStatus::Passed;
+    }
+    c.snapshot.steps[4].status = OnboardingStatus::Checking;
+    manager
+        .app
+        .account_home()
+        .set_account_onboarding(&id, &serde_json::to_vec(&c).unwrap())
+        .unwrap();
+    let upgraded = manager.onboarding_checkpoint(&id).unwrap().unwrap();
+    assert_eq!(upgraded.version, ONBOARDING_VERSION);
+    assert_eq!(
+        upgraded.snapshot.steps[4].step,
+        OnboardingStep::SingleDevice
+    );
+    assert_eq!(upgraded.snapshot.steps[5].status, OnboardingStatus::Pending);
+    assert!(!manager.onboarding_worker_allowed(&id).unwrap());
+    c.snapshot.ready = true;
+    c.snapshot.steps[4].status = OnboardingStatus::Passed;
+    manager
+        .app
+        .account_home()
+        .set_account_onboarding(&id, &serde_json::to_vec(&c).unwrap())
+        .unwrap();
+    assert!(manager.onboarding_snapshot(&id).unwrap().unwrap().ready);
+    assert!(manager.onboarding_worker_allowed(&id).unwrap());
     runtime.shutdown_and_close().await.unwrap();
 }

--- a/crates/marmot-app/src/runtime/onboarding/tests.rs
+++ b/crates/marmot-app/src/runtime/onboarding/tests.rs
@@ -11,6 +11,8 @@ struct Network {
     events: StdMutex<Vec<NostrTransportEvent>>,
     attempts: StdMutex<Vec<NostrTransportEvent>>,
     fail_reads: AtomicBool,
+    return_off_filter_events: AtomicBool,
+    fail_index_only: AtomicBool,
     zero_acks: AtomicBool,
     block_publish: AtomicBool,
     publishing: Notify,
@@ -21,7 +23,13 @@ impl DirectoryRelayFetcher for Network {
         &self,
         request: DirectoryFetchRequest,
     ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
-        if self.fail_reads.load(Ordering::SeqCst) {
+        if self.fail_reads.load(Ordering::SeqCst)
+            || (self.fail_index_only.load(Ordering::SeqCst)
+                && request
+                    .endpoints
+                    .iter()
+                    .any(|e| e.0.contains("index.example")))
+        {
             return Err("timeout".into());
         }
         Ok(self
@@ -30,6 +38,9 @@ impl DirectoryRelayFetcher for Network {
             .unwrap()
             .iter()
             .filter(|event| {
+                if self.return_off_filter_events.load(Ordering::SeqCst) {
+                    return true;
+                }
                 request
                     .queries
                     .iter()
@@ -46,9 +57,285 @@ impl DirectoryRelayFetcher for Network {
         &self,
         request: DirectoryFetchRequest,
         _signer: Option<Arc<dyn nostr::NostrSigner>>,
-    ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
-        self.fetch_directory_events(request).await
+    ) -> Result<Vec<DirectoryRelayEventRecord>, crate::relay_plane::DirectoryInspectionError> {
+        self.fetch_directory_events(request)
+            .await
+            .map_err(|_| crate::relay_plane::DirectoryInspectionError::TimedOut)
     }
+}
+
+#[tokio::test]
+async fn onboarding_legacy_setup_admission_does_not_mutate_account() {
+    let directory = tempfile::tempdir().unwrap();
+    let network = Arc::new(Network::default());
+    let runtime = runtime(directory.path(), network);
+    let keys = nostr::Keys::generate();
+    let secret = keys.secret_key().to_bech32().unwrap();
+    let account = runtime
+        .accounts()
+        .app
+        .account_home()
+        .import_nostr_account_idempotent(&secret)
+        .unwrap()
+        .account()
+        .clone();
+    assert!(
+        runtime
+            .accounts()
+            .begin_onboarding(Zeroizing::new(secret), options())
+            .await
+            .is_err()
+    );
+    assert_eq!(runtime.accounts().resolve(&account.label).unwrap(), account);
+    assert!(
+        runtime
+            .accounts()
+            .onboarding_snapshot(&account.label)
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        runtime
+            .accounts()
+            .app
+            .account_home()
+            .account_setup_state(&account.label)
+            .unwrap()
+            .unwrap()
+            .kind,
+        AccountSetupKind::ImportedIdentity
+    );
+    runtime.shutdown_and_close().await.unwrap();
+}
+
+#[tokio::test]
+async fn onboarding_legacy_import_rejects_before_reactivating_the_identity() {
+    let (_dir, runtime, network, keys, id) = fixture().await;
+    let home = runtime.accounts().app.account_home();
+    let before = home.set_account_signed_out(&id, true).unwrap();
+    let checkpoint = home.account_onboarding(&id).unwrap();
+    let result = runtime
+        .create_or_import_account(AccountSetupRequest {
+            import_nsec: Some(Zeroizing::new(keys.secret_key().to_bech32().unwrap())),
+            ..AccountSetupRequest::default()
+        })
+        .await;
+    assert!(matches!(result, Err(AppError::OnboardingRequired)));
+    assert_eq!(home.account(&id).unwrap(), before);
+    assert_eq!(home.account_onboarding(&id).unwrap(), checkpoint);
+    assert!(network.attempts.lock().unwrap().is_empty());
+    runtime.shutdown_and_close().await.unwrap();
+}
+
+#[tokio::test]
+async fn onboarding_retry_preserves_declined_steps_and_invalidates_device_evidence() {
+    let (_directory, runtime, _network, _keys, id) = fixture().await;
+    let manager = runtime.accounts();
+    let pending = manager.onboarding_snapshot(&id).unwrap().unwrap();
+    assert!(
+        manager
+            .retry_onboarding_step(&id, OnboardingStep::Follows)
+            .await
+            .is_err()
+    );
+    assert_eq!(manager.onboarding_snapshot(&id).unwrap().unwrap(), pending);
+    let mut c = manager.onboarding_checkpoint(&id).unwrap().unwrap();
+    c.set(OnboardingStep::Profile, OnboardingStatus::Passed, vec![]);
+    c.set(OnboardingStep::Follows, OnboardingStatus::Skipped, vec![]);
+    c.set(
+        OnboardingStep::SingleDevice,
+        OnboardingStatus::Passed,
+        vec![finding(OnboardingIssue::OtherInstallationPossible)],
+    );
+    c.single_device_acknowledged = true;
+    c.snapshot.single_device_notice = Some(OnboardingSingleDeviceNotice {
+        discovery: OnboardingDeviceDiscovery::OtherInstallationPossible,
+        other_packages: vec![],
+        discovery_complete: false,
+        acknowledged_at: Some(1),
+    });
+    manager.save_onboarding(&mut c).unwrap();
+    let retried = manager
+        .retry_onboarding_step(&id, OnboardingStep::Profile)
+        .await
+        .unwrap();
+    assert_eq!(
+        retried.steps[OnboardingStep::Follows.index()].status,
+        OnboardingStatus::Skipped
+    );
+    assert_eq!(
+        retried.steps[OnboardingStep::SingleDevice.index()].status,
+        OnboardingStatus::Pending
+    );
+    assert!(retried.single_device_notice.is_none());
+    assert!(
+        !manager
+            .onboarding_checkpoint(&id)
+            .unwrap()
+            .unwrap()
+            .single_device_acknowledged
+    );
+    // Changing sources invalidates even an already acknowledged notice.
+    manager.save_onboarding(&mut c).unwrap();
+    let changed = manager
+        .set_onboarding_discovery_relays(&id, vec!["wss://alternate.example".into()])
+        .await
+        .unwrap();
+    assert!(changed.single_device_notice.is_none());
+    assert_eq!(
+        changed.steps[OnboardingStep::Follows.index()].status,
+        OnboardingStatus::Skipped
+    );
+    runtime.shutdown_and_close().await.unwrap();
+}
+
+#[tokio::test]
+async fn onboarding_partial_discovery_and_off_filter_noise_have_distinct_results() {
+    let (_directory, runtime, network, keys, id) = fixture().await;
+    let manager = runtime.accounts();
+    let mut c = manager.onboarding_checkpoint(&id).unwrap().unwrap();
+    c.options
+        .discovery_relays
+        .push("wss://healthy.example".into());
+    network
+        .events
+        .lock()
+        .unwrap()
+        .push(signed(&keys, 0, vec![], "{}", unix_now_seconds()));
+    network.fail_index_only.store(true, Ordering::SeqCst);
+    let (status, findings, _) = manager
+        .check_onboarding_step(&c, OnboardingStep::Profile)
+        .await;
+    assert_eq!(status, OnboardingStatus::Passed);
+    assert!(
+        findings
+            .iter()
+            .any(|f| f.issue == OnboardingIssue::DiscoveryIncomplete)
+    );
+    network.fail_index_only.store(false, Ordering::SeqCst);
+    network.events.lock().unwrap().clear();
+    network.events.lock().unwrap().push(signed(
+        &nostr::Keys::generate(),
+        30443,
+        vec![vec!["d".into(), "foreign-author".into()]],
+        "noise",
+        unix_now_seconds(),
+    ));
+    network
+        .return_off_filter_events
+        .store(true, Ordering::SeqCst);
+    manager
+        .check_onboarding_single_device(&mut c)
+        .await
+        .unwrap();
+    assert_eq!(
+        c.snapshot.single_device_notice.unwrap().discovery,
+        OnboardingDeviceDiscovery::NoneFound
+    );
+    runtime.shutdown_and_close().await.unwrap();
+}
+
+#[tokio::test]
+async fn onboarding_cancellation_retries_local_intent_and_allows_explicit_restart() {
+    let (directory, runtime, network, keys, id) = fixture().await;
+    let manager = runtime.accounts();
+    let mut c = manager.onboarding_checkpoint(&id).unwrap().unwrap();
+    // Simulate interruption after the cancellation intent, before sign-out.
+    c.snapshot.cancellation_pending = true;
+    manager.save_onboarding(&mut c).unwrap();
+    assert!(manager.run_onboarding(&id).await.is_err());
+    manager.cancel_onboarding(&id).await.unwrap();
+    manager.cancel_onboarding(&id).await.unwrap();
+    assert!(manager.resolve(&id).unwrap().signed_out);
+    assert!(manager.onboarding_snapshot(&id).unwrap().is_none());
+    assert!(manager.require_onboarding_complete(&id).is_ok());
+    assert!(
+        manager
+            .app
+            .account_home()
+            .cancelled_account_onboarding(&id)
+            .unwrap()
+            .is_some()
+    );
+    assert!(network.attempts.lock().unwrap().is_empty());
+    runtime.shutdown_and_close().await.unwrap();
+    let reopened = super::tests::runtime(directory.path(), network);
+    let resumed = reopened
+        .accounts()
+        .begin_onboarding(
+            Zeroizing::new(keys.secret_key().to_bech32().unwrap()),
+            options(),
+        )
+        .await
+        .unwrap();
+    assert!(!resumed.cancellation_pending && !resumed.ready);
+    assert!(!reopened.accounts().managed_accounts().unwrap()[0].running);
+    reopened.shutdown_and_close().await.unwrap();
+}
+
+#[tokio::test]
+async fn onboarding_completed_checkpoint_does_not_hide_or_clear_later_setup() {
+    let (_dir, runtime, _network, keys, id) = fixture().await;
+    let manager = runtime.accounts();
+    let mut c = manager.onboarding_checkpoint(&id).unwrap().unwrap();
+    for step in c.snapshot.steps.clone() {
+        c.set(step.step, OnboardingStatus::Passed, vec![]);
+    }
+    manager.save_onboarding(&mut c).unwrap();
+    let account = manager.resolve(&id).unwrap();
+    manager
+        .app
+        .account_home()
+        .begin_account_setup_with(
+            &account,
+            false,
+            AccountSetupKind::ImportedIdentity,
+            AccountSetupPhase::KeyPackagePublicationStarted,
+        )
+        .unwrap();
+    assert_eq!(
+        runtime.account_setup_readiness(&id).unwrap(),
+        AccountSetupReadiness::Publishing
+    );
+    for cleanup_pending in [false, true] {
+        c.setup_cleanup_pending = cleanup_pending;
+        manager.save_onboarding(&mut c).unwrap();
+        assert!(
+            manager
+                .begin_onboarding(
+                    Zeroizing::new(keys.secret_key().to_bech32().unwrap()),
+                    options(),
+                )
+                .await
+                .is_err()
+        );
+        assert!(manager.run_onboarding(&id).await.unwrap().ready);
+        assert_eq!(
+            runtime.account_setup_readiness(&id).unwrap(),
+            AccountSetupReadiness::Publishing
+        );
+    }
+    assert_eq!(
+        manager
+            .app
+            .account_home()
+            .account_setup_state(&id)
+            .unwrap()
+            .unwrap()
+            .phase,
+        AccountSetupPhase::KeyPackagePublicationStarted
+    );
+    manager
+        .app
+        .account_home()
+        .complete_account_setup(&id)
+        .unwrap();
+    let _storage = manager.app.account_storage(&id).unwrap();
+    assert_eq!(
+        runtime.account_setup_readiness(&id).unwrap(),
+        AccountSetupReadiness::RecoveryRequired
+    );
+    runtime.shutdown_and_close().await.unwrap();
 }
 #[async_trait]
 impl NostrRelayClient for Network {
@@ -236,6 +523,7 @@ async fn zero_ack_repair_survives_restart_and_retries_exact_signed_bytes() {
         .unwrap()
         .unwrap();
     assert!(c.approved);
+    assert!(second.accounts().cancel_onboarding(&id).await.is_err());
     assert_eq!(c.signed_repair, Some(expected.clone()));
     network.zero_acks.store(false, Ordering::SeqCst);
     assert!(
@@ -362,7 +650,8 @@ async fn corrupt_or_future_checkpoint_fails_closed() {
         .set_account_onboarding(&id, &serde_json::to_vec(&c).unwrap())
         .unwrap();
     assert!(manager.onboarding_snapshot(&id).is_err());
-    assert!(manager.reconcile().await.is_err());
+    assert!(manager.reconcile().await.is_ok());
+    assert!(!manager.managed_accounts().unwrap()[0].running);
     runtime.shutdown_and_close().await.unwrap();
 }
 
@@ -411,6 +700,12 @@ async fn completed_checkpoint_resumes_interrupted_journal_cleanup() {
     ] {
         c.set(step, OnboardingStatus::Passed, Vec::new());
     }
+    c.setup_cleanup_pending = true;
+    manager
+        .app
+        .account_home()
+        .set_account_setup_phase(&id, AccountSetupPhase::KeyPackagePublicationConfirmed)
+        .unwrap();
     manager.save_onboarding(&mut c).unwrap();
     assert!(
         manager
@@ -422,7 +717,7 @@ async fn completed_checkpoint_resumes_interrupted_journal_cleanup() {
     );
     assert_eq!(
         runtime.account_setup_readiness(&id).unwrap(),
-        AccountSetupReadiness::NetworkReady
+        AccountSetupReadiness::Publishing
     );
     assert!(manager.run_onboarding(&id).await.unwrap().ready);
     assert!(
@@ -488,9 +783,12 @@ async fn single_device_notice_distinguishes_empty_failed_and_invalid_discovery_w
     let notice = c.snapshot.single_device_notice.as_ref().unwrap();
     assert_eq!(notice.discovery, OnboardingDeviceDiscovery::NoneFound);
     assert!(notice.discovery_complete);
-    assert_eq!(c.snapshot.steps[4].status, OnboardingStatus::NeedsInput);
+    assert_eq!(
+        c.snapshot.steps[OnboardingStep::SingleDevice.index()].status,
+        OnboardingStatus::NeedsInput
+    );
     assert!(
-        c.snapshot.steps[4]
+        c.snapshot.steps[OnboardingStep::SingleDevice.index()]
             .actions
             .contains(&OnboardingAction::CancelOnboarding)
     );
@@ -516,10 +814,10 @@ async fn single_device_notice_distinguishes_empty_failed_and_invalid_discovery_w
         .unwrap();
     assert_eq!(
         c.snapshot.single_device_notice.as_ref().unwrap().discovery,
-        OnboardingDeviceDiscovery::Unknown
+        OnboardingDeviceDiscovery::OtherInstallationPossible
     );
     assert!(
-        c.snapshot.steps[4]
+        c.snapshot.steps[OnboardingStep::SingleDevice.index()]
             .findings
             .iter()
             .any(|f| f.issue == OnboardingIssue::Malformed)
@@ -538,10 +836,10 @@ async fn single_device_notice_distinguishes_empty_failed_and_invalid_discovery_w
         .unwrap();
     assert_eq!(
         c.snapshot.single_device_notice.as_ref().unwrap().discovery,
-        OnboardingDeviceDiscovery::Unknown
+        OnboardingDeviceDiscovery::OtherInstallationPossible
     );
     assert!(
-        c.snapshot.steps[4]
+        c.snapshot.steps[OnboardingStep::SingleDevice.index()]
             .findings
             .iter()
             .any(|f| f.issue == OnboardingIssue::FutureDated)

--- a/crates/marmot-app/src/runtime/onboarding/tests.rs
+++ b/crates/marmot-app/src/runtime/onboarding/tests.rs
@@ -1,0 +1,472 @@
+use super::*;
+use crate::relay_plane::{DirectoryFetchRequest, DirectoryRelayFetcher};
+use async_trait::async_trait;
+use cgka_traits::{MemberId, TransportAdapterError};
+use nostr::prelude::ToBech32;
+use std::sync::atomic::{AtomicBool, Ordering};
+use transport_nostr_adapter::{NostrPublishOutcome, NostrRelayClient, NostrSubscription};
+
+#[derive(Default)]
+struct Network {
+    events: StdMutex<Vec<NostrTransportEvent>>,
+    attempts: StdMutex<Vec<NostrTransportEvent>>,
+    fail_reads: AtomicBool,
+    zero_acks: AtomicBool,
+    block_publish: AtomicBool,
+    publishing: Notify,
+}
+#[async_trait]
+impl DirectoryRelayFetcher for Network {
+    async fn fetch_directory_events(
+        &self,
+        request: DirectoryFetchRequest,
+    ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
+        if self.fail_reads.load(Ordering::SeqCst) {
+            return Err("timeout".into());
+        }
+        Ok(self
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|event| {
+                request
+                    .queries
+                    .iter()
+                    .any(|q| q.kind == event.kind && q.authors.contains(&event.pubkey))
+            })
+            .cloned()
+            .map(|event| DirectoryRelayEventRecord {
+                endpoints: request.endpoints.clone(),
+                event,
+            })
+            .collect())
+    }
+    async fn inspect_directory_events(
+        &self,
+        request: DirectoryFetchRequest,
+        _signer: Option<Arc<dyn nostr::NostrSigner>>,
+    ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
+        self.fetch_directory_events(request).await
+    }
+}
+#[async_trait]
+impl NostrRelayClient for Network {
+    async fn subscribe(&self, _: NostrSubscription) -> Result<(), TransportAdapterError> {
+        Ok(())
+    }
+    async fn unsubscribe(&self, _: NostrSubscription) -> Result<(), TransportAdapterError> {
+        Ok(())
+    }
+    async fn unsubscribe_account(&self, _: &MemberId) -> Result<(), TransportAdapterError> {
+        Ok(())
+    }
+    async fn publish_event(
+        &self,
+        endpoints: &[TransportEndpoint],
+        event: &NostrTransportEvent,
+        _: usize,
+    ) -> Result<NostrPublishOutcome, TransportAdapterError> {
+        self.attempts.lock().unwrap().push(event.clone());
+        self.publishing.notify_one();
+        if self.block_publish.load(Ordering::SeqCst) {
+            std::future::pending::<()>().await;
+        }
+        if self.zero_acks.load(Ordering::SeqCst) {
+            return Ok(NostrPublishOutcome::default());
+        }
+        self.events.lock().unwrap().push(event.clone());
+        Ok(NostrPublishOutcome::accepted(endpoints.iter().cloned()))
+    }
+}
+fn options() -> OnboardingOptions {
+    OnboardingOptions {
+        default_relays: vec!["wss://default.example".into()],
+        discovery_relays: vec!["wss://index.example".into()],
+    }
+}
+fn runtime(path: &std::path::Path, network: Arc<Network>) -> MarmotAppRuntime {
+    let mut app = MarmotApp::with_relay(path, "wss://default.example")
+        .with_test_relay_client(network.clone());
+    app.relay_plane =
+        MarmotRelayPlane::new_with_directory_fetcher_for_test(network.clone(), network);
+    MarmotAppRuntime::new(app)
+}
+async fn fixture() -> (
+    tempfile::TempDir,
+    MarmotAppRuntime,
+    Arc<Network>,
+    nostr::Keys,
+    String,
+) {
+    let dir = tempfile::tempdir().unwrap();
+    let network = Arc::new(Network::default());
+    let runtime = runtime(dir.path(), network.clone());
+    let keys = nostr::Keys::generate();
+    let id = keys.public_key().to_hex();
+    runtime
+        .accounts()
+        .begin_onboarding(
+            Zeroizing::new(keys.secret_key().to_bech32().unwrap()),
+            options(),
+        )
+        .await
+        .unwrap();
+    (dir, runtime, network, keys, id)
+}
+fn signed(
+    keys: &nostr::Keys,
+    kind: u16,
+    tags: Vec<Vec<String>>,
+    content: &str,
+    at: u64,
+) -> NostrTransportEvent {
+    let event = EventBuilder::new(Kind::from(kind), content)
+        .tags(tags.into_iter().map(|t| Tag::parse(t).unwrap()))
+        .custom_created_at(Timestamp::from(at))
+        .sign_with_keys(keys)
+        .unwrap();
+    NostrTransportEvent::from_nostr_event(&event).unwrap()
+}
+async fn missing_relays(runtime: &MarmotAppRuntime, id: &str) {
+    let manager = runtime.accounts();
+    manager.run_onboarding(id).await.unwrap();
+    manager
+        .continue_onboarding_without(id, OnboardingStep::Profile)
+        .await
+        .unwrap();
+    let snapshot = manager
+        .continue_onboarding_without(id, OnboardingStep::Follows)
+        .await
+        .unwrap();
+    assert_eq!(snapshot.steps[2].status, OnboardingStatus::NeedsInput);
+}
+#[tokio::test]
+async fn failed_discovery_never_authorizes_default_replacement() {
+    let (_dir, runtime, network, _keys, id) = fixture().await;
+    network.fail_reads.store(true, Ordering::SeqCst);
+    let result = runtime.accounts().run_onboarding(&id).await.unwrap();
+    assert_eq!(result.steps[0].status, OnboardingStatus::RetryableFailure);
+    runtime
+        .accounts()
+        .continue_onboarding_without(&id, OnboardingStep::Profile)
+        .await
+        .unwrap();
+    let result = runtime
+        .accounts()
+        .continue_onboarding_without(&id, OnboardingStep::Follows)
+        .await
+        .unwrap();
+    assert_eq!(result.steps[2].status, OnboardingStatus::RetryableFailure);
+    assert!(
+        runtime
+            .accounts()
+            .propose_onboarding_relays(&id, OnboardingStep::Relays, None)
+            .await
+            .is_err()
+    );
+    assert!(network.attempts.lock().unwrap().is_empty());
+    runtime.shutdown_and_close().await.unwrap();
+}
+#[tokio::test]
+async fn newest_malformed_profile_is_not_hidden_by_older_valid_metadata() {
+    let (_dir, runtime, network, keys, id) = fixture().await;
+    network.events.lock().unwrap().extend([
+        signed(
+            &keys,
+            0,
+            vec![],
+            "{\"name\":\"older\"}",
+            unix_now_seconds() - 2,
+        ),
+        signed(&keys, 0, vec![], "[]", unix_now_seconds() - 1),
+    ]);
+    let result = runtime.accounts().run_onboarding(&id).await.unwrap();
+    assert_eq!(
+        result.steps[0].findings[0].issue,
+        OnboardingIssue::Malformed
+    );
+    assert_eq!(result.steps[0].status, OnboardingStatus::NeedsInput);
+    runtime.shutdown_and_close().await.unwrap();
+}
+#[tokio::test]
+async fn future_dated_record_is_inconclusive_and_cannot_be_repaired_automatically() {
+    let (_dir, runtime, network, keys, id) = fixture().await;
+    network
+        .events
+        .lock()
+        .unwrap()
+        .push(signed(&keys, 0, vec![], "{}", unix_now_seconds() + 3600));
+    let result = runtime.accounts().run_onboarding(&id).await.unwrap();
+    assert_eq!(
+        result.steps[0].findings[0].issue,
+        OnboardingIssue::FutureDated
+    );
+    assert_eq!(result.steps[0].status, OnboardingStatus::RetryableFailure);
+    assert!(
+        !result.steps[0]
+            .actions
+            .contains(&OnboardingAction::EditProfile)
+    );
+    runtime.shutdown_and_close().await.unwrap();
+}
+#[tokio::test]
+async fn zero_ack_repair_survives_restart_and_retries_exact_signed_bytes() {
+    let (dir, first, network, _keys, id) = fixture().await;
+    missing_relays(&first, &id).await;
+    let proposal = first
+        .accounts()
+        .propose_onboarding_relays(&id, OnboardingStep::Relays, None)
+        .await
+        .unwrap();
+    network.zero_acks.store(true, Ordering::SeqCst);
+    let result = first
+        .accounts()
+        .approve_onboarding_repair(&id, proposal.revision)
+        .await
+        .unwrap();
+    assert_eq!(result.steps[2].status, OnboardingStatus::RetryableFailure);
+    let expected = network.attempts.lock().unwrap()[0].clone();
+    assert!(expected.sig.is_some());
+    first.shutdown_and_close().await.unwrap();
+    let second = runtime(dir.path(), network.clone());
+    let mut c = second
+        .accounts()
+        .onboarding_checkpoint(&id)
+        .unwrap()
+        .unwrap();
+    assert!(c.approved);
+    assert_eq!(c.signed_repair, Some(expected.clone()));
+    network.zero_acks.store(false, Ordering::SeqCst);
+    assert!(
+        second
+            .accounts()
+            .publish_onboarding_repair(&mut c)
+            .await
+            .unwrap()
+    );
+    assert_eq!(network.attempts.lock().unwrap()[1], expected);
+    assert!(c.snapshot.steps[4].status == OnboardingStatus::Pending && !c.snapshot.ready);
+    second.shutdown_and_close().await.unwrap();
+}
+#[tokio::test]
+async fn cancelled_publication_retains_approval_and_signed_bytes() {
+    let (_dir, runtime, network, _keys, id) = fixture().await;
+    missing_relays(&runtime, &id).await;
+    let proposal = runtime
+        .accounts()
+        .propose_onboarding_relays(&id, OnboardingStep::Relays, None)
+        .await
+        .unwrap();
+    network.block_publish.store(true, Ordering::SeqCst);
+    let manager = runtime.accounts();
+    let account = id.clone();
+    let task = tokio::spawn(async move {
+        manager
+            .approve_onboarding_repair(&account, proposal.revision)
+            .await
+    });
+    network.publishing.notified().await;
+    task.abort();
+    let _ = task.await;
+    let c = runtime
+        .accounts()
+        .onboarding_checkpoint(&id)
+        .unwrap()
+        .unwrap();
+    assert!(c.approved);
+    assert_eq!(
+        c.signed_repair,
+        Some(network.attempts.lock().unwrap()[0].clone())
+    );
+    assert!(
+        runtime
+            .accounts()
+            .cancel_onboarding_repair(&id)
+            .await
+            .is_err()
+    );
+    runtime.shutdown_and_close().await.unwrap();
+}
+#[tokio::test]
+async fn optional_repairs_preserve_unknown_profile_fields_and_follow_tag_metadata() {
+    let (_dir, runtime, _network, keys, id) = fixture().await;
+    let mut c = runtime
+        .accounts()
+        .onboarding_checkpoint(&id)
+        .unwrap()
+        .unwrap();
+    c.records[0] = Some(signed(
+        &keys,
+        0,
+        vec![vec!["client".into(), "keep".into()]],
+        "{\"name\":7,\"custom\":{\"keep\":true},\"website\":\"https://example.com\"}",
+        unix_now_seconds() - 1,
+    ));
+    let mut proposal = OnboardingRepairProposal {
+        step: OnboardingStep::Profile,
+        revision: 1,
+        previous_event_id: None,
+        read_relays: vec![],
+        write_relays: vec![],
+        profile: Some(UserProfileMetadata {
+            name: Some("fixed".into()),
+            ..Default::default()
+        }),
+        follows: None,
+    };
+    let (tags, content, _) = relay_repair_event(&c, &proposal);
+    let json: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert_eq!(json["custom"]["keep"], true);
+    assert_eq!(json["name"], "fixed");
+    assert_eq!(json["website"], "https://example.com");
+    assert_eq!(tags[0][1], "keep");
+    let retained = nostr::Keys::generate().public_key().to_hex();
+    c.records[1] = Some(signed(
+        &keys,
+        3,
+        vec![
+            vec![
+                "p".into(),
+                retained.clone(),
+                "wss://hint.example".into(),
+                "petname".into(),
+            ],
+            vec!["p".into(), "bad".into()],
+            vec!["client".into(), "keep".into()],
+        ],
+        "opaque legacy content",
+        unix_now_seconds() - 1,
+    ));
+    proposal.step = OnboardingStep::Follows;
+    proposal.profile = None;
+    proposal.follows = Some(vec![retained]);
+    let (tags, content, _) = relay_repair_event(&c, &proposal);
+    assert_eq!(tags[0][3], "petname");
+    assert_eq!(tags.len(), 2);
+    assert_eq!(content, "opaque legacy content");
+    runtime.shutdown_and_close().await.unwrap();
+}
+#[tokio::test]
+async fn corrupt_or_future_checkpoint_fails_closed() {
+    let (_dir, runtime, _network, _keys, id) = fixture().await;
+    let manager = runtime.accounts();
+    let mut c = manager.onboarding_checkpoint(&id).unwrap().unwrap();
+    c.version += 1;
+    manager
+        .app
+        .account_home()
+        .set_account_onboarding(&id, &serde_json::to_vec(&c).unwrap())
+        .unwrap();
+    assert!(manager.onboarding_snapshot(&id).is_err());
+    assert!(manager.reconcile().await.is_err());
+    runtime.shutdown_and_close().await.unwrap();
+}
+
+#[tokio::test]
+async fn interactive_import_without_detailed_checkpoint_remains_gated() {
+    let directory = tempfile::tempdir().unwrap();
+    let network = Arc::new(Network::default());
+    let runtime = runtime(directory.path(), network.clone());
+    let keys = nostr::Keys::generate();
+    let secret = keys.secret_key().to_bech32().unwrap();
+    let id = keys.public_key().to_hex();
+    let manager = runtime.accounts();
+    manager
+        .app
+        .account_home()
+        .import_nostr_account_for_onboarding(&secret)
+        .unwrap();
+    assert!(manager.onboarding_snapshot(&id).unwrap().is_none());
+    assert!(!manager.onboarding_worker_allowed(&id).unwrap());
+    assert!(matches!(
+        manager.require_onboarding_complete(&id),
+        Err(AppError::OnboardingRequired)
+    ));
+    let resumed = manager
+        .begin_onboarding(Zeroizing::new(secret), options())
+        .await
+        .unwrap();
+    assert_eq!(resumed.account_id_hex, id);
+    assert!(!resumed.ready);
+    assert!(network.attempts.lock().unwrap().is_empty());
+    runtime.shutdown_and_close().await.unwrap();
+}
+
+#[tokio::test]
+async fn completed_checkpoint_resumes_interrupted_journal_cleanup() {
+    let (_directory, runtime, _network, _keys, id) = fixture().await;
+    let manager = runtime.accounts();
+    let mut c = manager.onboarding_checkpoint(&id).unwrap().unwrap();
+    for step in [
+        OnboardingStep::Profile,
+        OnboardingStep::Follows,
+        OnboardingStep::Relays,
+        OnboardingStep::InboxRelays,
+        OnboardingStep::KeyPackage,
+    ] {
+        c.set(step, OnboardingStatus::Passed, Vec::new());
+    }
+    manager.save_onboarding(&mut c).unwrap();
+    assert!(
+        manager
+            .app
+            .account_home()
+            .account_setup_state(&id)
+            .unwrap()
+            .is_some()
+    );
+    assert_eq!(
+        runtime.account_setup_readiness(&id).unwrap(),
+        AccountSetupReadiness::NetworkReady
+    );
+    assert!(manager.run_onboarding(&id).await.unwrap().ready);
+    assert!(
+        manager
+            .app
+            .account_home()
+            .account_setup_state(&id)
+            .unwrap()
+            .is_none()
+    );
+    runtime.shutdown_and_close().await.unwrap();
+}
+
+#[tokio::test]
+async fn profile_url_validation_and_explicit_clear_preserve_unrelated_fields() {
+    let (_directory, runtime, _network, keys, id) = fixture().await;
+    let mut c = runtime
+        .accounts()
+        .onboarding_checkpoint(&id)
+        .unwrap()
+        .unwrap();
+    let record = signed(
+        &keys,
+        0,
+        vec![],
+        "{\"picture\":\"file:///private/avatar\",\"custom\":true}",
+        unix_now_seconds(),
+    );
+    assert_eq!(
+        validate_onboarding_record(&record),
+        vec![finding(OnboardingIssue::Malformed)]
+    );
+    c.records[0] = Some(record);
+    let proposal = OnboardingRepairProposal {
+        step: OnboardingStep::Profile,
+        revision: 1,
+        previous_event_id: None,
+        read_relays: vec![],
+        write_relays: vec![],
+        profile: Some(UserProfileMetadata {
+            picture: Some(String::new()),
+            ..Default::default()
+        }),
+        follows: None,
+    };
+    let (_, content, _) = relay_repair_event(&c, &proposal);
+    let json: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert!(json.get("picture").is_none());
+    assert_eq!(json["custom"], true);
+    runtime.shutdown_and_close().await.unwrap();
+}

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -12962,3 +12962,162 @@ async fn onboarding_single_device_unknown_discovery_still_offers_explicit_contin
     );
     runtime.shutdown_and_close().await.unwrap();
 }
+
+#[tokio::test]
+async fn onboarding_contains_corruption_and_preserves_legacy_account_and_cancel_exit() {
+    use nostr::prelude::ToBech32;
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, app, url) = mock_app(&dir).await;
+    let runtime = MarmotAppRuntime::new(app);
+    let keys = Keys::generate();
+    let secret = keys.secret_key().to_bech32().unwrap();
+    let request = || AccountSetupRequest {
+        import_nsec: Some(zeroize::Zeroizing::new(secret.clone())),
+        default_relays: vec![endpoint(&url)],
+        bootstrap_relays: vec![endpoint(&url)],
+        publish_missing_relay_lists: true,
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+    let old = runtime
+        .create_or_import_account(request())
+        .await
+        .unwrap()
+        .account;
+    let options = || marmot_app::OnboardingOptions {
+        default_relays: vec![url.clone()],
+        discovery_relays: vec![url.clone()],
+    };
+    assert!(
+        runtime
+            .accounts()
+            .begin_onboarding(zeroize::Zeroizing::new(secret.clone()), options())
+            .await
+            .is_err()
+    );
+    assert!(
+        runtime
+            .accounts()
+            .onboarding_snapshot(&old.label)
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        runtime
+            .accounts()
+            .managed_accounts()
+            .unwrap()
+            .iter()
+            .any(|a| a.account_id_hex == old.account_id_hex && a.running)
+    );
+    let bad = runtime
+        .accounts()
+        .begin_onboarding(
+            zeroize::Zeroizing::new(Keys::generate().secret_key().to_bech32().unwrap()),
+            options(),
+        )
+        .await
+        .unwrap();
+    AccountHome::open(dir.path())
+        .set_account_onboarding(&bad.account_id_hex, b"{")
+        .unwrap();
+    runtime.reconcile_accounts().await.unwrap();
+    let managed = runtime.accounts().managed_accounts().unwrap();
+    assert!(
+        managed
+            .iter()
+            .any(|a| a.account_id_hex == old.account_id_hex && a.running)
+    );
+    assert!(
+        managed
+            .iter()
+            .any(|a| a.account_id_hex == bad.account_id_hex && !a.running)
+    );
+    assert!(runtime.publish_key_package(&old.label).await.unwrap() > 0);
+    runtime
+        .sign_out(
+            &old.label,
+            SignOutOptions {
+                delete_key_packages: false,
+            },
+        )
+        .await
+        .unwrap();
+    runtime
+        .accounts()
+        .begin_onboarding(zeroize::Zeroizing::new(secret.clone()), options())
+        .await
+        .unwrap();
+    runtime
+        .accounts()
+        .cancel_onboarding(&old.label)
+        .await
+        .unwrap();
+    assert!(
+        runtime
+            .accounts()
+            .onboarding_snapshot(&old.label)
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        AccountHome::open(dir.path())
+            .account(&old.label)
+            .unwrap()
+            .signed_out
+    );
+    assert!(
+        runtime
+            .create_or_import_account(request())
+            .await
+            .unwrap()
+            .key_package_bytes
+            .is_some()
+    );
+    runtime.shutdown_and_close().await.unwrap();
+}
+
+#[tokio::test]
+async fn onboarding_cancelled_new_identity_can_resume_through_legacy_login() {
+    use nostr::prelude::ToBech32;
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, app, url) = mock_app(&dir).await;
+    let runtime = MarmotAppRuntime::new(app);
+    let secret = Keys::generate().secret_key().to_bech32().unwrap();
+    let snapshot = runtime
+        .accounts()
+        .begin_onboarding(
+            zeroize::Zeroizing::new(secret.clone()),
+            marmot_app::OnboardingOptions {
+                default_relays: vec![url.clone()],
+                discovery_relays: vec![url.clone()],
+            },
+        )
+        .await
+        .unwrap();
+    runtime
+        .accounts()
+        .cancel_onboarding(&snapshot.account_id_hex)
+        .await
+        .unwrap();
+    let outcome = runtime
+        .create_or_import_account(AccountSetupRequest {
+            import_nsec: Some(zeroize::Zeroizing::new(secret)),
+            default_relays: vec![endpoint(&url)],
+            bootstrap_relays: vec![endpoint(&url)],
+            publish_missing_relay_lists: true,
+            publish_initial_key_package: true,
+            ..AccountSetupRequest::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(outcome.account.account_id_hex, snapshot.account_id_hex);
+    assert!(outcome.key_package_bytes.is_some());
+    assert_eq!(
+        runtime
+            .account_setup_readiness(&outcome.account.label)
+            .unwrap(),
+        marmot_app::AccountSetupReadiness::NetworkReady
+    );
+    runtime.shutdown_and_close().await.unwrap();
+}

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -3072,6 +3072,7 @@ async fn app_runtime_delete_group_local_removes_projection_without_publishing_le
 }
 
 #[tokio::test]
+#[cfg(feature = "test-policy-overrides")]
 async fn app_runtime_serves_member_reads_before_initial_catch_up_completes() {
     // Regression: the account worker must answer read commands as soon as the
     // session is hydrated, WITHOUT blocking on the initial relay catch-up. On
@@ -3093,11 +3094,7 @@ async fn app_runtime_serves_member_reads_before_initial_catch_up_completes() {
     let bob_id = bob.account.account_id_hex.clone();
     let mut events = runtime.subscribe();
 
-    // Alice creates a group with Bob. Waiting for Bob's GroupJoined guarantees
-    // Bob received the welcome over the relay (an inbound delivery), so his
-    // persisted transport cursor is advanced to ~now: his next worker startup
-    // re-subscribes from there and the catch-up genuinely has to wait
-    // (SDK_FIRST_SYNC_WAIT / drain) rather than short-circuiting.
+    // Establish a real group over the relay before restarting Bob's worker.
     let group_id = runtime
         .create_group(&alice_id, "fast reads", std::slice::from_ref(&bob_id), None)
         .await
@@ -3111,33 +3108,24 @@ async fn app_runtime_serves_member_reads_before_initial_catch_up_completes() {
     })
     .await;
 
-    // `AccountSync` is recorded only when a worker's catch-up sync COMPLETES.
-    let account_sync_attempts = || {
-        runtime
-            .shared_services()
-            .app_performance_telemetry()
-            .snapshot()
-            .account_sync
-            .attempts
-    };
-    let before_restart = account_sync_attempts();
+    // Finish the existing workers' startup before arming the one-shot gate.
+    // A global sync counter includes Alice and detached post-create work, and
+    // a relay drain duration does not establish ordering across task polls.
+    runtime.catch_up_accounts().await.unwrap();
+    let startup_sync_barrier = Arc::new(tokio::sync::Barrier::new(2));
+    runtime
+        .shared_services()
+        .set_next_startup_sync_barrier(startup_sync_barrier.clone());
 
-    // Foreground-resume analog: tear down and rebuild Bob's worker.
-    runtime.restart_account(&bob_id).await.unwrap();
-
-    // Deterministic discriminator: in the fixed code `restart_account` returns
-    // once the worker is hydrated and command-ready, BEFORE the background
-    // catch-up completes — so no new `AccountSync` has been recorded yet. (The
-    // catch-up has a >=250ms drain floor, so it cannot have finished in the
-    // synchronous gap between `restart_account` returning and this read.) In the
-    // pre-fix code, `restart_account`/`reconcile` blocked on the startup sync,
-    // so a new `AccountSync` would already be recorded here. No `.await` runs
-    // between `restart_account` and this read.
-    assert_eq!(
-        account_sync_attempts(),
-        before_restart,
-        "restart must become command-ready before the initial catch-up completes",
-    );
+    // Foreground-resume analog: Bob must become command-ready while his
+    // initial sync is unable to finish, regardless of scheduler timing.
+    timeout(Duration::from_secs(5), runtime.restart_account(&bob_id))
+        .await
+        .expect("restart must not wait for initial catch-up")
+        .unwrap();
+    timeout(Duration::from_secs(5), startup_sync_barrier.wait())
+        .await
+        .expect("restarted worker must reach initial sync");
 
     // The bounded chat-list companion read uses the same snapshot during the
     // detached catch-up, so batching does not reintroduce a readiness wait.
@@ -3159,16 +3147,8 @@ async fn app_runtime_serves_member_reads_before_initial_catch_up_completes() {
         !member_ids_page[0].admin_ids_hex.contains(&bob_id),
         "invited member must not be reported as an admin"
     );
-    assert_eq!(
-        account_sync_attempts(),
-        before_restart,
-        "member-id page must complete before the initial catch-up finishes",
-    );
-
-    // The combined roster read is answered with a session-consistent group
-    // record, member list, and MLS state while (or right after) catch-up runs.
-    // During the catch-up window it comes from the post-hydration snapshot;
-    // afterwards it comes from the live session. Either way it must not block.
+    // The combined roster read must also use the post-hydration snapshot
+    // while the startup sync is held behind the barrier.
     let roster = timeout(
         Duration::from_secs(2),
         runtime.group_roster(&bob_id, &group_id),
@@ -3205,19 +3185,15 @@ async fn app_runtime_serves_member_reads_before_initial_catch_up_completes() {
         "snapshot/live read must report the full roster",
     );
 
-    // The catch-up is not dropped — it still runs in the background and records
-    // its completion.
-    let catch_up_deadline = std::time::Instant::now() + Duration::from_secs(5);
-    loop {
-        if account_sync_attempts() > before_restart {
-            break;
-        }
-        assert!(
-            std::time::Instant::now() < catch_up_deadline,
-            "background catch-up must still complete after readiness",
-        );
-        sleep(Duration::from_millis(25)).await;
-    }
+    // Release Bob's initial sync and await the real catch-up result so the
+    // test also proves this work is not dropped.
+    timeout(Duration::from_secs(5), startup_sync_barrier.wait())
+        .await
+        .expect("initial sync must remain at the release barrier during reads");
+    timeout(Duration::from_secs(5), runtime.catch_up_accounts())
+        .await
+        .expect("background catch-up must complete after release")
+        .unwrap();
 
     runtime.shutdown().await;
 }

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -12337,6 +12337,7 @@ async fn onboarding_valid_account_completes_all_checks_and_publishes_key_package
     let (directory, _relay, _app, runtime, _keys, id, url) = onboarding_fixture().await;
     seed_onboarding_records(&AccountHome::open(directory.path()), &id, &url).await;
     let snapshot = runtime.accounts().run_onboarding(&id).await.unwrap();
+    let snapshot = acknowledge_single_device_notice(&runtime, snapshot).await;
     assert!(snapshot.ready, "{snapshot:?}");
     assert!(
         snapshot
@@ -12406,6 +12407,7 @@ async fn onboarding_relay_repair_requires_approval_and_preserves_unrelated_tags(
         .approve_onboarding_repair(&id, proposal.revision)
         .await
         .unwrap();
+    let snapshot = acknowledge_single_device_notice(&runtime, snapshot).await;
     assert!(snapshot.ready, "{snapshot:?}");
     let client = NostrSdkClient::builder().build();
     client.add_relay(&url).await.unwrap();
@@ -12471,12 +12473,14 @@ async fn onboarding_stale_repair_detects_a_new_remote_record() {
         snapshot.steps[2].findings[0].issue,
         marmot_app::OnboardingIssue::RecordChanged
     );
+    let snapshot = runtime
+        .accounts()
+        .retry_onboarding_step(&id, OnboardingStep::Relays)
+        .await
+        .unwrap();
     assert!(
-        runtime
-            .accounts()
-            .retry_onboarding_step(&id, OnboardingStep::Relays)
+        acknowledge_single_device_notice(&runtime, snapshot)
             .await
-            .unwrap()
             .ready
     );
     runtime.shutdown_and_close().await.unwrap();
@@ -12495,6 +12499,32 @@ async fn onboarding_external_signer_uses_the_same_gate_and_workflow() {
         .accounts()
         .begin_external_signer_onboarding(
             id.clone(),
+            TestExternalAccountSigner { keys: keys.clone() },
+            marmot_app::OnboardingOptions {
+                default_relays: vec![url.clone()],
+                discovery_relays: vec![url.clone()],
+            },
+        )
+        .await
+        .unwrap();
+    assert!(!snapshot.ready);
+    assert!(!runtime.accounts().managed_accounts().unwrap()[0].running);
+    let snapshot = runtime.accounts().run_onboarding(&id).await.unwrap();
+    let snapshot = acknowledge_single_device_notice(&runtime, snapshot).await;
+    assert!(snapshot.ready, "{snapshot:?}");
+    runtime
+        .sign_out(
+            &id,
+            SignOutOptions {
+                delete_key_packages: false,
+            },
+        )
+        .await
+        .unwrap();
+    let reentered = runtime
+        .accounts()
+        .begin_external_signer_onboarding(
+            id.clone(),
             TestExternalAccountSigner { keys },
             marmot_app::OnboardingOptions {
                 default_relays: vec![url.clone()],
@@ -12503,10 +12533,9 @@ async fn onboarding_external_signer_uses_the_same_gate_and_workflow() {
         )
         .await
         .unwrap();
-    assert!(!snapshot.ready);
+    assert!(!reentered.ready);
+    assert!(reentered.single_device_notice.is_none());
     assert!(!runtime.accounts().managed_accounts().unwrap()[0].running);
-    let snapshot = runtime.accounts().run_onboarding(&id).await.unwrap();
-    assert!(snapshot.ready, "{snapshot:?}");
     runtime.shutdown_and_close().await.unwrap();
     drop(directory);
 }
@@ -12585,9 +12614,10 @@ async fn onboarding_key_package_rejection_retains_identity_until_confirmed_retry
         .unwrap();
     seed_onboarding_records(&AccountHome::open(directory.path()), &id, &url).await;
     let snapshot = runtime.accounts().run_onboarding(&id).await.unwrap();
+    let snapshot = acknowledge_single_device_notice(&runtime, snapshot).await;
     assert!(!snapshot.ready);
     assert_eq!(
-        snapshot.steps[4].status,
+        snapshot.steps[5].status,
         marmot_app::OnboardingStatus::RetryableFailure
     );
     assert!(matches!(
@@ -12600,6 +12630,15 @@ async fn onboarding_key_package_rejection_retains_identity_until_confirmed_retry
             .unwrap()
             .is_some()
     );
+    let acknowledged_notice = snapshot.single_device_notice.clone();
+    runtime.shutdown_and_close().await.unwrap();
+    let runtime = MarmotAppRuntime::new(MarmotApp::with_relay(directory.path(), url.clone()));
+    let resumed = runtime.accounts().run_onboarding(&id).await.unwrap();
+    assert_eq!(resumed.single_device_notice, acknowledged_notice);
+    assert_eq!(
+        resumed.steps[4].status,
+        marmot_app::OnboardingStatus::Passed
+    );
     rejecting.store(false, Ordering::SeqCst);
     let snapshot = runtime
         .accounts()
@@ -12607,5 +12646,319 @@ async fn onboarding_key_package_rejection_retains_identity_until_confirmed_retry
         .await
         .unwrap();
     assert!(snapshot.ready, "{snapshot:?}");
+    runtime.shutdown_and_close().await.unwrap();
+}
+
+async fn acknowledge_single_device_notice(
+    runtime: &MarmotAppRuntime,
+    snapshot: marmot_app::OnboardingSnapshot,
+) -> marmot_app::OnboardingSnapshot {
+    assert!(!snapshot.ready, "{snapshot:?}");
+    assert_eq!(
+        snapshot.steps[4].step,
+        marmot_app::OnboardingStep::SingleDevice
+    );
+    assert_eq!(
+        snapshot.steps[4].status,
+        marmot_app::OnboardingStatus::NeedsInput,
+        "{snapshot:?}"
+    );
+    assert!(
+        snapshot.steps[4]
+            .actions
+            .contains(&marmot_app::OnboardingAction::ContinueAnyway)
+    );
+    assert!(!runtime.accounts().managed_accounts().unwrap()[0].running);
+    assert!(matches!(
+        runtime
+            .accounts()
+            .publish_key_package(&snapshot.account_id_hex)
+            .await,
+        Err(AppError::OnboardingRequired)
+    ));
+    runtime
+        .accounts()
+        .acknowledge_onboarding_single_device(&snapshot.account_id_hex, snapshot.revision)
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn onboarding_single_device_detects_other_installation_and_retains_notice_across_restart() {
+    use marmot_app::{OnboardingDeviceDiscovery, OnboardingOptions, OnboardingStep};
+    use nostr::prelude::ToBech32;
+    let (first_directory, _relay, first_app, first, keys, id, url) = onboarding_fixture().await;
+    seed_onboarding_records(&AccountHome::open(first_directory.path()), &id, &url).await;
+    let notice = first.accounts().run_onboarding(&id).await.unwrap();
+    assert_eq!(
+        notice.single_device_notice.as_ref().unwrap().discovery,
+        OnboardingDeviceDiscovery::NoneFound
+    );
+    assert!(acknowledge_single_device_notice(&first, notice).await.ready);
+
+    // An older publication under another slot still carries usable material.
+    // Its timestamp is not grounds for asserting that installation is inactive.
+    let client = NostrSdkClient::builder().build();
+    client.add_relay(&url).await.unwrap();
+    client.connect().await;
+    let events = client
+        .fetch_events_from(
+            [url.clone()],
+            nostr::Filter::new()
+                .author(keys.public_key())
+                .kind(Kind::from(30443)),
+            Duration::from_secs(3),
+        )
+        .await
+        .unwrap();
+    let event = events.first().unwrap();
+    let mut tags = event
+        .tags
+        .iter()
+        .map(|t| t.as_slice().to_vec())
+        .collect::<Vec<_>>();
+    tags.iter_mut().find(|t| t[0] == "d").unwrap()[1] = "older-installation-slot".into();
+    let old_publication_time = NostrTimestamp::now().as_secs() - 30 * 24 * 60 * 60;
+    publish_nostr_event_at(
+        &AccountHome::open(first_directory.path()),
+        &id,
+        &url,
+        30443,
+        tags,
+        event.content.clone(),
+        old_publication_time,
+    )
+    .await;
+    client.shutdown().await;
+
+    // The same private package advertised under a different slot is still ours.
+    let own_notice = first
+        .accounts()
+        .retry_onboarding_step(&id, OnboardingStep::SingleDevice)
+        .await
+        .unwrap();
+    assert_eq!(
+        own_notice.single_device_notice.as_ref().unwrap().discovery,
+        OnboardingDeviceDiscovery::NoneFound
+    );
+    assert!(
+        acknowledge_single_device_notice(&first, own_notice)
+            .await
+            .ready
+    );
+    first.publish_new_key_package(&id).await.unwrap();
+    let rotated_notice = first
+        .accounts()
+        .retry_onboarding_step(&id, OnboardingStep::SingleDevice)
+        .await
+        .unwrap();
+    assert_eq!(
+        rotated_notice
+            .single_device_notice
+            .as_ref()
+            .unwrap()
+            .discovery,
+        OnboardingDeviceDiscovery::NoneFound
+    );
+    assert!(
+        acknowledge_single_device_notice(&first, rotated_notice)
+            .await
+            .ready
+    );
+
+    let second_directory = tempfile::tempdir().unwrap();
+    let make_second =
+        || MarmotAppRuntime::new(MarmotApp::with_relay(second_directory.path(), url.clone()));
+    let second = make_second();
+    second
+        .accounts()
+        .begin_onboarding(
+            zeroize::Zeroizing::new(keys.secret_key().to_bech32().unwrap()),
+            OnboardingOptions {
+                default_relays: vec![url.clone()],
+                discovery_relays: vec![url.clone()],
+            },
+        )
+        .await
+        .unwrap();
+    let snapshot = second.accounts().run_onboarding(&id).await.unwrap();
+    let notice = snapshot.single_device_notice.as_ref().unwrap();
+    assert_eq!(
+        notice.discovery,
+        OnboardingDeviceDiscovery::OtherInstallationPossible
+    );
+    assert!(
+        notice
+            .other_packages
+            .iter()
+            .any(|p| p.published_at == old_publication_time)
+    );
+    assert!(notice.acknowledged_at.is_none());
+    assert!(matches!(
+        second.durably_owned_key_packages(&id).await,
+        Err(AppError::OnboardingRequired)
+    ));
+    assert_eq!(
+        first_app
+            .account_key_package_records(&id, vec![endpoint(&url)], Vec::new())
+            .await
+            .unwrap()
+            .len(),
+        2
+    );
+    // Cancel means the host leaves this pause; simply resuming cannot publish.
+    let resumed = second.accounts().run_onboarding(&id).await.unwrap();
+    assert_eq!(resumed.single_device_notice, snapshot.single_device_notice);
+    assert_eq!(resumed.steps, snapshot.steps);
+    let snapshot = resumed;
+    second.shutdown_and_close().await.unwrap();
+    let second = make_second();
+    assert_eq!(
+        second.accounts().onboarding_snapshot(&id).unwrap().unwrap(),
+        snapshot
+    );
+    assert!(matches!(
+        second
+            .accounts()
+            .acknowledge_onboarding_single_device(&id, snapshot.revision - 1)
+            .await,
+        Err(AppError::OnboardingActionUnavailable)
+    ));
+    let completed = acknowledge_single_device_notice(&second, snapshot).await;
+    assert!(completed.ready);
+    assert!(
+        completed
+            .single_device_notice
+            .as_ref()
+            .unwrap()
+            .acknowledged_at
+            .is_some()
+    );
+    second.shutdown_and_close().await.unwrap();
+    let second = make_second();
+    assert_eq!(
+        second.accounts().run_onboarding(&id).await.unwrap(),
+        completed
+    );
+    // Continue never deletes the other installation's slots.
+    let packages = first_app
+        .account_key_package_records(&id, vec![endpoint(&url)], Vec::new())
+        .await
+        .unwrap();
+    assert!(
+        packages
+            .iter()
+            .any(|p| p.key_package_id == "older-installation-slot")
+    );
+    assert!(
+        packages
+            .iter()
+            .map(|p| &p.key_package_id)
+            .collect::<std::collections::HashSet<_>>()
+            .len()
+            >= 3
+    );
+    second
+        .sign_out(
+            &id,
+            SignOutOptions {
+                delete_key_packages: false,
+            },
+        )
+        .await
+        .unwrap();
+    let next_sign_in = second
+        .accounts()
+        .begin_onboarding(
+            zeroize::Zeroizing::new(keys.secret_key().to_bech32().unwrap()),
+            OnboardingOptions {
+                default_relays: vec![url.clone()],
+                discovery_relays: vec![url.clone()],
+            },
+        )
+        .await
+        .unwrap();
+    assert!(!next_sign_in.ready);
+    assert!(next_sign_in.single_device_notice.is_none());
+    let next_notice = second.accounts().run_onboarding(&id).await.unwrap();
+    assert_eq!(
+        next_notice.steps[4].status,
+        marmot_app::OnboardingStatus::NeedsInput
+    );
+    assert!(
+        next_notice
+            .single_device_notice
+            .unwrap()
+            .acknowledged_at
+            .is_none()
+    );
+    second.shutdown_and_close().await.unwrap();
+    first.shutdown_and_close().await.unwrap();
+}
+
+#[derive(Debug)]
+struct OnboardingKeyPackageQueriesRestricted;
+impl nostr_relay_builder::prelude::QueryPolicy for OnboardingKeyPackageQueriesRestricted {
+    fn admit_query<'a>(
+        &'a self,
+        filter: &'a nostr::Filter,
+        _: &'a SocketAddr,
+    ) -> BoxedFuture<'a, PolicyResult> {
+        Box::pin(async move {
+            if filter
+                .kinds
+                .as_ref()
+                .is_some_and(|kinds| kinds.contains(&Kind::from(30443)))
+            {
+                PolicyResult::Reject("restricted".into())
+            } else {
+                PolicyResult::Accept
+            }
+        })
+    }
+}
+
+#[tokio::test]
+async fn onboarding_single_device_unknown_discovery_still_offers_explicit_continue() {
+    use nostr::prelude::ToBech32;
+    let directory = tempfile::tempdir().unwrap();
+    let relay = LocalRelay::new(
+        RelayBuilder::default().query_policy(OnboardingKeyPackageQueriesRestricted),
+    );
+    relay.run().await.unwrap();
+    let url = relay.url().await.to_string();
+    let runtime = MarmotAppRuntime::new(MarmotApp::with_relay(directory.path(), url.clone()));
+    let keys = Keys::generate();
+    let id = keys.public_key().to_hex();
+    runtime
+        .accounts()
+        .begin_onboarding(
+            zeroize::Zeroizing::new(keys.secret_key().to_bech32().unwrap()),
+            marmot_app::OnboardingOptions {
+                default_relays: vec![url.clone()],
+                discovery_relays: vec![url.clone()],
+            },
+        )
+        .await
+        .unwrap();
+    seed_onboarding_records(&AccountHome::open(directory.path()), &id, &url).await;
+    let snapshot = runtime.accounts().run_onboarding(&id).await.unwrap();
+    let notice = snapshot.single_device_notice.as_ref().unwrap();
+    assert_eq!(
+        notice.discovery,
+        marmot_app::OnboardingDeviceDiscovery::Unknown
+    );
+    assert!(!notice.discovery_complete);
+    assert!(
+        snapshot.steps[4]
+            .findings
+            .iter()
+            .any(|f| f.issue == marmot_app::OnboardingIssue::AccessRestricted)
+    );
+    assert!(
+        acknowledge_single_device_notice(&runtime, snapshot)
+            .await
+            .ready
+    );
     runtime.shutdown_and_close().await.unwrap();
 }

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -12540,6 +12540,52 @@ async fn onboarding_external_signer_uses_the_same_gate_and_workflow() {
     drop(directory);
 }
 
+#[tokio::test]
+async fn onboarding_cancellation_retains_external_signer_for_explicit_sign_in() {
+    let (directory, _relay, _app, first, keys, id, url) = onboarding_fixture().await;
+    seed_onboarding_records(&AccountHome::open(directory.path()), &id, &url).await;
+    first.shutdown_and_close().await.unwrap();
+    let external_directory = tempfile::tempdir().unwrap();
+    let runtime = MarmotAppRuntime::new(MarmotApp::with_relay(
+        external_directory.path(),
+        url.clone(),
+    ));
+    runtime
+        .accounts()
+        .begin_external_signer_onboarding(
+            id.clone(),
+            TestExternalAccountSigner { keys },
+            marmot_app::OnboardingOptions {
+                default_relays: vec![url.clone()],
+                discovery_relays: vec![url],
+            },
+        )
+        .await
+        .unwrap();
+    let snapshot = runtime.accounts().run_onboarding(&id).await.unwrap();
+    assert!(!snapshot.ready);
+    assert_eq!(
+        snapshot.steps[4].status,
+        marmot_app::OnboardingStatus::NeedsInput
+    );
+
+    runtime.accounts().cancel_onboarding(&id).await.unwrap();
+    assert!(
+        runtime
+            .accounts()
+            .onboarding_snapshot(&id)
+            .unwrap()
+            .is_none()
+    );
+    assert!(!runtime.accounts().managed_accounts().unwrap()[0].running);
+
+    // The host has already attached this signer. An explicit sign-in after
+    // reversible cancellation must be able to use it without registration.
+    assert!(runtime.sign_in_account(&id).await.unwrap().running);
+    assert!(runtime.publish_key_package(&id).await.unwrap() > 0);
+    runtime.shutdown_and_close().await.unwrap();
+}
+
 #[derive(Debug)]
 struct OnboardingPaymentRequired;
 impl nostr_relay_builder::prelude::QueryPolicy for OnboardingPaymentRequired {

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -12224,3 +12224,388 @@ async fn outbox_acceptance_closed_multi_author_queries_fall_back_per_member() {
         "the resolver must issue accepted single-author fallbacks for both members"
     );
 }
+
+// Interactive onboarding must be tested against real EOSE and publication
+// acknowledgements, not only directory-cache fixtures.
+async fn onboarding_fixture() -> (
+    tempfile::TempDir,
+    MockRelay,
+    MarmotApp,
+    MarmotAppRuntime,
+    Keys,
+    String,
+    String,
+) {
+    use nostr::prelude::ToBech32;
+    let directory = tempfile::tempdir().unwrap();
+    let (relay, app, url) = mock_app(&directory).await;
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let keys = Keys::generate();
+    let id = keys.public_key().to_hex();
+    let snapshot = runtime
+        .accounts()
+        .begin_onboarding(
+            zeroize::Zeroizing::new(keys.secret_key().to_bech32().unwrap()),
+            marmot_app::OnboardingOptions {
+                default_relays: vec![url.clone()],
+                discovery_relays: vec![url.clone()],
+            },
+        )
+        .await
+        .unwrap();
+    assert!(!snapshot.ready);
+    (directory, relay, app, runtime, keys, id, url)
+}
+async fn seed_onboarding_records(home: &AccountHome, id: &str, url: &str) {
+    let at = NostrTimestamp::now().as_secs() - 10;
+    publish_nostr_event_at(
+        home,
+        id,
+        url,
+        0,
+        vec![],
+        "{\"name\":\"Alice\",\"custom\":{\"keep\":true}}".into(),
+        at,
+    )
+    .await;
+    publish_nostr_event_at(
+        home,
+        id,
+        url,
+        3,
+        vec![],
+        "legacy relay preferences".into(),
+        at,
+    )
+    .await;
+    publish_account_relay_lists_at(home, id, url, url, at).await;
+}
+#[tokio::test]
+async fn onboarding_identity_only_is_durable_gated_and_never_publishes() {
+    let (directory, _relay, app, runtime, _keys, id, url) = onboarding_fixture().await;
+    runtime.reconcile_accounts().await.unwrap();
+    assert!(
+        !runtime
+            .accounts()
+            .managed_accounts()
+            .unwrap()
+            .iter()
+            .find(|a| a.account_id_hex == id)
+            .unwrap()
+            .running
+    );
+    assert!(
+        app.fetch_current_account_relay_list_status_for_account_id(&id, vec![endpoint(&url)], None)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    let mut subscription = runtime.accounts().subscribe_onboarding(&id).unwrap();
+    let snapshot = runtime.accounts().run_onboarding(&id).await.unwrap();
+    assert_eq!(
+        snapshot.steps[0].status,
+        marmot_app::OnboardingStatus::NeedsInput
+    );
+    assert_eq!(
+        snapshot.steps[0].findings[0].issue,
+        marmot_app::OnboardingIssue::Missing
+    );
+    assert!(subscription.recv().await.unwrap().revision > subscription.snapshot.revision);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let path = AccountHome::open(directory.path())
+            .account_dir(&id)
+            .join("onboarding.json");
+        assert_eq!(
+            std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+    runtime.shutdown_and_close().await.unwrap();
+    let reopened = MarmotAppRuntime::new(MarmotApp::with_relay(directory.path(), url));
+    assert_eq!(
+        reopened.accounts().onboarding_snapshot(&id).unwrap(),
+        Some(snapshot)
+    );
+    reopened.reconcile_accounts().await.unwrap();
+    assert!(!reopened.accounts().managed_accounts().unwrap()[0].running);
+    reopened.shutdown_and_close().await.unwrap();
+}
+#[tokio::test]
+async fn onboarding_valid_account_completes_all_checks_and_publishes_key_package() {
+    let (directory, _relay, _app, runtime, _keys, id, url) = onboarding_fixture().await;
+    seed_onboarding_records(&AccountHome::open(directory.path()), &id, &url).await;
+    let snapshot = runtime.accounts().run_onboarding(&id).await.unwrap();
+    assert!(snapshot.ready, "{snapshot:?}");
+    assert!(
+        snapshot
+            .steps
+            .iter()
+            .all(|s| s.status == marmot_app::OnboardingStatus::Passed)
+    );
+    assert_eq!(
+        runtime.account_setup_readiness(&id).unwrap(),
+        marmot_app::AccountSetupReadiness::NetworkReady
+    );
+    assert!(
+        AccountHome::open(directory.path())
+            .account_setup_state(&id)
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        !runtime
+            .accounts()
+            .account_key_packages(&id, vec![endpoint(&url)])
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    runtime.shutdown_and_close().await.unwrap();
+}
+#[tokio::test]
+async fn onboarding_relay_repair_requires_approval_and_preserves_unrelated_tags() {
+    use marmot_app::OnboardingStep;
+    let (directory, _relay, _app, runtime, _keys, id, url) = onboarding_fixture().await;
+    seed_onboarding_records(&AccountHome::open(directory.path()), &id, &url).await;
+    let tags = vec![
+        vec!["r".into(), "not a relay".into()],
+        vec!["client".into(), "preserve-me".into()],
+    ];
+    publish_nostr_event_at(
+        &AccountHome::open(directory.path()),
+        &id,
+        &url,
+        10002,
+        tags,
+        "preserve content".into(),
+        NostrTimestamp::now().as_secs() - 5,
+    )
+    .await;
+    let snapshot = runtime.accounts().run_onboarding(&id).await.unwrap();
+    assert_eq!(
+        snapshot.steps[2].status,
+        marmot_app::OnboardingStatus::NeedsInput
+    );
+    assert!(!snapshot.ready);
+    let proposal = runtime
+        .accounts()
+        .propose_onboarding_relays(&id, OnboardingStep::Relays, None)
+        .await
+        .unwrap();
+    assert!(matches!(
+        runtime
+            .accounts()
+            .approve_onboarding_repair(&id, proposal.revision - 1)
+            .await,
+        Err(AppError::OnboardingActionUnavailable)
+    ));
+    let snapshot = runtime
+        .accounts()
+        .approve_onboarding_repair(&id, proposal.revision)
+        .await
+        .unwrap();
+    assert!(snapshot.ready, "{snapshot:?}");
+    let client = NostrSdkClient::builder().build();
+    client.add_relay(&url).await.unwrap();
+    client.connect().await;
+    let events = client
+        .fetch_events_from(
+            [url],
+            nostr::Filter::new()
+                .author(nostr::PublicKey::parse(&id).unwrap())
+                .kind(Kind::RelayList),
+            Duration::from_secs(3),
+        )
+        .await
+        .unwrap();
+    let event = events.first().unwrap();
+    assert_eq!(event.content, "preserve content");
+    assert!(
+        event
+            .tags
+            .iter()
+            .any(|tag| tag.as_slice() == ["client", "preserve-me"])
+    );
+    client.shutdown().await;
+    runtime.shutdown_and_close().await.unwrap();
+}
+#[tokio::test]
+async fn onboarding_stale_repair_detects_a_new_remote_record() {
+    use marmot_app::OnboardingStep;
+    let (directory, _relay, _app, runtime, _keys, id, url) = onboarding_fixture().await;
+    seed_onboarding_records(&AccountHome::open(directory.path()), &id, &url).await;
+    publish_nostr_event_at(
+        &AccountHome::open(directory.path()),
+        &id,
+        &url,
+        10002,
+        vec![],
+        String::new(),
+        NostrTimestamp::now().as_secs() - 5,
+    )
+    .await;
+    runtime.accounts().run_onboarding(&id).await.unwrap();
+    let proposal = runtime
+        .accounts()
+        .propose_onboarding_relays(&id, OnboardingStep::Relays, None)
+        .await
+        .unwrap();
+    publish_account_relay_lists_at(
+        &AccountHome::open(directory.path()),
+        &id,
+        &url,
+        &url,
+        NostrTimestamp::now().as_secs(),
+    )
+    .await;
+    let snapshot = runtime
+        .accounts()
+        .approve_onboarding_repair(&id, proposal.revision)
+        .await
+        .unwrap();
+    assert!(!snapshot.ready);
+    assert!(snapshot.proposal.is_none());
+    assert_eq!(
+        snapshot.steps[2].findings[0].issue,
+        marmot_app::OnboardingIssue::RecordChanged
+    );
+    assert!(
+        runtime
+            .accounts()
+            .retry_onboarding_step(&id, OnboardingStep::Relays)
+            .await
+            .unwrap()
+            .ready
+    );
+    runtime.shutdown_and_close().await.unwrap();
+}
+#[tokio::test]
+async fn onboarding_external_signer_uses_the_same_gate_and_workflow() {
+    let (directory, _relay, _app, runtime, keys, id, url) = onboarding_fixture().await;
+    seed_onboarding_records(&AccountHome::open(directory.path()), &id, &url).await;
+    runtime.shutdown_and_close().await.unwrap();
+    let external_directory = tempfile::tempdir().unwrap();
+    let runtime = MarmotAppRuntime::new(MarmotApp::with_relay(
+        external_directory.path(),
+        url.clone(),
+    ));
+    let snapshot = runtime
+        .accounts()
+        .begin_external_signer_onboarding(
+            id.clone(),
+            TestExternalAccountSigner { keys },
+            marmot_app::OnboardingOptions {
+                default_relays: vec![url.clone()],
+                discovery_relays: vec![url],
+            },
+        )
+        .await
+        .unwrap();
+    assert!(!snapshot.ready);
+    assert!(!runtime.accounts().managed_accounts().unwrap()[0].running);
+    let snapshot = runtime.accounts().run_onboarding(&id).await.unwrap();
+    assert!(snapshot.ready, "{snapshot:?}");
+    runtime.shutdown_and_close().await.unwrap();
+    drop(directory);
+}
+
+#[derive(Debug)]
+struct OnboardingPaymentRequired;
+impl nostr_relay_builder::prelude::QueryPolicy for OnboardingPaymentRequired {
+    fn admit_query<'a>(
+        &'a self,
+        _: &'a nostr::Filter,
+        _: &'a SocketAddr,
+    ) -> BoxedFuture<'a, PolicyResult> {
+        Box::pin(async { PolicyResult::Reject("payment-required: subscription needed".into()) })
+    }
+}
+#[tokio::test]
+async fn onboarding_access_restricted_query_is_not_a_missing_record() {
+    use nostr::prelude::ToBech32;
+    let dir = tempfile::tempdir().unwrap();
+    let relay = LocalRelay::new(RelayBuilder::default().query_policy(OnboardingPaymentRequired));
+    relay.run().await.unwrap();
+    let url = relay.url().await.to_string();
+    let runtime = MarmotAppRuntime::new(MarmotApp::with_relay(dir.path(), url.clone()));
+    let keys = Keys::generate();
+    let snapshot = runtime
+        .accounts()
+        .begin_onboarding(
+            zeroize::Zeroizing::new(keys.secret_key().to_bech32().unwrap()),
+            marmot_app::OnboardingOptions {
+                default_relays: vec![url.clone()],
+                discovery_relays: vec![url],
+            },
+        )
+        .await
+        .unwrap();
+    let result = runtime
+        .accounts()
+        .run_onboarding(&snapshot.account_id_hex)
+        .await
+        .unwrap();
+    assert_eq!(
+        result.steps[0].status,
+        marmot_app::OnboardingStatus::RetryableFailure
+    );
+    assert_eq!(
+        result.steps[0].findings[0].issue,
+        marmot_app::OnboardingIssue::AccessRestricted
+    );
+    runtime.shutdown_and_close().await.unwrap();
+}
+
+#[tokio::test]
+async fn onboarding_key_package_rejection_retains_identity_until_confirmed_retry() {
+    use nostr::prelude::ToBech32;
+    let directory = tempfile::tempdir().unwrap();
+    let rejecting = Arc::new(AtomicBool::new(true));
+    let relay = LocalRelay::new(
+        RelayBuilder::default().write_policy(RejectKeyPackagesWhileArmed(rejecting.clone())),
+    );
+    relay.run().await.unwrap();
+    let url = relay.url().await.to_string();
+    let app = MarmotApp::with_relay(directory.path(), url.clone());
+    let runtime = MarmotAppRuntime::new(app);
+    let keys = Keys::generate();
+    let id = keys.public_key().to_hex();
+    runtime
+        .accounts()
+        .begin_onboarding(
+            zeroize::Zeroizing::new(keys.secret_key().to_bech32().unwrap()),
+            marmot_app::OnboardingOptions {
+                default_relays: vec![url.clone()],
+                discovery_relays: vec![url.clone()],
+            },
+        )
+        .await
+        .unwrap();
+    seed_onboarding_records(&AccountHome::open(directory.path()), &id, &url).await;
+    let snapshot = runtime.accounts().run_onboarding(&id).await.unwrap();
+    assert!(!snapshot.ready);
+    assert_eq!(
+        snapshot.steps[4].status,
+        marmot_app::OnboardingStatus::RetryableFailure
+    );
+    assert!(matches!(
+        runtime.accounts().publish_key_package(&id).await,
+        Err(AppError::OnboardingRequired)
+    ));
+    assert!(
+        AccountHome::open(directory.path())
+            .account_setup_state(&id)
+            .unwrap()
+            .is_some()
+    );
+    rejecting.store(false, Ordering::SeqCst);
+    let snapshot = runtime
+        .accounts()
+        .retry_onboarding_step(&id, marmot_app::OnboardingStep::KeyPackage)
+        .await
+        .unwrap();
+    assert!(snapshot.ready, "{snapshot:?}");
+    runtime.shutdown_and_close().await.unwrap();
+}

--- a/crates/marmot-c/include/marmot.h
+++ b/crates/marmot-c/include/marmot.h
@@ -128,6 +128,8 @@ enum MarmotStatus
   MARMOT_STATUS_GROUP_INVITE_NOT_PENDING = 61,
   MARMOT_STATUS_MISSING_MEMBER_INBOX_ROUTE = 62,
   MARMOT_STATUS_GROUP_REMOVED = 63,
+  MARMOT_STATUS_ONBOARDING_ACTION_UNAVAILABLE = 64,
+  MARMOT_STATUS_ONBOARDING_REQUIRED = 65,
 };
 #ifndef __cplusplus
 #if __STDC_VERSION__ >= 202311L
@@ -136,6 +138,58 @@ typedef enum MarmotStatus MarmotStatus;
 typedef int32_t MarmotStatus;
 #endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
+
+typedef enum MarmotOnboardingStep {
+  MARMOT_ONBOARDING_STEP_PROFILE,
+  MARMOT_ONBOARDING_STEP_FOLLOWS,
+  MARMOT_ONBOARDING_STEP_RELAYS,
+  MARMOT_ONBOARDING_STEP_INBOX_RELAYS,
+  MARMOT_ONBOARDING_STEP_KEY_PACKAGE,
+} MarmotOnboardingStep;
+
+typedef enum MarmotOnboardingStatus {
+  MARMOT_ONBOARDING_STATUS_PENDING,
+  MARMOT_ONBOARDING_STATUS_CHECKING,
+  MARMOT_ONBOARDING_STATUS_PASSED,
+  MARMOT_ONBOARDING_STATUS_NEEDS_INPUT,
+  MARMOT_ONBOARDING_STATUS_RETRYABLE_FAILURE,
+  MARMOT_ONBOARDING_STATUS_WAITING_FOR_SIGNER,
+  MARMOT_ONBOARDING_STATUS_SKIPPED,
+} MarmotOnboardingStatus;
+
+typedef enum MarmotOnboardingIssue {
+  MARMOT_ONBOARDING_ISSUE_MISSING,
+  MARMOT_ONBOARDING_ISSUE_MALFORMED,
+  MARMOT_ONBOARDING_ISSUE_FUTURE_DATED,
+  MARMOT_ONBOARDING_ISSUE_INVALID_RELAY,
+  MARMOT_ONBOARDING_ISSUE_RETIRED_RELAY,
+  MARMOT_ONBOARDING_ISSUE_UNSAFE_RELAY,
+  MARMOT_ONBOARDING_ISSUE_UNREACHABLE,
+  MARMOT_ONBOARDING_ISSUE_TIMED_OUT,
+  MARMOT_ONBOARDING_ISSUE_AUTHENTICATION_REQUIRED,
+  MARMOT_ONBOARDING_ISSUE_PAYMENT_REQUIRED,
+  MARMOT_ONBOARDING_ISSUE_ACCESS_RESTRICTED,
+  MARMOT_ONBOARDING_ISSUE_NO_USABLE_ROUTE,
+  MARMOT_ONBOARDING_ISSUE_PUBLICATION_FAILED,
+  MARMOT_ONBOARDING_ISSUE_SIGNER_UNAVAILABLE,
+  MARMOT_ONBOARDING_ISSUE_SIGNER_REJECTED,
+  MARMOT_ONBOARDING_ISSUE_RECORD_CHANGED,
+  MARMOT_ONBOARDING_ISSUE_INTERRUPTED,
+  MARMOT_ONBOARDING_ISSUE_TOO_MANY_RELAYS,
+} MarmotOnboardingIssue;
+
+typedef enum MarmotOnboardingAction {
+  MARMOT_ONBOARDING_ACTION_RETRY,
+  MARMOT_ONBOARDING_ACTION_CONTINUE_WITHOUT,
+  MARMOT_ONBOARDING_ACTION_USE_RECOMMENDED_RELAYS,
+  MARMOT_ONBOARDING_ACTION_EDIT_RELAYS,
+  MARMOT_ONBOARDING_ACTION_EDIT_PROFILE,
+  MARMOT_ONBOARDING_ACTION_EDIT_FOLLOWS,
+  MARMOT_ONBOARDING_ACTION_APPROVE_REPAIR,
+  MARMOT_ONBOARDING_ACTION_CANCEL_REPAIR,
+  MARMOT_ONBOARDING_ACTION_RECONNECT_SIGNER,
+  MARMOT_ONBOARDING_ACTION_EDIT_DISCOVERY_RELAYS,
+} MarmotOnboardingAction;
 
 /**
  * Which relay list is missing from an incomplete account relay setup.
@@ -690,6 +744,11 @@ typedef struct MarmotMessagesSubscription MarmotMessagesSubscription;
 typedef struct MarmotNotificationsSubscription MarmotNotificationsSubscription;
 
 /**
+ * A current onboarding snapshot followed by durable progress updates.
+ */
+typedef struct MarmotOnboardingSubscription MarmotOnboardingSubscription;
+
+/**
  * Opaque handle to one conversation's materialized timeline window.
  * `next` returns the full authoritative window after each update;
  * `next_update` returns the raw delta; pagination extends the
@@ -775,6 +834,71 @@ typedef struct MarmotSecretStore {
    */
   MarmotSecretStoreDestroyFn destroy;
 } MarmotSecretStore;
+
+typedef struct MarmotOnboardingFinding {
+  enum MarmotOnboardingIssue issue;
+  char *endpoint;
+} MarmotOnboardingFinding;
+
+typedef struct MarmotOnboardingStepState {
+  enum MarmotOnboardingStep step;
+  enum MarmotOnboardingStatus status;
+  struct MarmotOnboardingFinding *findings;
+  uintptr_t findings_len;
+  enum MarmotOnboardingAction *actions;
+  uintptr_t actions_len;
+  bool has_checked_at;
+  /**
+   *Only meaningful when the matching `has_` flag is set.
+   */
+  uint64_t checked_at;
+} MarmotOnboardingStepState;
+
+/**
+ * Nostr user profile metadata. All fields nullable. Used both as a
+ * return value (owned; free the root) and as a borrowed input to
+ * `marmot_publish_user_profile` (caller-owned; never freed by the
+ * library).
+ */
+typedef struct MarmotUserProfileMetadata {
+  char *name;
+  char *display_name;
+  char *about;
+  char *picture;
+  char *banner;
+  char *nip05;
+  char *lud16;
+} MarmotUserProfileMetadata;
+
+/**
+ * Owned list of strings (relay lists, admin ids, …). Free with
+ * `marmot_string_list_free`.
+ */
+typedef struct MarmotStringList {
+  char **items;
+  uintptr_t len;
+} MarmotStringList;
+
+typedef struct MarmotOnboardingRepairProposal {
+  enum MarmotOnboardingStep step;
+  uint64_t revision;
+  char *previous_event_id;
+  char **read_relays;
+  uintptr_t read_relays_len;
+  char **write_relays;
+  uintptr_t write_relays_len;
+  struct MarmotUserProfileMetadata *profile;
+  struct MarmotStringList *follows;
+} MarmotOnboardingRepairProposal;
+
+typedef struct MarmotOnboardingSnapshot {
+  char *account_id_hex;
+  uint64_t revision;
+  bool ready;
+  struct MarmotOnboardingStepState *steps;
+  uintptr_t steps_len;
+  struct MarmotOnboardingRepairProposal *proposal;
+} MarmotOnboardingSnapshot;
 
 /**
  * One signed-in (or signed-out but known) account.
@@ -888,15 +1012,6 @@ typedef struct MarmotSignOutOutcome {
   uintptr_t key_package_failures_len;
   struct MarmotLocalCleanupReport local_cleanup;
 } MarmotSignOutOutcome;
-
-/**
- * Owned list of strings (relay lists, admin ids, …). Free with
- * `marmot_string_list_free`.
- */
-typedef struct MarmotStringList {
-  char **items;
-  uintptr_t len;
-} MarmotStringList;
 
 /**
  * One published (or locally known) MLS KeyPackage.
@@ -1950,22 +2065,6 @@ typedef struct MarmotMediaRecordList {
   struct MarmotMediaRecord *items;
   uintptr_t len;
 } MarmotMediaRecordList;
-
-/**
- * Nostr user profile metadata. All fields nullable. Used both as a
- * return value (owned; free the root) and as a borrowed input to
- * `marmot_publish_user_profile` (caller-owned; never freed by the
- * library).
- */
-typedef struct MarmotUserProfileMetadata {
-  char *name;
-  char *display_name;
-  char *about;
-  char *picture;
-  char *banner;
-  char *nip05;
-  char *lud16;
-} MarmotUserProfileMetadata;
 
 /**
  * A freshly created identity plus its published profile and setup
@@ -3613,6 +3712,13 @@ typedef struct MarmotUserSearchUpdate {
 typedef void (*MarmotUserSearchUpdateCallback)(const struct MarmotUserSearchUpdate *item,
                                                void *user_data);
 
+/**
+ * Callback invoked with each item (borrowed; valid only during
+ * the call) and finally with NULL when the stream closes.
+ */
+typedef void (*MarmotOnboardingCallback)(const struct MarmotOnboardingSnapshot *item,
+                                         void *user_data);
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -3746,6 +3852,21 @@ void marmot_string_free(char *s);
  * been freed already.
  */
 void marmot_bytes_free(uint8_t *data, uintptr_t len);
+
+/**
+ * Retry onboarding against explicitly selected discovery relays.
+ *
+ * # Safety
+ * `client` must be a live handle; string arguments must be valid
+ * NUL-terminated strings (nullable ones may be NULL); array
+ * arguments must hold their stated length (or be NULL with
+ * length 0); out-pointers must be valid.
+ */
+MarmotStatus marmot_set_onboarding_discovery_relays(const struct MarmotClient *client,
+                                                    const char *account_ref,
+                                                    const char *const *discovery_relays,
+                                                    uintptr_t discovery_relays_len,
+                                                    struct MarmotOnboardingSnapshot **out);
 
 /**
  * List every account known to this device. Free the result with
@@ -6225,6 +6346,132 @@ MarmotStatus marmot_record_host_performance(const struct MarmotClient *client,
                                             uint32_t outcome);
 
 /**
+ * Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+ *
+ * # Safety
+ * The client must be live, input pointers valid and borrowed, and out writable.
+ */
+MarmotStatus marmot_begin_onboarding(const struct MarmotClient *client,
+                                     const char *nsec,
+                                     const char *const *default_relays,
+                                     uintptr_t default_relays_len,
+                                     const char *const *discovery_relays,
+                                     uintptr_t discovery_relays_len,
+                                     struct MarmotOnboardingSnapshot **out);
+
+/**
+ * Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+ *
+ * # Safety
+ * The client must be live, input pointers valid and borrowed, and out writable.
+ */
+MarmotStatus marmot_onboarding_snapshot(const struct MarmotClient *client,
+                                        const char *account_ref,
+                                        struct MarmotOnboardingSnapshot **out);
+
+/**
+ * Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+ *
+ * # Safety
+ * The client must be live, input pointers valid and borrowed, and out writable.
+ */
+MarmotStatus marmot_run_onboarding(const struct MarmotClient *client,
+                                   const char *account_ref,
+                                   struct MarmotOnboardingSnapshot **out);
+
+/**
+ * Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+ *
+ * # Safety
+ * The client must be live, input pointers valid and borrowed, and out writable.
+ */
+MarmotStatus marmot_retry_onboarding_step(const struct MarmotClient *client,
+                                          const char *account_ref,
+                                          uint32_t step,
+                                          struct MarmotOnboardingSnapshot **out);
+
+/**
+ * Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+ *
+ * # Safety
+ * The client must be live, input pointers valid and borrowed, and out writable.
+ */
+MarmotStatus marmot_continue_onboarding_without(const struct MarmotClient *client,
+                                                const char *account_ref,
+                                                uint32_t step,
+                                                struct MarmotOnboardingSnapshot **out);
+
+/**
+ * Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+ *
+ * # Safety
+ * The client must be live, input pointers valid and borrowed, and out writable.
+ */
+MarmotStatus marmot_propose_onboarding_recommended_relays(const struct MarmotClient *client,
+                                                          const char *account_ref,
+                                                          uint32_t step,
+                                                          struct MarmotOnboardingSnapshot **out);
+
+/**
+ * Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+ *
+ * # Safety
+ * The client must be live, input pointers valid and borrowed, and out writable.
+ */
+MarmotStatus marmot_propose_onboarding_relays(const struct MarmotClient *client,
+                                              const char *account_ref,
+                                              uint32_t step,
+                                              const char *const *read_relays,
+                                              uintptr_t read_relays_len,
+                                              const char *const *write_relays,
+                                              uintptr_t write_relays_len,
+                                              struct MarmotOnboardingSnapshot **out);
+
+/**
+ * Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+ *
+ * # Safety
+ * The client must be live, input pointers valid and borrowed, and out writable.
+ */
+MarmotStatus marmot_propose_onboarding_profile(const struct MarmotClient *client,
+                                               const char *account_ref,
+                                               const struct MarmotUserProfileMetadata *profile,
+                                               struct MarmotOnboardingSnapshot **out);
+
+/**
+ * Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+ *
+ * # Safety
+ * The client must be live, input pointers valid and borrowed, and out writable.
+ */
+MarmotStatus marmot_propose_onboarding_follows(const struct MarmotClient *client,
+                                               const char *account_ref,
+                                               const char *const *follows,
+                                               uintptr_t follows_len,
+                                               struct MarmotOnboardingSnapshot **out);
+
+/**
+ * Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+ *
+ * # Safety
+ * The client must be live, input pointers valid and borrowed, and out writable.
+ */
+MarmotStatus marmot_approve_onboarding_repair(const struct MarmotClient *client,
+                                              const char *account_ref,
+                                              uint64_t revision,
+                                              struct MarmotOnboardingSnapshot **out);
+
+/**
+ * Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+ *
+ * # Safety
+ * The client must be live, input pointers valid and borrowed, and out writable.
+ */
+MarmotStatus marmot_cancel_onboarding_repair(const struct MarmotClient *client,
+                                             const char *account_ref,
+                                             struct MarmotOnboardingSnapshot **out);
+
+/**
  *Block until the next item, the timeout, or stream close. `timeout_ms == 0` waits indefinitely. Returns `MARMOT_STATUS_OK` (out set; free with `marmot_event_free`), `MARMOT_STATUS_TIMEOUT`, or `MARMOT_STATUS_CLOSED` (out NULL for both).
  *
  * # Safety
@@ -6915,6 +7162,74 @@ MarmotStatus marmot_search_users(const struct MarmotClient *client,
                                  uint8_t radius_start,
                                  uint8_t radius_end,
                                  struct MarmotUserSearchSubscription **out_sub);
+
+/**
+ *Block until the next item, the timeout, or stream close. `timeout_ms == 0` waits indefinitely. Returns `MARMOT_STATUS_OK` (out set; free with `marmot_onboarding_snapshot_free`), `MARMOT_STATUS_TIMEOUT`, or `MARMOT_STATUS_CLOSED` (out NULL for both).
+ *
+ * # Safety
+ * `sub` must be a live handle; `out` must be a valid pointer.
+ */
+MarmotStatus marmot_onboarding_subscription_next(const struct MarmotOnboardingSubscription *sub,
+                                                 uint32_t timeout_ms,
+                                                 struct MarmotOnboardingSnapshot **out);
+
+/**
+ * Install a callback pump for this subscription. `callback` runs
+ * on a runtime worker thread with a borrowed item pointer (valid
+ * only during the call; do not store or free it) and a final
+ * NULL item on close. `callback` and `user_data` access must be
+ * thread-safe. Fails if a callback is already installed.
+ *
+ * # Safety
+ * `sub` must be a live handle; `callback` a valid function
+ * pointer. `user_data` must outlive every callback invocation —
+ * clear/free only *request* cancellation without waiting (see
+ * the module docs).
+ */
+MarmotStatus marmot_onboarding_subscription_set_callback(const struct MarmotOnboardingSubscription *sub,
+                                                         MarmotOnboardingCallback callback,
+                                                         void *user_data);
+
+/**
+ * Request cancellation of this subscription's callback pump, if
+ * any. Non-blocking: a callback already running keeps executing
+ * after this returns (see the module docs).
+ *
+ * # Safety
+ * `sub` must be a live handle.
+ */
+MarmotStatus marmot_onboarding_subscription_clear_callback(const struct MarmotOnboardingSubscription *sub);
+
+/**
+ * Free the subscription handle. Requests callback-pump
+ * cancellation without waiting (a callback may still be running
+ * after this returns — do not free `user_data` on that basis).
+ * NULL is a no-op. Free every handle before the client that
+ * created it.
+ *
+ * # Safety
+ * `sub` must be NULL or an unfreed handle pointer.
+ */
+void marmot_onboarding_subscription_free(struct MarmotOnboardingSubscription *sub);
+
+/**
+ * Subscribe to durable onboarding state for an account.
+ *
+ * # Safety
+ * Client and account_ref must be valid; out_sub must be writable.
+ */
+MarmotStatus marmot_subscribe_onboarding(const struct MarmotClient *client,
+                                         const char *account_ref,
+                                         struct MarmotOnboardingSubscription **out_sub);
+
+/**
+ * Return the initial snapshot. Free with marmot_onboarding_snapshot_free.
+ *
+ * # Safety
+ * Sub must be live and out must be writable.
+ */
+MarmotStatus marmot_onboarding_subscription_snapshot(const struct MarmotOnboardingSubscription *sub,
+                                                     struct MarmotOnboardingSnapshot **out);
 
 /**
  * Free a value of this type returned by this library. NULL
@@ -7698,6 +8013,16 @@ void marmot_timeline_page_free(struct MarmotTimelinePage *ptr);
  * `update` must be NULL or an unfreed pointer returned by this library.
  */
 void marmot_timeline_subscription_update_free(struct MarmotTimelineSubscriptionUpdate *update);
+
+/**
+ * Free a value of this type returned by this library. NULL
+ * is a no-op.
+ *
+ * # Safety
+ * The pointer must be NULL or an unfreed pointer returned by
+ * this library.
+ */
+void marmot_onboarding_snapshot_free(struct MarmotOnboardingSnapshot *ptr);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/crates/marmot-c/include/marmot.h
+++ b/crates/marmot-c/include/marmot.h
@@ -144,8 +144,8 @@ typedef enum MarmotOnboardingStep {
   MARMOT_ONBOARDING_STEP_FOLLOWS,
   MARMOT_ONBOARDING_STEP_RELAYS,
   MARMOT_ONBOARDING_STEP_INBOX_RELAYS,
-  MARMOT_ONBOARDING_STEP_KEY_PACKAGE,
   MARMOT_ONBOARDING_STEP_SINGLE_DEVICE,
+  MARMOT_ONBOARDING_STEP_KEY_PACKAGE,
 } MarmotOnboardingStep;
 
 typedef enum MarmotOnboardingStatus {
@@ -847,92 +847,6 @@ typedef struct MarmotSecretStore {
   MarmotSecretStoreDestroyFn destroy;
 } MarmotSecretStore;
 
-typedef struct MarmotOnboardingFinding {
-  enum MarmotOnboardingIssue issue;
-  char *endpoint;
-} MarmotOnboardingFinding;
-
-typedef struct MarmotOnboardingStepState {
-  enum MarmotOnboardingStep step;
-  enum MarmotOnboardingStatus status;
-  struct MarmotOnboardingFinding *findings;
-  uintptr_t findings_len;
-  enum MarmotOnboardingAction *actions;
-  uintptr_t actions_len;
-  bool has_checked_at;
-  /**
-   *Only meaningful when the matching `has_` flag is set.
-   */
-  uint64_t checked_at;
-} MarmotOnboardingStepState;
-
-/**
- * Nostr user profile metadata. All fields nullable. Used both as a
- * return value (owned; free the root) and as a borrowed input to
- * `marmot_publish_user_profile` (caller-owned; never freed by the
- * library).
- */
-typedef struct MarmotUserProfileMetadata {
-  char *name;
-  char *display_name;
-  char *about;
-  char *picture;
-  char *banner;
-  char *nip05;
-  char *lud16;
-} MarmotUserProfileMetadata;
-
-/**
- * Owned list of strings (relay lists, admin ids, …). Free with
- * `marmot_string_list_free`.
- */
-typedef struct MarmotStringList {
-  char **items;
-  uintptr_t len;
-} MarmotStringList;
-
-typedef struct MarmotOnboardingRepairProposal {
-  enum MarmotOnboardingStep step;
-  uint64_t revision;
-  char *previous_event_id;
-  char **read_relays;
-  uintptr_t read_relays_len;
-  char **write_relays;
-  uintptr_t write_relays_len;
-  struct MarmotUserProfileMetadata *profile;
-  struct MarmotStringList *follows;
-} MarmotOnboardingRepairProposal;
-
-typedef struct MarmotOnboardingDevicePackage {
-  char *slot_id;
-  char *key_package_ref_hex;
-  char *event_id_hex;
-  uint64_t published_at;
-  uint64_t expires_at;
-} MarmotOnboardingDevicePackage;
-
-typedef struct MarmotOnboardingSingleDeviceNotice {
-  enum MarmotOnboardingDeviceDiscovery discovery;
-  struct MarmotOnboardingDevicePackage *other_packages;
-  uintptr_t other_packages_len;
-  bool discovery_complete;
-  bool has_acknowledged_at;
-  /**
-   *Only meaningful when the matching `has_` flag is set.
-   */
-  uint64_t acknowledged_at;
-} MarmotOnboardingSingleDeviceNotice;
-
-typedef struct MarmotOnboardingSnapshot {
-  char *account_id_hex;
-  uint64_t revision;
-  bool ready;
-  struct MarmotOnboardingStepState *steps;
-  uintptr_t steps_len;
-  struct MarmotOnboardingRepairProposal *proposal;
-  struct MarmotOnboardingSingleDeviceNotice *single_device_notice;
-} MarmotOnboardingSnapshot;
-
 /**
  * One signed-in (or signed-out but known) account.
  */
@@ -1045,6 +959,98 @@ typedef struct MarmotSignOutOutcome {
   uintptr_t key_package_failures_len;
   struct MarmotLocalCleanupReport local_cleanup;
 } MarmotSignOutOutcome;
+
+typedef struct MarmotOnboardingFinding {
+  enum MarmotOnboardingIssue issue;
+  char *endpoint;
+} MarmotOnboardingFinding;
+
+typedef struct MarmotOnboardingStepState {
+  enum MarmotOnboardingStep step;
+  enum MarmotOnboardingStatus status;
+  struct MarmotOnboardingFinding *findings;
+  uintptr_t findings_len;
+  enum MarmotOnboardingAction *actions;
+  uintptr_t actions_len;
+  bool has_checked_at;
+  /**
+   *Only meaningful when the matching `has_` flag is set.
+   */
+  uint64_t checked_at;
+} MarmotOnboardingStepState;
+
+/**
+ * Nostr user profile metadata. All fields nullable. Used both as a
+ * return value (owned; free the root) and as a borrowed input to
+ * `marmot_publish_user_profile` (caller-owned; never freed by the
+ * library).
+ */
+typedef struct MarmotUserProfileMetadata {
+  char *name;
+  char *display_name;
+  char *about;
+  char *picture;
+  char *banner;
+  char *nip05;
+  char *lud16;
+} MarmotUserProfileMetadata;
+
+/**
+ * Owned list of strings (relay lists, admin ids, …). Free with
+ * `marmot_string_list_free`.
+ */
+typedef struct MarmotStringList {
+  char **items;
+  uintptr_t len;
+} MarmotStringList;
+
+typedef struct MarmotOnboardingRepairProposal {
+  enum MarmotOnboardingStep step;
+  uint64_t revision;
+  char *previous_event_id;
+  char **read_relays;
+  uintptr_t read_relays_len;
+  char **write_relays;
+  uintptr_t write_relays_len;
+  struct MarmotUserProfileMetadata *profile;
+  struct MarmotStringList *follows;
+} MarmotOnboardingRepairProposal;
+
+typedef struct MarmotOnboardingDevicePackage {
+  char *slot_id;
+  char *key_package_ref_hex;
+  char *event_id_hex;
+  uint64_t published_at;
+  bool has_expires_at;
+  /**
+   *Only meaningful when the matching `has_` flag is set.
+   */
+  uint64_t expires_at;
+  bool usable;
+} MarmotOnboardingDevicePackage;
+
+typedef struct MarmotOnboardingSingleDeviceNotice {
+  enum MarmotOnboardingDeviceDiscovery discovery;
+  struct MarmotOnboardingDevicePackage *other_packages;
+  uintptr_t other_packages_len;
+  bool discovery_complete;
+  bool has_acknowledged_at;
+  /**
+   *Only meaningful when the matching `has_` flag is set.
+   */
+  uint64_t acknowledged_at;
+} MarmotOnboardingSingleDeviceNotice;
+
+typedef struct MarmotOnboardingSnapshot {
+  char *account_id_hex;
+  uint64_t revision;
+  bool ready;
+  struct MarmotOnboardingStepState *steps;
+  uintptr_t steps_len;
+  struct MarmotOnboardingRepairProposal *proposal;
+  struct MarmotOnboardingSingleDeviceNotice *single_device_notice;
+  bool cancellation_pending;
+} MarmotOnboardingSnapshot;
 
 /**
  * One published (or locally known) MLS KeyPackage.
@@ -3887,35 +3893,6 @@ void marmot_string_free(char *s);
 void marmot_bytes_free(uint8_t *data, uintptr_t len);
 
 /**
- * Retry onboarding against explicitly selected discovery relays.
- *
- * # Safety
- * `client` must be a live handle; string arguments must be valid
- * NUL-terminated strings (nullable ones may be NULL); array
- * arguments must hold their stated length (or be NULL with
- * length 0); out-pointers must be valid.
- */
-MarmotStatus marmot_set_onboarding_discovery_relays(const struct MarmotClient *client,
-                                                    const char *account_ref,
-                                                    const char *const *discovery_relays,
-                                                    uintptr_t discovery_relays_len,
-                                                    struct MarmotOnboardingSnapshot **out);
-
-/**
- * Acknowledge the displayed one-device notice and resume setup.
- *
- * # Safety
- * `client` must be a live handle; string arguments must be valid
- * NUL-terminated strings (nullable ones may be NULL); array
- * arguments must hold their stated length (or be NULL with
- * length 0); out-pointers must be valid.
- */
-MarmotStatus marmot_acknowledge_onboarding_single_device(const struct MarmotClient *client,
-                                                         const char *account_ref,
-                                                         uint64_t revision,
-                                                         struct MarmotOnboardingSnapshot **out);
-
-/**
  * List every account known to this device. Free the result with
  * `marmot_account_summary_list_free`.
  *
@@ -3983,6 +3960,47 @@ MarmotStatus marmot_sign_out(const struct MarmotClient *client,
                              const char *account_ref,
                              uint8_t delete_key_packages,
                              struct MarmotSignOutOutcome **out);
+
+/**
+ * Retry onboarding against explicitly selected discovery relays.
+ *
+ * # Safety
+ * `client` must be a live handle; string arguments must be valid
+ * NUL-terminated strings (nullable ones may be NULL); array
+ * arguments must hold their stated length (or be NULL with
+ * length 0); out-pointers must be valid.
+ */
+MarmotStatus marmot_set_onboarding_discovery_relays(const struct MarmotClient *client,
+                                                    const char *account_ref,
+                                                    const char *const *discovery_relays,
+                                                    uintptr_t discovery_relays_len,
+                                                    struct MarmotOnboardingSnapshot **out);
+
+/**
+ * Acknowledge the displayed one-device notice and resume setup.
+ *
+ * # Safety
+ * `client` must be a live handle; string arguments must be valid
+ * NUL-terminated strings (nullable ones may be NULL); array
+ * arguments must hold their stated length (or be NULL with
+ * length 0); out-pointers must be valid.
+ */
+MarmotStatus marmot_acknowledge_onboarding_single_device(const struct MarmotClient *client,
+                                                         const char *account_ref,
+                                                         uint64_t revision,
+                                                         struct MarmotOnboardingSnapshot **out);
+
+/**
+ * Cancel unfinished onboarding, retaining the signed-out identity and private state.
+ * An approved unfinished repair must be resumed first; cancellation performs no relay deletion.
+ *
+ * # Safety
+ * `client` must be a live handle; string arguments must be valid
+ * NUL-terminated strings (nullable ones may be NULL); array
+ * arguments must hold their stated length (or be NULL with
+ * length 0); out-pointers must be valid.
+ */
+MarmotStatus marmot_cancel_onboarding(const struct MarmotClient *client, const char *account_ref);
 
 /**
  * Create a brand-new Nostr identity, store its secret in the account
@@ -6393,7 +6411,7 @@ MarmotStatus marmot_record_host_performance(const struct MarmotClient *client,
                                             uint32_t outcome);
 
 /**
- * Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+ * Import an identity and persist its onboarding gate without publishing. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
  *
  * # Safety
  * The client must be live, input pointers valid and borrowed, and out writable.
@@ -6407,7 +6425,8 @@ MarmotStatus marmot_begin_onboarding(const struct MarmotClient *client,
                                      struct MarmotOnboardingSnapshot **out);
 
 /**
- * Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+ * Read the persisted onboarding snapshot. Writes NULL with MARMOT_STATUS_OK when no checkpoint exists.
+ * Free the returned snapshot with `marmot_onboarding_snapshot_free`.
  *
  * # Safety
  * The client must be live, input pointers valid and borrowed, and out writable.
@@ -6417,7 +6436,7 @@ MarmotStatus marmot_onboarding_snapshot(const struct MarmotClient *client,
                                         struct MarmotOnboardingSnapshot **out);
 
 /**
- * Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+ * Resume pending checks until user input or a retry is needed. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
  *
  * # Safety
  * The client must be live, input pointers valid and borrowed, and out writable.
@@ -6427,7 +6446,8 @@ MarmotStatus marmot_run_onboarding(const struct MarmotClient *client,
                                    struct MarmotOnboardingSnapshot **out);
 
 /**
- * Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+ * Retry an offered step; earlier checks invalidate downstream readiness. `step` is a MarmotOnboardingStep discriminant; out-of-range values return MARMOT_STATUS_INVALID_ARGUMENT.
+ * Free the returned snapshot with `marmot_onboarding_snapshot_free`.
  *
  * # Safety
  * The client must be live, input pointers valid and borrowed, and out writable.
@@ -6438,7 +6458,8 @@ MarmotStatus marmot_retry_onboarding_step(const struct MarmotClient *client,
                                           struct MarmotOnboardingSnapshot **out);
 
 /**
- * Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+ * Explicitly skip an optional profile or follows step when offered. `step` is a MarmotOnboardingStep discriminant; out-of-range values return MARMOT_STATUS_INVALID_ARGUMENT.
+ * Free the returned snapshot with `marmot_onboarding_snapshot_free`.
  *
  * # Safety
  * The client must be live, input pointers valid and borrowed, and out writable.
@@ -6449,7 +6470,8 @@ MarmotStatus marmot_continue_onboarding_without(const struct MarmotClient *clien
                                                 struct MarmotOnboardingSnapshot **out);
 
 /**
- * Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+ * Prepare the configured default relay proposal without publishing. `step` is a MarmotOnboardingStep discriminant; out-of-range values return MARMOT_STATUS_INVALID_ARGUMENT.
+ * Free the returned snapshot with `marmot_onboarding_snapshot_free`.
  *
  * # Safety
  * The client must be live, input pointers valid and borrowed, and out writable.
@@ -6460,7 +6482,8 @@ MarmotStatus marmot_propose_onboarding_recommended_relays(const struct MarmotCli
                                                           struct MarmotOnboardingSnapshot **out);
 
 /**
- * Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+ * Prepare a relay proposal without publishing; inbox proposals require an empty write list. `step` is a MarmotOnboardingStep discriminant; out-of-range values return MARMOT_STATUS_INVALID_ARGUMENT.
+ * Free the returned snapshot with `marmot_onboarding_snapshot_free`.
  *
  * # Safety
  * The client must be live, input pointers valid and borrowed, and out writable.
@@ -6475,7 +6498,7 @@ MarmotStatus marmot_propose_onboarding_relays(const struct MarmotClient *client,
                                               struct MarmotOnboardingSnapshot **out);
 
 /**
- * Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+ * Prepare profile edits without publishing; NULL fields preserve existing values and empty strings clear them. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
  *
  * # Safety
  * The client must be live, input pointers valid and borrowed, and out writable.
@@ -6486,7 +6509,7 @@ MarmotStatus marmot_propose_onboarding_profile(const struct MarmotClient *client
                                                struct MarmotOnboardingSnapshot **out);
 
 /**
- * Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+ * Prepare a follow-list replacement without publishing; an empty list is valid. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
  *
  * # Safety
  * The client must be live, input pointers valid and borrowed, and out writable.
@@ -6498,7 +6521,7 @@ MarmotStatus marmot_propose_onboarding_follows(const struct MarmotClient *client
                                                struct MarmotOnboardingSnapshot **out);
 
 /**
- * Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+ * Approve the proposal at the current snapshot revision and resume publication; stale revisions are rejected. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
  *
  * # Safety
  * The client must be live, input pointers valid and borrowed, and out writable.
@@ -6509,7 +6532,7 @@ MarmotStatus marmot_approve_onboarding_repair(const struct MarmotClient *client,
                                               struct MarmotOnboardingSnapshot **out);
 
 /**
- * Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+ * Dismiss an unapproved repair proposal; an approved repair must be resumed. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
  *
  * # Safety
  * The client must be live, input pointers valid and borrowed, and out writable.

--- a/crates/marmot-c/include/marmot.h
+++ b/crates/marmot-c/include/marmot.h
@@ -145,6 +145,7 @@ typedef enum MarmotOnboardingStep {
   MARMOT_ONBOARDING_STEP_RELAYS,
   MARMOT_ONBOARDING_STEP_INBOX_RELAYS,
   MARMOT_ONBOARDING_STEP_KEY_PACKAGE,
+  MARMOT_ONBOARDING_STEP_SINGLE_DEVICE,
 } MarmotOnboardingStep;
 
 typedef enum MarmotOnboardingStatus {
@@ -176,6 +177,9 @@ typedef enum MarmotOnboardingIssue {
   MARMOT_ONBOARDING_ISSUE_RECORD_CHANGED,
   MARMOT_ONBOARDING_ISSUE_INTERRUPTED,
   MARMOT_ONBOARDING_ISSUE_TOO_MANY_RELAYS,
+  MARMOT_ONBOARDING_ISSUE_MULTI_DEVICE_UNSUPPORTED,
+  MARMOT_ONBOARDING_ISSUE_OTHER_INSTALLATION_POSSIBLE,
+  MARMOT_ONBOARDING_ISSUE_DISCOVERY_INCOMPLETE,
 } MarmotOnboardingIssue;
 
 typedef enum MarmotOnboardingAction {
@@ -189,7 +193,15 @@ typedef enum MarmotOnboardingAction {
   MARMOT_ONBOARDING_ACTION_CANCEL_REPAIR,
   MARMOT_ONBOARDING_ACTION_RECONNECT_SIGNER,
   MARMOT_ONBOARDING_ACTION_EDIT_DISCOVERY_RELAYS,
+  MARMOT_ONBOARDING_ACTION_CONTINUE_ANYWAY,
+  MARMOT_ONBOARDING_ACTION_CANCEL_ONBOARDING,
 } MarmotOnboardingAction;
+
+typedef enum MarmotOnboardingDeviceDiscovery {
+  MARMOT_ONBOARDING_DEVICE_DISCOVERY_NONE_FOUND,
+  MARMOT_ONBOARDING_DEVICE_DISCOVERY_OTHER_INSTALLATION_POSSIBLE,
+  MARMOT_ONBOARDING_DEVICE_DISCOVERY_UNKNOWN,
+} MarmotOnboardingDeviceDiscovery;
 
 /**
  * Which relay list is missing from an incomplete account relay setup.
@@ -891,6 +903,26 @@ typedef struct MarmotOnboardingRepairProposal {
   struct MarmotStringList *follows;
 } MarmotOnboardingRepairProposal;
 
+typedef struct MarmotOnboardingDevicePackage {
+  char *slot_id;
+  char *key_package_ref_hex;
+  char *event_id_hex;
+  uint64_t published_at;
+  uint64_t expires_at;
+} MarmotOnboardingDevicePackage;
+
+typedef struct MarmotOnboardingSingleDeviceNotice {
+  enum MarmotOnboardingDeviceDiscovery discovery;
+  struct MarmotOnboardingDevicePackage *other_packages;
+  uintptr_t other_packages_len;
+  bool discovery_complete;
+  bool has_acknowledged_at;
+  /**
+   *Only meaningful when the matching `has_` flag is set.
+   */
+  uint64_t acknowledged_at;
+} MarmotOnboardingSingleDeviceNotice;
+
 typedef struct MarmotOnboardingSnapshot {
   char *account_id_hex;
   uint64_t revision;
@@ -898,6 +930,7 @@ typedef struct MarmotOnboardingSnapshot {
   struct MarmotOnboardingStepState *steps;
   uintptr_t steps_len;
   struct MarmotOnboardingRepairProposal *proposal;
+  struct MarmotOnboardingSingleDeviceNotice *single_device_notice;
 } MarmotOnboardingSnapshot;
 
 /**
@@ -3867,6 +3900,20 @@ MarmotStatus marmot_set_onboarding_discovery_relays(const struct MarmotClient *c
                                                     const char *const *discovery_relays,
                                                     uintptr_t discovery_relays_len,
                                                     struct MarmotOnboardingSnapshot **out);
+
+/**
+ * Acknowledge the displayed one-device notice and resume setup.
+ *
+ * # Safety
+ * `client` must be a live handle; string arguments must be valid
+ * NUL-terminated strings (nullable ones may be NULL); array
+ * arguments must hold their stated length (or be NULL with
+ * length 0); out-pointers must be valid.
+ */
+MarmotStatus marmot_acknowledge_onboarding_single_device(const struct MarmotClient *client,
+                                                         const char *account_ref,
+                                                         uint64_t revision,
+                                                         struct MarmotOnboardingSnapshot **out);
 
 /**
  * List every account known to this device. Free the result with

--- a/crates/marmot-c/src/commands.rs
+++ b/crates/marmot-c/src/commands.rs
@@ -510,6 +510,8 @@ macro_rules! c_cmd {
 c_cmd! {
     /// Retry onboarding against explicitly selected discovery relays.
     async fn marmot_set_onboarding_discovery_relays(account_ref: str, discovery_relays/discovery_relays_len: str_arr) -> rec(MarmotOnboardingSnapshot) = set_onboarding_discovery_relays;
+    /// Acknowledge the displayed one-device notice and resume setup.
+    async fn marmot_acknowledge_onboarding_single_device(account_ref: str, revision: val u64) -> rec(MarmotOnboardingSnapshot) = acknowledge_onboarding_single_device;
     /// List every account known to this device. Free the result with
     /// `marmot_account_summary_list_free`.
     sync fn marmot_list_accounts() -> rec(MarmotAccountSummaryList) = list_accounts;

--- a/crates/marmot-c/src/commands.rs
+++ b/crates/marmot-c/src/commands.rs
@@ -508,6 +508,8 @@ macro_rules! c_cmd {
 }
 
 c_cmd! {
+    /// Retry onboarding against explicitly selected discovery relays.
+    async fn marmot_set_onboarding_discovery_relays(account_ref: str, discovery_relays/discovery_relays_len: str_arr) -> rec(MarmotOnboardingSnapshot) = set_onboarding_discovery_relays;
     /// List every account known to this device. Free the result with
     /// `marmot_account_summary_list_free`.
     sync fn marmot_list_accounts() -> rec(MarmotAccountSummaryList) = list_accounts;
@@ -2238,4 +2240,296 @@ where
         out.push(convert(unsafe { &*ptr.add(i) })?);
     }
     Ok(out)
+}
+
+use crate::types::onboarding::{MarmotOnboardingSnapshot, MarmotOnboardingStep};
+/// Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+///
+/// # Safety
+/// The client must be live, input pointers valid and borrowed, and out writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn marmot_begin_onboarding(
+    client: *const MarmotClient,
+    nsec: *const c_char,
+    default_relays: *const *const c_char,
+    default_relays_len: usize,
+    discovery_relays: *const *const c_char,
+    discovery_relays_len: usize,
+    out: *mut *mut MarmotOnboardingSnapshot,
+) -> MarmotStatus {
+    ffi_guard(|| {
+        try_arg!(unsafe { crate::preflight_out_ptr(out) });
+        let client = try_arg!(unsafe { client_ref(client) });
+        let nsec = try_arg!(unsafe { required_str(nsec) });
+        let default_relays = try_arg!(unsafe { str_array(default_relays, default_relays_len) });
+        let discovery_relays =
+            try_arg!(unsafe { str_array(discovery_relays, discovery_relays_len) });
+        let options = marmot_uniffi::OnboardingOptionsFfi {
+            default_relays,
+            discovery_relays,
+        };
+        unsafe {
+            deliver(
+                client.block_on(client.marmot.begin_onboarding(nsec, options)),
+                out,
+            )
+        }
+    })
+}
+/// Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+///
+/// # Safety
+/// The client must be live, input pointers valid and borrowed, and out writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn marmot_onboarding_snapshot(
+    client: *const MarmotClient,
+    account_ref: *const c_char,
+    out: *mut *mut MarmotOnboardingSnapshot,
+) -> MarmotStatus {
+    ffi_guard(|| {
+        try_arg!(unsafe { crate::preflight_out_ptr(out) });
+        let client = try_arg!(unsafe { client_ref(client) });
+        let account_ref = try_arg!(unsafe { required_str(account_ref) });
+        unsafe { deliver_opt(client.marmot.onboarding_snapshot(account_ref), out) }
+    })
+}
+/// Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+///
+/// # Safety
+/// The client must be live, input pointers valid and borrowed, and out writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn marmot_run_onboarding(
+    client: *const MarmotClient,
+    account_ref: *const c_char,
+    out: *mut *mut MarmotOnboardingSnapshot,
+) -> MarmotStatus {
+    ffi_guard(|| {
+        try_arg!(unsafe { crate::preflight_out_ptr(out) });
+        let client = try_arg!(unsafe { client_ref(client) });
+        let account_ref = try_arg!(unsafe { required_str(account_ref) });
+        unsafe {
+            deliver(
+                client.block_on(client.marmot.run_onboarding(account_ref)),
+                out,
+            )
+        }
+    })
+}
+/// Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+///
+/// # Safety
+/// The client must be live, input pointers valid and borrowed, and out writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn marmot_retry_onboarding_step(
+    client: *const MarmotClient,
+    account_ref: *const c_char,
+    step: u32,
+    out: *mut *mut MarmotOnboardingSnapshot,
+) -> MarmotStatus {
+    ffi_guard(|| {
+        try_arg!(unsafe { crate::preflight_out_ptr(out) });
+        let client = try_arg!(unsafe { client_ref(client) });
+        let account_ref = try_arg!(unsafe { required_str(account_ref) });
+        let step = try_arg!(MarmotOnboardingStep::from_c(step)).to_ffi();
+        unsafe {
+            deliver(
+                client.block_on(client.marmot.retry_onboarding_step(account_ref, step)),
+                out,
+            )
+        }
+    })
+}
+/// Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+///
+/// # Safety
+/// The client must be live, input pointers valid and borrowed, and out writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn marmot_continue_onboarding_without(
+    client: *const MarmotClient,
+    account_ref: *const c_char,
+    step: u32,
+    out: *mut *mut MarmotOnboardingSnapshot,
+) -> MarmotStatus {
+    ffi_guard(|| {
+        try_arg!(unsafe { crate::preflight_out_ptr(out) });
+        let client = try_arg!(unsafe { client_ref(client) });
+        let account_ref = try_arg!(unsafe { required_str(account_ref) });
+        let step = try_arg!(MarmotOnboardingStep::from_c(step)).to_ffi();
+        unsafe {
+            deliver(
+                client.block_on(client.marmot.continue_onboarding_without(account_ref, step)),
+                out,
+            )
+        }
+    })
+}
+/// Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+///
+/// # Safety
+/// The client must be live, input pointers valid and borrowed, and out writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn marmot_propose_onboarding_recommended_relays(
+    client: *const MarmotClient,
+    account_ref: *const c_char,
+    step: u32,
+    out: *mut *mut MarmotOnboardingSnapshot,
+) -> MarmotStatus {
+    ffi_guard(|| {
+        try_arg!(unsafe { crate::preflight_out_ptr(out) });
+        let client = try_arg!(unsafe { client_ref(client) });
+        let account_ref = try_arg!(unsafe { required_str(account_ref) });
+        let step = try_arg!(MarmotOnboardingStep::from_c(step)).to_ffi();
+        unsafe {
+            deliver(
+                client.block_on(
+                    client
+                        .marmot
+                        .propose_onboarding_recommended_relays(account_ref, step),
+                ),
+                out,
+            )
+        }
+    })
+}
+/// Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+///
+/// # Safety
+/// The client must be live, input pointers valid and borrowed, and out writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn marmot_propose_onboarding_relays(
+    client: *const MarmotClient,
+    account_ref: *const c_char,
+    step: u32,
+    read_relays: *const *const c_char,
+    read_relays_len: usize,
+    write_relays: *const *const c_char,
+    write_relays_len: usize,
+    out: *mut *mut MarmotOnboardingSnapshot,
+) -> MarmotStatus {
+    ffi_guard(|| {
+        try_arg!(unsafe { crate::preflight_out_ptr(out) });
+        let client = try_arg!(unsafe { client_ref(client) });
+        let account_ref = try_arg!(unsafe { required_str(account_ref) });
+        let step = try_arg!(MarmotOnboardingStep::from_c(step)).to_ffi();
+        let read_relays = try_arg!(unsafe { str_array(read_relays, read_relays_len) });
+        let write_relays = try_arg!(unsafe { str_array(write_relays, write_relays_len) });
+        unsafe {
+            deliver(
+                client.block_on(client.marmot.propose_onboarding_relays(
+                    account_ref,
+                    step,
+                    read_relays,
+                    write_relays,
+                )),
+                out,
+            )
+        }
+    })
+}
+/// Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+///
+/// # Safety
+/// The client must be live, input pointers valid and borrowed, and out writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn marmot_propose_onboarding_profile(
+    client: *const MarmotClient,
+    account_ref: *const c_char,
+    profile: *const MarmotUserProfileMetadata,
+    out: *mut *mut MarmotOnboardingSnapshot,
+) -> MarmotStatus {
+    ffi_guard(|| {
+        try_arg!(unsafe { crate::preflight_out_ptr(out) });
+        let client = try_arg!(unsafe { client_ref(client) });
+        let account_ref = try_arg!(unsafe { required_str(account_ref) });
+        let profile = try_arg!(unsafe { borrowed(profile) });
+        let profile = try_arg!(unsafe { profile.to_ffi() });
+        unsafe {
+            deliver(
+                client.block_on(
+                    client
+                        .marmot
+                        .propose_onboarding_profile(account_ref, profile),
+                ),
+                out,
+            )
+        }
+    })
+}
+/// Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+///
+/// # Safety
+/// The client must be live, input pointers valid and borrowed, and out writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn marmot_propose_onboarding_follows(
+    client: *const MarmotClient,
+    account_ref: *const c_char,
+    follows: *const *const c_char,
+    follows_len: usize,
+    out: *mut *mut MarmotOnboardingSnapshot,
+) -> MarmotStatus {
+    ffi_guard(|| {
+        try_arg!(unsafe { crate::preflight_out_ptr(out) });
+        let client = try_arg!(unsafe { client_ref(client) });
+        let account_ref = try_arg!(unsafe { required_str(account_ref) });
+        let follows = try_arg!(unsafe { str_array(follows, follows_len) });
+        unsafe {
+            deliver(
+                client.block_on(
+                    client
+                        .marmot
+                        .propose_onboarding_follows(account_ref, follows),
+                ),
+                out,
+            )
+        }
+    })
+}
+/// Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+///
+/// # Safety
+/// The client must be live, input pointers valid and borrowed, and out writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn marmot_approve_onboarding_repair(
+    client: *const MarmotClient,
+    account_ref: *const c_char,
+    revision: u64,
+    out: *mut *mut MarmotOnboardingSnapshot,
+) -> MarmotStatus {
+    ffi_guard(|| {
+        try_arg!(unsafe { crate::preflight_out_ptr(out) });
+        let client = try_arg!(unsafe { client_ref(client) });
+        let account_ref = try_arg!(unsafe { required_str(account_ref) });
+        unsafe {
+            deliver(
+                client.block_on(
+                    client
+                        .marmot
+                        .approve_onboarding_repair(account_ref, revision),
+                ),
+                out,
+            )
+        }
+    })
+}
+/// Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+///
+/// # Safety
+/// The client must be live, input pointers valid and borrowed, and out writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn marmot_cancel_onboarding_repair(
+    client: *const MarmotClient,
+    account_ref: *const c_char,
+    out: *mut *mut MarmotOnboardingSnapshot,
+) -> MarmotStatus {
+    ffi_guard(|| {
+        try_arg!(unsafe { crate::preflight_out_ptr(out) });
+        let client = try_arg!(unsafe { client_ref(client) });
+        let account_ref = try_arg!(unsafe { required_str(account_ref) });
+        unsafe {
+            deliver(
+                client.block_on(client.marmot.cancel_onboarding_repair(account_ref)),
+                out,
+            )
+        }
+    })
 }

--- a/crates/marmot-c/src/commands.rs
+++ b/crates/marmot-c/src/commands.rs
@@ -508,10 +508,6 @@ macro_rules! c_cmd {
 }
 
 c_cmd! {
-    /// Retry onboarding against explicitly selected discovery relays.
-    async fn marmot_set_onboarding_discovery_relays(account_ref: str, discovery_relays/discovery_relays_len: str_arr) -> rec(MarmotOnboardingSnapshot) = set_onboarding_discovery_relays;
-    /// Acknowledge the displayed one-device notice and resume setup.
-    async fn marmot_acknowledge_onboarding_single_device(account_ref: str, revision: val u64) -> rec(MarmotOnboardingSnapshot) = acknowledge_onboarding_single_device;
     /// List every account known to this device. Free the result with
     /// `marmot_account_summary_list_free`.
     sync fn marmot_list_accounts() -> rec(MarmotAccountSummaryList) = list_accounts;
@@ -533,6 +529,14 @@ c_cmd! {
     /// `delete_key_packages` is true, relay-published KeyPackages get
     /// NIP-09 deletions. Free with `marmot_sign_out_outcome_free`.
     async fn marmot_sign_out(account_ref: str, delete_key_packages: flag) -> rec(MarmotSignOutOutcome) = sign_out;
+
+    /// Retry onboarding against explicitly selected discovery relays.
+    async fn marmot_set_onboarding_discovery_relays(account_ref: str, discovery_relays/discovery_relays_len: str_arr) -> rec(MarmotOnboardingSnapshot) = set_onboarding_discovery_relays;
+    /// Acknowledge the displayed one-device notice and resume setup.
+    async fn marmot_acknowledge_onboarding_single_device(account_ref: str, revision: val u64) -> rec(MarmotOnboardingSnapshot) = acknowledge_onboarding_single_device;
+    /// Cancel unfinished onboarding, retaining the signed-out identity and private state.
+    /// An approved unfinished repair must be resumed first; cancellation performs no relay deletion.
+    async fn marmot_cancel_onboarding(account_ref: str) -> unit = cancel_onboarding;
 
     /// Create a brand-new Nostr identity, store its secret in the account
     /// secret store, and publish initial relay lists + key package. Free with
@@ -2245,7 +2249,7 @@ where
 }
 
 use crate::types::onboarding::{MarmotOnboardingSnapshot, MarmotOnboardingStep};
-/// Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+/// Import an identity and persist its onboarding gate without publishing. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
 ///
 /// # Safety
 /// The client must be live, input pointers valid and borrowed, and out writable.
@@ -2278,7 +2282,8 @@ pub unsafe extern "C" fn marmot_begin_onboarding(
         }
     })
 }
-/// Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+/// Read the persisted onboarding snapshot. Writes NULL with MARMOT_STATUS_OK when no checkpoint exists.
+/// Free the returned snapshot with `marmot_onboarding_snapshot_free`.
 ///
 /// # Safety
 /// The client must be live, input pointers valid and borrowed, and out writable.
@@ -2295,7 +2300,7 @@ pub unsafe extern "C" fn marmot_onboarding_snapshot(
         unsafe { deliver_opt(client.marmot.onboarding_snapshot(account_ref), out) }
     })
 }
-/// Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+/// Resume pending checks until user input or a retry is needed. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
 ///
 /// # Safety
 /// The client must be live, input pointers valid and borrowed, and out writable.
@@ -2317,7 +2322,8 @@ pub unsafe extern "C" fn marmot_run_onboarding(
         }
     })
 }
-/// Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+/// Retry an offered step; earlier checks invalidate downstream readiness. `step` is a MarmotOnboardingStep discriminant; out-of-range values return MARMOT_STATUS_INVALID_ARGUMENT.
+/// Free the returned snapshot with `marmot_onboarding_snapshot_free`.
 ///
 /// # Safety
 /// The client must be live, input pointers valid and borrowed, and out writable.
@@ -2341,7 +2347,8 @@ pub unsafe extern "C" fn marmot_retry_onboarding_step(
         }
     })
 }
-/// Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+/// Explicitly skip an optional profile or follows step when offered. `step` is a MarmotOnboardingStep discriminant; out-of-range values return MARMOT_STATUS_INVALID_ARGUMENT.
+/// Free the returned snapshot with `marmot_onboarding_snapshot_free`.
 ///
 /// # Safety
 /// The client must be live, input pointers valid and borrowed, and out writable.
@@ -2365,7 +2372,8 @@ pub unsafe extern "C" fn marmot_continue_onboarding_without(
         }
     })
 }
-/// Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+/// Prepare the configured default relay proposal without publishing. `step` is a MarmotOnboardingStep discriminant; out-of-range values return MARMOT_STATUS_INVALID_ARGUMENT.
+/// Free the returned snapshot with `marmot_onboarding_snapshot_free`.
 ///
 /// # Safety
 /// The client must be live, input pointers valid and borrowed, and out writable.
@@ -2393,7 +2401,8 @@ pub unsafe extern "C" fn marmot_propose_onboarding_recommended_relays(
         }
     })
 }
-/// Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+/// Prepare a relay proposal without publishing; inbox proposals require an empty write list. `step` is a MarmotOnboardingStep discriminant; out-of-range values return MARMOT_STATUS_INVALID_ARGUMENT.
+/// Free the returned snapshot with `marmot_onboarding_snapshot_free`.
 ///
 /// # Safety
 /// The client must be live, input pointers valid and borrowed, and out writable.
@@ -2428,7 +2437,7 @@ pub unsafe extern "C" fn marmot_propose_onboarding_relays(
         }
     })
 }
-/// Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+/// Prepare profile edits without publishing; NULL fields preserve existing values and empty strings clear them. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
 ///
 /// # Safety
 /// The client must be live, input pointers valid and borrowed, and out writable.
@@ -2457,7 +2466,7 @@ pub unsafe extern "C" fn marmot_propose_onboarding_profile(
         }
     })
 }
-/// Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+/// Prepare a follow-list replacement without publishing; an empty list is valid. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
 ///
 /// # Safety
 /// The client must be live, input pointers valid and borrowed, and out writable.
@@ -2486,7 +2495,7 @@ pub unsafe extern "C" fn marmot_propose_onboarding_follows(
         }
     })
 }
-/// Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+/// Approve the proposal at the current snapshot revision and resume publication; stale revisions are rejected. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
 ///
 /// # Safety
 /// The client must be live, input pointers valid and borrowed, and out writable.
@@ -2513,7 +2522,7 @@ pub unsafe extern "C" fn marmot_approve_onboarding_repair(
         }
     })
 }
-/// Onboarding operation. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
+/// Dismiss an unapproved repair proposal; an approved repair must be resumed. Free the returned snapshot with `marmot_onboarding_snapshot_free`.
 ///
 /// # Safety
 /// The client must be live, input pointers valid and borrowed, and out writable.

--- a/crates/marmot-c/src/status.rs
+++ b/crates/marmot-c/src/status.rs
@@ -198,6 +198,13 @@ mod tests {
     use super::*;
 
     #[test]
+    fn onboarding_status_codes_preserve_the_master_group_removed_value() {
+        assert_eq!(MarmotStatus::GroupRemoved as i32, 63);
+        assert_eq!(MarmotStatus::OnboardingActionUnavailable as i32, 64);
+        assert_eq!(MarmotStatus::OnboardingRequired as i32, 65);
+    }
+
+    #[test]
     fn every_runtime_error_variant_maps_to_a_distinct_status() {
         let _guard = crate::memory::audit::test_lock();
         let variants: Vec<MarmotKitError> = vec![

--- a/crates/marmot-c/src/status.rs
+++ b/crates/marmot-c/src/status.rs
@@ -96,6 +96,8 @@ pub enum MarmotStatus {
     GroupInviteNotPending = 61,
     MissingMemberInboxRoute = 62,
     GroupRemoved = 63,
+    OnboardingActionUnavailable = 64,
+    OnboardingRequired = 65,
 }
 
 thread_local! {
@@ -155,6 +157,8 @@ pub(crate) fn status_from_error(err: &MarmotKitError) -> MarmotStatus {
         MarmotKitError::RuntimeBusy => MarmotStatus::RuntimeBusy,
         MarmotKitError::AccountSessionBusy => MarmotStatus::AccountSessionBusy,
         MarmotKitError::AccountSetupRecoveryRequired => MarmotStatus::AccountSetupRecoveryRequired,
+        MarmotKitError::OnboardingActionUnavailable => MarmotStatus::OnboardingActionUnavailable,
+        MarmotKitError::OnboardingRequired => MarmotStatus::OnboardingRequired,
         MarmotKitError::AccountSetupRetryRequired => MarmotStatus::AccountSetupRetryRequired,
         MarmotKitError::AccountSetupResetNotApplicable => {
             MarmotStatus::AccountSetupResetNotApplicable

--- a/crates/marmot-c/src/subscriptions.rs
+++ b/crates/marmot-c/src/subscriptions.rs
@@ -1156,3 +1156,64 @@ pub unsafe extern "C" fn marmot_search_users(
         }
     })
 }
+
+use crate::types::onboarding::MarmotOnboardingSnapshot;
+use marmot_uniffi::{MarmotKitError, OnboardingSubscription};
+use std::ffi::c_char;
+// Snapshot pointers exclusively own their allocations and are moved together.
+unsafe impl Send for MarmotOnboardingSnapshot {}
+c_subscription! {
+    /// A current onboarding snapshot followed by durable progress updates.
+    MarmotOnboardingSubscription(OnboardingSubscription),
+    item MarmotOnboardingSnapshot from marmot_uniffi::OnboardingSnapshotFfi,
+    item_free "marmot_onboarding_snapshot_free",
+    callback MarmotOnboardingCallback,
+    read next,
+    next marmot_onboarding_subscription_next,
+    set_callback marmot_onboarding_subscription_set_callback,
+    clear_callback marmot_onboarding_subscription_clear_callback,
+    free marmot_onboarding_subscription_free
+}
+/// Subscribe to durable onboarding state for an account.
+///
+/// # Safety
+/// Client and account_ref must be valid; out_sub must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn marmot_subscribe_onboarding(
+    client: *const MarmotClient,
+    account_ref: *const c_char,
+    out_sub: *mut *mut MarmotOnboardingSubscription,
+) -> MarmotStatus {
+    ffi_guard(|| {
+        try_arg!(unsafe { preflight_out_ptr(out_sub) });
+        let client = try_arg!(unsafe { client_ref(client) });
+        let account_ref = try_arg!(unsafe { required_str(account_ref) });
+        match client.marmot.subscribe_onboarding(account_ref) {
+            Ok(inner) => unsafe {
+                write_handle(
+                    MarmotOnboardingSubscription {
+                        core: SubscriptionCore::new(client.runtime.handle().clone()),
+                        inner,
+                    },
+                    out_sub,
+                )
+            },
+            Err(error) => status_from_error(&error),
+        }
+    })
+}
+/// Return the initial snapshot. Free with marmot_onboarding_snapshot_free.
+///
+/// # Safety
+/// Sub must be live and out must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn marmot_onboarding_subscription_snapshot(
+    sub: *const MarmotOnboardingSubscription,
+    out: *mut *mut MarmotOnboardingSnapshot,
+) -> MarmotStatus {
+    ffi_guard(|| {
+        try_arg!(unsafe { preflight_out_ptr(out) });
+        let sub = try_arg!(unsafe { sub_ref(sub) });
+        unsafe { deliver(Ok::<_, MarmotKitError>(sub.inner.snapshot()), out) }
+    })
+}

--- a/crates/marmot-c/src/subscriptions.rs
+++ b/crates/marmot-c/src/subscriptions.rs
@@ -41,7 +41,7 @@
 //! Lifetime rule: free every subscription handle before freeing the
 //! `MarmotClient` that created it.
 
-use std::ffi::c_void;
+use std::ffi::{c_char, c_void};
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
 use std::time::Duration;
@@ -51,6 +51,7 @@ use marmot_uniffi::subscriptions::{
     GroupStateSubscription, MessagesSubscription, NotificationsSubscription,
     TimelineMessagesSubscription, UserSearchSubscription,
 };
+use marmot_uniffi::{MarmotKitError, OnboardingSubscription};
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
 
@@ -69,6 +70,7 @@ use crate::types::event::MarmotEvent;
 use crate::types::group::MarmotAppGroupRecord;
 use crate::types::message::{MarmotAppMessageRecordList, MarmotMessageUpdate};
 use crate::types::notification::MarmotNotificationUpdate;
+use crate::types::onboarding::MarmotOnboardingSnapshot;
 use crate::types::timeline::{MarmotTimelinePage, MarmotTimelineSubscriptionUpdate};
 use crate::{MarmotClient, block_on_handle, client_ref, ffi_guard, preflight_out_ptr, write_out};
 
@@ -100,6 +102,7 @@ unsafe impl Send for MarmotChatListRow {}
 unsafe impl Send for MarmotMessageUpdate {}
 unsafe impl Send for MarmotAgentStreamUpdate {}
 unsafe impl Send for MarmotUserSearchUpdate {}
+unsafe impl Send for MarmotOnboardingSnapshot {}
 
 /// Shared body of every subscription handle: the runtime that drives it
 /// and the slot holding an installed callback task.
@@ -1157,11 +1160,6 @@ pub unsafe extern "C" fn marmot_search_users(
     })
 }
 
-use crate::types::onboarding::MarmotOnboardingSnapshot;
-use marmot_uniffi::{MarmotKitError, OnboardingSubscription};
-use std::ffi::c_char;
-// Snapshot pointers exclusively own their allocations and are moved together.
-unsafe impl Send for MarmotOnboardingSnapshot {}
 c_subscription! {
     /// A current onboarding snapshot followed by durable progress updates.
     MarmotOnboardingSubscription(OnboardingSubscription),

--- a/crates/marmot-c/src/types/mod.rs
+++ b/crates/marmot-c/src/types/mod.rs
@@ -24,3 +24,5 @@ pub mod push;
 pub mod relay;
 pub mod telemetry;
 pub mod timeline;
+
+pub mod onboarding;

--- a/crates/marmot-c/src/types/onboarding.rs
+++ b/crates/marmot-c/src/types/onboarding.rs
@@ -93,6 +93,10 @@ mod tests {
     fn onboarding_step_input_rejects_invalid_discriminants() {
         assert!(MarmotOnboardingStep::from_c(u32::MAX).is_err());
         assert_eq!(
+            MarmotOnboardingStep::from_c(4).unwrap().to_ffi(),
+            OnboardingStepFfi::SingleDevice
+        );
+        assert_eq!(
             MarmotOnboardingStep::from_c(5).unwrap().to_ffi(),
             OnboardingStepFfi::KeyPackage
         );

--- a/crates/marmot-c/src/types/onboarding.rs
+++ b/crates/marmot-c/src/types/onboarding.rs
@@ -3,7 +3,7 @@ use super::account::MarmotUserProfileMetadata;
 use super::common::MarmotStringList;
 use crate::macros::{c_enum, c_mirror};
 use marmot_uniffi::conversions::*;
-c_enum! { MarmotOnboardingStep from OnboardingStepFfi {  Profile, Follows, Relays, InboxRelays, KeyPackage  } }
+c_enum! { MarmotOnboardingStep from OnboardingStepFfi {  Profile, Follows, Relays, InboxRelays, KeyPackage, SingleDevice  } }
 impl MarmotOnboardingStep {
     pub(crate) fn to_ffi(self) -> OnboardingStepFfi {
         match self {
@@ -11,17 +11,22 @@ impl MarmotOnboardingStep {
             Self::Follows => OnboardingStepFfi::Follows,
             Self::Relays => OnboardingStepFfi::Relays,
             Self::InboxRelays => OnboardingStepFfi::InboxRelays,
+            Self::SingleDevice => OnboardingStepFfi::SingleDevice,
             Self::KeyPackage => OnboardingStepFfi::KeyPackage,
         }
     }
 }
 c_enum! { MarmotOnboardingStatus from OnboardingStatusFfi {  Pending, Checking, Passed, NeedsInput, RetryableFailure, WaitingForSigner, Skipped  } }
-c_enum! { MarmotOnboardingIssue from OnboardingIssueFfi {  Missing, Malformed, FutureDated, InvalidRelay, RetiredRelay, UnsafeRelay, Unreachable, TimedOut, AuthenticationRequired, PaymentRequired, AccessRestricted, NoUsableRoute, PublicationFailed, SignerUnavailable, SignerRejected, RecordChanged, Interrupted, TooManyRelays  } }
-c_enum! { MarmotOnboardingAction from OnboardingActionFfi {  Retry, ContinueWithout, UseRecommendedRelays, EditRelays, EditProfile, EditFollows, ApproveRepair, CancelRepair, ReconnectSigner, EditDiscoveryRelays  } }
+c_enum! { MarmotOnboardingIssue from OnboardingIssueFfi {  Missing, Malformed, FutureDated, InvalidRelay, RetiredRelay, UnsafeRelay, Unreachable, TimedOut, AuthenticationRequired, PaymentRequired, AccessRestricted, NoUsableRoute, PublicationFailed, SignerUnavailable, SignerRejected, RecordChanged, Interrupted, TooManyRelays, MultiDeviceUnsupported, OtherInstallationPossible, DiscoveryIncomplete  } }
+c_enum! { MarmotOnboardingAction from OnboardingActionFfi {  Retry, ContinueWithout, UseRecommendedRelays, EditRelays, EditProfile, EditFollows, ApproveRepair, CancelRepair, ReconnectSigner, EditDiscoveryRelays, ContinueAnyway, CancelOnboarding  } }
 c_mirror! { MarmotOnboardingFinding from OnboardingFindingFfi { copy issue: MarmotOnboardingIssue, opt_str endpoint, } }
 c_mirror! { MarmotOnboardingStepState from OnboardingStepStateFfi { copy step: MarmotOnboardingStep, copy status: MarmotOnboardingStatus, vec findings/findings_len: MarmotOnboardingFinding, vec actions/actions_len: MarmotOnboardingAction, opt_copy has_checked_at/checked_at: u64, } }
 c_mirror! { MarmotOnboardingRepairProposal from OnboardingRepairProposalFfi { copy step: MarmotOnboardingStep, copy revision: u64, opt_str previous_event_id, str_vec read_relays/read_relays_len, str_vec write_relays/write_relays_len, opt_rec profile: MarmotUserProfileMetadata, opt_rec follows: MarmotStringList, } }
-c_mirror! { MarmotOnboardingSnapshot from OnboardingSnapshotFfi, free marmot_onboarding_snapshot_free { str account_id_hex, copy revision: u64, copy ready: bool, vec steps/steps_len: MarmotOnboardingStepState, opt_rec proposal: MarmotOnboardingRepairProposal, } }
+c_mirror! { MarmotOnboardingSnapshot from OnboardingSnapshotFfi, free marmot_onboarding_snapshot_free { str account_id_hex, copy revision: u64, copy ready: bool, vec steps/steps_len: MarmotOnboardingStepState, opt_rec proposal: MarmotOnboardingRepairProposal, opt_rec single_device_notice: MarmotOnboardingSingleDeviceNotice, } }
+
+c_enum! { MarmotOnboardingDeviceDiscovery from OnboardingDeviceDiscoveryFfi { NoneFound, OtherInstallationPossible, Unknown } }
+c_mirror! { MarmotOnboardingDevicePackage from OnboardingDevicePackageFfi { str slot_id, str key_package_ref_hex, str event_id_hex, copy published_at: u64, copy expires_at: u64, } }
+c_mirror! { MarmotOnboardingSingleDeviceNotice from OnboardingSingleDeviceNoticeFfi { copy discovery: MarmotOnboardingDeviceDiscovery, vec other_packages/other_packages_len: MarmotOnboardingDevicePackage, copy discovery_complete: bool, opt_copy has_acknowledged_at/acknowledged_at: u64, } }
 
 #[cfg(all(test, feature = "alloc-audit"))]
 mod tests {
@@ -45,6 +50,18 @@ mod tests {
                 actions: vec![OnboardingActionFfi::ApproveRepair],
                 checked_at: Some(42),
             }],
+            single_device_notice: Some(OnboardingSingleDeviceNoticeFfi {
+                discovery: OnboardingDeviceDiscoveryFfi::OtherInstallationPossible,
+                other_packages: vec![OnboardingDevicePackageFfi {
+                    slot_id: "slot".into(),
+                    key_package_ref_hex: "ref".into(),
+                    event_id_hex: "event".into(),
+                    published_at: 40,
+                    expires_at: 90,
+                }],
+                discovery_complete: false,
+                acknowledged_at: Some(42),
+            }),
             proposal: Some(OnboardingRepairProposalFfi {
                 step: OnboardingStepFfi::Follows,
                 revision: 4,

--- a/crates/marmot-c/src/types/onboarding.rs
+++ b/crates/marmot-c/src/types/onboarding.rs
@@ -3,7 +3,7 @@ use super::account::MarmotUserProfileMetadata;
 use super::common::MarmotStringList;
 use crate::macros::{c_enum, c_mirror};
 use marmot_uniffi::conversions::*;
-c_enum! { MarmotOnboardingStep from OnboardingStepFfi {  Profile, Follows, Relays, InboxRelays, KeyPackage, SingleDevice  } }
+c_enum! { MarmotOnboardingStep from OnboardingStepFfi {  Profile, Follows, Relays, InboxRelays, SingleDevice, KeyPackage  } }
 impl MarmotOnboardingStep {
     pub(crate) fn to_ffi(self) -> OnboardingStepFfi {
         match self {
@@ -22,10 +22,10 @@ c_enum! { MarmotOnboardingAction from OnboardingActionFfi {  Retry, ContinueWith
 c_mirror! { MarmotOnboardingFinding from OnboardingFindingFfi { copy issue: MarmotOnboardingIssue, opt_str endpoint, } }
 c_mirror! { MarmotOnboardingStepState from OnboardingStepStateFfi { copy step: MarmotOnboardingStep, copy status: MarmotOnboardingStatus, vec findings/findings_len: MarmotOnboardingFinding, vec actions/actions_len: MarmotOnboardingAction, opt_copy has_checked_at/checked_at: u64, } }
 c_mirror! { MarmotOnboardingRepairProposal from OnboardingRepairProposalFfi { copy step: MarmotOnboardingStep, copy revision: u64, opt_str previous_event_id, str_vec read_relays/read_relays_len, str_vec write_relays/write_relays_len, opt_rec profile: MarmotUserProfileMetadata, opt_rec follows: MarmotStringList, } }
-c_mirror! { MarmotOnboardingSnapshot from OnboardingSnapshotFfi, free marmot_onboarding_snapshot_free { str account_id_hex, copy revision: u64, copy ready: bool, vec steps/steps_len: MarmotOnboardingStepState, opt_rec proposal: MarmotOnboardingRepairProposal, opt_rec single_device_notice: MarmotOnboardingSingleDeviceNotice, } }
+c_mirror! { MarmotOnboardingSnapshot from OnboardingSnapshotFfi, free marmot_onboarding_snapshot_free { str account_id_hex, copy revision: u64, copy ready: bool, vec steps/steps_len: MarmotOnboardingStepState, opt_rec proposal: MarmotOnboardingRepairProposal, opt_rec single_device_notice: MarmotOnboardingSingleDeviceNotice, copy cancellation_pending: bool, } }
 
 c_enum! { MarmotOnboardingDeviceDiscovery from OnboardingDeviceDiscoveryFfi { NoneFound, OtherInstallationPossible, Unknown } }
-c_mirror! { MarmotOnboardingDevicePackage from OnboardingDevicePackageFfi { str slot_id, str key_package_ref_hex, str event_id_hex, copy published_at: u64, copy expires_at: u64, } }
+c_mirror! { MarmotOnboardingDevicePackage from OnboardingDevicePackageFfi { str slot_id, opt_str key_package_ref_hex, str event_id_hex, copy published_at: u64, opt_copy has_expires_at/expires_at: u64, copy usable: bool, } }
 c_mirror! { MarmotOnboardingSingleDeviceNotice from OnboardingSingleDeviceNoticeFfi { copy discovery: MarmotOnboardingDeviceDiscovery, vec other_packages/other_packages_len: MarmotOnboardingDevicePackage, copy discovery_complete: bool, opt_copy has_acknowledged_at/acknowledged_at: u64, } }
 
 #[cfg(all(test, feature = "alloc-audit"))]
@@ -40,6 +40,7 @@ mod tests {
             account_id_hex: "account".into(),
             revision: 4,
             ready: false,
+            cancellation_pending: false,
             steps: vec![OnboardingStepStateFfi {
                 step: OnboardingStepFfi::Follows,
                 status: OnboardingStatusFfi::NeedsInput,
@@ -54,10 +55,11 @@ mod tests {
                 discovery: OnboardingDeviceDiscoveryFfi::OtherInstallationPossible,
                 other_packages: vec![OnboardingDevicePackageFfi {
                     slot_id: "slot".into(),
-                    key_package_ref_hex: "ref".into(),
+                    key_package_ref_hex: Some("ref".into()),
                     event_id_hex: "event".into(),
                     published_at: 40,
-                    expires_at: 90,
+                    expires_at: Some(90),
+                    usable: true,
                 }],
                 discovery_complete: false,
                 acknowledged_at: Some(42),
@@ -91,7 +93,7 @@ mod tests {
     fn onboarding_step_input_rejects_invalid_discriminants() {
         assert!(MarmotOnboardingStep::from_c(u32::MAX).is_err());
         assert_eq!(
-            MarmotOnboardingStep::from_c(4).unwrap().to_ffi(),
+            MarmotOnboardingStep::from_c(5).unwrap().to_ffi(),
             OnboardingStepFfi::KeyPackage
         );
     }

--- a/crates/marmot-c/src/types/onboarding.rs
+++ b/crates/marmot-c/src/types/onboarding.rs
@@ -1,0 +1,81 @@
+//! C mirrors of the durable onboarding contract.
+use super::account::MarmotUserProfileMetadata;
+use super::common::MarmotStringList;
+use crate::macros::{c_enum, c_mirror};
+use marmot_uniffi::conversions::*;
+c_enum! { MarmotOnboardingStep from OnboardingStepFfi {  Profile, Follows, Relays, InboxRelays, KeyPackage  } }
+impl MarmotOnboardingStep {
+    pub(crate) fn to_ffi(self) -> OnboardingStepFfi {
+        match self {
+            Self::Profile => OnboardingStepFfi::Profile,
+            Self::Follows => OnboardingStepFfi::Follows,
+            Self::Relays => OnboardingStepFfi::Relays,
+            Self::InboxRelays => OnboardingStepFfi::InboxRelays,
+            Self::KeyPackage => OnboardingStepFfi::KeyPackage,
+        }
+    }
+}
+c_enum! { MarmotOnboardingStatus from OnboardingStatusFfi {  Pending, Checking, Passed, NeedsInput, RetryableFailure, WaitingForSigner, Skipped  } }
+c_enum! { MarmotOnboardingIssue from OnboardingIssueFfi {  Missing, Malformed, FutureDated, InvalidRelay, RetiredRelay, UnsafeRelay, Unreachable, TimedOut, AuthenticationRequired, PaymentRequired, AccessRestricted, NoUsableRoute, PublicationFailed, SignerUnavailable, SignerRejected, RecordChanged, Interrupted, TooManyRelays  } }
+c_enum! { MarmotOnboardingAction from OnboardingActionFfi {  Retry, ContinueWithout, UseRecommendedRelays, EditRelays, EditProfile, EditFollows, ApproveRepair, CancelRepair, ReconnectSigner, EditDiscoveryRelays  } }
+c_mirror! { MarmotOnboardingFinding from OnboardingFindingFfi { copy issue: MarmotOnboardingIssue, opt_str endpoint, } }
+c_mirror! { MarmotOnboardingStepState from OnboardingStepStateFfi { copy step: MarmotOnboardingStep, copy status: MarmotOnboardingStatus, vec findings/findings_len: MarmotOnboardingFinding, vec actions/actions_len: MarmotOnboardingAction, opt_copy has_checked_at/checked_at: u64, } }
+c_mirror! { MarmotOnboardingRepairProposal from OnboardingRepairProposalFfi { copy step: MarmotOnboardingStep, copy revision: u64, opt_str previous_event_id, str_vec read_relays/read_relays_len, str_vec write_relays/write_relays_len, opt_rec profile: MarmotUserProfileMetadata, opt_rec follows: MarmotStringList, } }
+c_mirror! { MarmotOnboardingSnapshot from OnboardingSnapshotFfi, free marmot_onboarding_snapshot_free { str account_id_hex, copy revision: u64, copy ready: bool, vec steps/steps_len: MarmotOnboardingStepState, opt_rec proposal: MarmotOnboardingRepairProposal, } }
+
+#[cfg(all(test, feature = "alloc-audit"))]
+mod tests {
+    use super::*;
+    use crate::memory::{audit, boxed, free_boxed};
+    #[test]
+    fn onboarding_snapshot_deep_free_releases_nested_proposal_and_actions() {
+        let _guard = audit::test_lock();
+        let before = audit::live_allocations();
+        let ffi = OnboardingSnapshotFfi {
+            account_id_hex: "account".into(),
+            revision: 4,
+            ready: false,
+            steps: vec![OnboardingStepStateFfi {
+                step: OnboardingStepFfi::Follows,
+                status: OnboardingStatusFfi::NeedsInput,
+                findings: vec![OnboardingFindingFfi {
+                    issue: OnboardingIssueFfi::Malformed,
+                    endpoint: Some("wss://example.com".into()),
+                }],
+                actions: vec![OnboardingActionFfi::ApproveRepair],
+                checked_at: Some(42),
+            }],
+            proposal: Some(OnboardingRepairProposalFfi {
+                step: OnboardingStepFfi::Follows,
+                revision: 4,
+                previous_event_id: Some("previous".into()),
+                read_relays: vec!["wss://example.com".into()],
+                write_relays: vec![],
+                profile: Some(UserProfileMetadataFfi {
+                    name: Some("name".into()),
+                    display_name: None,
+                    about: None,
+                    picture: None,
+                    banner: None,
+                    nip05: None,
+                    lud16: None,
+                }),
+                follows: Some(vec!["follow".into()]),
+            }),
+        };
+        let value = boxed(MarmotOnboardingSnapshot::from(ffi));
+        assert!(audit::live_allocations() > before);
+        unsafe {
+            free_boxed(value);
+        }
+        assert_eq!(audit::live_allocations(), before);
+    }
+    #[test]
+    fn onboarding_step_input_rejects_invalid_discriminants() {
+        assert!(MarmotOnboardingStep::from_c(u32::MAX).is_err());
+        assert_eq!(
+            MarmotOnboardingStep::from_c(4).unwrap().to_ffi(),
+            OnboardingStepFfi::KeyPackage
+        );
+    }
+}

--- a/crates/marmot-uniffi/README.md
+++ b/crates/marmot-uniffi/README.md
@@ -114,3 +114,64 @@ The output directories are ignored because generated bindings and packaged nativ
 Regenerate them from this crate before vendoring into an app repository.
 
 See [`AGENTS.md`](AGENTS.md) for scope, invariants, and verification commands.
+
+## Interactive account onboarding
+
+Imported identities can use the durable preflight API instead of `login`:
+
+1. Call `begin_onboarding(nsec, options)` or
+   `begin_external_signer_onboarding(public_key, signer, options)`. Supply the
+   same `default_relays` as new-account creation and a separate set of trusted
+   `discovery_relays`. These methods return a persisted account and snapshot
+   before fetching or publishing Nostr records.
+2. Display the five snapshot steps (profile, follows, general relays, inbox
+   relays, KeyPackage). Subscribe with `subscribe_onboarding`, read its initial
+   `snapshot`, and drive `next` concurrently with `run_onboarding`.
+3. Localize the typed status, findings, and actions. A healthy account advances
+   automatically. `NeedsInput` offers a repair or, for profile/follows, an
+   explicit `continue_onboarding_without`. Empty follow lists are valid.
+4. `propose_onboarding_recommended_relays`, `propose_onboarding_relays`,
+   `propose_onboarding_profile`, and `propose_onboarding_follows` only prepare
+   a proposal. Profile fields left unset preserve their current values; an
+   explicit empty string clears a field. Display the proposed edits, then pass the returned
+   snapshot revision to `approve_onboarding_repair`. For an inbox proposal use
+   `read_relays` and an empty `write_relays`. `cancel_onboarding_repair` dismisses
+   a proposal until approval has been recorded.
+5. `retry_onboarding_step` retries a failure; `set_onboarding_discovery_relays`
+   retries with explicitly chosen discovery sources without publishing them.
+   After process restart, read `onboarding_snapshot`, register the external
+   signer again if applicable, and run/resume or retry the indicated step.
+6. Enter the normal app only when `snapshot.ready` is true. Normal worker
+   commands reject unfinished onboarding; the workflow alone can publish its
+   initial KeyPackage. `account_setup_readiness` stays `Initializing` until the
+   interactive workflow is complete.
+
+Snapshots are complete states, not deltas. A slow subscriber may miss
+intermediate states but receives the latest persisted state. Cancellation can
+leave a step `Checking`; `run_onboarding` resumes it. Once a repair is approved,
+a retry resumes that repair before other checks. It cannot be cancelled as if
+nothing had been published: a relay may already have accepted it. Signed bytes
+are retained before the first send and replayed unchanged on retry.
+
+Discovery reads require a completed relay query. Failed/partial empty discovery
+is distinct from absence and never offers automatic replacement. Fresh signed
+records remain available for inspection even when their contents are malformed;
+a newer malformed record does not silently fall back to an older valid one.
+Repairs re-fetch the source before signing and reject a changed record. Nostr
+has no conditional replace operation, so simultaneous edits after this check
+remain subject to its normal replaceable-event ordering.
+
+Relay checks include syntax, local safety/retirement policy, read/write roles,
+and bounded queries through the relevant routes. Inbox queries filter for the
+account's recipient tag and use an isolated account-bound signer. They retain no
+inbox payloads. Read permission and KeyPackage publication are checked separately;
+these checks do not guarantee future availability or every relay's acceptance of
+future third-party inbox messages. Incomplete workflows recheck reachability
+older than five minutes. Completed onboarding is retained and reruns when a
+signed-out account enters the identity-only flow again.
+
+The existing `login` and generated-account APIs remain compatible. Apps must
+adopt the new identity-only APIs and screen to enable this experience. Legacy
+accounts without an onboarding checkpoint are not retroactively blocked. C
+consumers have equivalent methods and subscriptions; external-signer entry
+points retain the C API's existing callback-vtable limitation.

--- a/crates/marmot-uniffi/README.md
+++ b/crates/marmot-uniffi/README.md
@@ -138,7 +138,7 @@ Imported identities can use the durable preflight API instead of `login`:
    snapshot revision to `approve_onboarding_repair`. For an inbox proposal use
    `read_relays` and an empty `write_relays`. `cancel_onboarding_repair` dismisses
    a proposal until approval has been recorded.
-5. `retry_onboarding_step` retries a failure; `set_onboarding_discovery_relays`
+5. `retry_onboarding_step` requires an offered `Retry` action; `set_onboarding_discovery_relays`
    retries with explicitly chosen discovery sources without publishing them.
    After process restart, read `onboarding_snapshot`, register the external
    signer again if applicable, and run/resume or retry the indicated step.
@@ -156,20 +156,30 @@ one installation and conversations will not automatically appear on both.
 Reinstallation or cleared local state can produce the same evidence; do not
 claim to have identified a physical device or a particular app.
 
-Offer **Cancel** and **Continue anyway**. `CancelOnboarding` means leave the
-onboarding view without acknowledging; the account remains persisted and gated.
-It does not call sign-out, delete packages, or remove an account. For Continue
-anyway, call `acknowledge_onboarding_single_device(account_ref, snapshot.revision)`.
+Offer **Cancel** and **Continue anyway**. For Cancel, call
+`cancel_onboarding(account_ref)`: it signs the identity out, retains local data and
+completed repairs, and archives the checkpoint to remove the active gate. A later
+sign-in can use either the legacy or interactive entry point. Cancellation is
+idempotent; if interrupted with `cancellation_pending`, call it again to finish.
+Normal onboarding mutations are blocked during that interval. Cancellation is
+not offered while an approved repair is unfinished and cannot discard that repair.
+For Continue anyway, call `acknowledge_onboarding_single_device(account_ref, snapshot.revision)`.
 MDK rejects a stale revision, persists the acknowledgment, and resumes setup.
-The acknowledgment survives publication failure, cancellation, and restart.
-An explicit retry of `SingleDevice`, or a new sign-in after signing out a completed
-account, requires a new acknowledgment. Ordinary setup retries preserve it.
+The acknowledgment survives KeyPackage publication failure, task interruption,
+and restart. Rechecking an earlier prerequisite, changing discovery sources,
+approving another repair, explicitly retrying `SingleDevice`, or signing in again
+after signing out a completed account invalidates it and requires a fresh notice.
+Retries preserve optional steps the user skipped unless that skipped step is the
+explicit retry target.
 
 Detection reads verified kind-30443 records through the validated relay routes
 without starting an account worker. It compares the newest record per slot with
 the local stable slot and durably owned private packages, including retained
-rotation material. `other_packages` includes original publication and expiration
-timestamps. No short recency cutoff excludes an otherwise usable package:
+rotation material. `other_packages` retains signed foreign-slot evidence even
+when the payload is malformed or expired. `usable` describes package validity;
+the reference and expiration are optional when validation cannot extract them.
+The publication timestamp comes from the verified event. No recency cutoff
+excludes a foreign slot:
 republication retains the original event timestamp, so it is not last-active time.
 No public device identifier is introduced, and continuing never deletes another
 installation's packages.
@@ -183,14 +193,18 @@ Completed pre-notice checkpoints remain ready; incomplete checkpoints acquire
 the notice before KeyPackage publication when upgraded.
 
 Snapshots are complete states, not deltas. A slow subscriber may miss
-intermediate states but receives the latest persisted state. Cancellation can
-leave a step `Checking`; `run_onboarding` resumes it. Once a repair is approved,
+intermediate states but receives the latest persisted state. Interrupting an
+async check can leave a step `Checking`; `run_onboarding` resumes it. Once a repair is approved,
 a retry resumes that repair before other checks. It cannot be cancelled as if
 nothing had been published: a relay may already have accepted it. Signed bytes
 are retained before the first send and replayed unchanged on retry.
 
 Discovery reads require a completed relay query. Failed/partial empty discovery
-is distinct from absence and never offers automatic replacement. Fresh signed
+is distinct from absence and never offers automatic replacement. A valid record
+from a partially successful lookup may pass while retaining `DiscoveryIncomplete`
+and source failures in its findings; a passed step is not necessarily warning-free.
+Off-filter records are ignored. Single-device discovery remains incomplete if
+any selected source fails, even when another source returns an empty result. Fresh signed
 records remain available for inspection even when their contents are malformed;
 a newer malformed record does not silently fall back to an older valid one.
 Repairs re-fetch the source before signing and reject a changed record. Nostr
@@ -208,6 +222,12 @@ signed-out account enters the identity-only flow again.
 
 The existing `login` and generated-account APIs remain compatible. Apps must
 adopt the new identity-only APIs and screen to enable this experience. Legacy
-accounts without an onboarding checkpoint are not retroactively blocked. C
+accounts without an onboarding checkpoint are not retroactively blocked. Active
+legacy accounts and accounts with unfinished legacy setup are not silently
+enrolled: finish or resume their existing setup first. Signed-out legacy accounts
+without pending setup can explicitly opt in. Completed checkpoints defer to normal
+setup/recovery readiness. Corrupt or newer-version checkpoints gate only their own
+account; they must be restored or opened with a compatible runtime, not silently
+discarded because they may contain approved publication intent. C
 consumers have equivalent methods and subscriptions; external-signer entry
 points retain the C API's existing callback-vtable limitation.

--- a/crates/marmot-uniffi/README.md
+++ b/crates/marmot-uniffi/README.md
@@ -159,7 +159,9 @@ claim to have identified a physical device or a particular app.
 Offer **Cancel** and **Continue anyway**. For Cancel, call
 `cancel_onboarding(account_ref)`: it signs the identity out, retains local data and
 completed repairs, and archives the checkpoint to remove the active gate. A later
-sign-in can use either the legacy or interactive entry point. Cancellation is
+sign-in can use either the legacy or interactive entry point. The registered
+external-signer callback remains attached for explicit sign-in within this runtime;
+a process restart still requires the host to register it again. Cancellation is
 idempotent; if interrupted with `cancellation_pending`, call it again to finish.
 Normal onboarding mutations are blocked during that interval. Cancellation is
 not offered while an approved repair is unfinished and cannot discard that repair.
@@ -170,7 +172,8 @@ and restart. Rechecking an earlier prerequisite, changing discovery sources,
 approving another repair, explicitly retrying `SingleDevice`, or signing in again
 after signing out a completed account invalidates it and requires a fresh notice.
 Retries preserve optional steps the user skipped unless that skipped step is the
-explicit retry target.
+explicit retry target. Older checkpoints refresh their derived retry hints on
+read, and package records without a `usable` field default to `false`.
 
 Detection reads verified kind-30443 records through the validated relay routes
 without starting an account worker. It compares the newest record per slot with

--- a/crates/marmot-uniffi/README.md
+++ b/crates/marmot-uniffi/README.md
@@ -124,11 +124,12 @@ Imported identities can use the durable preflight API instead of `login`:
    same `default_relays` as new-account creation and a separate set of trusted
    `discovery_relays`. These methods return a persisted account and snapshot
    before fetching or publishing Nostr records.
-2. Display the five snapshot steps (profile, follows, general relays, inbox
-   relays, KeyPackage). Subscribe with `subscribe_onboarding`, read its initial
+2. Display the snapshot steps in their returned order (profile, follows, general
+   relays, inbox relays, single-device notice, KeyPackage). Use step identities,
+   not enum discriminants, as positions. Subscribe with `subscribe_onboarding`, read its initial
    `snapshot`, and drive `next` concurrently with `run_onboarding`.
 3. Localize the typed status, findings, and actions. A healthy account advances
-   automatically. `NeedsInput` offers a repair or, for profile/follows, an
+   automatically until the single-device acknowledgment. `NeedsInput` offers a repair or, for profile/follows, an
    explicit `continue_onboarding_without`. Empty follow lists are valid.
 4. `propose_onboarding_recommended_relays`, `propose_onboarding_relays`,
    `propose_onboarding_profile`, and `propose_onboarding_follows` only prepare
@@ -145,6 +146,41 @@ Imported identities can use the durable preflight API instead of `login`:
    commands reject unfinished onboarding; the workflow alone can publish its
    initial KeyPackage. `account_setup_readiness` stays `Initializing` until the
    interactive workflow is complete.
+
+The `SingleDevice` step always pauses before initial KeyPackage publication.
+Display a general notice that White Noise does not yet support synchronized
+multi-device use and recommends one device. The snapshot's `single_device_notice`
+adds evidence with `OtherInstallationPossible`, `NoneFound`, or `Unknown` discovery.
+When another installation is possible, explain that invitations may reach only
+one installation and conversations will not automatically appear on both.
+Reinstallation or cleared local state can produce the same evidence; do not
+claim to have identified a physical device or a particular app.
+
+Offer **Cancel** and **Continue anyway**. `CancelOnboarding` means leave the
+onboarding view without acknowledging; the account remains persisted and gated.
+It does not call sign-out, delete packages, or remove an account. For Continue
+anyway, call `acknowledge_onboarding_single_device(account_ref, snapshot.revision)`.
+MDK rejects a stale revision, persists the acknowledgment, and resumes setup.
+The acknowledgment survives publication failure, cancellation, and restart.
+An explicit retry of `SingleDevice`, or a new sign-in after signing out a completed
+account, requires a new acknowledgment. Ordinary setup retries preserve it.
+
+Detection reads verified kind-30443 records through the validated relay routes
+without starting an account worker. It compares the newest record per slot with
+the local stable slot and durably owned private packages, including retained
+rotation material. `other_packages` includes original publication and expiration
+timestamps. No short recency cutoff excludes an otherwise usable package:
+republication retains the original event timestamp, so it is not last-active time.
+No public device identifier is introduced, and continuing never deletes another
+installation's packages.
+
+`discovery_complete` describes only the bounded queries to the selected sources;
+it is false for failed, malformed, future-dated, or potentially truncated results.
+Positive evidence can accompany incomplete discovery. `Unknown` means discovery
+was inconclusive; `NoneFound` means none were found on those sources. Neither is
+an assurance that multi-device use is safe. Both still require the general notice.
+Completed pre-notice checkpoints remain ready; incomplete checkpoints acquire
+the notice before KeyPackage publication when upgraded.
 
 Snapshots are complete states, not deltas. A slow subscriber may miss
 intermediate states but receives the latest persisted state. Cancellation can

--- a/crates/marmot-uniffi/src/commands/mod.rs
+++ b/crates/marmot-uniffi/src/commands/mod.rs
@@ -8,8 +8,6 @@
 //! attached to the same methods, so the generated bindings are unaffected.
 
 mod account;
-mod onboarding;
-pub use onboarding::OnboardingSubscription;
 mod agent_stream;
 mod audit;
 mod chat_list;
@@ -19,6 +17,7 @@ mod group;
 mod media;
 mod message;
 mod notification;
+mod onboarding;
 mod push;
 mod relay;
 mod subscription;
@@ -30,3 +29,4 @@ pub use group::{
     PreparedGroupImageUploadFfi, PreparedGroupImageUploadStateFfi,
 };
 pub use media::parse_media_imeta_tag;
+pub use onboarding::OnboardingSubscription;

--- a/crates/marmot-uniffi/src/commands/mod.rs
+++ b/crates/marmot-uniffi/src/commands/mod.rs
@@ -8,6 +8,8 @@
 //! attached to the same methods, so the generated bindings are unaffected.
 
 mod account;
+mod onboarding;
+pub use onboarding::OnboardingSubscription;
 mod agent_stream;
 mod audit;
 mod chat_list;

--- a/crates/marmot-uniffi/src/commands/onboarding.rs
+++ b/crates/marmot-uniffi/src/commands/onboarding.rs
@@ -24,6 +24,16 @@ impl OnboardingSubscription {
 }
 #[uniffi::export(async_runtime = "tokio")]
 impl Marmot {
+    /// Cancel unfinished onboarding, retaining the signed-out identity and private state.
+    /// Approved unfinished repairs must be resumed before cancellation.
+    pub async fn cancel_onboarding(&self, account_ref: String) -> Result<(), MarmotKitError> {
+        Ok(self
+            .runtime
+            .accounts()
+            .cancel_onboarding(&account_ref)
+            .await?)
+    }
+
     /// Record Continue anyway for the displayed notice, then resume setup.
     pub async fn acknowledge_onboarding_single_device(
         &self,

--- a/crates/marmot-uniffi/src/commands/onboarding.rs
+++ b/crates/marmot-uniffi/src/commands/onboarding.rs
@@ -24,6 +24,19 @@ impl OnboardingSubscription {
 }
 #[uniffi::export(async_runtime = "tokio")]
 impl Marmot {
+    /// Record Continue anyway for the displayed notice, then resume setup.
+    pub async fn acknowledge_onboarding_single_device(
+        &self,
+        account_ref: String,
+        revision: u64,
+    ) -> Result<OnboardingSnapshotFfi, MarmotKitError> {
+        Ok(self
+            .runtime
+            .accounts()
+            .acknowledge_onboarding_single_device(&account_ref, revision)
+            .await?
+            .into())
+    }
     /// Persist the identity and return before any network preflight or publication.
     pub async fn begin_onboarding(
         &self,

--- a/crates/marmot-uniffi/src/commands/onboarding.rs
+++ b/crates/marmot-uniffi/src/commands/onboarding.rs
@@ -1,0 +1,197 @@
+//! Identity-only sign-in and resumable preflight commands.
+use crate::conversions::{
+    OnboardingOptionsFfi, OnboardingSnapshotFfi, OnboardingStepFfi, UserProfileMetadataFfi,
+};
+use crate::external_signer::{ExternalAccountSignerAdapter, ExternalAccountSignerFfi};
+use crate::{Marmot, MarmotKitError};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use zeroize::Zeroizing;
+
+#[derive(uniffi::Object)]
+pub struct OnboardingSubscription {
+    snapshot: OnboardingSnapshotFfi,
+    inner: Mutex<marmot_app::OnboardingSubscription>,
+}
+#[uniffi::export(async_runtime = "tokio")]
+impl OnboardingSubscription {
+    pub fn snapshot(&self) -> OnboardingSnapshotFfi {
+        self.snapshot.clone()
+    }
+    pub async fn next(&self) -> Option<OnboardingSnapshotFfi> {
+        self.inner.lock().await.recv().await.map(Into::into)
+    }
+}
+#[uniffi::export(async_runtime = "tokio")]
+impl Marmot {
+    /// Persist the identity and return before any network preflight or publication.
+    pub async fn begin_onboarding(
+        &self,
+        nsec: String,
+        options: OnboardingOptionsFfi,
+    ) -> Result<OnboardingSnapshotFfi, MarmotKitError> {
+        Ok(self
+            .runtime
+            .accounts()
+            .begin_onboarding(Zeroizing::new(nsec), options.into())
+            .await?
+            .into())
+    }
+    pub async fn begin_external_signer_onboarding(
+        &self,
+        public_key: String,
+        signer: Arc<dyn ExternalAccountSignerFfi>,
+        options: OnboardingOptionsFfi,
+    ) -> Result<OnboardingSnapshotFfi, MarmotKitError> {
+        Ok(self
+            .runtime
+            .accounts()
+            .begin_external_signer_onboarding(
+                public_key,
+                ExternalAccountSignerAdapter::new(signer),
+                options.into(),
+            )
+            .await?
+            .into())
+    }
+    pub fn onboarding_snapshot(
+        &self,
+        account_ref: String,
+    ) -> Result<Option<OnboardingSnapshotFfi>, MarmotKitError> {
+        Ok(self
+            .runtime
+            .accounts()
+            .onboarding_snapshot(&account_ref)?
+            .map(Into::into))
+    }
+    pub fn subscribe_onboarding(
+        &self,
+        account_ref: String,
+    ) -> Result<Arc<OnboardingSubscription>, MarmotKitError> {
+        let subscription = self.runtime.accounts().subscribe_onboarding(&account_ref)?;
+        Ok(Arc::new(OnboardingSubscription {
+            snapshot: subscription.snapshot.clone().into(),
+            inner: Mutex::new(subscription),
+        }))
+    }
+    pub async fn set_onboarding_discovery_relays(
+        &self,
+        account_ref: String,
+        discovery_relays: Vec<String>,
+    ) -> Result<OnboardingSnapshotFfi, MarmotKitError> {
+        Ok(self
+            .runtime
+            .accounts()
+            .set_onboarding_discovery_relays(&account_ref, discovery_relays)
+            .await?
+            .into())
+    }
+    pub async fn run_onboarding(
+        &self,
+        account_ref: String,
+    ) -> Result<OnboardingSnapshotFfi, MarmotKitError> {
+        Ok(self
+            .runtime
+            .accounts()
+            .run_onboarding(&account_ref)
+            .await?
+            .into())
+    }
+    pub async fn retry_onboarding_step(
+        &self,
+        account_ref: String,
+        step: OnboardingStepFfi,
+    ) -> Result<OnboardingSnapshotFfi, MarmotKitError> {
+        Ok(self
+            .runtime
+            .accounts()
+            .retry_onboarding_step(&account_ref, step.into())
+            .await?
+            .into())
+    }
+    pub async fn continue_onboarding_without(
+        &self,
+        account_ref: String,
+        step: OnboardingStepFfi,
+    ) -> Result<OnboardingSnapshotFfi, MarmotKitError> {
+        Ok(self
+            .runtime
+            .accounts()
+            .continue_onboarding_without(&account_ref, step.into())
+            .await?
+            .into())
+    }
+    pub async fn propose_onboarding_recommended_relays(
+        &self,
+        account_ref: String,
+        step: OnboardingStepFfi,
+    ) -> Result<OnboardingSnapshotFfi, MarmotKitError> {
+        Ok(self
+            .runtime
+            .accounts()
+            .propose_onboarding_relays(&account_ref, step.into(), None)
+            .await?
+            .into())
+    }
+    pub async fn propose_onboarding_relays(
+        &self,
+        account_ref: String,
+        step: OnboardingStepFfi,
+        read_relays: Vec<String>,
+        write_relays: Vec<String>,
+    ) -> Result<OnboardingSnapshotFfi, MarmotKitError> {
+        Ok(self
+            .runtime
+            .accounts()
+            .propose_onboarding_relays(&account_ref, step.into(), Some((read_relays, write_relays)))
+            .await?
+            .into())
+    }
+    pub async fn propose_onboarding_profile(
+        &self,
+        account_ref: String,
+        profile: UserProfileMetadataFfi,
+    ) -> Result<OnboardingSnapshotFfi, MarmotKitError> {
+        Ok(self
+            .runtime
+            .accounts()
+            .propose_onboarding_profile(&account_ref, profile.into())
+            .await?
+            .into())
+    }
+    pub async fn propose_onboarding_follows(
+        &self,
+        account_ref: String,
+        follows: Vec<String>,
+    ) -> Result<OnboardingSnapshotFfi, MarmotKitError> {
+        Ok(self
+            .runtime
+            .accounts()
+            .propose_onboarding_follows(&account_ref, follows)
+            .await?
+            .into())
+    }
+    pub async fn approve_onboarding_repair(
+        &self,
+        account_ref: String,
+        revision: u64,
+    ) -> Result<OnboardingSnapshotFfi, MarmotKitError> {
+        Ok(self
+            .runtime
+            .accounts()
+            .approve_onboarding_repair(&account_ref, revision)
+            .await?
+            .into())
+    }
+    pub async fn cancel_onboarding_repair(
+        &self,
+        account_ref: String,
+    ) -> Result<OnboardingSnapshotFfi, MarmotKitError> {
+        Ok(self
+            .runtime
+            .accounts()
+            .cancel_onboarding_repair(&account_ref)
+            .await?
+            .into())
+    }
+}

--- a/crates/marmot-uniffi/src/conversions/mod.rs
+++ b/crates/marmot-uniffi/src/conversions/mod.rs
@@ -11,6 +11,8 @@
 //! `crate::conversions::*`.
 
 mod account;
+mod onboarding;
+pub use onboarding::*;
 mod agent_stream;
 mod audit;
 mod chat_list;

--- a/crates/marmot-uniffi/src/conversions/mod.rs
+++ b/crates/marmot-uniffi/src/conversions/mod.rs
@@ -11,8 +11,6 @@
 //! `crate::conversions::*`.
 
 mod account;
-mod onboarding;
-pub use onboarding::*;
 mod agent_stream;
 mod audit;
 mod chat_list;
@@ -25,6 +23,7 @@ mod maintenance;
 mod media;
 mod message;
 mod notification;
+mod onboarding;
 mod push;
 mod relay;
 mod telemetry;
@@ -47,6 +46,7 @@ pub use maintenance::*;
 pub use media::*;
 pub use message::*;
 pub use notification::*;
+pub use onboarding::*;
 pub use push::*;
 pub use relay::*;
 pub use telemetry::*;

--- a/crates/marmot-uniffi/src/conversions/onboarding.rs
+++ b/crates/marmot-uniffi/src/conversions/onboarding.rs
@@ -1,0 +1,278 @@
+//! Typed onboarding contract for Swift and Kotlin.
+use super::UserProfileMetadataFfi;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum OnboardingStepFfi {
+    Profile,
+    Follows,
+    Relays,
+    InboxRelays,
+    KeyPackage,
+}
+impl From<marmot_app::OnboardingStep> for OnboardingStepFfi {
+    fn from(value: marmot_app::OnboardingStep) -> Self {
+        match value {
+            marmot_app::OnboardingStep::Profile => Self::Profile,
+            marmot_app::OnboardingStep::Follows => Self::Follows,
+            marmot_app::OnboardingStep::Relays => Self::Relays,
+            marmot_app::OnboardingStep::InboxRelays => Self::InboxRelays,
+            marmot_app::OnboardingStep::KeyPackage => Self::KeyPackage,
+        }
+    }
+}
+impl From<OnboardingStepFfi> for marmot_app::OnboardingStep {
+    fn from(value: OnboardingStepFfi) -> Self {
+        match value {
+            OnboardingStepFfi::Profile => Self::Profile,
+            OnboardingStepFfi::Follows => Self::Follows,
+            OnboardingStepFfi::Relays => Self::Relays,
+            OnboardingStepFfi::InboxRelays => Self::InboxRelays,
+            OnboardingStepFfi::KeyPackage => Self::KeyPackage,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum OnboardingStatusFfi {
+    Pending,
+    Checking,
+    Passed,
+    NeedsInput,
+    RetryableFailure,
+    WaitingForSigner,
+    Skipped,
+}
+impl From<marmot_app::OnboardingStatus> for OnboardingStatusFfi {
+    fn from(value: marmot_app::OnboardingStatus) -> Self {
+        match value {
+            marmot_app::OnboardingStatus::Pending => Self::Pending,
+            marmot_app::OnboardingStatus::Checking => Self::Checking,
+            marmot_app::OnboardingStatus::Passed => Self::Passed,
+            marmot_app::OnboardingStatus::NeedsInput => Self::NeedsInput,
+            marmot_app::OnboardingStatus::RetryableFailure => Self::RetryableFailure,
+            marmot_app::OnboardingStatus::WaitingForSigner => Self::WaitingForSigner,
+            marmot_app::OnboardingStatus::Skipped => Self::Skipped,
+        }
+    }
+}
+impl From<OnboardingStatusFfi> for marmot_app::OnboardingStatus {
+    fn from(value: OnboardingStatusFfi) -> Self {
+        match value {
+            OnboardingStatusFfi::Pending => Self::Pending,
+            OnboardingStatusFfi::Checking => Self::Checking,
+            OnboardingStatusFfi::Passed => Self::Passed,
+            OnboardingStatusFfi::NeedsInput => Self::NeedsInput,
+            OnboardingStatusFfi::RetryableFailure => Self::RetryableFailure,
+            OnboardingStatusFfi::WaitingForSigner => Self::WaitingForSigner,
+            OnboardingStatusFfi::Skipped => Self::Skipped,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum OnboardingIssueFfi {
+    Missing,
+    Malformed,
+    FutureDated,
+    InvalidRelay,
+    RetiredRelay,
+    UnsafeRelay,
+    Unreachable,
+    TimedOut,
+    AuthenticationRequired,
+    PaymentRequired,
+    AccessRestricted,
+    NoUsableRoute,
+    PublicationFailed,
+    SignerUnavailable,
+    SignerRejected,
+    RecordChanged,
+    Interrupted,
+    TooManyRelays,
+}
+impl From<marmot_app::OnboardingIssue> for OnboardingIssueFfi {
+    fn from(value: marmot_app::OnboardingIssue) -> Self {
+        match value {
+            marmot_app::OnboardingIssue::Missing => Self::Missing,
+            marmot_app::OnboardingIssue::Malformed => Self::Malformed,
+            marmot_app::OnboardingIssue::FutureDated => Self::FutureDated,
+            marmot_app::OnboardingIssue::InvalidRelay => Self::InvalidRelay,
+            marmot_app::OnboardingIssue::RetiredRelay => Self::RetiredRelay,
+            marmot_app::OnboardingIssue::UnsafeRelay => Self::UnsafeRelay,
+            marmot_app::OnboardingIssue::Unreachable => Self::Unreachable,
+            marmot_app::OnboardingIssue::TimedOut => Self::TimedOut,
+            marmot_app::OnboardingIssue::AuthenticationRequired => Self::AuthenticationRequired,
+            marmot_app::OnboardingIssue::PaymentRequired => Self::PaymentRequired,
+            marmot_app::OnboardingIssue::AccessRestricted => Self::AccessRestricted,
+            marmot_app::OnboardingIssue::NoUsableRoute => Self::NoUsableRoute,
+            marmot_app::OnboardingIssue::PublicationFailed => Self::PublicationFailed,
+            marmot_app::OnboardingIssue::SignerUnavailable => Self::SignerUnavailable,
+            marmot_app::OnboardingIssue::SignerRejected => Self::SignerRejected,
+            marmot_app::OnboardingIssue::RecordChanged => Self::RecordChanged,
+            marmot_app::OnboardingIssue::Interrupted => Self::Interrupted,
+            marmot_app::OnboardingIssue::TooManyRelays => Self::TooManyRelays,
+        }
+    }
+}
+impl From<OnboardingIssueFfi> for marmot_app::OnboardingIssue {
+    fn from(value: OnboardingIssueFfi) -> Self {
+        match value {
+            OnboardingIssueFfi::Missing => Self::Missing,
+            OnboardingIssueFfi::Malformed => Self::Malformed,
+            OnboardingIssueFfi::FutureDated => Self::FutureDated,
+            OnboardingIssueFfi::InvalidRelay => Self::InvalidRelay,
+            OnboardingIssueFfi::RetiredRelay => Self::RetiredRelay,
+            OnboardingIssueFfi::UnsafeRelay => Self::UnsafeRelay,
+            OnboardingIssueFfi::Unreachable => Self::Unreachable,
+            OnboardingIssueFfi::TimedOut => Self::TimedOut,
+            OnboardingIssueFfi::AuthenticationRequired => Self::AuthenticationRequired,
+            OnboardingIssueFfi::PaymentRequired => Self::PaymentRequired,
+            OnboardingIssueFfi::AccessRestricted => Self::AccessRestricted,
+            OnboardingIssueFfi::NoUsableRoute => Self::NoUsableRoute,
+            OnboardingIssueFfi::PublicationFailed => Self::PublicationFailed,
+            OnboardingIssueFfi::SignerUnavailable => Self::SignerUnavailable,
+            OnboardingIssueFfi::SignerRejected => Self::SignerRejected,
+            OnboardingIssueFfi::RecordChanged => Self::RecordChanged,
+            OnboardingIssueFfi::Interrupted => Self::Interrupted,
+            OnboardingIssueFfi::TooManyRelays => Self::TooManyRelays,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum OnboardingActionFfi {
+    Retry,
+    ContinueWithout,
+    UseRecommendedRelays,
+    EditRelays,
+    EditProfile,
+    EditFollows,
+    ApproveRepair,
+    CancelRepair,
+    ReconnectSigner,
+    EditDiscoveryRelays,
+}
+impl From<marmot_app::OnboardingAction> for OnboardingActionFfi {
+    fn from(value: marmot_app::OnboardingAction) -> Self {
+        match value {
+            marmot_app::OnboardingAction::Retry => Self::Retry,
+            marmot_app::OnboardingAction::ContinueWithout => Self::ContinueWithout,
+            marmot_app::OnboardingAction::UseRecommendedRelays => Self::UseRecommendedRelays,
+            marmot_app::OnboardingAction::EditRelays => Self::EditRelays,
+            marmot_app::OnboardingAction::EditProfile => Self::EditProfile,
+            marmot_app::OnboardingAction::EditFollows => Self::EditFollows,
+            marmot_app::OnboardingAction::ApproveRepair => Self::ApproveRepair,
+            marmot_app::OnboardingAction::CancelRepair => Self::CancelRepair,
+            marmot_app::OnboardingAction::EditDiscoveryRelays => Self::EditDiscoveryRelays,
+            marmot_app::OnboardingAction::ReconnectSigner => Self::ReconnectSigner,
+        }
+    }
+}
+impl From<OnboardingActionFfi> for marmot_app::OnboardingAction {
+    fn from(value: OnboardingActionFfi) -> Self {
+        match value {
+            OnboardingActionFfi::Retry => Self::Retry,
+            OnboardingActionFfi::ContinueWithout => Self::ContinueWithout,
+            OnboardingActionFfi::UseRecommendedRelays => Self::UseRecommendedRelays,
+            OnboardingActionFfi::EditRelays => Self::EditRelays,
+            OnboardingActionFfi::EditProfile => Self::EditProfile,
+            OnboardingActionFfi::EditFollows => Self::EditFollows,
+            OnboardingActionFfi::ApproveRepair => Self::ApproveRepair,
+            OnboardingActionFfi::CancelRepair => Self::CancelRepair,
+            OnboardingActionFfi::EditDiscoveryRelays => Self::EditDiscoveryRelays,
+            OnboardingActionFfi::ReconnectSigner => Self::ReconnectSigner,
+        }
+    }
+}
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct OnboardingFindingFfi {
+    pub issue: OnboardingIssueFfi,
+    pub endpoint: Option<String>,
+}
+impl From<marmot_app::OnboardingFinding> for OnboardingFindingFfi {
+    fn from(value: marmot_app::OnboardingFinding) -> Self {
+        Self {
+            issue: value.issue.into(),
+            endpoint: value.endpoint,
+        }
+    }
+}
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct OnboardingStepStateFfi {
+    pub step: OnboardingStepFfi,
+    pub status: OnboardingStatusFfi,
+    pub findings: Vec<OnboardingFindingFfi>,
+    pub actions: Vec<OnboardingActionFfi>,
+    pub checked_at: Option<u64>,
+}
+impl From<marmot_app::OnboardingStepState> for OnboardingStepStateFfi {
+    fn from(value: marmot_app::OnboardingStepState) -> Self {
+        Self {
+            step: value.step.into(),
+            status: value.status.into(),
+            findings: value.findings.into_iter().map(Into::into).collect(),
+            actions: value.actions.into_iter().map(Into::into).collect(),
+            checked_at: value.checked_at,
+        }
+    }
+}
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct OnboardingRepairProposalFfi {
+    pub step: OnboardingStepFfi,
+    pub revision: u64,
+    pub previous_event_id: Option<String>,
+    pub read_relays: Vec<String>,
+    pub write_relays: Vec<String>,
+    pub profile: Option<UserProfileMetadataFfi>,
+    pub follows: Option<Vec<String>>,
+}
+impl From<marmot_app::OnboardingRepairProposal> for OnboardingRepairProposalFfi {
+    fn from(value: marmot_app::OnboardingRepairProposal) -> Self {
+        Self {
+            step: value.step.into(),
+            revision: value.revision,
+            previous_event_id: value.previous_event_id,
+            read_relays: value.read_relays,
+            write_relays: value.write_relays,
+            profile: value.profile.map(Into::into),
+            follows: value.follows,
+        }
+    }
+}
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct OnboardingSnapshotFfi {
+    pub account_id_hex: String,
+    pub revision: u64,
+    pub ready: bool,
+    pub steps: Vec<OnboardingStepStateFfi>,
+    pub proposal: Option<OnboardingRepairProposalFfi>,
+}
+impl From<marmot_app::OnboardingSnapshot> for OnboardingSnapshotFfi {
+    fn from(value: marmot_app::OnboardingSnapshot) -> Self {
+        Self {
+            account_id_hex: value.account_id_hex,
+            revision: value.revision,
+            ready: value.ready,
+            steps: value.steps.into_iter().map(Into::into).collect(),
+            proposal: value.proposal.map(Into::into),
+        }
+    }
+}
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct OnboardingOptionsFfi {
+    pub default_relays: Vec<String>,
+    pub discovery_relays: Vec<String>,
+}
+impl From<marmot_app::OnboardingOptions> for OnboardingOptionsFfi {
+    fn from(value: marmot_app::OnboardingOptions) -> Self {
+        Self {
+            default_relays: value.default_relays,
+            discovery_relays: value.discovery_relays,
+        }
+    }
+}
+impl From<OnboardingOptionsFfi> for marmot_app::OnboardingOptions {
+    fn from(value: OnboardingOptionsFfi) -> Self {
+        Self {
+            default_relays: value.default_relays,
+            discovery_relays: value.discovery_relays,
+        }
+    }
+}

--- a/crates/marmot-uniffi/src/conversions/onboarding.rs
+++ b/crates/marmot-uniffi/src/conversions/onboarding.rs
@@ -8,6 +8,7 @@ pub enum OnboardingStepFfi {
     Relays,
     InboxRelays,
     KeyPackage,
+    SingleDevice,
 }
 impl From<marmot_app::OnboardingStep> for OnboardingStepFfi {
     fn from(value: marmot_app::OnboardingStep) -> Self {
@@ -17,6 +18,7 @@ impl From<marmot_app::OnboardingStep> for OnboardingStepFfi {
             marmot_app::OnboardingStep::Relays => Self::Relays,
             marmot_app::OnboardingStep::InboxRelays => Self::InboxRelays,
             marmot_app::OnboardingStep::KeyPackage => Self::KeyPackage,
+            marmot_app::OnboardingStep::SingleDevice => Self::SingleDevice,
         }
     }
 }
@@ -28,6 +30,7 @@ impl From<OnboardingStepFfi> for marmot_app::OnboardingStep {
             OnboardingStepFfi::Relays => Self::Relays,
             OnboardingStepFfi::InboxRelays => Self::InboxRelays,
             OnboardingStepFfi::KeyPackage => Self::KeyPackage,
+            OnboardingStepFfi::SingleDevice => Self::SingleDevice,
         }
     }
 }
@@ -87,6 +90,9 @@ pub enum OnboardingIssueFfi {
     RecordChanged,
     Interrupted,
     TooManyRelays,
+    MultiDeviceUnsupported,
+    OtherInstallationPossible,
+    DiscoveryIncomplete,
 }
 impl From<marmot_app::OnboardingIssue> for OnboardingIssueFfi {
     fn from(value: marmot_app::OnboardingIssue) -> Self {
@@ -109,6 +115,11 @@ impl From<marmot_app::OnboardingIssue> for OnboardingIssueFfi {
             marmot_app::OnboardingIssue::RecordChanged => Self::RecordChanged,
             marmot_app::OnboardingIssue::Interrupted => Self::Interrupted,
             marmot_app::OnboardingIssue::TooManyRelays => Self::TooManyRelays,
+            marmot_app::OnboardingIssue::MultiDeviceUnsupported => Self::MultiDeviceUnsupported,
+            marmot_app::OnboardingIssue::OtherInstallationPossible => {
+                Self::OtherInstallationPossible
+            }
+            marmot_app::OnboardingIssue::DiscoveryIncomplete => Self::DiscoveryIncomplete,
         }
     }
 }
@@ -133,6 +144,9 @@ impl From<OnboardingIssueFfi> for marmot_app::OnboardingIssue {
             OnboardingIssueFfi::RecordChanged => Self::RecordChanged,
             OnboardingIssueFfi::Interrupted => Self::Interrupted,
             OnboardingIssueFfi::TooManyRelays => Self::TooManyRelays,
+            OnboardingIssueFfi::MultiDeviceUnsupported => Self::MultiDeviceUnsupported,
+            OnboardingIssueFfi::OtherInstallationPossible => Self::OtherInstallationPossible,
+            OnboardingIssueFfi::DiscoveryIncomplete => Self::DiscoveryIncomplete,
         }
     }
 }
@@ -148,6 +162,8 @@ pub enum OnboardingActionFfi {
     CancelRepair,
     ReconnectSigner,
     EditDiscoveryRelays,
+    ContinueAnyway,
+    CancelOnboarding,
 }
 impl From<marmot_app::OnboardingAction> for OnboardingActionFfi {
     fn from(value: marmot_app::OnboardingAction) -> Self {
@@ -162,6 +178,8 @@ impl From<marmot_app::OnboardingAction> for OnboardingActionFfi {
             marmot_app::OnboardingAction::CancelRepair => Self::CancelRepair,
             marmot_app::OnboardingAction::EditDiscoveryRelays => Self::EditDiscoveryRelays,
             marmot_app::OnboardingAction::ReconnectSigner => Self::ReconnectSigner,
+            marmot_app::OnboardingAction::ContinueAnyway => Self::ContinueAnyway,
+            marmot_app::OnboardingAction::CancelOnboarding => Self::CancelOnboarding,
         }
     }
 }
@@ -178,6 +196,8 @@ impl From<OnboardingActionFfi> for marmot_app::OnboardingAction {
             OnboardingActionFfi::CancelRepair => Self::CancelRepair,
             OnboardingActionFfi::EditDiscoveryRelays => Self::EditDiscoveryRelays,
             OnboardingActionFfi::ReconnectSigner => Self::ReconnectSigner,
+            OnboardingActionFfi::ContinueAnyway => Self::ContinueAnyway,
+            OnboardingActionFfi::CancelOnboarding => Self::CancelOnboarding,
         }
     }
 }
@@ -243,6 +263,7 @@ pub struct OnboardingSnapshotFfi {
     pub ready: bool,
     pub steps: Vec<OnboardingStepStateFfi>,
     pub proposal: Option<OnboardingRepairProposalFfi>,
+    pub single_device_notice: Option<OnboardingSingleDeviceNoticeFfi>,
 }
 impl From<marmot_app::OnboardingSnapshot> for OnboardingSnapshotFfi {
     fn from(value: marmot_app::OnboardingSnapshot) -> Self {
@@ -251,6 +272,7 @@ impl From<marmot_app::OnboardingSnapshot> for OnboardingSnapshotFfi {
             revision: value.revision,
             ready: value.ready,
             steps: value.steps.into_iter().map(Into::into).collect(),
+            single_device_notice: value.single_device_notice.map(Into::into),
             proposal: value.proposal.map(Into::into),
         }
     }
@@ -273,6 +295,60 @@ impl From<OnboardingOptionsFfi> for marmot_app::OnboardingOptions {
         Self {
             default_relays: value.default_relays,
             discovery_relays: value.discovery_relays,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum OnboardingDeviceDiscoveryFfi {
+    NoneFound,
+    OtherInstallationPossible,
+    Unknown,
+}
+impl From<marmot_app::OnboardingDeviceDiscovery> for OnboardingDeviceDiscoveryFfi {
+    fn from(value: marmot_app::OnboardingDeviceDiscovery) -> Self {
+        match value {
+            marmot_app::OnboardingDeviceDiscovery::NoneFound => Self::NoneFound,
+            marmot_app::OnboardingDeviceDiscovery::OtherInstallationPossible => {
+                Self::OtherInstallationPossible
+            }
+            marmot_app::OnboardingDeviceDiscovery::Unknown => Self::Unknown,
+        }
+    }
+}
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct OnboardingDevicePackageFfi {
+    pub slot_id: String,
+    pub key_package_ref_hex: String,
+    pub event_id_hex: String,
+    pub published_at: u64,
+    pub expires_at: u64,
+}
+impl From<marmot_app::OnboardingDevicePackage> for OnboardingDevicePackageFfi {
+    fn from(value: marmot_app::OnboardingDevicePackage) -> Self {
+        Self {
+            slot_id: value.slot_id,
+            key_package_ref_hex: value.key_package_ref_hex,
+            event_id_hex: value.event_id_hex,
+            published_at: value.published_at,
+            expires_at: value.expires_at,
+        }
+    }
+}
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct OnboardingSingleDeviceNoticeFfi {
+    pub discovery: OnboardingDeviceDiscoveryFfi,
+    pub other_packages: Vec<OnboardingDevicePackageFfi>,
+    pub discovery_complete: bool,
+    pub acknowledged_at: Option<u64>,
+}
+impl From<marmot_app::OnboardingSingleDeviceNotice> for OnboardingSingleDeviceNoticeFfi {
+    fn from(value: marmot_app::OnboardingSingleDeviceNotice) -> Self {
+        Self {
+            discovery: value.discovery.into(),
+            other_packages: value.other_packages.into_iter().map(Into::into).collect(),
+            discovery_complete: value.discovery_complete,
+            acknowledged_at: value.acknowledged_at,
         }
     }
 }

--- a/crates/marmot-uniffi/src/conversions/onboarding.rs
+++ b/crates/marmot-uniffi/src/conversions/onboarding.rs
@@ -7,8 +7,8 @@ pub enum OnboardingStepFfi {
     Follows,
     Relays,
     InboxRelays,
-    KeyPackage,
     SingleDevice,
+    KeyPackage,
 }
 impl From<marmot_app::OnboardingStep> for OnboardingStepFfi {
     fn from(value: marmot_app::OnboardingStep) -> Self {
@@ -264,6 +264,7 @@ pub struct OnboardingSnapshotFfi {
     pub steps: Vec<OnboardingStepStateFfi>,
     pub proposal: Option<OnboardingRepairProposalFfi>,
     pub single_device_notice: Option<OnboardingSingleDeviceNoticeFfi>,
+    pub cancellation_pending: bool,
 }
 impl From<marmot_app::OnboardingSnapshot> for OnboardingSnapshotFfi {
     fn from(value: marmot_app::OnboardingSnapshot) -> Self {
@@ -273,6 +274,7 @@ impl From<marmot_app::OnboardingSnapshot> for OnboardingSnapshotFfi {
             ready: value.ready,
             steps: value.steps.into_iter().map(Into::into).collect(),
             single_device_notice: value.single_device_notice.map(Into::into),
+            cancellation_pending: value.cancellation_pending,
             proposal: value.proposal.map(Into::into),
         }
     }
@@ -319,10 +321,11 @@ impl From<marmot_app::OnboardingDeviceDiscovery> for OnboardingDeviceDiscoveryFf
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct OnboardingDevicePackageFfi {
     pub slot_id: String,
-    pub key_package_ref_hex: String,
+    pub key_package_ref_hex: Option<String>,
     pub event_id_hex: String,
     pub published_at: u64,
-    pub expires_at: u64,
+    pub expires_at: Option<u64>,
+    pub usable: bool,
 }
 impl From<marmot_app::OnboardingDevicePackage> for OnboardingDevicePackageFfi {
     fn from(value: marmot_app::OnboardingDevicePackage) -> Self {
@@ -332,6 +335,7 @@ impl From<marmot_app::OnboardingDevicePackage> for OnboardingDevicePackageFfi {
             event_id_hex: value.event_id_hex,
             published_at: value.published_at,
             expires_at: value.expires_at,
+            usable: value.usable,
         }
     }
 }

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -85,6 +85,10 @@ pub enum MarmotKitError {
     AccountSetupRecoveryRequired,
     #[error("durable account setup can be resumed by retrying")]
     AccountSetupRetryRequired,
+    #[error("onboarding action is unavailable or stale")]
+    OnboardingActionUnavailable,
+    #[error("account must complete interactive onboarding")]
+    OnboardingRequired,
     #[error("account is not eligible for incomplete-setup reset")]
     AccountSetupResetNotApplicable,
     #[error("recoverable KeyPackage setup state exists; retry instead of resetting")]
@@ -325,6 +329,8 @@ impl From<AppError> for MarmotKitError {
             AppError::AccountWorkerBusy => Self::AccountWorkerBusy,
             AppError::AccountWorkerResponseTimedOut => Self::AccountWorkerResponseTimedOut,
             AppError::AccountSetupRecoveryRequired => Self::AccountSetupRecoveryRequired,
+            AppError::OnboardingActionUnavailable => Self::OnboardingActionUnavailable,
+            AppError::OnboardingRequired => Self::OnboardingRequired,
             AppError::AccountSetupRetryRequired => Self::AccountSetupRetryRequired,
             AppError::AccountSetupResetNotApplicable => Self::AccountSetupResetNotApplicable,
             AppError::AccountSetupKeyPackageRecoveryAvailable => {

--- a/crates/marmot-uniffi/src/lib.rs
+++ b/crates/marmot-uniffi/src/lib.rs
@@ -83,8 +83,9 @@ pub use conversions::{
     TransportFanoutStatusFfi,
 };
 pub use conversions::{
-    OnboardingActionFfi, OnboardingFindingFfi, OnboardingIssueFfi, OnboardingOptionsFfi,
-    OnboardingRepairProposalFfi, OnboardingSnapshotFfi, OnboardingStatusFfi, OnboardingStepFfi,
+    OnboardingActionFfi, OnboardingDeviceDiscoveryFfi, OnboardingDevicePackageFfi,
+    OnboardingFindingFfi, OnboardingIssueFfi, OnboardingOptionsFfi, OnboardingRepairProposalFfi,
+    OnboardingSingleDeviceNoticeFfi, OnboardingSnapshotFfi, OnboardingStatusFfi, OnboardingStepFfi,
     OnboardingStepStateFfi,
 };
 

--- a/crates/marmot-uniffi/src/lib.rs
+++ b/crates/marmot-uniffi/src/lib.rs
@@ -46,6 +46,7 @@ pub use secret_store::SecretStore;
 
 uniffi::setup_scaffolding!();
 
+pub use commands::OnboardingSubscription;
 pub use commands::{
     CreateGroupOptionsFfi, InitialGroupImageFfi, MemberKeyPackagePrewarmSummaryFfi,
     PreparedGroupImageUploadFfi, PreparedGroupImageUploadStateFfi, parse_media_imeta_tag,
@@ -80,6 +81,11 @@ pub use conversions::{
     TimelineReactionEmojiFfi, TimelineReactionSummaryFfi, TimelineRemoveReasonFfi,
     TimelineSubscriptionUpdateFfi, TimelineUpdateTriggerFfi, TimelineUserReactionFfi,
     TransportFanoutStatusFfi,
+};
+pub use conversions::{
+    OnboardingActionFfi, OnboardingFindingFfi, OnboardingIssueFfi, OnboardingOptionsFfi,
+    OnboardingRepairProposalFfi, OnboardingSnapshotFfi, OnboardingStatusFfi, OnboardingStepFfi,
+    OnboardingStepStateFfi,
 };
 
 /// Convenience: turn an FFI string list of relay URLs into the engine's

--- a/crates/marmot-uniffi/src/lib.rs
+++ b/crates/marmot-uniffi/src/lib.rs
@@ -46,10 +46,10 @@ pub use secret_store::SecretStore;
 
 uniffi::setup_scaffolding!();
 
-pub use commands::OnboardingSubscription;
 pub use commands::{
     CreateGroupOptionsFfi, InitialGroupImageFfi, MemberKeyPackagePrewarmSummaryFfi,
-    PreparedGroupImageUploadFfi, PreparedGroupImageUploadStateFfi, parse_media_imeta_tag,
+    OnboardingSubscription, PreparedGroupImageUploadFfi, PreparedGroupImageUploadStateFfi,
+    parse_media_imeta_tag,
 };
 pub use conversions::{
     AppBlobEndpointFfi, AppGroupEncryptedMediaComponentFfi, AppGroupMemberIdsFfi,
@@ -70,8 +70,11 @@ pub use conversions::{
     MediaUploadResultFfi, MessageDraftAttachmentFfi, MessageDraftAttachmentSummaryFfi,
     MessageDraftFfi, MessageDraftSummaryFfi, MessageTagFfi, NotificationCollectionStatusFfi,
     NotificationSettingsFfi, NotificationTrafficClassFfi, NotificationTriggerFfi,
-    NotificationUpdateFfi, NotificationUserFfi, NotificationWakeSourceFfi,
-    PeriodicMaintenancePolicyFfi, PushPlatformFfi, PushRegistrationFfi,
+    NotificationUpdateFfi, NotificationUserFfi, NotificationWakeSourceFfi, OnboardingActionFfi,
+    OnboardingDeviceDiscoveryFfi, OnboardingDevicePackageFfi, OnboardingFindingFfi,
+    OnboardingIssueFfi, OnboardingOptionsFfi, OnboardingRepairProposalFfi,
+    OnboardingSingleDeviceNoticeFfi, OnboardingSnapshotFfi, OnboardingStatusFfi, OnboardingStepFfi,
+    OnboardingStepStateFfi, PeriodicMaintenancePolicyFfi, PushPlatformFfi, PushRegistrationFfi,
     PushRegistrationShareOutcomeFfi, PushRegistrationShareStatusFfi, PushRegistrationSyncResultFfi,
     RelayEndpointClassificationFfi, RelayEndpointPolicyFfi, RelayTelemetryResourceFfi,
     RelayTelemetryRuntimeConfigFfi, RelayTelemetrySettingsFfi, RetentionSweepGroupOutcomeFfi,
@@ -81,12 +84,6 @@ pub use conversions::{
     TimelineReactionEmojiFfi, TimelineReactionSummaryFfi, TimelineRemoveReasonFfi,
     TimelineSubscriptionUpdateFfi, TimelineUpdateTriggerFfi, TimelineUserReactionFfi,
     TransportFanoutStatusFfi,
-};
-pub use conversions::{
-    OnboardingActionFfi, OnboardingDeviceDiscoveryFfi, OnboardingDevicePackageFfi,
-    OnboardingFindingFfi, OnboardingIssueFfi, OnboardingOptionsFfi, OnboardingRepairProposalFfi,
-    OnboardingSingleDeviceNoticeFfi, OnboardingSnapshotFfi, OnboardingStatusFfi, OnboardingStepFfi,
-    OnboardingStepStateFfi,
 };
 
 /// Convenience: turn an FFI string list of relay URLs into the engine's

--- a/docs/marmot-architecture/overview/current-state.md
+++ b/docs/marmot-architecture/overview/current-state.md
@@ -19,6 +19,12 @@ status: overview
 
 # Current State — Implementations & Spec
 
+MDK now exposes opt-in durable onboarding for imported identities, with per-step
+validation, repair proposals, explicit approval, and Swift/Kotlin/C bindings.
+Account onboarding gates normal worker commands until required checks and
+KeyPackage publication complete. Host apps still need to adopt the identity-only
+entry points and render the screen; see the [binding integration contract](../../../crates/marmot-uniffi/README.md#interactive-account-onboarding).
+
 Where Marmot is today: the merged MIPs define the deployed protocol shape, this workspace is MDK at `0.9.0` (the
 unifying bump above the previous `0.8.0` release), Marmot-TS gives us an independent TypeScript implementation, and the
 CGKA engine/convergence workspace here is being shaped into spec text.

--- a/docs/marmot-architecture/overview/current-state.md
+++ b/docs/marmot-architecture/overview/current-state.md
@@ -21,6 +21,8 @@ status: overview
 
 MDK now exposes opt-in durable onboarding for imported identities, with per-step
 validation, repair proposals, explicit approval, and Swift/Kotlin/C bindings.
+It requires single-device acknowledgment before KeyPackage publication and offers
+advisory detection of packages that may belong to another installation.
 Account onboarding gates normal worker commands until required checks and
 KeyPackage publication complete. Host apps still need to adopt the identity-only
 entry points and render the screen; see the [binding integration contract](../../../crates/marmot-uniffi/README.md#interactive-account-onboarding).

--- a/scripts/check_c_binding_parity.py
+++ b/scripts/check_c_binding_parity.py
@@ -30,6 +30,7 @@ C_SRC = REPO / "crates" / "marmot-c" / "src"
 # Commands deliberately absent from the C ABI, each with the reason it is
 # not drift. Removing an entry here is how you turn it back into a gap.
 DELIBERATELY_UNEXPORTED = {
+    "begin_external_signer_onboarding": ("Same host-implemented signer trait as register_external_signer."),
     "register_external_signer": (
         "Takes a host-implemented ExternalAccountSignerFfi trait. A C mapping "
         "needs a callback vtable (function pointers + user_data) invoked from "


### PR DESCRIPTION
Imported Nostr identities can carry malformed records, unusable relay declarations, or KeyPackages from another installation. This adds an opt-in, durable onboarding workflow between accepting an identity and activating the account, with typed progress, explicit repair approval, and a one-device notice before publishing this installation's KeyPackage.

Related: #1679. This PR partially implements its inbox-onboarding requirements; account-wide readiness enforcement and legacy binding adoption remain tracked there.

### Behavior

- Persist the identity before network work. Check kind 0 metadata, kind 3 follows, kind 10002 relays, and kind 10050 inbox relays through bounded, validated routes. Retain partial-discovery findings and distinguish absence from failed queries or access restrictions.
- Offer host-supplied new-account defaults as repair proposals. Preserve unrelated metadata/tags, re-fetch before signing, persist signed bytes before sending, and replay them unchanged after interruption. Zero acknowledgments never count as success.
- Pause at `SingleDevice` before KeyPackage publication. Compare verified kind-30443 records with local slots and durably owned packages. Signed foreign slots remain evidence even with malformed or expired payloads; optional metadata and `usable` describe validity separately. Publication time is not last-active time.
- Require explicit Continue anyway. Rechecking prerequisites or changing discovery sources invalidates the acknowledgment; retrying KeyPackage publication preserves it. Optional steps remain skipped unless explicitly retried.
- Implement Cancel across Rust, UniFFI, and C. It durably signs out, retains local state, the registered signer callback, and completed repairs, and archives the checkpoint. Interrupted cancellation can be resumed, followed by either interactive or legacy sign-in. An unfinished approved repair cannot be discarded.
- Expose six ordered steps, full snapshot subscriptions, actions, and findings through the bindings. Update the generated C header and the host integration contract.

### Compatibility and rollout

The requested design is an additive binding API so clients can adopt the onboarding screen independently. Existing login and generated-account entry points remain available. This PR includes the requested single-device notice in that workflow; it does not include client UI, a new protocol event/device identifier, or a workspace version bump.

Active legacy accounts and unfinished legacy setups are rejected before interactive enrollment mutates them. Signed-out legacy accounts without pending setup can opt in. Ordinary commands validate the gate before mutation. Completed checkpoints defer to normal setup/recovery readiness; unreadable or future-version checkpoints gate only their own account. Older checkpoints conservatively default missing package validity to false and refresh retry actions for finished steps. Unknown checkpoint contents are not automatically erased because they may contain approved publication intent.

Discovery is advisory: a reinstall can resemble another installation, and empty or failed discovery never establishes that multi-device use is safe. Relay inspections use scoped clients with or without a signer. The host must localize findings, render the screen, and update generated bindings with the matching native library. C external-signer entry points retain the existing callback-vtable limitation.

### Validation

Rebased onto master `dbf45c83`. Conflict resolution preserves completion-aware outbox discovery and `GroupRemoved = 63`; new onboarding C statuses are appended as 64/65.

- `just fast-ci` passed, including workspace default/OTLP checks, clippy, binding parity, and convergence-policy tests.
- All 173 selected onboarding, directory, outbox, and C binding tests passed, including the newly merged master discovery regressions and new signer-retention, own-slot, and older-checkpoint regressions.
- All 33 C tests passed with allocation auditing. Header regeneration produced no diff; shared and static C smoke tests passed. Valgrind was unavailable.
- All four tracing audits passed. All six branch commits have locally verified signatures.
- Replaced the startup-read test's global telemetry/timing assumption with a test-only catch-up gate. All three related tests passed in 10 serial stress iterations (30 executions); a temporary negative control failed as expected. `just fast-ci` passed again on this fix.
- Full workspace tests are delegated to GitHub CI. No packaged mobile or device validation is claimed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added durable, resumable onboarding with progress snapshots, retries, repair approvals, and optional step continuation.
  - Added single-device discovery notices, device-package details, acknowledgment, and detection of possible other installations.
  - Added onboarding cancellation with restart support.
  - Added onboarding APIs and subscriptions for C, Swift, and Kotlin integrations.
- **Bug Fixes**
  - Improved relay discovery diagnostics and request handling.
  - Added clearer errors when onboarding is required, an action is unavailable, or a group has been removed.
- **Documentation**
  - Expanded onboarding behavior and integration documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->