### PR TITLE
fix(engine): keep default MLS capabilities implicit

### DIFF
--- a/crates/cgka-engine/src/app_components.rs
+++ b/crates/cgka-engine/src/app_components.rs
@@ -1261,18 +1261,16 @@ fn validate_resulting_leaf_capabilities<'a>(
     })?;
     for leaf in leaves {
         let capabilities = leaf.capabilities();
-        let supports_required = required
-            .extension_types()
+        let supports_required = required.extension_types().iter().all(|required| {
+            crate::capabilities::DEFAULT_MLS_EXTENSION_TYPES.contains(&u16::from(*required))
+                || capabilities.extensions().contains(required)
+        }) && required.proposal_types().iter().all(|required| {
+            crate::capabilities::DEFAULT_MLS_PROPOSAL_TYPES.contains(&u16::from(*required))
+                || capabilities.proposals().contains(required)
+        }) && required
+            .credential_types()
             .iter()
-            .all(|required| capabilities.extensions().contains(required))
-            && required
-                .proposal_types()
-                .iter()
-                .all(|required| capabilities.proposals().contains(required))
-            && required
-                .credential_types()
-                .iter()
-                .all(|required| capabilities.credentials().contains(required));
+            .all(|required| capabilities.credentials().contains(required));
         if !supports_required {
             return Err(EngineError::Other(
                 "invalid current-profile resulting state: member lacks a required MLS capability"

--- a/crates/cgka-engine/src/capabilities.rs
+++ b/crates/cgka-engine/src/capabilities.rs
@@ -16,9 +16,13 @@ use openmls::extensions::RequiredCapabilitiesExtension;
 use openmls::prelude::{Capabilities, ExtensionType, ProposalType};
 use openmls_traits::types::Ciphersuite;
 
+// RFC 9420 section 7.2. These types are implicitly supported, never advertised.
+pub(crate) const DEFAULT_MLS_EXTENSION_TYPES: std::ops::RangeInclusive<u16> = 1..=5;
+pub(crate) const DEFAULT_MLS_PROPOSAL_TYPES: std::ops::RangeInclusive<u16> = 1..=7;
+
 /// Derive the per-leaf `Capabilities` this client advertises. Includes every
-/// feature in the registry regardless of level — that's what "I support this"
-/// means at the leaf.
+/// non-default MLS capability in the registry regardless of requirement level;
+/// default MLS capabilities are implicitly supported and must be omitted.
 ///
 /// Runtime support deliberately remains broader than the profile emitted for
 /// new KeyPackages: create/invite gates require candidates to match the target
@@ -45,6 +49,9 @@ pub(crate) fn leaf_capabilities(
             CTCapability::AppComponent(_) => {}
         }
     }
+    // Registry entries must not reintroduce default types into signed leaves.
+    ext_types.retain(|t| !DEFAULT_MLS_EXTENSION_TYPES.contains(&u16::from(*t)));
+    proposal_types.retain(|t| !DEFAULT_MLS_PROPOSAL_TYPES.contains(&u16::from(*t)));
     ext_types.sort();
     ext_types.dedup();
     proposal_types.sort();
@@ -145,25 +152,40 @@ pub(crate) fn extension_from_group_capabilities(
     RequiredCapabilitiesExtension::new(&ext_types, &proposal_types, &[])
 }
 
-/// Read a KeyPackage's advertised capabilities into a Marmot
-/// [`GroupCapabilities`]. Used by `constructable_capabilities` and by the
+/// Read a KeyPackage's supported capabilities, including implicit MLS defaults,
+/// into Marmot [`GroupCapabilities`]. Used by `constructable_capabilities` and by the
 /// invite-validation path.
 pub(crate) fn capabilities_of_key_package(kp: &openmls::prelude::KeyPackage) -> GroupCapabilities {
     capabilities_of_leaf(kp.leaf_node())
 }
 
-/// Read a LeafNode's advertised capabilities for constructability checks and
+/// Read a LeafNode's supported capabilities for constructability checks and
 /// cache-on-ingest updates.
 pub(crate) fn capabilities_of_leaf(leaf: &openmls::prelude::LeafNode) -> GroupCapabilities {
-    let mut out = group_capabilities_from_caps(leaf.capabilities());
+    with_implicit_default_capabilities(advertised_capabilities_of_leaf(leaf))
+}
+
+/// Read only the signed advertisements for publication metadata. Implicit MLS
+/// support must never be added to these wire-facing lists.
+pub(crate) fn advertised_capabilities_of_leaf(
+    leaf: &openmls::prelude::LeafNode,
+) -> GroupCapabilities {
+    let mut out = advertised_capabilities_from_caps(leaf.capabilities());
     out.app_components = crate::app_components::app_components_of_leaf(leaf)
         .unwrap_or_else(|_| AppComponentSet::default());
     out
 }
 
+/// Expand an internal support set without changing any wire advertisements.
+pub(crate) fn with_implicit_default_capabilities(mut caps: GroupCapabilities) -> GroupCapabilities {
+    caps.extensions.extend(DEFAULT_MLS_EXTENSION_TYPES);
+    caps.proposals.extend(DEFAULT_MLS_PROPOSAL_TYPES);
+    caps
+}
+
 /// Convert OpenMLS [`Capabilities`] into Marmot [`GroupCapabilities`]
 /// (extensions + proposals only; app components are carried separately).
-fn group_capabilities_from_caps(caps: &Capabilities) -> GroupCapabilities {
+fn advertised_capabilities_from_caps(caps: &Capabilities) -> GroupCapabilities {
     let mut out = GroupCapabilities::default();
     for ext in caps.extensions() {
         if !ext.is_grease() {
@@ -176,10 +198,10 @@ fn group_capabilities_from_caps(caps: &Capabilities) -> GroupCapabilities {
     out
 }
 
-/// The full set of capabilities this client supports at runtime: the MLS
-/// extensions/proposals it advertises (derived from the feature registry, same
-/// as [`leaf_capabilities`]) plus the app components it supports. Used by the
-/// join path to reject a Welcome whose group requires capabilities this client
+/// The full set of capabilities this client supports at runtime:
+/// implicit MLS defaults, extensions/proposals it advertises (derived from the
+/// feature registry, same as [`leaf_capabilities`]), and supported app components.
+/// Used by the join path to reject a Welcome whose group requires capabilities this client
 /// cannot apply (joining.md:65, convergence.md:19), independent of what the
 /// consumed KeyPackage's leaf happened to advertise.
 pub(crate) fn self_supported_capabilities(
@@ -190,7 +212,7 @@ pub(crate) fn self_supported_capabilities(
     // Runtime support is deliberately broader than the profile emitted by a
     // fresh KeyPackage: one upgraded engine must continue operating existing
     // legacy groups while producing current-profile state for new groups.
-    let mut out = group_capabilities_from_caps(&leaf_capabilities(
+    let mut out = advertised_capabilities_from_caps(&leaf_capabilities(
         registry,
         ciphersuite,
         ProtocolProfile::Legacy,
@@ -198,5 +220,5 @@ pub(crate) fn self_supported_capabilities(
     out.app_components = supported_app_components.clone();
     out.app_components
         .insert(cgka_traits::app_components::ACCOUNT_IDENTITY_PROOF_COMPONENT_ID);
-    out
+    with_implicit_default_capabilities(out)
 }

--- a/crates/cgka-engine/src/capabilities.rs
+++ b/crates/cgka-engine/src/capabilities.rs
@@ -29,10 +29,10 @@ pub(crate) fn leaf_capabilities(
     ciphersuite: Ciphersuite,
     protocol_profile: ProtocolProfile,
 ) -> Capabilities {
-    let mut ext_types: Vec<ExtensionType> = vec![
-        ExtensionType::RequiredCapabilities,
-        ExtensionType::AppDataDictionary,
-    ];
+    // RFC 9420 section 7.2 forbids advertising default extension types such
+    // as RequiredCapabilities. Their support is implicit; the GroupContext
+    // still carries its RequiredCapabilities extension as usual.
+    let mut ext_types: Vec<ExtensionType> = vec![ExtensionType::AppDataDictionary];
     if protocol_profile == ProtocolProfile::Legacy {
         ext_types.push(crate::account_identity_proof::account_identity_proof_capability());
     }

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -1606,7 +1606,8 @@ fn leaf_capabilities_as_marmot(
     supported_app_components: &cgka_traits::app_components::AppComponentSet,
     protocol_profile: ProtocolProfile,
 ) -> GroupCapabilities {
-    let mut out = GroupCapabilities::default();
+    let mut out =
+        crate::capabilities::with_implicit_default_capabilities(GroupCapabilities::default());
     for (_f, req) in registry.iter() {
         out.insert(req.requires);
     }

--- a/crates/cgka-engine/src/key_package.rs
+++ b/crates/cgka-engine/src/key_package.rs
@@ -128,7 +128,8 @@ pub fn key_package_metadata(kp: &KeyPackage) -> Result<KeyPackageMetadata, Engin
         key_package.ciphersuite(),
     )?;
     ensure_key_package_profile(kp, protocol_profile)?;
-    let capabilities = crate::capabilities::capabilities_of_key_package(&key_package);
+    let capabilities =
+        crate::capabilities::advertised_capabilities_of_leaf(key_package.leaf_node());
     let key_package_ref = key_package
         .hash_ref(&crypto)
         .map_err(|e| EngineError::Backend(format!("key_package ref: {e:?}")))?;

--- a/crates/cgka-engine/tests/group_creation.rs
+++ b/crates/cgka-engine/tests/group_creation.rs
@@ -2412,6 +2412,103 @@ async fn create_group_rejects_relabelled_legacy_key_package_profile() {
 }
 
 #[tokio::test]
+async fn fresh_key_packages_omit_default_mls_capabilities() {
+    for profile in [ProtocolProfile::Current, ProtocolProfile::Legacy] {
+        let mut alice = build_profile_client_on_storage(
+            b"alice",
+            SqliteAccountStorage::in_memory().unwrap(),
+            profile,
+        );
+        let kp = alice.fresh_key_package().await.unwrap();
+        let message = MlsMessageIn::tls_deserialize_exact(kp.bytes()).unwrap();
+        let key_package = match message.extract() {
+            MlsMessageBodyIn::KeyPackage(key_package) => key_package,
+            other => panic!("expected KeyPackage, got {other:?}"),
+        }
+        .validate(
+            &openmls_rust_crypto::RustCrypto::default(),
+            ProtocolVersion::Mls10,
+        )
+        .unwrap();
+        assert_non_default_mls_capabilities(key_package.leaf_node().capabilities());
+        assert_eq!(
+            key_package
+                .leaf_node()
+                .capabilities()
+                .extensions()
+                .contains(&ExtensionType::from(ACCOUNT_IDENTITY_PROOF_EXTENSION_TYPE)),
+            profile == ProtocolProfile::Legacy,
+        );
+    }
+}
+
+#[tokio::test]
+async fn founding_leaves_omit_default_mls_capabilities() {
+    for profile in [ProtocolProfile::Current, ProtocolProfile::Legacy] {
+        let storage = SqliteAccountStorage::in_memory().unwrap();
+        let mut alice = build_profile_client_on_storage(b"alice", storage.clone(), profile);
+        let (group_id, _) = alice
+            .create_group(CreateGroupRequest {
+                name: "capability advertisement".into(),
+                description: String::new(),
+                members: vec![],
+                required_features: vec![],
+                app_components: vec![],
+                initial_admins: vec![],
+            })
+            .await
+            .unwrap();
+        let group = openmls::group::MlsGroup::load(
+            storage.mls_storage(),
+            &openmls::group::GroupId::from_slice(group_id.as_slice()),
+        )
+        .unwrap()
+        .unwrap();
+        assert_non_default_mls_capabilities(group.own_leaf_node().unwrap().capabilities());
+        // RequiredCapabilities remains a valid GroupContext extension even
+        // though its default type must not be advertised in LeafNode capabilities.
+        let required = group.extensions().required_capabilities().unwrap();
+        assert!(
+            required
+                .extension_types()
+                .contains(&ExtensionType::AppDataDictionary)
+        );
+        assert!(
+            required
+                .proposal_types()
+                .contains(&openmls::prelude::ProposalType::AppDataUpdate)
+        );
+    }
+}
+
+fn assert_non_default_mls_capabilities(capabilities: &Capabilities) {
+    // RFC 9420 section 7.2: default extension ids 1..=5 and proposal ids
+    // 1..=7 MUST NOT appear in the signed LeafNode capability lists.
+    for extension in capabilities.extensions() {
+        assert!(
+            !(1..=5).contains(&u16::from(*extension)),
+            "default extension {extension:?}"
+        );
+    }
+    for proposal in capabilities.proposals() {
+        assert!(
+            !(1..=7).contains(&u16::from(*proposal)),
+            "default proposal {proposal:?}"
+        );
+    }
+    assert!(
+        capabilities
+            .extensions()
+            .contains(&ExtensionType::AppDataDictionary)
+    );
+    assert!(
+        capabilities
+            .proposals()
+            .contains(&openmls::prelude::ProposalType::AppDataUpdate)
+    );
+}
+
+#[tokio::test]
 async fn fresh_key_package_uses_draft10_last_resort_component() {
     let mut alice = build_client(b"a", selfremove_registry());
     let kp = alice.fresh_key_package().await.unwrap();

--- a/crates/cgka-engine/tests/group_creation.rs
+++ b/crates/cgka-engine/tests/group_creation.rs
@@ -2443,6 +2443,185 @@ async fn fresh_key_packages_omit_default_mls_capabilities() {
 }
 
 #[tokio::test]
+async fn registry_defaults_are_implicit_for_key_packages_and_group_membership() {
+    for profile in [ProtocolProfile::Current, ProtocolProfile::Legacy] {
+        let mut registry = FeatureRegistry::new();
+        for (index, name) in [
+            "application-id",
+            "ratchet-tree",
+            "required-capabilities",
+            "external-pub",
+            "external-senders",
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            registry.register(
+                Feature(name),
+                CapabilityRequirement {
+                    requires: Capability::Extension(index as u16 + 1),
+                    level: RequirementLevel::Required,
+                    description: "implicit MLS extension support",
+                },
+            );
+        }
+        for (index, name) in [
+            "add",
+            "update",
+            "remove",
+            "psk",
+            "reinit",
+            "external-init",
+            "group-context-extensions",
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            registry.register(
+                Feature(name),
+                CapabilityRequirement {
+                    requires: Capability::Proposal(index as u16 + 1),
+                    level: RequirementLevel::Required,
+                    description: "implicit MLS proposal support",
+                },
+            );
+        }
+        for (name, capability) in [
+            ("custom-extension", Capability::Extension(0xff01)),
+            ("custom-proposal", Capability::Proposal(0xff02)),
+        ] {
+            registry.register(
+                Feature(name),
+                CapabilityRequirement {
+                    requires: capability,
+                    level: RequirementLevel::Optional,
+                    description: "non-default advertisement control",
+                },
+            );
+        }
+        let storage = SqliteAccountStorage::in_memory().unwrap();
+        let builder = EngineBuilder::new(storage.clone())
+            .identity(pad32(b"alice"))
+            .account_identity_proof_signer(proof_signer(b"alice"))
+            .protocol_profile(profile)
+            .feature_registry(registry)
+            .peeler(Box::new(MockPeeler::default()));
+        let builder = if profile == ProtocolProfile::Legacy {
+            builder.legacy_compatibility_profile()
+        } else {
+            builder
+        };
+        let mut alice = builder.build().unwrap();
+        let kp = alice.fresh_key_package().await.unwrap();
+        let metadata = key_package_metadata(&kp).unwrap();
+        assert!(
+            metadata
+                .mls_extensions
+                .iter()
+                .all(|id| !(1..=5).contains(id))
+        );
+        assert!(
+            metadata
+                .mls_proposals
+                .iter()
+                .all(|id| !(1..=7).contains(id))
+        );
+        assert!(metadata.mls_extensions.contains(&0xff01));
+        assert!(metadata.mls_proposals.contains(&0xff02));
+        let message = MlsMessageIn::tls_deserialize_exact(kp.bytes()).unwrap();
+        let MlsMessageBodyIn::KeyPackage(kp) = message.extract() else {
+            panic!("expected KeyPackage")
+        };
+        let kp = kp
+            .validate(
+                &openmls_rust_crypto::RustCrypto::default(),
+                ProtocolVersion::Mls10,
+            )
+            .unwrap();
+        assert_non_default_mls_capabilities(kp.leaf_node().capabilities());
+
+        // Peers have no registry entries for defaults and do not advertise
+        // them, but must be accepted when GroupContext explicitly requires them.
+        let mut bob = build_profile_client_on_storage(
+            b"bob",
+            SqliteAccountStorage::in_memory().unwrap(),
+            profile,
+        );
+        let bob_kp = bob.fresh_key_package().await.unwrap();
+        let constructable = alice
+            .constructable_capabilities(std::slice::from_ref(&bob_kp))
+            .unwrap();
+        assert!((1..=5).all(|id| constructable.extensions.contains(&id)));
+        assert!((1..=7).all(|id| constructable.proposals.contains(&id)));
+        let (group_id, result) = alice
+            .create_group(CreateGroupRequest {
+                name: "explicit default requirements".into(),
+                description: String::new(),
+                members: vec![bob_kp],
+                required_features: vec![],
+                app_components: vec![],
+                initial_admins: vec![],
+            })
+            .await
+            .unwrap();
+        let welcomes = match result {
+            SendResult::FoundingGroupCreated { welcomes } => welcomes,
+            SendResult::GroupCreated { welcomes, pending } => {
+                alice.confirm_published(pending).await.unwrap();
+                welcomes
+            }
+            other => panic!("expected founding result, got {other:?}"),
+        };
+        bob.join_welcome(welcomes.into_iter().next().unwrap())
+            .await
+            .unwrap();
+        let group = openmls::group::MlsGroup::load(
+            storage.mls_storage(),
+            &openmls::group::GroupId::from_slice(group_id.as_slice()),
+        )
+        .unwrap()
+        .unwrap();
+        assert_non_default_mls_capabilities(group.own_leaf_node().unwrap().capabilities());
+        let required = group.extensions().required_capabilities().unwrap();
+        assert!((1..=5).all(|id| {
+            required
+                .extension_types()
+                .contains(&ExtensionType::from(id))
+        }));
+        assert!((1..=7).all(|id| {
+            required
+                .proposal_types()
+                .contains(&openmls::prelude::ProposalType::from(id))
+        }));
+        let mut carol = build_profile_client_on_storage(
+            b"carol",
+            SqliteAccountStorage::in_memory().unwrap(),
+            profile,
+        );
+        let result = alice
+            .send(SendIntent::Invite {
+                group_id: group_id.clone(),
+                key_packages: vec![carol.fresh_key_package().await.unwrap()],
+                initial_admins: vec![],
+            })
+            .await
+            .unwrap();
+        let SendResult::GroupEvolution {
+            welcomes, pending, ..
+        } = result
+        else {
+            panic!("expected invite")
+        };
+        alice.confirm_published(pending).await.unwrap();
+        carol
+            .join_welcome(welcomes.into_iter().next().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(carol.members(&group_id).unwrap().len(), 3);
+    }
+}
+
+#[tokio::test]
 async fn founding_leaves_omit_default_mls_capabilities() {
     for profile in [ProtocolProfile::Current, ProtocolProfile::Legacy] {
         let storage = SqliteAccountStorage::in_memory().unwrap();
@@ -2465,6 +2644,15 @@ async fn founding_leaves_omit_default_mls_capabilities() {
         .unwrap()
         .unwrap();
         assert_non_default_mls_capabilities(group.own_leaf_node().unwrap().capabilities());
+        assert_eq!(
+            group
+                .own_leaf_node()
+                .unwrap()
+                .capabilities()
+                .extensions()
+                .contains(&ExtensionType::from(ACCOUNT_IDENTITY_PROOF_EXTENSION_TYPE)),
+            profile == ProtocolProfile::Legacy,
+        );
         // RequiredCapabilities remains a valid GroupContext extension even
         // though its default type must not be advertised in LeafNode capabilities.
         let required = group.extensions().required_capabilities().unwrap();


### PR DESCRIPTION
MDK-generated KeyPackages and founding group leaves advertised `required_capabilities` (`0x0003`), which RFC 9420 section 7.2 forbids in LeafNode capability lists. The shared builder now omits all default extension/proposal IDs, including defaults supplied through a custom feature registry.

Internal capability checks recognize implicit MLS support separately from signed advertisements. This keeps create, join, invite, and current-profile group validation compatible with groups that explicitly list default types in GroupContext `required_capabilities`. KeyPackage publication metadata continues to reflect the signed advertisements, so implicit defaults do not leak back into public tags. The actual GroupContext requirements remain intact.

Regression coverage checks current and legacy KeyPackages and stored founding leaves, preserves the legacy proof capability, and exercises a registry containing every default extension/proposal plus non-default controls. Conformant peers can create, join, and be invited into a group that explicitly requires the defaults.

Validation:

- Original wire-regression tests failed on `RequiredCapabilities` before the initial fix.
- `cargo nextest run -p cgka-engine --features test-policy-overrides` — 529 passed.
- `just fast-ci` — passed.

Deployment requires generating replacement KeyPackages: republishing an existing stored signed event preserves its original capabilities. This change also does not rewrite leaves already present in existing groups.
