### PR TITLE
fix(app): pin relay telemetry collector addresses

### DIFF
--- a/crates/marmot-app/AGENTS.md
+++ b/crates/marmot-app/AGENTS.md
@@ -121,7 +121,10 @@ App runtime bridge for the first real Marmot app surfaces.
   opt-in and off by default: `MarmotRelayPlane::telemetry_exporter` is the single construction gate, relay-identity
   resolution requires it, and export points carry only a `relay` label. Keep the OTLP wire encoding and HTTP push behind
   the `otlp-export` feature; keep the privacy-critical mapping (`build_export_batch`) and the opt-in gate in the default
-  build. See `docs/marmot-architecture/relay-observability.md`.
+  build. Keep per-attempt collector DNS validation and pinning in `relay_telemetry_export/host_safety.rs`: validate
+  every address, pin reqwest, disable redirects/proxies, and retain TLS verification. Only exact `localhost` or a
+  loopback IP literal is a local-test endpoint, and all its addresses must be loopback. See
+  `docs/marmot-architecture/relay-observability.md` and `overview/dial-safety.md`.
 
 ## Verification
 

--- a/crates/marmot-app/src/config.rs
+++ b/crates/marmot-app/src/config.rs
@@ -804,7 +804,7 @@ impl RelayTelemetryExportConfig {
             && self
                 .endpoint
                 .as_deref()
-                .is_some_and(endpoint_transport_allowed)
+                .is_some_and(|endpoint| parse_relay_telemetry_endpoint(endpoint).is_some())
             && self
                 .authorization_bearer_token
                 .as_deref()
@@ -814,6 +814,24 @@ impl RelayTelemetryExportConfig {
                 .as_ref()
                 .is_some_and(RelayTelemetryResource::has_required_attributes)
     }
+}
+
+/// Structural gate shared by exporter construction and each OTLP dial attempt.
+/// Keep the exact `localhost`/loopback-IP test contract; do not admit subdomains
+/// or grant loopback access because an ordinary hostname resolves there.
+pub(crate) fn parse_relay_telemetry_endpoint(endpoint: &str) -> Option<url::Url> {
+    let url = url::Url::parse(endpoint).ok()?;
+    let host = url.host()?;
+    if url.port_or_known_default()? == 0
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.fragment().is_some()
+        || !matches!(url.scheme(), "https" | "http")
+        || (url.scheme() == "http" && !host_is_loopback(host))
+    {
+        return None;
+    }
+    Some(url)
 }
 
 /// Accept `https` for any host; accept `http` only for a loopback host (a local
@@ -978,6 +996,27 @@ mod tests {
                 .with_runtime_config(runtime_config())
                 .export_allowed()
         );
+    }
+
+    #[test]
+    fn relay_telemetry_host_safety_rejects_invalid_structure() {
+        for endpoint in [
+            "https://user:password@collector.example/v1/metrics",
+            "https://user@collector.example/v1/metrics",
+            "https://collector.example/v1/metrics#fragment",
+            "https://collector.example:0/v1/metrics",
+            "https://collector.example:65536/v1/metrics",
+            "https:///",
+            "file:///v1/metrics",
+            "http://collector.example/v1/metrics",
+            "http://10.0.0.1/v1/metrics",
+            "http://dev.localhost/v1/metrics",
+        ] {
+            let mut config =
+                RelayTelemetryExportConfig::enabled(endpoint).with_runtime_config(runtime_config());
+            config.endpoint = Some(endpoint.to_owned());
+            assert!(!config.export_allowed(), "accepted invalid structure");
+        }
     }
 
     #[test]

--- a/crates/marmot-app/src/relay_telemetry_export.rs
+++ b/crates/marmot-app/src/relay_telemetry_export.rs
@@ -1746,8 +1746,11 @@ impl RelayTelemetryExporter {
 }
 
 #[cfg(feature = "otlp-export")]
+mod host_safety;
+
+#[cfg(feature = "otlp-export")]
 mod otlp {
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
     use opentelemetry_proto::tonic::common::v1::{
@@ -1762,6 +1765,7 @@ mod otlp {
 
     use crate::config::RelayTelemetryResource;
 
+    use super::host_safety::{self, REQUEST_TIMEOUT};
     use super::{ExportMetricValue, RelayExportError, RelayTelemetryExportBatch};
 
     const SCOPE_NAME: &str = "marmot.relay_telemetry";
@@ -1925,33 +1929,55 @@ mod otlp {
         authorization_bearer_token: &str,
         started_at: SystemTime,
     ) -> Result<(), RelayExportError> {
-        let request = to_request(
+        push_with_resolver(
             batch,
+            metrics_url,
             resource,
-            unix_nano(started_at),
-            unix_nano(SystemTime::now()),
-        );
-        let body = request.encode_to_vec();
-        // Bound both connect and overall request time so a stuck collector
-        // cannot hang an export indefinitely (both stay well under the default
-        // poll interval).
-        let client = reqwest::Client::builder()
-            .connect_timeout(Duration::from_secs(10))
-            .timeout(Duration::from_secs(30))
-            .build()
-            .map_err(|_| RelayExportError::Request)?;
-        let response = client
-            .post(metrics_url)
-            .header("content-type", "application/x-protobuf")
-            .bearer_auth(authorization_bearer_token)
-            .body(body)
-            .send()
-            .await
-            .map_err(|_| RelayExportError::Request)?;
-        if !response.status().is_success() {
-            return Err(RelayExportError::Status(response.status().as_u16()));
-        }
-        Ok(())
+            authorization_bearer_token,
+            started_at,
+            host_safety::system_resolve,
+        )
+        .await
+    }
+
+    async fn push_with_resolver<F, Fut>(
+        batch: &RelayTelemetryExportBatch,
+        metrics_url: &str,
+        resource: &RelayTelemetryResource,
+        authorization_bearer_token: &str,
+        started_at: SystemTime,
+        resolver: F,
+    ) -> Result<(), RelayExportError>
+    where
+        F: FnOnce(String, u16) -> Fut,
+        Fut: std::future::Future<Output = std::io::Result<Vec<std::net::IpAddr>>>,
+    {
+        // Include our explicit DNS lookup in the overall attempt deadline.
+        tokio::time::timeout(REQUEST_TIMEOUT, async {
+            let pin = host_safety::resolve_with(metrics_url, resolver).await?;
+            let client = pin.build_client()?;
+            let request = to_request(
+                batch,
+                resource,
+                unix_nano(started_at),
+                unix_nano(SystemTime::now()),
+            );
+            let body = request.encode_to_vec();
+            let response = client
+                .post(pin.url)
+                .header("content-type", "application/x-protobuf")
+                .bearer_auth(authorization_bearer_token)
+                .body(body)
+                .send()
+                .await
+                .map_err(|_| RelayExportError::Request)?;
+            if !response.status().is_success() {
+                return Err(RelayExportError::Status(response.status().as_u16()));
+            }
+            Ok(())
+        })
+        .await
+        .map_err(|_| RelayExportError::Request)?
     }
 
     #[cfg(test)]
@@ -1963,6 +1989,93 @@ mod otlp {
             ExportHistogram, ExportMetricPoint, ExportMetricValue, RelayTelemetryExportBatch,
             metric_names,
         };
+
+        fn test_resource() -> RelayTelemetryResource {
+            RelayTelemetryResource {
+                service_version: "1.0".into(),
+                service_instance_id: "test-instance".into(),
+                deployment_environment: "test".into(),
+                tenant: "test-tenant".into(),
+                os_type: "test-os".into(),
+                os_version: "1.0".into(),
+                device_model_identifier: None,
+            }
+        }
+
+        #[tokio::test]
+        async fn relay_telemetry_host_safety_rejects_before_any_connection() {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            for endpoint in [
+                format!(
+                    "https://public.example:{}/private?secret=query",
+                    addr.port()
+                ),
+                format!("http://public.example:{}/private?secret=query", addr.port()),
+                format!("http://user:password@localhost:{}/", addr.port()),
+                format!("http://localhost:{}/#fragment", addr.port()),
+            ] {
+                let result = push_with_resolver(
+                    &RelayTelemetryExportBatch::default(),
+                    &endpoint,
+                    &test_resource(),
+                    "bearer-secret",
+                    SystemTime::now(),
+                    |_, _| async { Ok(vec![addr.ip()]) },
+                )
+                .await;
+                let error = result.unwrap_err();
+                assert_eq!(format!("{error:?}"), "Request");
+                assert_eq!(
+                    error.to_string(),
+                    "relay telemetry export request failed to send"
+                );
+            }
+            assert!(
+                tokio::time::timeout(std::time::Duration::from_millis(100), listener.accept())
+                    .await
+                    .is_err(),
+                "unsafe or malformed destination received a connection"
+            );
+        }
+
+        #[tokio::test]
+        async fn relay_telemetry_host_safety_incomplete_config_never_resolves_or_sends() {
+            use crate::config::RelayTelemetryExportConfig;
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let complete = RelayTelemetryExportConfig {
+                enabled: true,
+                endpoint: Some(format!(
+                    "http://localhost:{}/metrics",
+                    listener.local_addr().unwrap().port()
+                )),
+                authorization_bearer_token: Some("bearer-secret".into()),
+                resource: Some(test_resource()),
+                ..Default::default()
+            };
+            let plane = crate::MarmotRelayPlane::full_history();
+            assert!(plane.telemetry_exporter(complete.clone()).is_some());
+            for case in 0..7 {
+                let mut config = complete.clone();
+                match case {
+                    0 => config.enabled = false,
+                    1 => config.endpoint = None,
+                    2 => config.authorization_bearer_token = None,
+                    3 => config.authorization_bearer_token = Some(" ".into()),
+                    4 => config.resource = None,
+                    5 => config.resource.as_mut().unwrap().tenant.clear(),
+                    _ => config.endpoint = Some("https://user:password@localhost/".into()),
+                }
+                // Construction is the only entrance to export; no exporter
+                // exists on these paths to invoke a DNS resolver or HTTP push.
+                assert!(plane.telemetry_exporter(config).is_none());
+            }
+            assert!(
+                tokio::time::timeout(std::time::Duration::from_millis(100), listener.accept())
+                    .await
+                    .is_err()
+            );
+        }
 
         #[test]
         fn to_request_maps_points_to_otlp_metrics() {

--- a/crates/marmot-app/src/relay_telemetry_export/host_safety.rs
+++ b/crates/marmot-app/src/relay_telemetry_export/host_safety.rs
@@ -1,0 +1,102 @@
+//! Per-attempt collector resolution and pinning. No DNS cache or connection
+//! pool survives an export attempt; retries must clear the same gate again.
+
+use std::{
+    future::Future,
+    net::{IpAddr, SocketAddr},
+    time::Duration,
+};
+
+use cgka_traits::app_components::{is_loopback_ip, reject_non_public_ip};
+use url::{Host, Url};
+
+use super::RelayExportError;
+use crate::config::{endpoint_host_is_loopback, parse_relay_telemetry_endpoint};
+
+pub(super) const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+pub(super) const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+// Deliberately no Debug: the configured URL and DNS answers are private.
+pub(super) struct PinnedCollector {
+    pub(super) url: Url,
+    addrs: Vec<SocketAddr>,
+}
+
+impl PinnedCollector {
+    pub(super) fn build_client(&self) -> Result<reqwest::Client, RelayExportError> {
+        self.build_client_from(reqwest::Client::builder())
+    }
+
+    fn build_client_from(
+        &self,
+        builder: reqwest::ClientBuilder,
+    ) -> Result<reqwest::Client, RelayExportError> {
+        builder
+            // Proxies can resolve the original hostname themselves, bypassing
+            // the validated addresses. This exporter always dials directly.
+            .no_proxy()
+            .redirect(reqwest::redirect::Policy::none())
+            .connect_timeout(CONNECT_TIMEOUT)
+            .timeout(REQUEST_TIMEOUT)
+            .resolve_to_addrs(
+                self.url.host_str().ok_or(RelayExportError::Request)?,
+                &self.addrs,
+            )
+            // Keep the original URL for TLS trust/SNI and the HTTP Host header.
+            // Literal IP URLs dial that already-validated IP without DNS.
+            .build()
+            .map_err(|_| RelayExportError::Request)
+    }
+}
+
+pub(super) async fn system_resolve(host: String, port: u16) -> std::io::Result<Vec<IpAddr>> {
+    tokio::net::lookup_host((host.as_str(), port))
+        .await
+        .map(|addrs| addrs.map(|addr| addr.ip()).collect())
+}
+
+pub(super) async fn resolve_with<F, Fut>(
+    endpoint: &str,
+    resolver: F,
+) -> Result<PinnedCollector, RelayExportError>
+where
+    F: FnOnce(String, u16) -> Fut,
+    Fut: Future<Output = std::io::Result<Vec<IpAddr>>>,
+{
+    let url = parse_relay_telemetry_endpoint(endpoint).ok_or(RelayExportError::Request)?;
+    let port = url
+        .port_or_known_default()
+        .ok_or(RelayExportError::Request)?;
+    let loopback_test = endpoint_host_is_loopback(url.as_str());
+    let ips = match url.host().ok_or(RelayExportError::Request)? {
+        Host::Domain(host) => {
+            tokio::time::timeout(CONNECT_TIMEOUT, resolver(host.to_owned(), port))
+                .await
+                .map_err(|_| RelayExportError::Request)?
+                .map_err(|_| RelayExportError::Request)?
+        }
+        Host::Ipv4(ip) => vec![IpAddr::V4(ip)],
+        Host::Ipv6(ip) => vec![IpAddr::V6(ip)],
+    };
+    if ips.is_empty() {
+        return Err(RelayExportError::Request);
+    }
+    for ip in &ips {
+        // The test endpoint must stay on this device. In particular, HTTP
+        // localhost resolving to a public IP must never send plaintext auth.
+        if loopback_test && !is_loopback_ip(*ip) {
+            return Err(RelayExportError::Request);
+        }
+        reject_non_public_ip(*ip, loopback_test).map_err(|_| RelayExportError::Request)?;
+    }
+    Ok(PinnedCollector {
+        url,
+        addrs: ips
+            .into_iter()
+            .map(|ip| SocketAddr::new(ip, port))
+            .collect(),
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/marmot-app/src/relay_telemetry_export/host_safety/tests.rs
+++ b/crates/marmot-app/src/relay_telemetry_export/host_safety/tests.rs
@@ -1,0 +1,309 @@
+use super::*;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
+
+async fn resolve(endpoint: &str, ips: &[&str]) -> Result<PinnedCollector, RelayExportError> {
+    let ips = ips.iter().map(|ip| ip.parse().unwrap()).collect();
+    resolve_with(endpoint, |_, _| async { Ok(ips) }).await
+}
+
+#[tokio::test]
+async fn public_https_addresses_are_accepted_and_keep_hostname_port_path_query() {
+    let pin = resolve(
+        "https://collector.example:8443/custom/metrics?tenant=one%2Ftwo",
+        &["8.8.8.8", "2606:4700:4700::1111"],
+    )
+    .await
+    .unwrap();
+    assert_eq!(pin.url.host_str(), Some("collector.example"));
+    assert_eq!(pin.url.path(), "/custom/metrics");
+    assert_eq!(pin.url.query(), Some("tenant=one%2Ftwo"));
+    assert_eq!(
+        pin.addrs,
+        vec![
+            "8.8.8.8:8443".parse().unwrap(),
+            "[2606:4700:4700::1111]:8443".parse().unwrap()
+        ]
+    );
+}
+
+#[tokio::test]
+async fn unsafe_or_mixed_dns_rejects_every_attempt() {
+    for ip in [
+        "127.0.0.1",
+        "10.0.0.1",
+        "172.16.0.1",
+        "192.168.0.1",
+        "169.254.169.254",
+        "169.254.1.2",
+        "100.64.0.1",
+        "0.0.0.0",
+        "224.0.0.1",
+        "240.0.0.1",
+        "192.0.2.1",
+        "198.18.0.1",
+        "::1",
+        "::",
+        "fc00::1",
+        "fe80::1",
+        "ff02::1",
+        "::ffff:127.0.0.1",
+        "::ffff:10.0.0.1",
+        "2001::1",
+        "2001:2::1",
+        "2002:0808:0808::1",
+        "2001:db8::1",
+        "3fff::1",
+        "64:ff9b::808:808",
+    ] {
+        assert!(
+            resolve("https://collector.example/v1/metrics", &[ip])
+                .await
+                .is_err(),
+            "accepted {ip}"
+        );
+        // Both orders: a safe first result must not short-circuit validation.
+        for ips in [["8.8.8.8", ip], [ip, "8.8.8.8"]] {
+            assert!(
+                resolve("https://collector.example/v1/metrics", &ips)
+                    .await
+                    .is_err()
+            );
+        }
+    }
+    // The canonical classifier accepts mapped public IPv4; do not invent a
+    // different IPv6 policy in this exporter.
+    assert!(
+        resolve("https://collector.example", &["::ffff:8.8.8.8"])
+            .await
+            .is_ok()
+    );
+}
+
+#[tokio::test]
+async fn literal_ips_use_the_same_classifier_without_dns() {
+    for host in [
+        "8.8.8.8",
+        "[2606:4700:4700::1111]",
+        "[::ffff:8.8.8.8]",
+        "127.0.0.1",
+        "[::1]",
+    ] {
+        let pin = resolve_with(&format!("https://{host}/v1/metrics"), |_, _| async {
+            panic!("literal address must not use DNS");
+        })
+        .await
+        .unwrap();
+        assert_eq!(pin.addrs.len(), 1);
+        assert_eq!(pin.addrs[0].port(), 443);
+    }
+    for host in [
+        "10.0.0.1",
+        "169.254.169.254",
+        "100.64.0.1",
+        "[fc00::1]",
+        "[2002:0808:0808::1]",
+        "[::ffff:127.0.0.1]",
+    ] {
+        assert!(resolve(&format!("https://{host}/"), &[]).await.is_err());
+    }
+}
+
+#[tokio::test]
+async fn loopback_test_hosts_require_exclusively_loopback_resolution() {
+    for scheme in ["http", "https"] {
+        let endpoint = format!("{scheme}://localhost:4318/v1/metrics");
+        assert!(resolve(&endpoint, &["127.0.0.1", "::1"]).await.is_ok());
+        for ips in [
+            vec!["8.8.8.8"],
+            vec!["10.0.0.1"],
+            vec!["127.0.0.1", "8.8.8.8"],
+            vec!["::ffff:127.0.0.1"],
+        ] {
+            assert!(resolve(&endpoint, &ips).await.is_err());
+        }
+        for host in ["127.0.0.1", "[::1]"] {
+            assert!(
+                resolve(&format!("{scheme}://{host}:4318/"), &[])
+                    .await
+                    .is_ok()
+            );
+        }
+        assert!(
+            resolve(&format!("{scheme}://public.example/"), &["127.0.0.1"])
+                .await
+                .is_err()
+        );
+        assert!(
+            resolve(&format!("{scheme}://dev.localhost/"), &["127.0.0.1"])
+                .await
+                .is_err()
+        );
+    }
+}
+
+#[tokio::test]
+async fn invalid_structure_never_resolves() {
+    for endpoint in [
+        "http://public.example/",
+        "http://10.0.0.1/",
+        "http://[fc00::1]/",
+        "https://user:password@collector.example/",
+        "https://collector.example/#fragment",
+        "https://collector.example:0/",
+        "https://collector.example:65536/",
+        "https:///",
+        "ftp://collector.example/",
+    ] {
+        assert!(
+            resolve_with(endpoint, |_, _| async {
+                panic!("invalid URL reached DNS");
+            })
+            .await
+            .is_err()
+        );
+    }
+}
+
+#[tokio::test]
+async fn resolution_failures_are_privacy_safe() {
+    let endpoint = "https://sensitive.example/secret?token=secret-query";
+    let errors = [
+        resolve(endpoint, &[]).await.err().unwrap(),
+        resolve_with(endpoint, |_, _| async {
+            Err(std::io::Error::other(
+                "sensitive.example secret-query 127.0.0.1 bearer-secret",
+            ))
+        })
+        .await
+        .err()
+        .unwrap(),
+        resolve(endpoint, &["127.0.0.1"]).await.err().unwrap(),
+    ];
+    for error in errors {
+        assert_eq!(
+            error.to_string(),
+            "relay telemetry export request failed to send"
+        );
+        assert_eq!(format!("{error:?}"), "Request");
+        assert!(std::error::Error::source(&error).is_none());
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn resolution_is_deadline_bound() {
+    let start = tokio::time::Instant::now();
+    assert!(
+        resolve_with("https://collector.example/", |_, _| async {
+            std::future::pending().await
+        })
+        .await
+        .is_err()
+    );
+    assert_eq!(start.elapsed(), CONNECT_TIMEOUT);
+}
+
+#[tokio::test]
+async fn every_attempt_resolves_fresh_and_checks_host_and_port() {
+    let calls = AtomicUsize::new(0);
+    let resolver = |host: String, port| {
+        assert_eq!(host, "collector.example");
+        assert_eq!(port, 8443);
+        let call = calls.fetch_add(1, Ordering::SeqCst);
+        async move {
+            Ok(vec![
+                if call == 0 { "8.8.8.8" } else { "127.0.0.1" }
+                    .parse()
+                    .unwrap(),
+            ])
+        }
+    };
+    assert!(
+        resolve_with("https://collector.example:8443/", &resolver)
+            .await
+            .is_ok()
+    );
+    assert!(
+        resolve_with("https://collector.example:8443/", &resolver)
+            .await
+            .is_err()
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+}
+
+struct ForbiddenDns(Arc<AtomicUsize>);
+impl reqwest::dns::Resolve for ForbiddenDns {
+    fn resolve(&self, _: reqwest::dns::Name) -> reqwest::dns::Resolving {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async { Err(std::io::Error::other("second DNS lookup").into()) })
+    }
+}
+
+#[tokio::test]
+async fn reqwest_uses_only_pinned_addresses_and_ignores_proxies() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let proxy = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let pin = resolve(
+        &format!("http://localhost:{}/metrics?exact=one%2Ftwo", addr.port()),
+        &["127.0.0.1"],
+    )
+    .await
+    .unwrap();
+    let client = pin
+        .build_client_from(
+            reqwest::Client::builder()
+                .dns_resolver(Arc::new(ForbiddenDns(calls.clone())))
+                .proxy(
+                    reqwest::Proxy::all(format!("http://{}", proxy.local_addr().unwrap())).unwrap(),
+                ),
+        )
+        .unwrap();
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut bytes = Vec::new();
+        loop {
+            let mut buf = [0; 1024];
+            let n = stream.read(&mut buf).await.unwrap();
+            assert!(n > 0);
+            bytes.extend_from_slice(&buf[..n]);
+            if bytes.windows(4).any(|w| w == b"\r\n\r\n") {
+                break;
+            }
+        }
+        let headers = String::from_utf8(bytes).unwrap().to_lowercase();
+        assert!(headers.starts_with("post /metrics?exact=one%2ftwo http/1.1\r\n"));
+        assert!(headers.contains(&format!("host: localhost:{}\r\n", addr.port())));
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+            .await
+            .unwrap();
+    });
+    assert!(
+        client
+            .post(pin.url)
+            .send()
+            .await
+            .unwrap()
+            .status()
+            .is_success()
+    );
+    server.await.unwrap();
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "reqwest must not resolve again"
+    );
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), proxy.accept())
+            .await
+            .is_err()
+    );
+}

--- a/crates/marmot-app/tests/relay_telemetry_otlp.rs
+++ b/crates/marmot-app/tests/relay_telemetry_otlp.rs
@@ -25,6 +25,7 @@ struct CapturedRequest {
     authorization: Option<String>,
     content_type: Option<String>,
     body_len: usize,
+    body: Vec<u8>,
 }
 
 fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
@@ -90,6 +91,7 @@ async fn capture_one_request(listener: TcpListener, tx: oneshot::Sender<Captured
             authorization,
             content_type,
             body_len: content_length,
+            body: buf[header_end..header_end + content_length].to_vec(),
         });
         return;
     }
@@ -163,6 +165,7 @@ async fn read_request(stream: &mut tokio::net::TcpStream) -> Option<CapturedRequ
             authorization: header_value("authorization"),
             content_type: header_value("content-type"),
             body_len: content_length,
+            body: buf[header_end..header_end + content_length].to_vec(),
         });
     }
 }
@@ -201,40 +204,60 @@ fn runtime_config_without_endpoint() -> RelayTelemetryRuntimeConfig {
 
 #[tokio::test]
 async fn export_once_pushes_otlp_metrics_over_http() {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    let (tx, rx) = oneshot::channel();
-    let server = tokio::spawn(capture_one_request(listener, tx));
+    for host in ["127.0.0.1", "[::1]", "localhost"] {
+        let bind = if host == "[::1]" {
+            "[::1]:0"
+        } else {
+            "127.0.0.1:0"
+        };
+        let listener = TcpListener::bind(bind).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = oneshot::channel();
+        let server = tokio::spawn(capture_one_request(listener, tx));
 
-    let relay_plane = MarmotRelayPlane::full_history();
-    let endpoint = format!("http://{addr}/custom/v1/metrics");
-    let exporter = relay_plane
-        .telemetry_exporter(
-            RelayTelemetryExportConfig::enabled(endpoint.clone())
-                .with_runtime_config(runtime_config(endpoint)),
+        let relay_plane = MarmotRelayPlane::full_history();
+        let endpoint = format!(
+            "http://{host}:{}/custom/v1/metrics?tenant=one%2Ftwo",
+            addr.port()
+        );
+        let exporter = relay_plane
+            .telemetry_exporter(
+                RelayTelemetryExportConfig::enabled(endpoint.clone())
+                    .with_runtime_config(runtime_config(endpoint)),
+            )
+            .expect("opted-in exporter is constructed");
+
+        let count = exporter
+            .export_once(None)
+            .await
+            .expect("export push succeeds");
+        assert!(count > 0, "population metrics are always present");
+
+        let captured = tokio::time::timeout(Duration::from_secs(5), rx)
+            .await
+            .expect("server responded in time")
+            .expect("captured request");
+        assert_eq!(captured.method, "POST");
+        assert_eq!(captured.path, "/custom/v1/metrics?tenant=one%2Ftwo");
+        use prost::Message;
+        let decoded =
+        opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest::decode(
+            captured.body.as_slice(),
         )
-        .expect("opted-in exporter is constructed");
+        .unwrap();
+        assert_eq!(
+            decoded.resource_metrics[0].scope_metrics[0].metrics.len(),
+            count
+        );
+        assert_eq!(captured.authorization.as_deref(), Some("Bearer test-token"));
+        assert_eq!(
+            captured.content_type.as_deref(),
+            Some("application/x-protobuf")
+        );
+        assert!(captured.body_len > 0, "OTLP protobuf body is non-empty");
 
-    let count = exporter
-        .export_once(None)
-        .await
-        .expect("export push succeeds");
-    assert!(count > 0, "population metrics are always present");
-
-    let captured = tokio::time::timeout(Duration::from_secs(5), rx)
-        .await
-        .expect("server responded in time")
-        .expect("captured request");
-    assert_eq!(captured.method, "POST");
-    assert_eq!(captured.path, "/custom/v1/metrics");
-    assert_eq!(captured.authorization.as_deref(), Some("Bearer test-token"));
-    assert_eq!(
-        captured.content_type.as_deref(),
-        Some("application/x-protobuf")
-    );
-    assert!(captured.body_len > 0, "OTLP protobuf body is non-empty");
-
-    server.await.unwrap();
+        server.await.unwrap();
+    }
 }
 
 #[tokio::test]
@@ -403,4 +426,73 @@ async fn runtime_start_pushes_from_persisted_telemetry_settings() {
 
     runtime.shutdown().await;
     server.await.unwrap();
+}
+
+#[tokio::test]
+async fn relay_telemetry_host_safety_redirect_never_reaches_target() {
+    let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let source = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let endpoint = format!("http://{}/v1/metrics", source.local_addr().unwrap());
+    let location = format!("http://{}/stolen", target.local_addr().unwrap());
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = source.accept().await.unwrap();
+        let request = read_request(&mut stream).await.unwrap();
+        assert_eq!(request.authorization.as_deref(), Some("Bearer test-token"));
+        stream.write_all(format!(
+            "HTTP/1.1 307 Temporary Redirect\r\nLocation: {location}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        ).as_bytes()).await.unwrap();
+    });
+    // Respond if the vulnerable client follows, so the regression fails promptly.
+    let (tx, mut rx) = oneshot::channel();
+    let redirect_server = tokio::spawn(capture_one_request(target, tx));
+    let exporter = MarmotRelayPlane::full_history()
+        .telemetry_exporter(
+            RelayTelemetryExportConfig::enabled(endpoint.clone())
+                .with_runtime_config(runtime_config(endpoint)),
+        )
+        .unwrap();
+    let result = exporter.export_once(None).await;
+    server.await.unwrap();
+    let received = tokio::time::timeout(Duration::from_millis(150), &mut rx).await;
+    redirect_server.abort();
+    assert!(received.is_err(), "redirect target received a request");
+    assert!(matches!(
+        result,
+        Err(marmot_app::RelayExportError::Status(307))
+    ));
+}
+
+#[tokio::test]
+async fn relay_telemetry_host_safety_stalled_push_keeps_export_window_deadline() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let endpoint = format!("http://{}/v1/metrics", listener.local_addr().unwrap());
+    let (tx, rx) = oneshot::channel();
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let request = read_request(&mut stream).await.unwrap();
+        tx.send(request).ok();
+        // Keep the accepted socket alive without a response until the test
+        // aborts this server, forcing the export-window deadline to win.
+        std::future::pending::<()>().await;
+        drop(stream);
+    });
+    let exporter = MarmotRelayPlane::full_history()
+        .telemetry_exporter(
+            RelayTelemetryExportConfig::enabled(endpoint.clone())
+                .with_interval(Duration::from_millis(250))
+                .with_runtime_config(runtime_config(endpoint)),
+        )
+        .unwrap();
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        exporter.export_once_with_retries(None),
+    )
+    .await;
+    server.abort();
+    assert!(matches!(
+        result.unwrap(),
+        Err(marmot_app::RelayExportError::Request)
+    ));
+    let received = rx.await.unwrap();
+    assert_eq!(received.authorization.as_deref(), Some("Bearer test-token"));
 }

--- a/docs/marmot-architecture/overview/current-state.md
+++ b/docs/marmot-architecture/overview/current-state.md
@@ -190,7 +190,9 @@ reached durable local readiness. `Publishing` includes bounded in-session retry 
 local visibility via `wn relay-stats`, an opt-in index→identity resolution boundary, a relay-plane rollup, and an
 opt-in OTLP exporter (wire encoding behind the `marmot-app` `otlp-export` feature) — all aggregate, off by default, and
 carrying relay identity as the sole label. Wiring its periodic push into a long-running host against the production
-first-party endpoint remains ops work; see [`../relay-observability.md`](../relay-observability.md).
+first-party endpoint remains ops work; see [`../relay-observability.md`](../relay-observability.md). Each OTLP attempt
+now validates every resolved collector address and pins the client, with redirects and proxies disabled. The existing
+explicit loopback-test endpoint contract remains local-only; see [Dial Safety](dial-safety.md).
 - **Nostr account transport shape** — the likely production shape includes a Nostr user directory, account bootstrap for
   relay-list events, a shared multi-account relay plane, `marmot.transport.nostr.routing.v1` group routing, and explicit
   relay URL safety policy. This is captured as a working note in

--- a/docs/marmot-architecture/overview/dial-safety.md
+++ b/docs/marmot-architecture/overview/dial-safety.md
@@ -1,7 +1,7 @@
 ---
 title: "Dial Safety"
 created: 2026-07-04
-updated: 2026-07-22
+updated: 2026-09-06
 tags: [marmot, overview, security, network, ssrf, transport]
 status: overview
 ---
@@ -33,22 +33,37 @@ loopback / private / link-local / CGNAT / metadata endpoint is an SSRF vector, a
   set (`MarmotAppConfig::allow_loopback_relay_endpoints` / `allow_loopback_blob_endpoints`, `WN_ALLOW_LOOPBACK_RELAYS` /
   `WN_ALLOW_LOOPBACK_BLOB_ENDPOINTS`, `wn --insecure-local`, `wn-agent --insecure-local-broker`). The flag opens
   loopback only; private/link-local/CGNAT ranges stay rejected even in dev mode. Production leaves every flag unset.
+  Relay telemetry preserves its separate local-test contract: explicitly configuring `localhost` (exact name) or a
+  loopback IP literal permits a local collector, and every resolved address must then be loopback. No separate flag
+  is added to that existing opt-in exporter contract.
 - **Public Nostr relays require TLS.** Runtime relay connections use `wss://`. Plaintext `ws://` remains structurally
   valid signed routing data, but local policy admits it only for a literal loopback/`localhost` endpoint behind
   `allow_loopback_relay_endpoints`; the flag never admits public or private-network plaintext relays.
 - **A connect timeout on every dial.** A hung handshake to a black-holed target must not park indefinitely (media 5s,
-  Nostr relay 5s, QUIC broker 5s).
+  Nostr relay 5s, QUIC broker 5s, relay telemetry 10s with a 30s overall attempt deadline).
 
 ## The chokepoints
 
 | Transport | Where the discipline lives |
 | --- | --- |
 | Blossom media (reqwest, download + upload) | `crates/marmot-app/src/media/blossom.rs`: `media_http_client_for_url` → `validate_blossom_fetch_url` + `resolve_media_host` (per-address `reject_non_public_ip`, `resolve_to_addrs` pin, connect/read/total timeouts, per-redirect re-validation). |
+| Relay telemetry OTLP (reqwest, push) | `crates/marmot-app/src/relay_telemetry_export/host_safety.rs`: structural URL gate → resolve once per attempt → validate every address → `resolve_to_addrs` pin; redirects and proxies disabled, TLS trust/SNI from the configured URL, 10s connect and 30s overall attempt limits. |
 | Agent-stream broker watch (quinn) | `crates/marmot-app/src/runtime/agent_stream_watch.rs`: `resolve_broker_addr` validates + pins; `broker_trust_for_candidate` keys `InsecureLocal` on the literal candidate host + `insecure_local`. |
 | Agent-connector broker dial (quinn) | `crates/agent-connector/src/quic.rs`: `resolve_quic_candidate_addr` validates + pins; `broker_trust_for_candidate` gated on `AgentConnectorConfig::allow_insecure_local_broker` + literal loopback. |
 | CLI stream (quinn) | `crates/cli/src/commands/stream.rs`: `resolve_quic_candidate_addr` (`socket_addr_is_unsafe`), `broker_trust` / `ensure_insecure_local_endpoint`. |
 | Nostr relays (nostr-sdk) | `crates/marmot-app/src/relay_plane/safety.rs`: `RelaySafetyPolicy::sanitize_endpoints` → `reject_unsafe_relay_host`, the single funnel for activation, group sync, publish, and directory routes. |
 | QUIC broker client connect timeout | Shared QUIC-preview hardening (`connect_with_timeout` / `QUIC_PREVIEW_CONNECT_TIMEOUT`, #710), applied at both broker client connects in `crates/transport-quic-broker/src/client.rs`. |
+
+The OTLP exporter rejects missing hosts, unusable ports, credentials, fragments, and unsupported schemes before
+resolution. Public HTTPS names and literal IPs must pass the shared address classifier; a mixed safe/unsafe DNS answer
+or an empty result rejects the whole attempt. Only an explicitly configured exact `localhost` or loopback IP literal
+gets the local-test exception, for either HTTP or HTTPS, and it must resolve exclusively to loopback. HTTP never
+reaches a non-loopback address. TLS verification remains enabled even for local HTTPS collectors. The original path
+and query are retained; bearer auth is attached only after validation and pinning. Automatic redirects are disabled:
+3xx is a non-success status, with no request or bearer token sent to the redirect target. Each retry resolves afresh;
+there is no DNS cache or cross-attempt connection pool. Resolution itself has a 10s bound within the 30s attempt
+limit. Failures expose only the existing generic `Request` error or a numeric HTTP status, without endpoint, address,
+auth, or body material. System proxies are disabled because proxy-side DNS would bypass the pin.
 
 The broker TLS client (`crates/transport-quic-broker/src/tls.rs`) keeps a resolved-address backstop
 (`InsecureLocalRequiresLoopback`): even if a caller mis-selects `InsecureLocal`, a non-loopback resolved address is
@@ -63,7 +78,10 @@ routing through this discipline is a contract violation — the transport crates
 
 ## Accepted residual
 
-Nostr relays are the one path that cannot pin: nostr-sdk owns DNS resolution and the WebSocket, so a public-looking
+This table documents the listed chokepoints; it is not an assurance that every other reqwest client in the workspace
+has been audited or hardened.
+
+The Nostr relay path cannot pin: nostr-sdk owns DNS resolution and the WebSocket, so a public-looking
 `wss://` domain is accepted after scheme/format validation and only its literal-IP form (and `localhost`) can be
 classified before the SDK connects. A hostname that resolves to a private address at connect time is a TOCTOU
 residual, rated LOW. Public plaintext `ws://` is rejected before this residual is reachable. A resolve-time pre-check

--- a/docs/marmot-architecture/telemetry.md
+++ b/docs/marmot-architecture/telemetry.md
@@ -1,7 +1,7 @@
 ---
 title: "Telemetry, Logging, and Tracing Inventory"
 created: 2026-06-10
-updated: 2026-09-04
+updated: 2026-09-06
 tags: [marmot, architecture, telemetry, logging, tracing, privacy]
 status: current
 ---
@@ -392,13 +392,29 @@ be resolved. The gate requires all the following:
 
 - `enabled == true`;
 - an endpoint is configured;
-- the endpoint is `https`, or `http` to a loopback host (`localhost`, `127.0.0.1`, or `::1`) for local testing;
+- the endpoint has a host and a usable port, no embedded credentials or fragment, and uses `https`, or `http` to
+  exact `localhost` or a loopback IP literal for local testing;
 - `authorization_bearer_token` is present and non-empty;
 - `resource` is present and has all required attributes.
 
 If export is enabled but the URL/auth/resource gate is incomplete, construction fails closed and logs a warning without
 resolving relay identities or pushing metrics. If `marmot-app` is built without `otlp-export`, runtime configuration
 logs a warning when export is requested, but no exporter task is started.
+
+Before each OTLP request attempt (including retries), the exporter resolves the configured hostname once, validates
+**every** address with the shared host-safety classifier, and pins reqwest to those addresses. Mixed public/unsafe
+answers and empty/failed DNS results fail closed. Literal IPs use the same classifier without DNS. The explicit
+loopback-test endpoints must resolve exclusively to loopback, so even a misresolved HTTP `localhost` cannot send
+plaintext bearer auth off-device. Normal HTTPS names resolving to loopback are rejected. TLS certificate verification
+and SNI stay tied to the original URL; local HTTPS does not bypass verification.
+
+The exporter disables automatic redirects and system proxies, keeps the configured path/query, and attaches bearer
+auth only after the destination is validated and pinned. A 3xx response returns a numeric non-success status without
+contacting its target. Connect and overall attempt limits remain 10s and 30s; DNS has its own 10s bound inside the
+30s attempt. No DNS lease or connection pool survives to a retry. Validation, DNS, and transport failures map to the
+existing privacy-safe `RelayExportError::Request`; error display/debug contains no endpoint, address, token, or body.
+See [Dial Safety](./overview/dial-safety.md). This change does not alter collection, labels, consent, batching, retry
+scheduling, or the no-disk-queue contract, and does not add private-network collector support.
 
 Runtime behavior:
 


### PR DESCRIPTION
A public-looking HTTPS telemetry collector could resolve to a private or loopback address because the OTLP push used a bare reqwest client after only a scheme check. Automatic redirects could also escape the original collector. This closes that SSRF/DNS-rebinding gap without changing the telemetry payload or export schedule.

Each attempt now parses and structurally validates the URL, resolves its hostname once, validates every returned address with the canonical classifier, and pins reqwest with `resolve_to_addrs`. Literal IPv4/IPv6 hosts use the same policy without DNS. Empty answers, resolver failures, and any unsafe member of a mixed DNS answer reject the whole attempt. The original URL supplies TLS trust/SNI, Host, path, and query; certificate verification stays enabled.

The existing local-test contract is preserved: only exact `localhost` or a loopback IP literal admits HTTP. An explicitly configured loopback test collector (HTTP or HTTPS) must resolve exclusively to loopback. A normal HTTPS hostname resolving to loopback is rejected. This cannot send plaintext bearer credentials to a non-loopback address.

Redirects and proxies are disabled. A 3xx returns `Status(code)` without contacting the redirect target. Bearer auth is attached only after validation and pinning, so neither DNS rebinding, proxy-side DNS, nor a redirect can route it to an unvalidated target. Each retry resolves and validates afresh; no DNS cache or cross-attempt pool is introduced. Connect timeout remains 10 seconds and the overall attempt remains 30 seconds, now including explicit DNS resolution (itself bounded to 10 seconds).

URL, classifier, resolver, client, and transport errors map to the existing privacy-safe `Request` variant, with no source error, endpoint, hostname, address, query, token, relay identity, or body exposed. No public error variant was added.

Validation:

- TDD: structural-URL and redirect regressions both failed against the original implementation; the redirect target actually received a request. Both pass after the fix.
- `cargo test -p marmot-app --features otlp-export --lib host_safety`: **12 passed**. Covers public/mixed/unsafe IPv4 and IPv6 answers, shared mapped/transition-address behavior, literals, loopback-only resolution, empty/failed DNS, fresh attempts, DNS deadline, privacy-safe failures, inert construction, zero connections on rejection, and a live pin/proxy test with a forbidden fallback DNS resolver.
- `cargo test -p marmot-app --features otlp-export --test relay_telemetry_otlp`: **7 passed**. Exercises IPv4, IPv6, and localhost collectors, original path/query, decoded protobuf body, content type/auth, runtime opt-in, retries, stalled-request export-window deadline, and zero requests to a redirect target.
- `just fast-ci`: **passed**, including workspace default/OTLP checks and Clippy plus the policy-pin tests.
- Documentation stale-marker scan: **2 matches inspected**; the engine layering TODO still exists in source, and the other match is the scan command itself. `git diff --check`: **passed**.

The required full commands are **not green**:

| Command | Library result |
| --- | --- |
| `cargo test -p marmot-app` | 921 passed, 6 failed, 1 ignored |
| `cargo test -p marmot-app --features otlp-export` | 932 passed, 7 failed, 1 ignored |

Both stop at library failures, before the remaining integration/doc suites. All seven failure names and their assertion sites/messages reproduce on unmodified master `36835ece` (includes #1707), in a separate clean checkout using `cargo test -p marmot-app --lib -- --skip tests::thirty_incremental_invites_with_large_directory_cache_converge_without_false_success`: 918 passed, 7 failed, 1 ignored, 1 filtered out. The skipped large-directory test passed in both changed-tree runs. The pre-existing failures are:

- `account_reconcile_returns_local_readiness_before_relay_subscription_registration` (OTLP run and baseline; default changed-tree run passed)
- `deferred_primary_epoch_backfill_rotates_behind_queued_older_operation`
- `drains_that_never_confirmed_stored_history_are_not_evidence`
- `failed_epoch_backfill_activation_retains_one_correlated_retry` (also reproduced in isolation)
- `frozen_epoch_evidence_outlives_the_process_that_gathered_it`
- `in_flight_epoch_backfill_arm_preserves_both_operation_intents_on_failure`
- `three_fruitless_end_of_stored_events_replays_at_one_epoch_escalate`

Scope and limitations: collection, relay labels/k-anonymity, opt-in/resource/auth requirements, batching, retry scheduling, and no-disk-queue behavior are unchanged. No token/endpoint persistence, schema/migration/version changes, arbitrary private collectors, or Blossom/Nostr/host-safety ownership refactors. Collector ownership remains a host-configuration responsibility. Proxy-only environments cannot use this direct-dial exporter. Public HTTPS policy and preservation of normal TLS configuration are covered by code/unit checks; no production collector or end-to-end TLS certificate/SNI fixture was exercised. This is not an assurance about other reqwest paths.
