### PR TITLE
Fix offline replay liveness and bounded background recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,6 +428,8 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Run relay runtime tests serially
+        env:
+          RUST_BACKTRACE: "1"
         run: cargo test -p marmot-app --test relay_runtime --features test-policy-overrides --locked -- --test-threads=1
 
       - name: Run held peer-index upgrade lookup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,7 +543,11 @@ jobs:
     needs: changes
     if: needs.changes.outputs.run_conformance == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 65
+    env:
+      CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS: "false"
+      MDK_APP_JOURNEY_ARTIFACTS: ${{ github.workspace }}/target/public-app-catchup-evidence
+      MDK_BACKLOG_TRACE: "1"
 
     steps:
       - name: Check out repository
@@ -572,18 +576,30 @@ jobs:
           git rev-parse HEAD > target/public-app-catchup-evidence/source-commit.txt
           rustc --version > target/public-app-catchup-evidence/rust-version.txt
 
-      - name: Recover the full backlog through the public app
-        timeout-minutes: 35
-        env:
-          CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS: "false"
-          MDK_APP_JOURNEY_ARTIFACTS: ${{ github.workspace }}/target/public-app-catchup-evidence
-          MDK_BACKLOG_TRACE: "1"
+      - name: Build public recovery tests with production policy
+        id: build_catchup
+        timeout-minutes: 15
         # Keep this separate from workspace test-policy feature unification.
-        # Both journeys own a 900-second watchdog and close every runtime.
         run: >-
           cargo test --release --locked -p cgka-conformance-simulator
-          --test app_runtime_journeys public_app_1024_message_backlog
-          -- --ignored --test-threads=1 --nocapture
+          --test app_runtime_journeys --no-run
+
+      - name: Recover the original 1024-message backlog
+        if: ${{ !cancelled() && steps.build_catchup.outcome == 'success' }}
+        timeout-minutes: 20
+        # Each journey owns a 900-second watchdog and closes every runtime.
+        run: >-
+          cargo test --release --locked -p cgka-conformance-simulator
+          --test app_runtime_journeys public_app_1024_message_backlog_recovers_completely
+          -- --exact --ignored --test-threads=1 --nocapture
+
+      - name: Recover the 1024-message backlog with extra epochs
+        if: ${{ !cancelled() && steps.build_catchup.outcome == 'success' }}
+        timeout-minutes: 20
+        run: >-
+          cargo test --release --locked -p cgka-conformance-simulator
+          --test app_runtime_journeys public_app_1024_message_backlog_with_extra_epochs_recovers_completely
+          -- --exact --ignored --test-threads=1 --nocapture
 
       - name: Upload public recovery evidence
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,6 +575,7 @@ jobs:
         env:
           CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS: "false"
           MDK_APP_JOURNEY_ARTIFACTS: ${{ github.workspace }}/target/public-app-catchup-evidence
+          MDK_BACKLOG_TRACE: "1"
         # Keep this separate from workspace test-policy feature unification.
         # Both journeys own a 900-second watchdog and close every runtime.
         run: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -576,11 +576,11 @@ jobs:
           CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS: "false"
           MDK_APP_JOURNEY_ARTIFACTS: ${{ github.workspace }}/target/public-app-catchup-evidence
         # Keep this separate from workspace test-policy feature unification.
-        # The journey owns a 900-second watchdog and closes every runtime.
+        # Both journeys own a 900-second watchdog and close every runtime.
         run: >-
           cargo test --release --locked -p cgka-conformance-simulator
-          --test app_runtime_journeys public_app_1024_message_backlog_recovers_completely
-          -- --ignored --exact --test-threads=1 --nocapture
+          --test app_runtime_journeys public_app_1024_message_backlog
+          -- --ignored --test-threads=1 --nocapture
 
       - name: Upload public recovery evidence
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,6 +894,7 @@ dependencies = [
  "tls_codec",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "transport-nostr-peeler",
  "transport-quic-broker",
  "transport-quic-stream",

--- a/crates/cgka-conformance-simulator/APP_PATH_COVERAGE.md
+++ b/crates/cgka-conformance-simulator/APP_PATH_COVERAGE.md
@@ -23,8 +23,9 @@ This is a public workload companion to the pinned 1,024-message engine input. It
 order; this does **not** reproduce the engine fixture's forced reverse delivery. Initial group creation uses public
 app acknowledgement semantics. Private MLS assertions and simulated relay steps are not presented as app coverage.
 
-The reproduction allows 30 explicit full-history repairs, two seconds between passes, and up to three recipient
-reopens after six unchanged transitions. A 900-second watchdog bounds the whole journey. Success additionally checks
+The reproduction repeats explicit full-history repairs with two seconds between passes, allowing up to three recipient
+reopens after six unchanged transitions. A 900-second watchdog bounds the whole journey; there is no separate pass-count
+cutoff because production time-bounded slices guarantee no minimum message throughput per call. Success additionally checks
 every participant's exact payload multiset, then fresh bidirectional messaging and recipient restart persistence.
 These latter checks strengthen the earlier private diagnostic driver and run only after full recovery.
 

--- a/crates/cgka-conformance-simulator/APP_PATH_COVERAGE.md
+++ b/crates/cgka-conformance-simulator/APP_PATH_COVERAGE.md
@@ -34,6 +34,11 @@ uses the same conformance path classifier, and participates in **Required CI**. 
 expanded synthetic input and public observations, excluding participant databases and keys. It asserts successful
 recovery, not a particular failure count. A run that skips this job is not recovery evidence.
 
+Set `MDK_BACKLOG_TRACE=1` to include aggregate engine preparation, retry-slice and transport-release diagnostics
+on stderr. The required recovery job enables this to distinguish slow preparation with zero attempts from
+retry progress or resource release. These traces contain counts, durations and fixed outcome labels; participant
+databases and keys remain excluded from uploaded evidence.
+
 On September 6, the worker-responsiveness fix passed this unchanged recovery contract twice. Background engine
 advance now shares a 64-row allowance and a cooperative 500-ms budget across sweeps; historical peel contexts
 are materialized once per sweep and released afterward. All 1,024 original payloads recovered, all four participants

--- a/crates/cgka-conformance-simulator/APP_PATH_COVERAGE.md
+++ b/crates/cgka-conformance-simulator/APP_PATH_COVERAGE.md
@@ -30,15 +30,22 @@ every participant's exact payload multiset, then fresh bidirectional messaging a
 These latter checks strengthen the earlier private diagnostic driver and run only after full recovery.
 
 The test remains ignored in ordinary crate runs because it is slow. The dedicated **Public app 1024-message
-recovery** job in `.github/workflows/ci.yml` explicitly selects both journeys in release mode without test-policy overrides,
+recovery** job in `.github/workflows/ci.yml` builds once, then selects each journey with `--exact` in its own timed
+step, in release mode without test-policy overrides. The second runs even if the first fails. The job
 uses the same conformance path classifier, and participates in **Required CI**. It uploads source provenance,
 expanded synthetic input and public observations, excluding participant databases and keys. It asserts successful
 recovery, not a particular failure count. A run that skips this job is not recovery evidence.
 
 Set `MDK_BACKLOG_TRACE=1` to include aggregate engine preparation, retry-slice and transport-release diagnostics
 on stderr. The required recovery job enables this to distinguish slow preparation with zero attempts from
-retry progress or resource release. These traces contain counts, durations and fixed outcome labels; participant
+retry progress or resource release. Preparation and per-slice traces use debug level, enabled by this test flag,
+so idle sweeps do not add production INFO traffic. These traces contain counts, durations and fixed outcome labels; participant
 databases and keys remain excluded from uploaded evidence.
+
+Recovery artifacts have fixed filenames: `recovery-progress.json` retains compact counts and the last completed pass,
+and `recovery-checkpoint.json` retains the latest tenth-pass or successful full observation. `terminal.json` captures
+the final observation when available. Files are replaced rather than accumulated across passes. Watchdog failures
+include the active phase, current/last-completed pass, last observed counts and completed restart count.
 
 On September 6, the worker-responsiveness fix passed this unchanged recovery contract twice. Background engine
 advance now shares a 64-row allowance and a cooperative 500-ms budget across sweeps; historical peel contexts

--- a/crates/cgka-conformance-simulator/APP_PATH_COVERAGE.md
+++ b/crates/cgka-conformance-simulator/APP_PATH_COVERAGE.md
@@ -3,7 +3,11 @@
 ## Large offline catch-up regression
 
 `public_app_1024_message_backlog_recovers_completely` in
-[`tests/app_runtime_journeys.rs`](tests/app_runtime_journeys.rs) is the maintained public regression.
+[`tests/app_runtime_journeys.rs`](tests/app_runtime_journeys.rs) is the original maintained public regression.
+`public_app_1024_message_backlog_with_extra_epochs_recovers_completely` adds two public profile updates while
+the recipient is offline, before the same workload. This variant reproduced retry-budget release followed by
+blocked app redelivery in #1721; it requires the same complete recovery contract. Each run records its extra
+updates in `prelude.json`, alongside the unchanged expanded `backlog-input.json`.
 It requires all 1,024 original payloads exactly once, shared public group state, fresh messages from every member,
 and complete recipient history after restart. Reaching the repair budget is a failure, never success.
 
@@ -25,7 +29,7 @@ every participant's exact payload multiset, then fresh bidirectional messaging a
 These latter checks strengthen the earlier private diagnostic driver and run only after full recovery.
 
 The test remains ignored in ordinary crate runs because it is slow. The dedicated **Public app 1024-message
-recovery** job in `.github/workflows/ci.yml` explicitly selects it in release mode without test-policy overrides,
+recovery** job in `.github/workflows/ci.yml` explicitly selects both journeys in release mode without test-policy overrides,
 uses the same conformance path classifier, and participates in **Required CI**. It uploads source provenance,
 expanded synthetic input and public observations, excluding participant databases and keys. It asserts successful
 recovery, not a particular failure count. A run that skips this job is not recovery evidence.
@@ -126,7 +130,7 @@ Run the large regression explicitly:
 MDK_APP_JOURNEY_ARTIFACTS="$PWD/target/app-path-evidence" \
 CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=false \
 cargo test --release --locked -p cgka-conformance-simulator --test app_runtime_journeys \
-  public_app_1024_message_backlog_recovers_completely -- --ignored --exact --test-threads=1 --nocapture
+  public_app_1024_message_backlog -- --ignored --test-threads=1 --nocapture
 ```
 
 Release mode without policy-override features is the production-policy verification command. Workspace debug or

--- a/crates/cgka-conformance-simulator/APP_PATH_COVERAGE.md
+++ b/crates/cgka-conformance-simulator/APP_PATH_COVERAGE.md
@@ -249,15 +249,18 @@ The investigation separated several causes:
   interval. Unrelated publications remain on the relay and are excluded only from that action's fault selectors.
 
 Repeated effect observation refreshes local `received_at`; projection replay tests compare stable identities,
-insertion order and all other message fields across that timestamp change. No native SQLCipher crash has been
-reproduced in these maintained runs; ordinary assertion failures and worker response timeouts are separate evidence.
+insertion order and all other message fields across that timestamp change. The large-recovery journeys have not
+reproduced a native SQLCipher crash. A separate concurrent storage-close test exited with SIGSEGV after a failed
+assertion in Linux CI; without a native trace, its origin is unproven. Keep that evidence separate from ordinary
+recovery assertion failures and worker response timeouts.
 
 
 ## Recovery implementation boundaries
 
 The durable deferred-generation barrier covers uncontested catch-up as well as competing branches: all admitted
-raw rows must try the current context before recovered commits can prune it. Background host calls share 64 rows
-and a cooperative 500-ms deadline; explicit-time engine calls share the row bound without consulting elapsed real
+raw rows must try the current context before recovered commits can prune it. Each background recovery slice shares
+64 rows and a cooperative 500-ms deadline; queued-intent foreground preflights retain their separate budgets.
+Explicit-time engine calls share the recovery row bound without consulting elapsed real
 time. Partial work survives cancellation and restart. Historical peel contexts are materialized once per sweep,
 and live storage is restored before awaiting the peeler; secret retention policy is unchanged.
 

--- a/crates/cgka-conformance-simulator/APP_PATH_COVERAGE.md
+++ b/crates/cgka-conformance-simulator/APP_PATH_COVERAGE.md
@@ -220,11 +220,37 @@ a group-members query hits `AccountWorkerResponseTimedOut` during repair pass 3;
 reported no errors. The 191.60-second run exited as an ordinary test failure; it did not exhaust the full recovery
 budget or reach fresh-message/persistence checks.
 
-**Current large-backlog acceptance status:** passing at `fe395e8c`. The bounded background recovery fix
+**Historical large-backlog acceptance at PR #1711:** passing at `fe395e8c`. The bounded background recovery fix
 resolved this worker timeout. The post-cleanup run passed all seven public journeys (330.50 seconds), including
 all 1,024 original messages, fresh traffic and recipient persistence after restart. The release-policy commands are maintained above; PR #1711 records local artifact provenance. Full GitHub CI
 subsequently passed at `be004e3d`, before the dedicated large public recovery job was introduced; that CI result
 must not be represented as execution of the newly added job.
+
+### Subsequent recovery investigation (2026-09-07)
+
+The dedicated Linux job exposed intermittent failures after that checkpoint. Keep the original 1,024-message
+journey and its extra-epoch companion as required regressions, including exact message sets, fresh traffic and
+reopen persistence. A successful earlier run does not establish that every recovery path is correct.
+
+The investigation separated several causes:
+
+- Released raw inputs must retire their transport receipts and durably re-arm replay. The SQLCipher release
+  journal bridges that engine/app boundary across failures and reopen; its acknowledgement also retains a
+  retry obligation if loading the newly armed work fails. Historical pre-journal losses require separate repair
+  ([#1724](https://github.com/marmot-protocol/mdk/issues/1724)).
+- Queued outbound work incorrectly selected the four-row foreground preflight from background convergence.
+  Background recovery must retain its 64-row allowance and generation barrier even when an outbound intent is
+  waiting. A deterministic queued-output regression distinguishes this from foreground send latency limits.
+- Slow preparation can consume the cooperative slice budget before an attempt. A bounded minimum-progress
+  regression covers that case. However, the instrumented Linux plateau had fast preparation and repeated
+  four-row slices; it is not evidence that slow preparation caused that plateau.
+- A chat send can publish older queued work in the same engine pass. The harness must correlate its own
+  message through the public timeline's transport identity, rather than count every relay publication in the
+  interval. Unrelated publications remain on the relay and are excluded only from that action's fault selectors.
+
+Repeated effect observation refreshes local `received_at`; projection replay tests compare stable identities,
+insertion order and all other message fields across that timestamp change. No native SQLCipher crash has been
+reproduced in these maintained runs; ordinary assertion failures and worker response timeouts are separate evidence.
 
 
 ## Recovery implementation boundaries

--- a/crates/cgka-conformance-simulator/Cargo.toml
+++ b/crates/cgka-conformance-simulator/Cargo.toml
@@ -44,6 +44,7 @@ tempfile.workspace = true
 libc.workspace = true
 
 [dev-dependencies]
+tracing-subscriber.workspace = true
 # Byte-level conformance vectors for the agent text stream QUIC feature pin
 # the transport crates' key derivation, AAD, and broker control bytes.
 transport-quic-stream.workspace = true

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -1060,7 +1060,11 @@ messaging, and recipient restart persistence. These are ordinary smoke tests.
 The same file maintains `public_app_1024_message_backlog_recovers_completely`, an explicitly ignored slow
 full-recovery regression using all sends and 16 profile updates from the pinned 1,024-message input. It uses native
 relay order and public app operations, not the engine fixture's forced reverse schedule or private oracles. Skipping
-it is not a passing catch-up result. Commands, limits, and remaining coverage gaps are in
+it is not a passing catch-up result. Its companion
+`public_app_1024_message_backlog_with_extra_epochs_recovers_completely` prepends two public profile updates
+while the recipient is offline, pinning the workload that exposed released transport objects being suppressed
+by app deduplication (#1721). Both run in the required public recovery CI job.
+Commands, limits, and remaining coverage gaps are in
 [`APP_PATH_COVERAGE.md`](APP_PATH_COVERAGE.md).
 
 `cgka-conformance-app-inventory` inventories unchanged generated inputs against the actual public adapter's action

--- a/crates/cgka-conformance-simulator/src/app_runtime.rs
+++ b/crates/cgka-conformance-simulator/src/app_runtime.rs
@@ -1068,7 +1068,7 @@ impl ConvergenceSubject for AppRuntimeHarness {
                         .and_then(|message| message.source_message_id_hex)
                         .ok_or_else(|| {
                             SubjectError::classified(
-                                SubjectFailureCategory::Environment,
+                                SubjectFailureCategory::Protocol,
                                 "published_message_transport_identity_missing",
                                 "a published chat message has no public transport identity",
                             )
@@ -1077,7 +1077,7 @@ impl ConvergenceSubject for AppRuntimeHarness {
                 }
                 if transport_ids.len() != summary.published {
                     return Err(SubjectError::classified(
-                        SubjectFailureCategory::Environment,
+                        SubjectFailureCategory::Protocol,
                         "relay_action_publication_identity_count_mismatch",
                         "published chat count does not match its public transport identities",
                     ));

--- a/crates/cgka-conformance-simulator/src/app_runtime.rs
+++ b/crates/cgka-conformance-simulator/src/app_runtime.rs
@@ -262,25 +262,35 @@ impl AppRuntimeHarness {
         expected_event_ids: &[String],
     ) -> Result<(), SubjectError> {
         self.participant(actor)?;
-        // Scenario commands execute serially. Where the public app API exposes
-        // transport message ids, validate those exact relay events; chat sends
-        // expose only application-event ids, so they retain the bounded count
-        // fallback at this command boundary. Kind-445 outer authors are
-        // intentionally ephemeral and cannot identify the actor.
-        self.relay_control
-            .wait_for_action_events(
-                &mut self.relay_action_events,
-                action_id,
-                before,
-                RelayActionExpectation {
-                    include_welcomes,
-                    expected_publications,
-                    expected_event_ids,
-                    timeout: RELAY_ACTION_PUBLICATION_TIMEOUT,
-                },
-            )
-            .await
-            .map_err(relay_control_error)
+        // Maintenance and queued work can publish alongside a serial scenario
+        // command. Complete public transport identities distinguish that work
+        // from the action without relying on ephemeral kind-445 outer authors.
+        let expectation = RelayActionExpectation {
+            include_welcomes,
+            expected_publications,
+            expected_event_ids,
+            timeout: RELAY_ACTION_PUBLICATION_TIMEOUT,
+        };
+        let result = if expected_event_ids.len() == expected_publications {
+            self.relay_control
+                .wait_for_exact_action_events(
+                    &mut self.relay_action_events,
+                    action_id,
+                    before,
+                    expectation,
+                )
+                .await
+        } else {
+            self.relay_control
+                .wait_for_action_events(
+                    &mut self.relay_action_events,
+                    action_id,
+                    before,
+                    expectation,
+                )
+                .await
+        };
+        result.map_err(relay_control_error)
     }
 
     async fn set_shared_relay_event_presence(
@@ -1040,13 +1050,46 @@ impl ConvergenceSubject for AppRuntimeHarness {
                 )
                 .await
                 .map_err(app_error)?;
+            // SendSummary names application events. Resolve their published
+            // transport identity through the public timeline projection, which
+            // the send completes before returning. The same engine pass may
+            // also publish an older queued maintenance operation.
+            let mut transport_ids = Vec::new();
+            if summary.published > 0 {
+                for app_event_id in &summary.message_ids {
+                    let transport_id = participant
+                        .runtime()?
+                        .timeline_message(
+                            &participant.account_id,
+                            &hex::encode(group_id.as_slice()),
+                            app_event_id,
+                        )
+                        .map_err(app_error)?
+                        .and_then(|message| message.source_message_id_hex)
+                        .ok_or_else(|| {
+                            SubjectError::classified(
+                                SubjectFailureCategory::Environment,
+                                "published_message_transport_identity_missing",
+                                "a published chat message has no public transport identity",
+                            )
+                        })?;
+                    transport_ids.push(transport_id);
+                }
+                if transport_ids.len() != summary.published {
+                    return Err(SubjectError::classified(
+                        SubjectFailureCategory::Environment,
+                        "relay_action_publication_identity_count_mismatch",
+                        "published chat count does not match its public transport identities",
+                    ));
+                }
+            }
             self.record_relay_action_events(
                 action.action_id,
                 action.sender,
                 before,
                 false,
                 summary.published,
-                &[],
+                &transport_ids,
             )
             .await
         }

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -271,6 +271,9 @@ pub(crate) fn merge_engine_metrics(
     target.deferred_peel_sweeps = target
         .deferred_peel_sweeps
         .saturating_add(source.deferred_peel_sweeps);
+    target.deferred_lineage_classifications = target
+        .deferred_lineage_classifications
+        .saturating_add(source.deferred_lineage_classifications);
     target.deferred_peel_candidate_enumerations = target
         .deferred_peel_candidate_enumerations
         .saturating_add(source.deferred_peel_candidate_enumerations);
@@ -437,6 +440,7 @@ mod tests {
             foreground_deferred_errors: 43,
             foreground_deferred_budget_overrun_ms: histogram(44, 45, 46),
             deferred_peel_sweeps: 47,
+            deferred_lineage_classifications: 69,
             deferred_peel_candidate_enumerations: 48,
             deferred_peel_candidate_contexts: 49,
             deferred_peel_candidate_context_depth: histogram(50, 51, 52),

--- a/crates/cgka-conformance-simulator/src/relay_control.rs
+++ b/crates/cgka-conformance-simulator/src/relay_control.rs
@@ -189,6 +189,32 @@ impl RelayControl {
         before: usize,
         expectation: RelayActionExpectation<'_>,
     ) -> Result<(), RelayControlError> {
+        self.wait_for_action_events_inner(action_events, action_id, before, expectation, false)
+            .await
+    }
+
+    /// Correlate an action with a complete set of public transport identities.
+    /// Other runtime work can publish in the same interval; those events stay
+    /// on the relay but must never become targets of this action's selectors.
+    pub async fn wait_for_exact_action_events(
+        &self,
+        action_events: &mut RelayActionEvents,
+        action_id: &str,
+        before: usize,
+        expectation: RelayActionExpectation<'_>,
+    ) -> Result<(), RelayControlError> {
+        self.wait_for_action_events_inner(action_events, action_id, before, expectation, true)
+            .await
+    }
+
+    async fn wait_for_action_events_inner(
+        &self,
+        action_events: &mut RelayActionEvents,
+        action_id: &str,
+        before: usize,
+        expectation: RelayActionExpectation<'_>,
+        exact_identity: bool,
+    ) -> Result<(), RelayControlError> {
         let RelayActionExpectation {
             include_welcomes,
             expected_publications,
@@ -202,11 +228,26 @@ impl RelayControl {
             });
         }
         let expected_event_ids = expected_event_ids.iter().cloned().collect::<BTreeSet<_>>();
+        if exact_identity && expected_event_ids.len() != expected_publications {
+            return Err(RelayControlError {
+                code: "relay_action_publication_identity_count_mismatch",
+                message: "exact action correlation requires every publication identity",
+            });
+        }
         let deadline = Instant::now() + timeout;
         loop {
-            let recorded = self
-                .record_action_events(action_events, action_id, before, include_welcomes)
+            self.record_action_events(action_events, action_id, before, include_welcomes)
                 .await?;
+            if exact_identity {
+                let mut seen = BTreeSet::new();
+                if let Some(events) = action_events.get_mut(action_id) {
+                    events.retain(|event| {
+                        expected_event_ids.contains(&event.event.id.to_hex())
+                            && seen.insert(event.event.id)
+                    });
+                }
+            }
+            let recorded = action_events.get(action_id).map_or(0, Vec::len);
             let observed_event_ids = action_events
                 .get(action_id)
                 .into_iter()
@@ -437,6 +478,86 @@ mod tests {
             .await
             .unwrap();
         assert!(database.event_by_id(&welcome.id).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn exact_action_identity_waits_for_its_event_and_excludes_concurrent_work() {
+        let control = RelayControl::new();
+        let database = RecordingRelayDatabase {
+            inner: MemoryDatabase::with_opts(MemoryDatabaseOptions {
+                events: true,
+                max_events: None,
+            }),
+            publication_log: Arc::clone(&control.publication_log),
+            hidden_event_ids: Arc::clone(&control.hidden_event_ids),
+        };
+        let keys = nostr::Keys::generate();
+        let maintenance = nostr::EventBuilder::new(Kind::MlsGroupMessage, "queued maintenance")
+            .sign_with_keys(&keys)
+            .unwrap();
+        let current = nostr::EventBuilder::new(Kind::MlsGroupMessage, "current action")
+            .sign_with_keys(&keys)
+            .unwrap();
+        database.save_event(&maintenance).await.unwrap();
+        let expected_ids = [current.id.to_hex()];
+        let expectation = || RelayActionExpectation {
+            include_welcomes: false,
+            expected_publications: 1,
+            expected_event_ids: &expected_ids,
+            timeout: Duration::ZERO,
+        };
+        let mut actions = RelayActionEvents::new();
+        let error = control
+            .wait_for_exact_action_events(&mut actions, "current", 0, expectation())
+            .await
+            .unwrap_err();
+        assert_eq!(error.code, "relay_action_publication_timeout");
+        assert!(actions["current"].is_empty());
+
+        database.save_event(&current).await.unwrap();
+        control
+            .wait_for_exact_action_events(&mut actions, "current", 0, expectation())
+            .await
+            .unwrap();
+        assert_eq!(actions["current"].len(), 1);
+        assert_eq!(actions["current"][0].event.id, current.id);
+        assert_eq!(actions["current"][0].publication_sequence, 1);
+        let selector = ScenarioMessageSelectorV2 {
+            action_id: Some("current".into()),
+            occurrence: 0,
+            ..Default::default()
+        };
+        control
+            .set_action_event_visibility(&actions, &selector, false)
+            .await
+            .unwrap();
+        assert!(database.event_by_id(&current.id).await.unwrap().is_none());
+        assert!(
+            database
+                .event_by_id(&maintenance.id)
+                .await
+                .unwrap()
+                .is_some()
+        );
+
+        let error = control
+            .wait_for_exact_action_events(
+                &mut actions,
+                "incomplete",
+                0,
+                RelayActionExpectation {
+                    include_welcomes: false,
+                    expected_publications: 1,
+                    expected_event_ids: &[],
+                    timeout: Duration::ZERO,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error.code,
+            "relay_action_publication_identity_count_mismatch"
+        );
     }
 
     #[tokio::test]

--- a/crates/cgka-conformance-simulator/tests/AGENTS.md
+++ b/crates/cgka-conformance-simulator/tests/AGENTS.md
@@ -17,7 +17,8 @@ determinism, reachability, interaction-coverage, and promotion checks when addin
     capability preflight, interaction coverage, and explicit real-socket strict oracle canaries.
 
 - **File:** `app_runtime_journeys.rs`
-  - **Owns:** Basic public app acceptance journeys and the explicit slow 1,024-message public catch-up gate,
+  - **Owns:** Basic public app acceptance journeys and the explicit slow 1,024-message public catch-up gates,
+    including the extra-epoch released-object replay regression (#1721),
     also selected by the dedicated required public recovery CI job with production policy.
     Real local relay, SQLCipher roots, exact public payload/state checks, post-change messaging, and restart
     persistence. See `../APP_PATH_COVERAGE.md` for replay and evidence commands.

--- a/crates/cgka-conformance-simulator/tests/app_runtime_journeys.rs
+++ b/crates/cgka-conformance-simulator/tests/app_runtime_journeys.rs
@@ -412,6 +412,13 @@ async fn large_backlog(
 }
 
 async fn check(journey: Journey) {
+    if std::env::var_os("MDK_BACKLOG_TRACE").is_some() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter("cgka_engine::message_processor=info,marmot_app::relay_plane=info")
+            .with_ansi(false)
+            .with_writer(std::io::stderr)
+            .try_init();
+    }
     let label = format!("{journey:?}").to_lowercase();
     let mut builder = tempfile::Builder::new();
     let prefix = format!("app-journey-{label}-");

--- a/crates/cgka-conformance-simulator/tests/app_runtime_journeys.rs
+++ b/crates/cgka-conformance-simulator/tests/app_runtime_journeys.rs
@@ -25,6 +25,7 @@ enum Journey {
     Restart,
     Offline,
     LargeBacklog,
+    LargeBacklogExtraEpochs,
 }
 
 fn save(out: &Path, name: &str, value: &impl serde::Serialize) -> TestResult {
@@ -105,7 +106,10 @@ async fn exercise(
         clients
     };
     subject.select_scenario_group("main", true)?;
-    let admins = if matches!(journey, Journey::LargeBacklog) {
+    let admins = if matches!(
+        journey,
+        Journey::LargeBacklog | Journey::LargeBacklogExtraEpochs
+    ) {
         clients
     } else {
         &clients[..1]
@@ -125,8 +129,16 @@ async fn exercise(
     subject
         .await_observable_settlement(founders, SETTLEMENT)
         .await?;
-    if matches!(journey, Journey::LargeBacklog) {
-        return large_backlog(subject, clients, out).await;
+    if matches!(
+        journey,
+        Journey::LargeBacklog | Journey::LargeBacklogExtraEpochs
+    ) {
+        let prelude_updates = if matches!(journey, Journey::LargeBacklogExtraEpochs) {
+            2
+        } else {
+            0
+        };
+        return large_backlog(subject, clients, out, prelude_updates).await;
     }
 
     let mut expected = founders
@@ -216,7 +228,7 @@ async fn exercise(
             subject.set_online("bob", true).await?;
             subject.repair_full_history(&["bob".into()]).await?;
         }
-        Journey::LargeBacklog => unreachable!(),
+        Journey::LargeBacklog | Journey::LargeBacklogExtraEpochs => unreachable!(),
     }
     expect_timeline(subject, &expected, out, "after-change.json").await?;
     // Every remaining member must both send and receive in the recovered epoch.
@@ -248,6 +260,7 @@ async fn large_backlog(
     subject: &mut AppRuntimeHarness,
     clients: &[String],
     out: &Path,
+    prelude_updates: usize,
 ) -> TestResult {
     let input = resolve_scenario_input_bytes(&offline_catchup::bytes(1024))?;
     let online = clients
@@ -256,6 +269,30 @@ async fn large_backlog(
         .cloned()
         .collect::<Vec<_>>();
     subject.set_online("bob", false).await?;
+    // Extra legitimate epoch activity can cross the deferred retry boundary;
+    // released raw objects must remain replayable through the public app.
+    let prelude = (0..prelude_updates)
+        .map(|index| format!("recovery-prelude-{index}"))
+        .collect::<Vec<_>>();
+    save(
+        out,
+        "prelude.json",
+        &json!({ "version": 1, "sender": "alice", "profile_names": prelude }),
+    )?;
+    for name in prelude {
+        subject
+            .update_group_data(SubjectUpdateGroupData {
+                action_id: &name,
+                client: "alice",
+                name: Some(&name),
+                description: None,
+                pending: &name,
+            })
+            .await?;
+        subject
+            .await_observable_settlement(&online, SETTLEMENT)
+            .await?;
+    }
     let mut payloads = Vec::new();
     let mut rounds = 0;
     // Deliberate public workload companion, not an adapter override of private IR:
@@ -388,12 +425,17 @@ async fn check(journey: Journey) {
     fs_private::create_dir_all_private(artifacts.path()).unwrap();
     let labels: &[&str] = match journey {
         Journey::Invite | Journey::Removal => &["alice", "bob", "carol"],
-        Journey::LargeBacklog => &["alice", "bob", "carol", "david"],
+        Journey::LargeBacklog | Journey::LargeBacklogExtraEpochs => {
+            &["alice", "bob", "carol", "david"]
+        }
         _ => &["alice", "bob"],
     };
     let clients = labels.iter().map(|c| (*c).to_owned()).collect::<Vec<_>>();
-    let backlog_source =
-        matches!(journey, Journey::LargeBacklog).then(|| offline_catchup::bytes(1024));
+    let backlog_source = matches!(
+        journey,
+        Journey::LargeBacklog | Journey::LargeBacklogExtraEpochs
+    )
+    .then(|| offline_catchup::bytes(1024));
     if let Some(bytes) = &backlog_source {
         fs_private::write_private(&artifacts.path().join("backlog-input.json"), bytes).unwrap();
     }
@@ -476,4 +518,10 @@ journey_test!(public_app_06_small_offline_backlog, Offline);
 #[ignore = "explicit slow recovery gate; see APP_PATH_COVERAGE.md"]
 async fn public_app_1024_message_backlog_recovers_completely() {
     check(Journey::LargeBacklog).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "explicit slow recovery gate; covers resource release and replay"]
+async fn public_app_1024_message_backlog_with_extra_epochs_recovers_completely() {
+    check(Journey::LargeBacklogExtraEpochs).await;
 }

--- a/crates/cgka-conformance-simulator/tests/app_runtime_journeys.rs
+++ b/crates/cgka-conformance-simulator/tests/app_runtime_journeys.rs
@@ -28,8 +28,41 @@ enum Journey {
     LargeBacklogExtraEpochs,
 }
 
+#[derive(Debug, Default, serde::Serialize)]
+struct RecoveryProgress {
+    phase: &'static str,
+    pass: Option<usize>,
+    completed_pass: Option<usize>,
+    expected: usize,
+    observed: BTreeMap<String, usize>,
+    restarts: usize,
+}
+
 fn save(out: &Path, name: &str, value: &impl serde::Serialize) -> TestResult {
     fs_private::write_private(&out.join(name), &serde_json::to_vec_pretty(value)?)?;
+    Ok(())
+}
+
+fn save_recovery_checkpoint(
+    out: &Path,
+    progress: &RecoveryProgress,
+    observations: &impl serde::Serialize,
+    recovered: bool,
+) -> TestResult {
+    save(out, "recovery-progress.json", progress)?;
+    // Keep a bounded checkpoint set even when the watchdog permits hundreds
+    // of passes. The terminal observation is also retained by check().
+    if progress
+        .completed_pass
+        .is_some_and(|pass| pass.is_multiple_of(10))
+        || recovered
+    {
+        save(
+            out,
+            "recovery-checkpoint.json",
+            &json!({ "progress": progress, "complete": recovered, "observations": observations }),
+        )?;
+    }
     Ok(())
 }
 
@@ -99,6 +132,7 @@ async fn exercise(
     clients: &[String],
     journey: Journey,
     out: &Path,
+    recovery_progress: &mut RecoveryProgress,
 ) -> TestResult {
     let founders = if matches!(journey, Journey::Invite) {
         &clients[..2]
@@ -138,7 +172,7 @@ async fn exercise(
         } else {
             0
         };
-        return large_backlog(subject, clients, out, prelude_updates).await;
+        return large_backlog(subject, clients, out, prelude_updates, recovery_progress).await;
     }
 
     let mut expected = founders
@@ -261,7 +295,10 @@ async fn large_backlog(
     clients: &[String],
     out: &Path,
     prelude_updates: usize,
+    recovery_progress: &mut RecoveryProgress,
 ) -> TestResult {
+    recovery_progress.phase = "publishing_backlog";
+    recovery_progress.expected = 1024;
     let input = resolve_scenario_input_bytes(&offline_catchup::bytes(1024))?;
     let online = clients
         .iter()
@@ -337,6 +374,7 @@ async fn large_backlog(
         .map(|c| (c.clone(), payloads.clone()))
         .collect::<BTreeMap<_, _>>();
     save(out, "expected.json", &expected)?;
+    recovery_progress.phase = "reconnect";
     subject
         .set_online("bob", true)
         .await
@@ -348,14 +386,18 @@ async fn large_backlog(
     // minimum message throughput. Keep driving within check()'s existing
     // 900-second watchdog instead of declaring failure after 30 calls.
     for pass in 0_usize.. {
+        recovery_progress.pass = Some(pass);
+        recovery_progress.phase = "full_history_repair";
         subject
             .repair_full_history(&["bob".into()])
             .await
             .map_err(|error| format!("repair pass {pass}, full-history repair: {error}"))?;
+        recovery_progress.phase = "catch_up";
         subject
             .catch_up(clients)
             .await
             .map_err(|error| format!("repair pass {pass}, catch-up: {error}"))?;
+        recovery_progress.phase = "observations";
         let observations = subject
             .observations(clients)
             .await
@@ -365,14 +407,17 @@ async fn large_backlog(
             .find(|o| o.participant == "bob")
             .ok_or("missing bob")?;
         let recovered = complete(&observations, &expected, clients.len());
-        save(
-            out,
-            &format!("recovery-{pass:02}.json"),
-            &json!({
-                "pass": pass, "complete": recovered, "recovery_restarts": restarts,
-                "expected": 1024, "observations": observations,
-            }),
-        )?;
+        recovery_progress.completed_pass = Some(pass);
+        recovery_progress.observed = observations
+            .iter()
+            .map(|o| {
+                (
+                    o.participant.clone(),
+                    o.application.visible_plaintexts.len(),
+                )
+            })
+            .collect();
+        save_recovery_checkpoint(out, recovery_progress, &observations, recovered)?;
         eprintln!(
             "repair_pass={pass} observed={} expected=1024 complete={recovered}",
             bob.application.visible_plaintexts.len()
@@ -392,13 +437,17 @@ async fn large_backlog(
                     "large backlog stopped progressing after three recovery restarts".into(),
                 );
             }
+            recovery_progress.phase = "reopen";
             subject.reopen("bob").await?;
             restarts += 1;
+            recovery_progress.restarts = restarts;
             unchanged = 0;
         }
         previous = Some(progress);
+        recovery_progress.phase = "backoff";
         tokio::time::sleep(Duration::from_secs(2)).await;
     }
+    recovery_progress.phase = "post_recovery_messaging";
     for client in clients {
         let payload = format!("post-recovery-{client}");
         send(subject, client, &payload).await?;
@@ -407,6 +456,7 @@ async fn large_backlog(
         }
     }
     expect_timeline(subject, &expected, out, "post-recovery-messaging.json").await?;
+    recovery_progress.phase = "restart_persistence";
     subject.reopen("bob").await?;
     subject.repair_full_history(&["bob".into()]).await?;
     expect_timeline(subject, &expected, out, "after-restart.json").await
@@ -415,7 +465,7 @@ async fn large_backlog(
 async fn check(journey: Journey) {
     if std::env::var_os("MDK_BACKLOG_TRACE").is_some() {
         let _ = tracing_subscriber::fmt()
-            .with_env_filter("cgka_engine::message_processor=info,marmot_app::relay_plane=info")
+            .with_env_filter("cgka_engine::message_processor=debug,marmot_app::relay_plane=info")
             .with_ansi(false)
             .with_writer(std::io::stderr)
             .try_init();
@@ -462,15 +512,37 @@ async fn check(journey: Journey) {
     let mut subject = AppRuntimeHarness::new(&clients)
         .await
         .expect("public runtime setup");
-    let result = match tokio::time::timeout(
+    let mut recovery_progress = RecoveryProgress {
+        phase: "setup",
+        ..RecoveryProgress::default()
+    };
+    let mut result = match tokio::time::timeout(
         Duration::from_secs(900),
-        exercise(&mut subject, &clients, journey, artifacts.path()),
+        exercise(&mut subject, &clients, journey, artifacts.path(), &mut recovery_progress),
     )
     .await
     {
         Ok(result) => result,
+        Err(_) if backlog_source.is_some() => Err(format!(
+            "public journey exceeded 900-second watchdog; last recovery progress: {recovery_progress:?}"
+        ).into()),
         Err(_) => Err("public journey exceeded 900-second watchdog".into()),
     };
+    if backlog_source.is_some() {
+        if result.is_ok() {
+            recovery_progress.phase = "complete";
+        }
+        if let Err(error) = save(
+            artifacts.path(),
+            "recovery-progress.json",
+            &recovery_progress,
+        ) {
+            result = Err(format!(
+                "saving recovery progress failed: {error}; journey result: {result:?}"
+            )
+            .into());
+        }
+    }
     if let Ok(observations) = subject.observations(&clients).await {
         save(artifacts.path(), "terminal.json", &observations).unwrap();
     }
@@ -501,6 +573,40 @@ async fn check(journey: Journey) {
         "runtime close failed: {close_errors:?}"
     );
     assert!(result.is_ok(), "{label}: {}", result.unwrap_err());
+}
+
+#[test]
+fn recovery_checkpoints_bound_artifacts_and_preserve_final_state() {
+    let out = tempfile::tempdir().unwrap();
+    let mut progress = RecoveryProgress {
+        phase: "observations",
+        expected: 1024,
+        ..RecoveryProgress::default()
+    };
+    for pass in 0..=103 {
+        progress.pass = Some(pass);
+        progress.completed_pass = Some(pass);
+        progress.observed.insert("bob".into(), pass);
+        save_recovery_checkpoint(
+            out.path(),
+            &progress,
+            &json!({ "last_pass": pass }),
+            pass == 103,
+        )
+        .unwrap();
+    }
+    assert_eq!(std::fs::read_dir(out.path()).unwrap().count(), 2);
+    let checkpoint: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(out.path().join("recovery-checkpoint.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(checkpoint["progress"]["completed_pass"], 103);
+    assert_eq!(checkpoint["observations"]["last_pass"], 103);
+    assert_eq!(checkpoint["complete"], true);
+    let latest: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(out.path().join("recovery-progress.json")).unwrap())
+            .unwrap();
+    assert_eq!(latest["observed"]["bob"], 103);
 }
 
 macro_rules! journey_test {

--- a/crates/cgka-conformance-simulator/tests/app_runtime_journeys.rs
+++ b/crates/cgka-conformance-simulator/tests/app_runtime_journeys.rs
@@ -344,8 +344,10 @@ async fn large_backlog(
     let mut previous = None;
     let mut unchanged = 0;
     let mut restarts = 0;
-    let mut recovered = false;
-    for pass in 0..30 {
+    // Production slices are bounded by elapsed time, so a repair call has no
+    // minimum message throughput. Keep driving within check()'s existing
+    // 900-second watchdog instead of declaring failure after 30 calls.
+    for pass in 0_usize.. {
         subject
             .repair_full_history(&["bob".into()])
             .await
@@ -362,7 +364,7 @@ async fn large_backlog(
             .iter()
             .find(|o| o.participant == "bob")
             .ok_or("missing bob")?;
-        recovered = complete(&observations, &expected, clients.len());
+        let recovered = complete(&observations, &expected, clients.len());
         save(
             out,
             &format!("recovery-{pass:02}.json"),
@@ -386,7 +388,9 @@ async fn large_backlog(
         };
         if unchanged >= 6 {
             if restarts >= 3 {
-                break;
+                return Err(
+                    "large backlog stopped progressing after three recovery restarts".into(),
+                );
             }
             subject.reopen("bob").await?;
             restarts += 1;
@@ -394,9 +398,6 @@ async fn large_backlog(
         }
         previous = Some(progress);
         tokio::time::sleep(Duration::from_secs(2)).await;
-    }
-    if !recovered {
-        return Err("large backlog failed complete public recovery within 30 repair passes".into());
     }
     for client in clients {
         let payload = format!("post-recovery-{client}");

--- a/crates/cgka-engine/src/engine_metrics.rs
+++ b/crates/cgka-engine/src/engine_metrics.rs
@@ -237,6 +237,7 @@ pub struct EngineMetrics {
     /// Deferred-peel work-shape observability. All values are aggregate and
     /// candidate contexts themselves remain exclusively in engine memory.
     deferred_peel_sweeps: u64,
+    deferred_lineage_classifications: u64,
     deferred_peel_candidate_enumerations: u64,
     deferred_peel_candidate_contexts: u64,
     deferred_peel_candidate_context_depth: BucketHistogram,
@@ -284,6 +285,7 @@ impl Default for EngineMetrics {
             foreground_deferred_errors: 0,
             foreground_deferred_budget_overrun_ms: BucketHistogram::new(&LATENESS_BUCKET_BOUNDS_MS),
             deferred_peel_sweeps: 0,
+            deferred_lineage_classifications: 0,
             deferred_peel_candidate_enumerations: 0,
             deferred_peel_candidate_contexts: 0,
             deferred_peel_candidate_context_depth: BucketHistogram::new(&WORK_COUNT_BUCKET_BOUNDS),
@@ -440,6 +442,11 @@ impl EngineMetrics {
         self.outbound_queue_accept_ms.record(duration_ms);
     }
 
+    pub(crate) fn note_deferred_lineage_classification(&mut self) {
+        self.deferred_lineage_classifications =
+            self.deferred_lineage_classifications.saturating_add(1);
+    }
+
     pub(crate) fn note_deferred_peel_sweep(&mut self) {
         self.deferred_peel_sweeps = self.deferred_peel_sweeps.saturating_add(1);
     }
@@ -565,6 +572,7 @@ impl EngineMetrics {
                 .foreground_deferred_budget_overrun_ms
                 .snapshot(),
             deferred_peel_sweeps: self.deferred_peel_sweeps,
+            deferred_lineage_classifications: self.deferred_lineage_classifications,
             deferred_peel_candidate_enumerations: self.deferred_peel_candidate_enumerations,
             deferred_peel_candidate_contexts: self.deferred_peel_candidate_contexts,
             deferred_peel_candidate_context_depth: self
@@ -662,6 +670,9 @@ pub struct EngineMetricsSnapshot {
     pub foreground_deferred_budget_overrun_ms: HistogramSnapshot,
     /// Deferred-peel retry sweeps invoked, including empty or gated sweeps.
     pub deferred_peel_sweeps: u64,
+    /// Group graph classifications requested by live transport deferrals.
+    /// Retry sweeps consume no lineage report and must not increment this count.
+    pub deferred_lineage_classifications: u64,
     /// Candidate-branch enumerations actually performed (cache misses).
     pub deferred_peel_candidate_enumerations: u64,
     /// Candidate contexts captured across all enumerations.

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -40,6 +40,14 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tls_codec::{Deserialize as _, Serialize as _};
 
+/// Internal ingest result. An opaque row has no lineage verdict until a live
+/// caller needs to report one. Retry sweeps only maintain its durable lifecycle;
+/// classifying their discarded result would rescan the commit graph per row.
+pub(super) enum GroupMessageIngestOutcome {
+    Outcome(IngestOutcome),
+    Deferred(GroupId),
+}
+
 /// What a deferred-peel sweep offers the ingest seam for one retained row.
 ///
 /// The candidate branch states this sweep materialized are offered to a row the
@@ -295,8 +303,16 @@ impl<S: StorageProvider> Engine<S> {
         msg: &TransportMessage,
         transport_group_id: Vec<u8>,
     ) -> Result<IngestOutcome, EngineError> {
-        self.ingest_group_message_from_sweep(msg, transport_group_id, DeferredPeelSweep::LIVE)
-            .await
+        match self
+            .ingest_group_message_from_sweep(msg, transport_group_id, DeferredPeelSweep::LIVE)
+            .await?
+        {
+            GroupMessageIngestOutcome::Outcome(outcome) => Ok(outcome),
+            GroupMessageIngestOutcome::Deferred(group_id) => {
+                let lineage = self.deferral_lineage(&group_id)?;
+                Ok(IngestOutcome::TransportDeferred { group_id, lineage })
+            }
+        }
     }
 
     /// [`Self::ingest_group_message`] on behalf of a deferred-peel sweep.
@@ -307,12 +323,13 @@ impl<S: StorageProvider> Engine<S> {
     /// recovered application message is routed (see the evidence guard below).
     /// Every other step, from dedup to terminal classification, is shared with
     /// the ordinary path.
-    pub(crate) async fn ingest_group_message_from_sweep(
+    pub(super) async fn ingest_group_message_from_sweep(
         &mut self,
         msg: &TransportMessage,
         transport_group_id: Vec<u8>,
         sweep: DeferredPeelSweep<'_>,
-    ) -> Result<IngestOutcome, EngineError> {
+    ) -> Result<GroupMessageIngestOutcome, EngineError> {
+        let reported = |outcome| Ok(GroupMessageIngestOutcome::Outcome(outcome));
         let group_id = self.resolve_or_backfill_group_id_for_transport(&transport_group_id)?;
 
         // Authenticated terminal evidence is permanent. Drop late traffic
@@ -320,7 +337,7 @@ impl<S: StorageProvider> Engine<S> {
         // unknown-group input.
         if self.storage.disband_tombstone(&group_id)?.is_some() {
             self.storage.put_ingress_dedup_marker(&msg.id)?;
-            return Ok(IngestOutcome::Ignored {
+            return reported(IngestOutcome::Ignored {
                 category: InputRejectionCategory::UnknownGroup,
             });
         }
@@ -345,7 +362,7 @@ impl<S: StorageProvider> Engine<S> {
                     return Err(EngineError::Storage(error));
                 }
                 Err(DeferredPeelPayloadPreparationError::CodecLimit) => {
-                    return Ok(self.peel_deferred_capacity_refused(&group_id, &msg.id));
+                    return reported(self.peel_deferred_capacity_refused(&group_id, &msg.id));
                 }
             };
             let deferred_payload_bytes = prepared.encoded_payload.len();
@@ -371,9 +388,9 @@ impl<S: StorageProvider> Engine<S> {
                     ),
                 );
             } else {
-                return Ok(self.peel_deferred_capacity_refused(&group_id, &msg.id));
+                return reported(self.peel_deferred_capacity_refused(&group_id, &msg.id));
             }
-            return Ok(IngestOutcome::LocalState {
+            return reported(IngestOutcome::LocalState {
                 state: LocalIngestState::Quarantined,
             });
         }
@@ -403,7 +420,7 @@ impl<S: StorageProvider> Engine<S> {
                 // same event must process instead of classifying as a
                 // duplicate of a message that left no durable record.
                 self.retryable_unpersisted_ingest_id = Some(msg.id.clone());
-                return Ok(IngestOutcome::Ignored {
+                return reported(IngestOutcome::Ignored {
                     category: InputRejectionCategory::UnknownGroup,
                 });
             }
@@ -428,14 +445,14 @@ impl<S: StorageProvider> Engine<S> {
             self.persist_transport_message(msg, &group_id, current_epoch, MessageState::Failed)?;
             self.realize_self_eviction(&group_id, current_epoch)?;
             self.return_unmodified_mls_group(&group_id, mls_group);
-            return Ok(IngestOutcome::LocalState {
+            return reported(IngestOutcome::LocalState {
                 state: LocalIngestState::Removed,
             });
         }
         if !self.epoch_manager.can_ingest(&group_id) {
             self.persist_transport_message(msg, &group_id, current_epoch, MessageState::Retryable)?;
             self.return_unmodified_mls_group(&group_id, mls_group);
-            return Ok(IngestOutcome::Buffered {
+            return reported(IngestOutcome::Buffered {
                 group_id,
                 epoch: current_epoch,
             });
@@ -523,21 +540,21 @@ impl<S: StorageProvider> Engine<S> {
                             InputRejectionCategory::InvalidEncoding
                         };
                         self.return_unmodified_mls_group(&group_id, mls_group);
-                        return self.terminal_peel_rejection_ignored(
+                        return reported(self.terminal_peel_rejection_ignored(
                             &raw_msg_id,
                             &msg.id,
                             "malformed_payload_snapshot_fallback",
                             category,
-                        );
+                        )?);
                     }
                     Err(EngineError::Peeler(PeelerError::WrongRecipient)) => {
                         self.return_unmodified_mls_group(&group_id, mls_group);
-                        return self.terminal_peel_rejection_ignored(
+                        return reported(self.terminal_peel_rejection_ignored(
                             &raw_msg_id,
                             &msg.id,
                             "wrong_recipient_snapshot_fallback",
                             InputRejectionCategory::WrongRecipient,
-                        );
+                        )?);
                     }
                     Err(e) => return Err(e),
                 };
@@ -574,7 +591,9 @@ impl<S: StorageProvider> Engine<S> {
                         }
                         Err(DeferredPeelPayloadPreparationError::CodecLimit) => {
                             self.return_unmodified_mls_group(&group_id, mls_group);
-                            return Ok(self.peel_deferred_capacity_refused(&group_id, &msg.id));
+                            return reported(
+                                self.peel_deferred_capacity_refused(&group_id, &msg.id),
+                            );
                         }
                     };
                     let deferred_payload_bytes = prepared.encoded_payload.len();
@@ -589,7 +608,7 @@ impl<S: StorageProvider> Engine<S> {
                             "peel-deferred row cap reached; dropping undecryptable input unpersisted"
                         );
                         self.return_unmodified_mls_group(&group_id, mls_group);
-                        return Ok(self.peel_deferred_capacity_refused(&group_id, &msg.id));
+                        return reported(self.peel_deferred_capacity_refused(&group_id, &msg.id));
                     }
                     self.persist_encoded_transport_message_for_existing_group(
                         msg,
@@ -616,9 +635,8 @@ impl<S: StorageProvider> Engine<S> {
                             crate::message_disposition::MessageDisposition::RetryPending.tag(),
                         ),
                     );
-                    let lineage = self.deferral_lineage(&group_id)?;
                     self.return_unmodified_mls_group(&group_id, mls_group);
-                    return Ok(IngestOutcome::TransportDeferred { group_id, lineage });
+                    return Ok(GroupMessageIngestOutcome::Deferred(group_id));
                 }
             }
             Err(PeelerError::StaleEpoch {
@@ -653,21 +671,21 @@ impl<S: StorageProvider> Engine<S> {
                             InputRejectionCategory::InvalidEncoding
                         };
                         self.return_unmodified_mls_group(&group_id, mls_group);
-                        return self.terminal_peel_rejection_ignored(
+                        return reported(self.terminal_peel_rejection_ignored(
                             &raw_msg_id,
                             &msg.id,
                             "malformed_payload_snapshot_fallback",
                             category,
-                        );
+                        )?);
                     }
                     Err(EngineError::Peeler(PeelerError::WrongRecipient)) => {
                         self.return_unmodified_mls_group(&group_id, mls_group);
-                        return self.terminal_peel_rejection_ignored(
+                        return reported(self.terminal_peel_rejection_ignored(
                             &raw_msg_id,
                             &msg.id,
                             "wrong_recipient_snapshot_fallback",
                             InputRejectionCategory::WrongRecipient,
-                        );
+                        )?);
                     }
                     Err(e) => return Err(e),
                 };
@@ -714,7 +732,7 @@ impl<S: StorageProvider> Engine<S> {
                         ),
                     );
                     self.return_unmodified_mls_group(&group_id, mls_group);
-                    return Ok(IngestOutcome::Stale {
+                    return reported(IngestOutcome::Stale {
                         reason: StaleReason::AlreadyAtEpoch {
                             current: context_epoch,
                             msg_epoch: message_epoch,
@@ -746,21 +764,21 @@ impl<S: StorageProvider> Engine<S> {
                     InputRejectionCategory::InvalidEncoding
                 };
                 self.return_unmodified_mls_group(&group_id, mls_group);
-                return self.terminal_peel_rejection_ignored(
+                return reported(self.terminal_peel_rejection_ignored(
                     &raw_msg_id,
                     &msg.id,
                     reason,
                     category,
-                );
+                )?);
             }
             Err(PeelerError::WrongRecipient) => {
                 self.return_unmodified_mls_group(&group_id, mls_group);
-                return self.terminal_peel_rejection_ignored(
+                return reported(self.terminal_peel_rejection_ignored(
                     &raw_msg_id,
                     &msg.id,
                     "wrong_recipient",
                     InputRejectionCategory::WrongRecipient,
-                );
+                )?);
             }
             Err(e) => return Err(EngineError::Peeler(e)),
         };
@@ -781,7 +799,7 @@ impl<S: StorageProvider> Engine<S> {
                     MessageState::Failed,
                 )?;
                 self.return_unmodified_mls_group(&group_id, mls_group);
-                return Ok(IngestOutcome::Ignored {
+                return reported(IngestOutcome::Ignored {
                     category: InputRejectionCategory::InvalidEncoding,
                 });
             }
@@ -803,17 +821,17 @@ impl<S: StorageProvider> Engine<S> {
             // marker pool so a later restart can short-circuit before peel.
             self.storage
                 .put_processed_transport_id(&group_id, &raw_msg_id)?;
-            return Ok(outcome);
+            return reported(outcome);
         }
         if self.seen_message_ids.contains(&content_id) {
             self.return_unmodified_mls_group(&group_id, mls_group);
-            return Ok(IngestOutcome::Ignored {
+            return reported(IngestOutcome::Ignored {
                 category: InputRejectionCategory::Duplicate,
             });
         }
         if self.sent_message_ids.contains(&content_id) {
             self.return_unmodified_mls_group(&group_id, mls_group);
-            return Ok(IngestOutcome::Ignored {
+            return reported(IngestOutcome::Ignored {
                 category: InputRejectionCategory::OwnEcho,
             });
         }
@@ -853,7 +871,7 @@ impl<S: StorageProvider> Engine<S> {
                     "malformed_mls_message",
                 )?;
                 self.return_unmodified_mls_group(&group_id, mls_group);
-                return Ok(IngestOutcome::Ignored {
+                return reported(IngestOutcome::Ignored {
                     category: InputRejectionCategory::InvalidEncoding,
                 });
             }
@@ -878,7 +896,7 @@ impl<S: StorageProvider> Engine<S> {
                     "non_mls_message_body",
                 )?;
                 self.return_unmodified_mls_group(&group_id, mls_group);
-                return Ok(IngestOutcome::Ignored {
+                return reported(IngestOutcome::Ignored {
                     category: InputRejectionCategory::InvalidEncoding,
                 });
             }
@@ -914,7 +932,7 @@ impl<S: StorageProvider> Engine<S> {
             );
             self.mark_raw_transport_message_failed_if_awaiting_retry(&raw_msg_id, tag)?;
             self.return_unmodified_mls_group(&group_id, mls_group);
-            return Ok(IngestOutcome::Stale {
+            return reported(IngestOutcome::Stale {
                 reason: StaleReason::PreMembership,
             });
         }
@@ -946,7 +964,7 @@ impl<S: StorageProvider> Engine<S> {
         let evidence_for_a_contested_pass =
             msg_content_type == ContentType::Application && sweep.has_branch_contexts();
         if recovered_from_candidate_branch || evidence_for_a_contested_pass {
-            return self.buffer_openmls_message_into_convergence(
+            return reported(self.buffer_openmls_message_into_convergence(
                 group_id,
                 &openmls_msg,
                 msg,
@@ -960,7 +978,7 @@ impl<S: StorageProvider> Engine<S> {
                     },
                     drain: sweep.drain_policy(),
                 },
-            );
+            )?);
         }
 
         // Set when convergence admission is refused ONLY because the
@@ -1003,7 +1021,7 @@ impl<S: StorageProvider> Engine<S> {
             false
         };
         if commit_should_enter_convergence {
-            return self.buffer_openmls_message_into_convergence(
+            return reported(self.buffer_openmls_message_into_convergence(
                 group_id,
                 &openmls_msg,
                 msg,
@@ -1013,10 +1031,10 @@ impl<S: StorageProvider> Engine<S> {
                     wrapper_retirement_reason: "buffered_into_convergence",
                     drain: sweep.drain_policy(),
                 },
-            );
+            )?);
         }
         if msg_content_type == ContentType::Application && msg_epoch > current_epoch {
-            return self.buffer_openmls_message_into_convergence(
+            return reported(self.buffer_openmls_message_into_convergence(
                 group_id,
                 &openmls_msg,
                 msg,
@@ -1026,7 +1044,7 @@ impl<S: StorageProvider> Engine<S> {
                     wrapper_retirement_reason: "buffered_into_convergence",
                     drain: sweep.drain_policy(),
                 },
-            );
+            )?);
         }
 
         // The retained row, exact wrapper identity, and the secret-tree
@@ -1067,7 +1085,7 @@ impl<S: StorageProvider> Engine<S> {
                 };
                 self.update_stored_message_state(&msg.id, MessageState::Failed)?;
                 self.mark_raw_transport_message_failed_if_awaiting_retry(&raw_msg_id, tag)?;
-                return Ok(IngestOutcome::Stale {
+                return reported(IngestOutcome::Stale {
                     reason: if pre_membership {
                         StaleReason::PreMembership
                     } else {
@@ -1098,12 +1116,13 @@ impl<S: StorageProvider> Engine<S> {
                             "fork_rival_missing_retained_anchor",
                         )?;
                     }
-                    return self
-                        .unadjudicable_fork_rival_without_anchor(group_id, &msg.id, current);
+                    return reported(
+                        self.unadjudicable_fork_rival_without_anchor(group_id, &msg.id, current)?,
+                    );
                 }
 
                 self.update_stored_message_state(&msg.id, MessageState::Failed)?;
-                return Ok(IngestOutcome::Stale {
+                return reported(IngestOutcome::Stale {
                     reason: StaleReason::AlreadyAtEpoch { current, msg_epoch },
                 });
             }
@@ -1119,7 +1138,7 @@ impl<S: StorageProvider> Engine<S> {
                 // OpenMLS signal itself.
                 self.update_stored_message_state(&msg.id, MessageState::Failed)?;
                 self.realize_self_eviction(&group_id, current_epoch)?;
-                return Ok(IngestOutcome::LocalState {
+                return reported(IngestOutcome::LocalState {
                     state: LocalIngestState::Removed,
                 });
             }
@@ -1134,7 +1153,7 @@ impl<S: StorageProvider> Engine<S> {
                     let result = self
                         .converge_stored_openmls_messages(&group_id)
                         .map_err(|error| EngineError::Backend(format!("converge: {error}")))?;
-                    return Ok(convergence_ingest_outcome(
+                    return reported(convergence_ingest_outcome(
                         &result,
                         msg,
                         group_id,
@@ -1144,12 +1163,12 @@ impl<S: StorageProvider> Engine<S> {
                 if let Some(category) =
                     crate::app_components::classify_process_message_rejection(&e, msg_content_type)
                 {
-                    return self.terminalize_rejected_proposal(
+                    return reported(self.terminalize_rejected_proposal(
                         &group_id,
                         &msg.id,
                         Some(&raw_msg_id),
                         category,
-                    );
+                    )?);
                 }
                 self.update_stored_message_state(&msg.id, MessageState::Retryable)?;
                 return Err(EngineError::Backend(format!("process_message: {e:?}")));
@@ -1186,7 +1205,7 @@ impl<S: StorageProvider> Engine<S> {
                         &raw_msg_id,
                         "unattributable_sender",
                     )?;
-                    return Ok(IngestOutcome::Ignored {
+                    return reported(IngestOutcome::Ignored {
                         category: InputRejectionCategory::InvalidSignature,
                     });
                 };
@@ -1207,7 +1226,7 @@ impl<S: StorageProvider> Engine<S> {
                                 &raw_msg_id,
                                 "invalid_app_payload",
                             )?;
-                            return Ok(IngestOutcome::Ignored {
+                            return reported(IngestOutcome::Ignored {
                                 category: InputRejectionCategory::InvalidEncoding,
                             });
                         }
@@ -1263,7 +1282,7 @@ impl<S: StorageProvider> Engine<S> {
                 // before the durable lookup.
                 self.seen_message_ids.insert(msg.id.clone());
                 self.return_mls_group(&group_id, mls_group);
-                Ok(IngestOutcome::Processed)
+                reported(IngestOutcome::Processed)
             }
             ProcessedMessageContent::StagedCommitMessage(staged) => {
                 let before = EpochId(mls_group.epoch().as_u64());
@@ -1272,24 +1291,26 @@ impl<S: StorageProvider> Engine<S> {
                     staged.add_proposals().next().is_some(),
                 ) {
                     return match error {
-                        EngineError::InvalidTransition(_) => self.terminalize_rejected_proposal(
-                            &group_id,
-                            &msg.id,
-                            Some(&raw_msg_id),
-                            ProposalRejectionCategory::UnsupportedProposal,
-                        ),
+                        EngineError::InvalidTransition(_) => {
+                            reported(self.terminalize_rejected_proposal(
+                                &group_id,
+                                &msg.id,
+                                Some(&raw_msg_id),
+                                ProposalRejectionCategory::UnsupportedProposal,
+                            )?)
+                        }
                         error => Err(error),
                     };
                 }
                 if let Err(rejection) =
                     crate::app_components::authorize_staged_commit_proposals(&mls_group, &staged)
                 {
-                    return self.terminalize_rejected_proposal(
+                    return reported(self.terminalize_rejected_proposal(
                         &group_id,
                         &msg.id,
                         Some(&raw_msg_id),
                         rejection.category,
-                    );
+                    )?);
                 }
                 if let Err(err) = crate::app_components::require_admin_for_staged_commit(
                     &mls_group,
@@ -1379,7 +1400,7 @@ impl<S: StorageProvider> Engine<S> {
                     let result = self
                         .converge_stored_openmls_messages(&group_id)
                         .map_err(|error| EngineError::Backend(format!("converge: {error}")))?;
-                    return Ok(convergence_ingest_outcome(
+                    return reported(convergence_ingest_outcome(
                         &result,
                         msg,
                         group_id,
@@ -1636,7 +1657,7 @@ impl<S: StorageProvider> Engine<S> {
                 // caught before the durable lookup.
                 self.seen_message_ids.insert(msg.id.clone());
                 self.return_mls_group(&group_id, mls_group);
-                Ok(IngestOutcome::Processed)
+                reported(IngestOutcome::Processed)
             }
             ProcessedMessageContent::ProposalMessage(queued) => {
                 if let Err(error) = self.strict_cutover_rejects_legacy_group_addition(
@@ -1644,24 +1665,26 @@ impl<S: StorageProvider> Engine<S> {
                     matches!(queued.proposal(), Proposal::Add(_)),
                 ) {
                     return match error {
-                        EngineError::InvalidTransition(_) => self.terminalize_rejected_proposal(
-                            &group_id,
-                            &msg.id,
-                            Some(&raw_msg_id),
-                            ProposalRejectionCategory::UnsupportedProposal,
-                        ),
+                        EngineError::InvalidTransition(_) => {
+                            reported(self.terminalize_rejected_proposal(
+                                &group_id,
+                                &msg.id,
+                                Some(&raw_msg_id),
+                                ProposalRejectionCategory::UnsupportedProposal,
+                            )?)
+                        }
                         error => Err(error),
                     };
                 }
                 if let Err(rejection) =
                     crate::app_components::authorize_standalone_proposal(&mls_group, &queued)
                 {
-                    return self.terminalize_rejected_proposal(
+                    return reported(self.terminalize_rejected_proposal(
                         &group_id,
                         &msg.id,
                         Some(&raw_msg_id),
                         rejection.category,
-                    );
+                    )?);
                 }
                 // Ask the auto-committer policy whether we should commit
                 // this proposal. OpenMLS does not auto-enqueue processed
@@ -1695,15 +1718,16 @@ impl<S: StorageProvider> Engine<S> {
                 }
                 self.return_mls_group(&group_id, mls_group);
                 self.valid_proposal_groups.insert(group_id);
-                Ok(IngestOutcome::Processed)
+                reported(IngestOutcome::Processed)
             }
-            ProcessedMessageContent::ExternalJoinProposalMessage(_) => self
-                .terminalize_rejected_proposal(
+            ProcessedMessageContent::ExternalJoinProposalMessage(_) => {
+                reported(self.terminalize_rejected_proposal(
                     &group_id,
                     &msg.id,
                     Some(&raw_msg_id),
                     ProposalRejectionCategory::UnsupportedProposal,
-                ),
+                )?)
+            }
             ProcessedMessageContent::OwnPendingCommit
             | ProcessedMessageContent::OwnPrivateMessage => {
                 // This normally returns through the durable sent-content
@@ -1714,7 +1738,7 @@ impl<S: StorageProvider> Engine<S> {
                 self.update_stored_message_state(&msg.id, MessageState::Processed)?;
                 self.mark_raw_transport_message_failed_if_awaiting_retry(&raw_msg_id, "own_echo")?;
                 self.seen_message_ids.insert(msg.id.clone());
-                Ok(IngestOutcome::Ignored {
+                reported(IngestOutcome::Ignored {
                     category: InputRejectionCategory::OwnEcho,
                 })
             }

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -43,6 +43,8 @@ use tls_codec::{Deserialize as _, Serialize as _};
 /// Internal ingest result. An opaque row has no lineage verdict until a live
 /// caller needs to report one. Retry sweeps only maintain its durable lifecycle;
 /// classifying their discarded result would rescan the commit graph per row.
+/// Keeping that absence in a separate variant prevents a placeholder lineage
+/// from escaping as an apparently valid verdict when a caller starts using it.
 pub(super) enum GroupMessageIngestOutcome {
     Outcome(IngestOutcome),
     Deferred(GroupId),

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -1668,6 +1668,13 @@ impl<S: StorageProvider> Engine<S> {
         execution: &mut DeferredPeelExecution<'_>,
     ) -> Result<DeferredPeelWorkResult, EngineError> {
         let sweep_started = Instant::now();
+        // The background deadline is cooperative: a started row always finishes.
+        // Give a slice that started with available time the same guarantee when
+        // its synchronous preparation uses the quantum. Otherwise a slow storage
+        // read repeats forever without ever reaching one durable row attempt.
+        // Foreground preflight and already-expired slices retain strict checks.
+        let mut finish_one_background_row =
+            matches!(execution, DeferredPeelExecution::Background { .. }) && !execution.exhausted();
         self.engine_metrics.note_deferred_peel_sweep();
         let foreground_budget_ms = match execution {
             DeferredPeelExecution::Foreground(budget) => Some(budget.budget_ms),
@@ -1727,7 +1734,7 @@ impl<S: StorageProvider> Engine<S> {
             budget_exhausted = execution.exhausted(),
             "deferred-peel preparation"
         );
-        if execution.exhausted() {
+        if execution.exhausted() && !finish_one_background_row {
             self.note_foreground_deferred_phase(
                 sweep_started,
                 foreground_budget_ms,
@@ -1741,7 +1748,39 @@ impl<S: StorageProvider> Engine<S> {
             });
         }
         let row_limit = execution.row_limit();
-        if self.normalize_deferred_peel_lifecycles(&mut deferred, now, row_limit)? {
+        // Charge normalization only to the wall-clock worker's allowance.
+        // Deterministic retries retain their existing normalize-then-peel slice;
+        // foreground preflight retains its independent strict budget behavior.
+        let normalization_rows = if matches!(
+            execution,
+            DeferredPeelExecution::Background {
+                deadline: Some(_),
+                ..
+            }
+        ) {
+            deferred
+                .iter()
+                .filter(|record| {
+                    record.deferred_peel.as_ref().is_none_or(|lifecycle| {
+                        lifecycle.clock_instance_id != self.convergence_clock_instance_id
+                    })
+                })
+                .take(row_limit)
+                .count()
+        } else {
+            0
+        };
+        let normalization_pending =
+            self.normalize_deferred_peel_lifecycles(&mut deferred, now, row_limit)?;
+        for _ in 0..normalization_rows {
+            execution.consume_row();
+        }
+        if normalization_rows > 0 {
+            // Durable normalization is useful bounded progress too; do not
+            // grant an additional row past the deadline after making it.
+            finish_one_background_row = false;
+        }
+        if normalization_pending {
             // Legacy initialization and restart rebasing are durable writes,
             // so migrate them in the same bounded slices as peel attempts.
             // The pending edge keeps the scheduler advancing the backlog.
@@ -1758,6 +1797,21 @@ impl<S: StorageProvider> Engine<S> {
                 progressed: 0,
             });
         }
+
+        if execution.exhausted() && !finish_one_background_row {
+            self.note_foreground_deferred_phase(
+                sweep_started,
+                foreground_budget_ms,
+                0,
+                deferred.len(),
+                crate::engine_metrics::DeferredPeelMetricOutcome::BudgetExhausted,
+            );
+            return Ok(DeferredPeelWorkResult {
+                status: DeferredPeelWorkStatus::BudgetExhausted,
+                progressed: 0,
+            });
+        }
+        let row_limit = execution.row_limit();
 
         // Residence expiry is independent of peel-context changes. Check it
         // before the fingerprint gate so a permanently stable group can still
@@ -1776,9 +1830,10 @@ impl<S: StorageProvider> Engine<S> {
         if !due.is_empty() {
             let mut released = 0usize;
             for metadata in &due {
-                if execution.exhausted() {
+                if execution.exhausted() && !finish_one_background_row {
                     break;
                 }
+                finish_one_background_row = false;
                 execution.consume_row();
                 let record = self.storage.get_message(&metadata.id)?;
                 self.release_deferred_peel_row(
@@ -1895,7 +1950,7 @@ impl<S: StorageProvider> Engine<S> {
             .or_default()
             .sweep_count += 1;
 
-        if execution.exhausted() {
+        if execution.exhausted() && !finish_one_background_row {
             self.note_foreground_deferred_phase(
                 sweep_started,
                 foreground_budget_ms,
@@ -2029,7 +2084,7 @@ impl<S: StorageProvider> Engine<S> {
         let mut timed_out = false;
         let mut contexts_invalidated = false;
         for metadata in unattempted.into_iter().take(row_limit) {
-            if execution.exhausted() {
+            if execution.exhausted() && !finish_one_background_row {
                 timed_out = true;
                 break;
             }
@@ -2046,6 +2101,7 @@ impl<S: StorageProvider> Engine<S> {
                 contexts_invalidated = true;
                 break;
             }
+            finish_one_background_row = false;
             let record = self.storage.get_message(&metadata.id)?;
             let lifecycle = record
                 .deferred_peel

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -1625,7 +1625,7 @@ impl<S: StorageProvider> Engine<S> {
         backlog: usize,
         outcome: crate::engine_metrics::DeferredPeelMetricOutcome,
     ) {
-        tracing::info!(
+        tracing::debug!(
             target: "cgka_engine::message_processor",
             method = "retry_deferred_peels",
             phase = "slice_complete",
@@ -1725,7 +1725,7 @@ impl<S: StorageProvider> Engine<S> {
         // Prepare from metadata; payload reads belong only to selected rows.
         // State filtering also avoids touching unrelated retained history.
         let mut deferred = self.storage.list_deferred_message_metadata(group_id)?;
-        tracing::info!(
+        tracing::debug!(
             target: "cgka_engine::message_processor",
             method = "retry_deferred_peels",
             phase = "metadata_loaded",
@@ -1901,7 +1901,7 @@ impl<S: StorageProvider> Engine<S> {
         }
 
         let fingerprint = self.deferred_peel_context_fingerprint(group_id)?;
-        tracing::info!(
+        tracing::debug!(
             target: "cgka_engine::message_processor",
             method = "retry_deferred_peels",
             phase = "fingerprint_loaded",

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -1625,6 +1625,17 @@ impl<S: StorageProvider> Engine<S> {
         backlog: usize,
         outcome: crate::engine_metrics::DeferredPeelMetricOutcome,
     ) {
+        tracing::info!(
+            target: "cgka_engine::message_processor",
+            method = "retry_deferred_peels",
+            phase = "slice_complete",
+            foreground = budget_ms.is_some(),
+            rows_attempted = rows_attempted as u64,
+            backlog = backlog as u64,
+            duration_ms = started.elapsed().as_millis() as u64,
+            outcome = ?outcome,
+            "deferred-peel slice outcome"
+        );
         if let Some(budget_ms) = budget_ms {
             self.engine_metrics.note_outbound_deferred_peel(
                 started.elapsed().as_millis().try_into().unwrap_or(u64::MAX),
@@ -1707,6 +1718,15 @@ impl<S: StorageProvider> Engine<S> {
         // Prepare from metadata; payload reads belong only to selected rows.
         // State filtering also avoids touching unrelated retained history.
         let mut deferred = self.storage.list_deferred_message_metadata(group_id)?;
+        tracing::info!(
+            target: "cgka_engine::message_processor",
+            method = "retry_deferred_peels",
+            phase = "metadata_loaded",
+            backlog = deferred.len() as u64,
+            duration_ms = sweep_started.elapsed().as_millis() as u64,
+            budget_exhausted = execution.exhausted(),
+            "deferred-peel preparation"
+        );
         if execution.exhausted() {
             self.note_foreground_deferred_phase(
                 sweep_started,
@@ -1826,6 +1846,15 @@ impl<S: StorageProvider> Engine<S> {
         }
 
         let fingerprint = self.deferred_peel_context_fingerprint(group_id)?;
+        tracing::info!(
+            target: "cgka_engine::message_processor",
+            method = "retry_deferred_peels",
+            phase = "fingerprint_loaded",
+            backlog = total as u64,
+            duration_ms = sweep_started.elapsed().as_millis() as u64,
+            budget_exhausted = execution.exhausted(),
+            "deferred-peel preparation"
+        );
         let unattempted = deferred
             .iter()
             .filter(|record| {
@@ -1992,6 +2021,7 @@ impl<S: StorageProvider> Engine<S> {
         let past_contexts = crate::message_processor::ingest::PastPeelContextCache::default();
         let sweep = crate::message_processor::ingest::DeferredPeelSweep::over_branches(&peel)
             .with_past_contexts(&past_contexts);
+        let preparation_ms = sweep_started.elapsed().as_millis() as u64;
 
         let mut progressed = 0usize;
         let mut terminal = 0usize;
@@ -2163,6 +2193,8 @@ impl<S: StorageProvider> Engine<S> {
             candidate_cache_hit,
             queue_depth,
             sweep_duration_ms = duration_ms,
+            preparation_ms,
+            timed_out,
             budget_exhausted = status == DeferredPeelWorkStatus::BudgetExhausted,
             contexts_invalidated,
             "deferred-peel retry sweep"

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -28,7 +28,9 @@ use cgka_traits::error::EngineError;
 use cgka_traits::ingest::{
     DeferralLineage, InboundResourceLimit, IngestOutcome, InputRejectionCategory, LocalIngestState,
 };
-use cgka_traits::message::{MessageRecord, MessageState, StoredMessagePayload};
+use cgka_traits::message::{
+    DeferredMessageMetadata, MessageRecord, MessageState, StoredMessagePayload,
+};
 use cgka_traits::storage::{
     DeferredPeelGeneration, QueuedOutboundIntent, StorageError, StorageProvider,
 };
@@ -1702,14 +1704,9 @@ impl<S: StorageProvider> Engine<S> {
         }
 
         let now = self.convergence_now();
-        // State-filtered listing: this sweep runs on every drain and the
-        // backlog is usually empty, so let the backend's index find the
-        // `PeelDeferred` rows instead of decoding the whole retained window.
-        let mut deferred = self.storage.list_messages_in_states(
-            group_id,
-            &[MessageState::PeelDeferred],
-            EpochId(0),
-        )?;
+        // Prepare from metadata; payload reads belong only to selected rows.
+        // State filtering also avoids touching unrelated retained history.
+        let mut deferred = self.storage.list_deferred_message_metadata(group_id)?;
         if execution.exhausted() {
             self.note_foreground_deferred_phase(
                 sweep_started,
@@ -1758,13 +1755,14 @@ impl<S: StorageProvider> Engine<S> {
             .collect::<Vec<_>>();
         if !due.is_empty() {
             let mut released = 0usize;
-            for record in &due {
+            for metadata in &due {
                 if execution.exhausted() {
                     break;
                 }
                 execution.consume_row();
+                let record = self.storage.get_message(&metadata.id)?;
                 self.release_deferred_peel_row(
-                    record,
+                    &record,
                     InboundResourceLimit::TransportDeferredResidenceBudget,
                     crate::message_disposition::MessageDisposition::ResidenceBudgetRefused,
                 )?;
@@ -1799,7 +1797,7 @@ impl<S: StorageProvider> Engine<S> {
             });
         }
 
-        // The full row list is in hand: refresh the flood-cap count, then stop
+        // The complete metadata list is in hand: refresh exact usage, then stop
         // before the context work when there is nothing to sweep. Describing
         // this group's peel context reads storage, so an empty backlog must not
         // pay for it on every drain.
@@ -2000,7 +1998,7 @@ impl<S: StorageProvider> Engine<S> {
         let mut attempted = 0usize;
         let mut timed_out = false;
         let mut contexts_invalidated = false;
-        for record in unattempted.into_iter().take(row_limit) {
+        for metadata in unattempted.into_iter().take(row_limit) {
             if execution.exhausted() {
                 timed_out = true;
                 break;
@@ -2018,6 +2016,7 @@ impl<S: StorageProvider> Engine<S> {
                 contexts_invalidated = true;
                 break;
             }
+            let record = self.storage.get_message(&metadata.id)?;
             let lifecycle = record
                 .deferred_peel
                 .as_ref()
@@ -2089,7 +2088,7 @@ impl<S: StorageProvider> Engine<S> {
         }
         let remaining = self
             .storage
-            .list_messages_in_states(group_id, &[MessageState::PeelDeferred], EpochId(0))?
+            .list_deferred_message_metadata(group_id)?
             .into_iter()
             .filter(|record| {
                 record.deferred_peel.as_ref().is_none_or(|lifecycle| {
@@ -2404,12 +2403,8 @@ impl<S: StorageProvider> Engine<S> {
         }
         let now = self.convergence_now();
         // Match the sweep's indexed state filter. Readiness must inspect all
-        // deferred rows, but unrelated processed history need not be loaded.
-        let mut deferred = self.storage.list_messages_in_states(
-            group_id,
-            &[MessageState::PeelDeferred],
-            EpochId(0),
-        )?;
+        // deferred metadata, but neither payloads nor processed history are needed.
+        let mut deferred = self.storage.list_deferred_message_metadata(group_id)?;
         let normalization_pending = self.normalize_deferred_peel_lifecycles(
             &mut deferred,
             now,
@@ -2593,10 +2588,14 @@ impl<S: StorageProvider> Engine<S> {
 
     /// Refresh one group's cached usage from a durable row enumeration. This
     /// also reconciles the account total when it has already been initialized.
-    fn refresh_peel_deferred_group_usage(&mut self, group_id: &GroupId, records: &[MessageRecord]) {
+    fn refresh_peel_deferred_group_usage(
+        &mut self,
+        group_id: &GroupId,
+        records: &[DeferredMessageMetadata],
+    ) {
         let rows = records.len();
         let bytes = records.iter().fold(0_usize, |sum, record| {
-            sum.saturating_add(record.payload.len())
+            sum.saturating_add(record.payload_len)
         });
         let state = self.deferred_peel.entry(group_id.clone()).or_default();
         let previous_bytes = state.deferred_bytes;
@@ -2604,7 +2603,7 @@ impl<S: StorageProvider> Engine<S> {
         state.deferred_bytes = bytes;
         state.deferred_payload_bytes_by_id = records
             .iter()
-            .map(|record| (record.id.clone(), record.payload.len()))
+            .map(|record| (record.id.clone(), record.payload_len))
             .collect();
         // Incremental deferral already charges a group that started retaining
         // rows after the account-wide reconstruction. Always reconcile the

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -817,14 +817,14 @@ impl<S: StorageProvider> Engine<S> {
             return Ok(Vec::new());
         }
 
-        let has_queued = self.has_queued_outbound_intents(group_id)?;
-        let settled = if has_queued {
-            self.advance_before_queued_outbound_intents(group_id, now_ms)
-                .await?
-        } else {
-            self.advance_convergence_inputs_with_deadline(group_id, now_ms, deadline)
-                .await?
-        };
+        // This entry point belongs to background recovery even when output is
+        // queued. Borrowing a send's four-row preflight allowance here makes
+        // queued maintenance throttle the worker's entire deferred generation.
+        // The generation/fairness barriers still settle before output drains;
+        // each queued intent retains its foreground preflight below.
+        let settled = self
+            .advance_convergence_inputs_with_deadline(group_id, now_ms, deadline)
+            .await?;
         if !settled {
             return Ok(Vec::new());
         }

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -2200,7 +2200,12 @@ impl<S: StorageProvider> Engine<S> {
     /// group that has since forked, which is the inversion this whole
     /// discriminator exists to prevent.
     ///
-    /// The scan is therefore paid per deferral, and bounded by where it sits.
+    /// The scan is paid only for a live-ingest deferral. Internal retry sweeps
+    /// return an unclassified deferral: their caller only maintains the retry
+    /// lifecycle, so no lineage claim escapes that boundary. Live classifications
+    /// always read the current graph, including commits retained by earlier
+    /// sweeps; no cached verdict can become stale after graph mutation.
+    /// The live scan is bounded by where it sits.
     /// It runs only after the per-group retained-row cap has admitted the row
     /// (`has_peel_deferred_capacity`), so a flood of attacker-minted
     /// undecryptable input is answered `ResourceRefused` without ever reaching
@@ -2210,6 +2215,7 @@ impl<S: StorageProvider> Engine<S> {
         &mut self,
         group_id: &GroupId,
     ) -> Result<DeferralLineage, EngineError> {
+        self.engine_metrics.note_deferred_lineage_classification();
         let group = self.storage.get_group(group_id)?;
         let policy = self
             .convergence_policy_for_group_ungated(group_id)
@@ -2282,6 +2288,8 @@ impl<S: StorageProvider> Engine<S> {
         record: &MessageRecord,
         sweep: crate::message_processor::ingest::DeferredPeelSweep<'_>,
     ) -> Result<bool, EngineError> {
+        use ingest::GroupMessageIngestOutcome::{Deferred, Outcome};
+
         let stored_payload = StoredMessagePayload::decode(&record.payload)
             .map_err(|e| EngineError::Serialize(format!("{e:?}")))?;
         let Some(msg) = stored_payload.as_raw_transport().cloned() else {
@@ -2291,31 +2299,24 @@ impl<S: StorageProvider> Engine<S> {
             .ingest_group_message_from_sweep(&msg, group_id.as_slice().to_vec(), sweep)
             .await
         {
-            // Still unreadable: the row keeps its place in the retry lifecycle
-            // and the caller charges its budget. The verdict's `lineage` is
-            // dropped on purpose. There is exactly one lineage site
-            // (`Self::deferral_lineage`, reached from the single deferral return
-            // in `ingest_group_message_from_sweep`), and it answers about the
-            // GROUP's stored commit graph rather than about this row — so a
-            // sweep can only ever restate what live ingest already reported for
-            // this group, over rows the app's stall detector counted when they
-            // first arrived. Routing it out would re-count that evidence, not
-            // sharpen it.
-            Ok(IngestOutcome::TransportDeferred { .. }) => Ok(false),
-            Ok(IngestOutcome::ResourceRefused {
+            // The live caller classifies lineage for recovery evidence. A
+            // sweep consumes only retention/progress, so its opaque result
+            // deliberately carries no lineage and does not scan stored history.
+            Ok(Deferred(_)) | Ok(Outcome(IngestOutcome::TransportDeferred { .. })) => Ok(false),
+            Ok(Outcome(IngestOutcome::ResourceRefused {
                 resource: InboundResourceLimit::TransportDeferredCapacity,
                 ..
-            }) => Ok(false),
-            Ok(IngestOutcome::LocalState {
+            })) => Ok(false),
+            Ok(Outcome(IngestOutcome::LocalState {
                 state: LocalIngestState::Quarantined,
-            }) => {
+            })) => {
                 // Defense-in-depth: the gates above should keep this from
                 // running for a quarantined group at all, but if a row still
                 // classifies Quarantined it must keep its PeelDeferred state —
                 // the catch-all arm below would retire the replay buffer.
                 Ok(false)
             }
-            Ok(IngestOutcome::Buffered { .. } | IngestOutcome::Processed) => {
+            Ok(Outcome(IngestOutcome::Buffered { .. } | IngestOutcome::Processed)) => {
                 // The peeled content now has its own content-derived record;
                 // retire the raw transport wrapper so it does not keep
                 // re-entering this retry loop as a stale duplicate — but ONLY
@@ -2335,13 +2336,13 @@ impl<S: StorageProvider> Engine<S> {
                 self.note_peel_deferred_row_retired(record);
                 Ok(true)
             }
-            Ok(
+            Ok(Outcome(
                 IngestOutcome::Stale { .. }
                 | IngestOutcome::Ignored { .. }
                 | IngestOutcome::LocalState { .. }
                 | IngestOutcome::ResourceRefused { .. }
                 | IngestOutcome::Rejected { .. },
-            ) => {
+            )) => {
                 // Terminal stale classifications are still successful
                 // reclassifications of this raw deferred row. Retire it only
                 // while it is still awaiting retry: the reachable case is

--- a/crates/cgka-engine/src/message_processor/store.rs
+++ b/crates/cgka-engine/src/message_processor/store.rs
@@ -695,6 +695,14 @@ impl<S: StorageProvider> Engine<S> {
                 .saturating_sub(lifecycle.first_observed_wall_ms)
         });
         self.storage.release_message_for_replay(record)?;
+        tracing::info!(
+            target: "cgka_engine::message_processor",
+            method = "release_deferred_peel_row",
+            retry_count,
+            residence_ms,
+            release_reason = disposition.tag(),
+            "deferred transport row released for replay"
+        );
         self.audit_group(
             &record.group_id,
             crate::audit_helpers::deferred_peel_resource_refused_event(

--- a/crates/cgka-engine/src/message_processor/store.rs
+++ b/crates/cgka-engine/src/message_processor/store.rs
@@ -7,8 +7,8 @@ use cgka_traits::engine::GroupEvent;
 use cgka_traits::error::EngineError;
 use cgka_traits::ingest::{InboundResourceLimit, IngestOutcome, InputRejectionCategory};
 use cgka_traits::message::{
-    DeferredPeelLifecycle, MessageRecord, MessageState, OwnApplicationConvergenceStamp,
-    StoredMessagePayload,
+    DeferredMessageMetadata, DeferredPeelLifecycle, MessageRecord, MessageState,
+    OwnApplicationConvergenceStamp, StoredMessagePayload,
 };
 use cgka_traits::storage::{LeaveRequest, StorageError, StorageProvider};
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
@@ -649,7 +649,7 @@ impl<S: StorageProvider> Engine<S> {
     /// to be persisted by a later scheduler tick.
     pub(super) fn normalize_deferred_peel_lifecycles(
         &self,
-        records: &mut [MessageRecord],
+        records: &mut [DeferredMessageMetadata],
         now: crate::convergence_clock::ConvergenceTime,
         limit: usize,
     ) -> Result<bool, EngineError> {
@@ -665,7 +665,11 @@ impl<S: StorageProvider> Engine<S> {
             record.deferred_peel = Some(lifecycle);
             if changed {
                 if persisted < limit {
-                    self.storage.put_message(record)?;
+                    // Load only this bounded normalization slice, preserving
+                    // payloads and all unrelated row fields on the rewrite.
+                    let mut stored = self.storage.get_message(&record.id)?;
+                    stored.deferred_peel = record.deferred_peel.clone();
+                    self.storage.put_message(&stored)?;
                     persisted += 1;
                 } else {
                     normalization_pending = true;

--- a/crates/cgka-engine/src/message_processor/store.rs
+++ b/crates/cgka-engine/src/message_processor/store.rs
@@ -694,7 +694,7 @@ impl<S: StorageProvider> Engine<S> {
                 .max(self.convergence_now().wall_ms)
                 .saturating_sub(lifecycle.first_observed_wall_ms)
         });
-        self.storage.delete_message(&record.id)?;
+        self.storage.release_message_for_replay(record)?;
         self.audit_group(
             &record.group_id,
             crate::audit_helpers::deferred_peel_resource_refused_event(

--- a/crates/cgka-engine/tests/deferred_peel_lifecycle.rs
+++ b/crates/cgka-engine/tests/deferred_peel_lifecycle.rs
@@ -2591,3 +2591,39 @@ async fn historical_peel_context_materialization_is_amortized_within_a_sweep() {
         "32 failed peels must materialize the same anchor only once, like one failed peel"
     );
 }
+
+/// A failed opaque sweep must do real decryption work and persist attempts,
+/// without repeating the group-history classification only live ingest reports.
+#[tokio::test]
+async fn opaque_retry_batch_does_not_repeat_live_lineage_classification() {
+    let (mut alice, mut carol, storage, peeler, group_id, _commit2, _commit3) =
+        carol_behind_two_epochs().await;
+    let template = send_app(&mut alice, &group_id, "future opaque batch").await;
+    let classifications_before = carol.engine_metrics().deferred_lineage_classifications;
+    let mut rows = Vec::new();
+    for index in 0..32 {
+        let wrapped = TransportMessage {
+            id: MessageId::new(format!("lineage-scan-{index}").into_bytes()),
+            ..template.clone()
+        };
+        assert!(matches!(
+            carol.ingest(wrapped.clone()).await.unwrap(),
+            IngestOutcome::TransportDeferred { .. }
+        ));
+        rows.push((wrapped.id.clone(), peeler.attempts_for(&wrapped.id)));
+    }
+    let classifications = carol.engine_metrics().deferred_lineage_classifications;
+    assert_eq!(classifications - classifications_before, 32);
+    assert_eq!(carol.retry_deferred_peels(&group_id).await.unwrap(), 0);
+    for (id, attempts) in rows {
+        assert!(peeler.attempts_for(&id) > attempts, "each row was retried");
+        let retained = storage.get_message(&id).unwrap();
+        assert_eq!(retained.state, MessageState::PeelDeferred);
+        assert_eq!(retained.deferred_peel.unwrap().distinct_context_attempts, 1);
+    }
+    assert_eq!(
+        carol.engine_metrics().deferred_lineage_classifications,
+        classifications,
+        "the sweep must not rescan the stored graph for each discarded lineage"
+    );
+}

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -10155,3 +10155,38 @@ async fn by_reference_rival_that_wins_the_tiebreak_displaces_the_adopted_branch(
 async fn by_reference_rival_that_loses_the_tiebreak_leaves_the_adopted_branch() {
     assert_by_reference_rival_adjudicates(b"carol", b"alice").await;
 }
+
+/// A retry sweep cannot cache a group verdict for subsequent live arrivals:
+/// the graph can gain a rival between calls without the canonical epoch moving.
+#[tokio::test]
+async fn live_deferral_reclassifies_graph_after_a_retry_sweep_and_new_rival() {
+    let (mut carol, group_id, commits, witness) =
+        forked_epoch_with_an_unreadable_witness("deferral-lineage-after-retry").await;
+    carol
+        .buffer_openmls_convergence_message_at(&group_id, commits[0].clone(), 1_000)
+        .unwrap();
+    assert_eq!(
+        carol.ingest(witness.clone()).await.unwrap(),
+        IngestOutcome::TransportDeferred {
+            group_id: group_id.clone(),
+            lineage: DeferralLineage::Uncontested,
+        }
+    );
+    carol.retry_deferred_peels(&group_id).await.unwrap();
+    carol
+        .buffer_openmls_convergence_message_at(&group_id, commits[1].clone(), 1_000)
+        .unwrap();
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(1));
+    let redelivered = TransportMessage {
+        id: MessageId::new(b"new-wrapper-after-rival".to_vec()),
+        ..witness
+    };
+    assert_eq!(
+        carol.ingest(redelivered).await.unwrap(),
+        IngestOutcome::TransportDeferred {
+            group_id,
+            lineage: DeferralLineage::ContestedFork,
+        },
+        "live recovery evidence must use the current stored graph"
+    );
+}

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -267,17 +267,21 @@ fn build_client(id: &[u8]) -> (Engine<SqliteAccountStorage>, SqliteAccountStorag
     (engine, storage)
 }
 
-fn build_epoch_gate_client(id: &[u8]) -> (Engine<SqliteAccountStorage>, SqliteAccountStorage) {
+fn build_epoch_gate_client(
+    id: &[u8],
+    clock: Option<ManualConvergenceClock>,
+) -> (Engine<SqliteAccountStorage>, SqliteAccountStorage) {
     let storage = SqliteAccountStorage::in_memory().unwrap();
-    let engine = EngineBuilder::new(storage.clone())
+    let mut builder = EngineBuilder::new(storage.clone())
         .legacy_compatibility_profile()
         .identity(pad32(id))
         .account_identity_proof_signer(proof_signer(id))
         .feature_registry(selfremove_registry())
-        .peeler(Box::new(EpochGatePeeler))
-        .build()
-        .unwrap();
-    (engine, storage)
+        .peeler(Box::new(EpochGatePeeler));
+    if let Some(clock) = clock {
+        builder = builder.convergence_clock(Arc::new(clock));
+    }
+    (builder.build().unwrap(), storage)
 }
 
 fn build_client_with_storage(
@@ -8523,7 +8527,7 @@ async fn non_wire_and_unprojectable_convergence_rows_do_not_gate_sends() {
 #[tokio::test]
 async fn send_preflight_retries_deferred_peels_after_convergence_apply() {
     let (mut alice, _alice_storage) = build_client(b"alice");
-    let (mut carol, carol_storage) = build_epoch_gate_client(b"carol");
+    let (mut carol, carol_storage) = build_epoch_gate_client(b"carol", None);
     let (mut david, _david_storage) = build_client(b"david");
     let (mut eve, _eve_storage) = build_client(b"eve");
 
@@ -8636,7 +8640,7 @@ async fn send_preflight_retries_deferred_peels_after_convergence_apply() {
 #[tokio::test]
 async fn deferred_row_terminally_rejected_after_peel_leaves_the_deferred_queue() {
     let (mut alice, alice_storage) = build_client(b"alice");
-    let (mut carol, carol_storage) = build_epoch_gate_client(b"carol");
+    let (mut carol, carol_storage) = build_epoch_gate_client(b"carol", None);
     let (mut david, _david_storage) = build_client(b"david");
 
     let carol_kp = carol.fresh_key_package().await.unwrap();
@@ -9715,7 +9719,11 @@ async fn forked_epoch_with_an_unreadable_witness(
 ) {
     let (mut alice, _alice_storage) = build_client(b"alice");
     let (mut bob, _bob_storage) = build_client(b"bob");
-    let (mut carol, _carol_storage) = build_epoch_gate_client(b"carol");
+    // These lineage probes admit commits at 1_000 and must keep that
+    // generation collecting while they retry opaque input. Real elapsed time
+    // can cross the cutoff during fixture setup on a busy test runner.
+    let (mut carol, _carol_storage) =
+        build_epoch_gate_client(b"carol", Some(ManualConvergenceClock::new(1_000, 1_000)));
     let (mut david, _david_storage) = build_client(b"david");
     let (mut eve, _eve_storage) = build_client(b"eve");
 

--- a/crates/cgka-engine/tests/record_write_atomicity.rs
+++ b/crates/cgka-engine/tests/record_write_atomicity.rs
@@ -289,6 +289,7 @@ struct FaultStorage {
     fault: PutGroupFault,
     capability_fault: CapabilityWriteFault,
     leave_write_fault: LeaveWriteFault,
+    preparation_delay: PreparationDelay,
 }
 
 impl GroupStorage for FaultStorage {
@@ -309,7 +310,45 @@ impl GroupStorage for FaultStorage {
     }
 }
 
+#[derive(Clone, Default)]
+struct PreparationDelay {
+    metadata_ms: Arc<AtomicUsize>,
+    graph_ms: Arc<AtomicUsize>,
+    metadata_calls: Arc<AtomicUsize>,
+    graph_calls: Arc<AtomicUsize>,
+}
+
 impl MessageStorage for FaultStorage {
+    fn list_deferred_message_metadata(
+        &self,
+        group_id: &GroupId,
+    ) -> StorageResult<Vec<cgka_traits::message::DeferredMessageMetadata>> {
+        self.preparation_delay
+            .metadata_calls
+            .fetch_add(1, Ordering::SeqCst);
+        std::thread::sleep(std::time::Duration::from_millis(
+            self.preparation_delay.metadata_ms.load(Ordering::SeqCst) as u64,
+        ));
+        self.inner.list_deferred_message_metadata(group_id)
+    }
+
+    fn list_messages_in_states(
+        &self,
+        group_id: &GroupId,
+        states: &[MessageState],
+        at_or_after_epoch: EpochId,
+    ) -> StorageResult<Vec<MessageRecord>> {
+        if states.contains(&MessageState::Processed) {
+            self.preparation_delay
+                .graph_calls
+                .fetch_add(1, Ordering::SeqCst);
+            std::thread::sleep(std::time::Duration::from_millis(
+                self.preparation_delay.graph_ms.load(Ordering::SeqCst) as u64,
+            ));
+        }
+        self.inner
+            .list_messages_in_states(group_id, states, at_or_after_epoch)
+    }
     fn put_message(&self, record: &MessageRecord) -> StorageResult<()> {
         if self.leave_write_fault.should_fail() {
             return Err(StorageError::Busy(
@@ -684,6 +723,7 @@ fn build_fault_selfremove_client(
         fault,
         capability_fault: CapabilityWriteFault::default(),
         leave_write_fault: LeaveWriteFault::default(),
+        preparation_delay: PreparationDelay::default(),
     })
     .legacy_compatibility_profile()
     .identity(pad32(id))
@@ -706,6 +746,7 @@ fn build_capability_fault_client(
         fault: PutGroupFault::default(),
         capability_fault,
         leave_write_fault: LeaveWriteFault::default(),
+        preparation_delay: PreparationDelay::default(),
     })
     .legacy_compatibility_profile()
     .identity(pad32(id))
@@ -729,6 +770,7 @@ fn build_leave_write_fault_client(
         fault: PutGroupFault::default(),
         capability_fault: CapabilityWriteFault::default(),
         leave_write_fault,
+        preparation_delay: PreparationDelay::default(),
     })
     .legacy_compatibility_profile()
     .identity(pad32(identity))
@@ -1489,4 +1531,216 @@ async fn update_group_data_record_write_failure_leaves_group_stable() {
     let record = handle.get_group(&group_id).unwrap();
     assert_eq!(record.name, "successful rename");
     assert_eq!(record.description, "preserve me");
+}
+
+/// Opaque input remains retryable; it lets this test distinguish a completed
+/// failed peel (durable attempt) from a slice that never reaches the peeler.
+struct OpaquePeeler;
+
+#[async_trait]
+impl TransportPeeler for OpaquePeeler {
+    async fn peel_group_message(
+        &self,
+        _msg: &TransportMessage,
+        _ctx: &GroupContextSnapshot,
+    ) -> Result<PeeledMessage, PeelerError> {
+        Err(PeelerError::DecryptFailed)
+    }
+    async fn peel_welcome(&self, msg: &TransportMessage) -> Result<PeeledMessage, PeelerError> {
+        MockPeeler.peel_welcome(msg).await
+    }
+    async fn wrap_group_message(
+        &self,
+        payload: &EncryptedPayload,
+        ctx: &GroupContextSnapshot,
+    ) -> Result<TransportMessage, PeelerError> {
+        MockPeeler.wrap_group_message(payload, ctx).await
+    }
+    async fn wrap_welcome(
+        &self,
+        payload: &EncryptedPayload,
+        recipient: &MemberId,
+    ) -> Result<TransportMessage, PeelerError> {
+        MockPeeler.wrap_welcome(payload, recipient).await
+    }
+}
+
+async fn slow_preparation_case(
+    backlog: usize,
+) -> (
+    cgka_engine::Engine<FaultStorage>,
+    SqliteAccountStorage,
+    GroupId,
+    Vec<MessageId>,
+    PreparationDelay,
+) {
+    let delay = PreparationDelay::default();
+    let storage = SqliteAccountStorage::in_memory().unwrap();
+    let mut bob = EngineBuilder::new(FaultStorage {
+        inner: storage.clone(),
+        fault: PutGroupFault::default(),
+        capability_fault: CapabilityWriteFault::default(),
+        leave_write_fault: LeaveWriteFault::default(),
+        preparation_delay: delay.clone(),
+    })
+    .legacy_compatibility_profile()
+    .identity(pad32(b"slow-preparation"))
+    .account_identity_proof_signer(proof_signer(b"slow-preparation"))
+    .peeler(Box::new(OpaquePeeler))
+    .build()
+    .unwrap();
+    let (group_id, created) = bob
+        .create_group(CreateGroupRequest {
+            name: "slow preparation".into(),
+            description: String::new(),
+            members: vec![],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let SendResult::GroupCreated { pending, .. } = created else {
+        panic!("group creation");
+    };
+    bob.confirm_published(pending).await.unwrap();
+    let message = TransportMessage {
+        id: MessageId::new(b"slow-preparation-opaque".to_vec()),
+        payload: vec![42; 32],
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource("test".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+    };
+    let mut ids = Vec::new();
+    for index in 0..backlog {
+        let message = TransportMessage {
+            id: MessageId::new(format!("slow-preparation-{index}").into_bytes()),
+            ..message.clone()
+        };
+        assert!(matches!(
+            bob.ingest(message.clone()).await.unwrap(),
+            IngestOutcome::TransportDeferred { .. }
+        ));
+        ids.push(message.id);
+    }
+    (bob, storage, group_id, ids, delay)
+}
+
+fn deferred_attempts(storage: &SqliteAccountStorage, ids: &[MessageId]) -> u32 {
+    ids.iter()
+        .map(|id| {
+            storage
+                .get_message(id)
+                .unwrap()
+                .deferred_peel
+                .unwrap()
+                .distinct_context_attempts
+        })
+        .sum()
+}
+
+async fn assert_slow_preparation_makes_durable_progress(metadata: bool) {
+    let (mut bob, storage, group_id, ids, delay) = slow_preparation_case(4).await;
+    let before = deferred_attempts(&storage, &ids);
+    delay.metadata_calls.store(0, Ordering::SeqCst);
+    delay.graph_calls.store(0, Ordering::SeqCst);
+    let selected = if metadata {
+        &delay.metadata_ms
+    } else {
+        &delay.graph_ms
+    };
+    selected.store(600, Ordering::SeqCst);
+    for _ in 0..3 {
+        bob.advance_convergence(&group_id).await.unwrap();
+    }
+    let attempts = deferred_attempts(&storage, &ids);
+    eprintln!(
+        "slow preparation: metadata={metadata}, attempts_before={before}, attempts_after={attempts}, metadata_calls={}, graph_calls={}",
+        delay.metadata_calls.load(Ordering::SeqCst),
+        delay.graph_calls.load(Ordering::SeqCst)
+    );
+    // Positive control: identical durable work succeeds through the explicit-time
+    // API. Its deterministic row allowance still applies, but it has no deadline.
+    bob.advance_convergence_inputs_until_settled(&group_id, 1_000_000)
+        .await
+        .unwrap();
+    let control = deferred_attempts(&storage, &ids);
+    assert!(
+        control > before,
+        "control must perform real decryption work"
+    );
+    assert_eq!(
+        attempts, 3,
+        "each expired slice must finish exactly one row"
+    );
+}
+
+#[tokio::test]
+async fn slow_metadata_preparation_does_not_starve_background_retries() {
+    assert_slow_preparation_makes_durable_progress(true).await;
+}
+
+#[tokio::test]
+async fn slow_fingerprint_preparation_does_not_starve_background_retries() {
+    assert_slow_preparation_makes_durable_progress(false).await;
+}
+
+/// Restart/legacy normalization is a durable work unit, so a slow read must
+/// neither prevent it nor cause the same call to exceed its 64-row allowance.
+#[tokio::test]
+async fn slow_preparation_normalizes_bounded_slices_before_peeling() {
+    let (mut bob, storage, group_id, ids, delay) = slow_preparation_case(96).await;
+    for id in &ids {
+        let mut row = storage.get_message(id).unwrap();
+        row.deferred_peel = None;
+        storage.put_message(&row).unwrap();
+    }
+    delay.metadata_ms.store(600, Ordering::SeqCst);
+    bob.advance_convergence(&group_id).await.unwrap();
+    let normalized = ids
+        .iter()
+        .filter(|id| storage.get_message(id).unwrap().deferred_peel.is_some())
+        .count();
+    assert_eq!(normalized, 64, "normalization must obey the row allowance");
+    bob.advance_convergence(&group_id).await.unwrap();
+    assert_eq!(
+        deferred_attempts(&storage, &ids),
+        0,
+        "normalization consumes the expired slice"
+    );
+    bob.advance_convergence(&group_id).await.unwrap();
+    assert_eq!(
+        deferred_attempts(&storage, &ids),
+        1,
+        "the next slice must reach a peel"
+    );
+}
+
+/// Due rows spend the one progress allowance on release, rather than being
+/// retried after expiry or all released in a single already-expired quantum.
+#[tokio::test]
+async fn slow_preparation_releases_exactly_one_expired_row() {
+    let (mut bob, storage, group_id, ids, delay) = slow_preparation_case(4).await;
+    for id in &ids {
+        let mut row = storage.get_message(id).unwrap();
+        row.deferred_peel
+            .as_mut()
+            .unwrap()
+            .residence_deadline_monotonic_ms = 0;
+        storage.put_message(&row).unwrap();
+    }
+    delay.metadata_ms.store(600, Ordering::SeqCst);
+    bob.advance_convergence(&group_id).await.unwrap();
+    let remaining = storage.list_deferred_message_metadata(&group_id).unwrap();
+    assert_eq!(remaining.len(), 3);
+    assert!(remaining.iter().all(|row| {
+        row.deferred_peel
+            .as_ref()
+            .unwrap()
+            .distinct_context_attempts
+            == 0
+    }));
 }

--- a/crates/cgka-engine/tests/record_write_atomicity.rs
+++ b/crates/cgka-engine/tests/record_write_atomicity.rs
@@ -1744,3 +1744,127 @@ async fn slow_preparation_releases_exactly_one_expired_row() {
             == 0
     }));
 }
+
+/// Queued output must not turn background recovery into a four-row foreground
+/// send attempt. The frozen raw generation still completes before output drains.
+#[tokio::test]
+#[cfg(feature = "test-policy-overrides")]
+async fn queued_output_preserves_background_recovery_allowance() {
+    use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MarmotAppEvent};
+    use cgka_traits::storage::DeferredPeelGenerationStorage;
+
+    for explicit_time in [false, true] {
+        let (mut engine, storage, group_id, ids, _delay) = slow_preparation_case(96).await;
+        // Keep the production four-row foreground limit. Its independent time
+        // budget is enlarged only to make this row-accounting test deterministic.
+        engine.set_foreground_deferred_peel_budget(5_000, 4);
+        let payload = MarmotAppEvent::new(
+            hex::encode(engine.self_id().as_slice()),
+            1_700_000_000,
+            MARMOT_APP_EVENT_KIND_CHAT,
+            vec![],
+            "queued during opaque recovery",
+        )
+        .encode()
+        .unwrap();
+        let result = engine
+            .send(SendIntent::AppMessage {
+                group_id: group_id.clone(),
+                payload,
+            })
+            .await
+            .unwrap();
+        let SendResult::Queued { intent_id, .. } = result else {
+            panic!("foreground send must queue behind a partial generation");
+        };
+        assert_eq!(
+            deferred_attempts(&storage, &ids),
+            4,
+            "actual foreground send retains its four-row allowance"
+        );
+        let advanced = if explicit_time {
+            engine
+                .converge_and_drain_queued_outbound_intents(&group_id, 1_000_000)
+                .await
+                .unwrap()
+        } else {
+            engine.advance_convergence(&group_id).await.unwrap()
+        };
+        let background_attempts = deferred_attempts(&storage, &ids) - 4;
+        eprintln!(
+            "queued background recovery: explicit_time={explicit_time}, attempts={background_attempts}"
+        );
+        assert!(
+            (1..=64).contains(&background_attempts),
+            "wall-clock recovery must make progress within its row allowance: {background_attempts}"
+        );
+        if explicit_time {
+            assert_eq!(
+                background_attempts, 64,
+                "explicit-time recovery keeps its deterministic row slice"
+            );
+        }
+        assert!(
+            advanced.is_empty(),
+            "queued output must wait for the whole frozen generation"
+        );
+        assert!(
+            storage
+                .deferred_peel_generation(&group_id)
+                .unwrap()
+                .is_some()
+        );
+        assert_eq!(
+            storage
+                .list_queued_outbound_intents(&group_id)
+                .unwrap()
+                .len(),
+            1
+        );
+
+        // Complete with deterministic row slices. Wall-clock throughput is
+        // host-dependent; the public entry point was exercised above.
+        let mut drained = Vec::new();
+        for pass in 0..8 {
+            drained.extend(
+                engine
+                    .converge_and_drain_queued_outbound_intents(&group_id, 1_000_001 + pass)
+                    .await
+                    .unwrap(),
+            );
+            if !drained.is_empty() {
+                break;
+            }
+        }
+        assert!(matches!(
+            drained.as_slice(),
+            [SendResult::ApplicationMessage { .. }]
+        ));
+        assert_eq!(
+            deferred_attempts(&storage, &ids),
+            96,
+            "every opaque row gets one definitive attempt before output"
+        );
+        assert!(
+            storage
+                .deferred_peel_generation(&group_id)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            engine
+                .advance_convergence(&group_id)
+                .await
+                .unwrap()
+                .is_empty(),
+            "an in-flight queued result must not regenerate twice"
+        );
+        engine.confirm_queued_outbound_intent(&intent_id).unwrap();
+        assert!(
+            storage
+                .list_queued_outbound_intents(&group_id)
+                .unwrap()
+                .is_empty()
+        );
+    }
+}

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -402,6 +402,13 @@ pub struct AppClient {
     pub(crate) epoch_backfill_retry_not_before: Option<Instant>,
     /// Armed epoch-gap recovery intent awaiting its account-wide replay.
     pub(crate) pending_epoch_backfill: Option<epoch_stall::PendingEpochBackfill>,
+    /// Release consumption durably armed recovery, but loading its intents
+    /// failed. Retry on this client even though the journal is already empty;
+    /// account open independently restores these intents after a restart.
+    pub(crate) released_backfill_reload_pending: bool,
+    /// One-shot storage-read failure after durable release consumption.
+    #[cfg(test)]
+    pub(crate) fail_next_released_backfill_reload: bool,
     /// Additional armed intents queued behind [`Self::pending_epoch_backfill`]
     /// when a replay failure must not overwrite a newer arm minted in flight.
     pub(crate) queued_epoch_backfills:

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -652,6 +652,12 @@ impl AppClient {
         self.seen_events_index.retain(|id| !released.contains(id));
         self.state.seen_events.retain(|id| !released.contains(id));
         self.pending_seen_event_count = self.state.seen_events.len();
+        tracing::info!(
+            target: "marmot_app::relay_plane",
+            method = "reconcile_released_transport_receipts",
+            released_count = released.len(),
+            "retired released transport receipt claims and restored replay eligibility"
+        );
         self.restore_persisted_epoch_backfill_intents(storage.pending_epoch_backfill_intents()?);
         Ok(released.into_iter().collect())
     }
@@ -2902,9 +2908,21 @@ impl AppClient {
     }
 
     fn clear_epoch_backfill_intent(&self, pending: &PendingEpochBackfill) -> Result<(), AppError> {
+        let mut completed = pending.clone();
+        // A release during this execution can rearm the same group at the same
+        // epoch. Epoch equality alone cannot distinguish the new durable intent
+        // from the one this execution served. Leave cleanup to its next owner,
+        // including work rotated into the queue, so restart cannot lose it.
+        completed.groups.retain(|group_id, _| {
+            !self
+                .pending_epoch_backfill
+                .iter()
+                .chain(self.queued_epoch_backfills.iter())
+                .any(|next| next.groups.contains_key(group_id))
+        });
         self.app.clear_epoch_backfill_intents(
             &self.state.label,
-            &Self::stored_epoch_backfill_intents(pending),
+            &Self::stored_epoch_backfill_intents(&completed),
         )
     }
 
@@ -4993,6 +5011,102 @@ mod tests {
             crate::client::epoch_stall::PendingEpochBackfillGroup { stalled_epoch },
         );
         pending
+    }
+
+    #[tokio::test]
+    async fn older_backfill_completion_preserves_released_intent_across_reopen() {
+        use cgka_traits::storage::MessageStorage;
+        use cgka_traits::{EpochId, MessageId, MessageRecord, MessageState};
+        use marmot_forensics::EpochBackfillExecutionSeam;
+
+        for (queued, epoch_increment) in [(false, 0), (true, 0), (false, 1), (true, 1)] {
+            let dir = tempfile::tempdir().unwrap();
+            AccountHome::open(dir.path())
+                .create_account("alice")
+                .unwrap();
+            let app = MarmotApp::with_relay(dir.path(), "wss://backfill.example")
+                .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+            let mut client = app.client("alice").await.unwrap();
+            let group = client
+                .create_group("release during replay", &[])
+                .await
+                .unwrap();
+            let epoch = client.group_mls_state(&group).unwrap().epoch;
+            let old = armed_backfill(&group, epoch);
+            client.persist_epoch_backfill_intent(&old).unwrap();
+            client.pending_epoch_backfill = Some(old);
+            let execution = client
+                .begin_epoch_backfill_execution(EpochBackfillExecutionSeam::ExplicitCatchUp)
+                .unwrap();
+            assert!(!client.has_pending_epoch_backfill());
+
+            // Engine release occurs during the old replay's final drain. Its
+            // journal is consumed before EOSE completion clears old work.
+            let storage = app.account_storage("alice").unwrap();
+            let raw = MessageRecord {
+                id: MessageId::new(vec![0xfe; 32]),
+                group_id: group.clone(),
+                epoch: EpochId(epoch + epoch_increment),
+                state: MessageState::PeelDeferred,
+                payload: Vec::new(),
+                deferred_peel: None,
+            };
+            storage.put_message(&raw).unwrap();
+            storage.release_message_for_replay(&raw).unwrap();
+            client.reconcile_released_transport_receipts().unwrap();
+            if queued {
+                let pending = client.pending_epoch_backfill.take().unwrap();
+                client.queued_epoch_backfills.push_back(pending);
+            }
+            client
+                .clear_epoch_backfill_intent(&execution.pending)
+                .unwrap();
+            assert_eq!(
+                storage.pending_epoch_backfill_intents().unwrap().len(),
+                1,
+                "old completion consumed a rearmed intent: queued={queued}, epoch_increment={epoch_increment}"
+            );
+            drop(client); // Crash boundary: no later attempt has persisted again.
+            let mut reopened = app.client("alice").await.unwrap();
+            assert!(reopened.has_pending_epoch_backfill());
+            let next = reopened.take_next_pending_epoch_backfill().unwrap();
+            assert_eq!(next.groups[&group].stalled_epoch, epoch + epoch_increment);
+            reopened.clear_epoch_backfill_intent(&next).unwrap();
+            assert!(
+                storage.pending_epoch_backfill_intents().unwrap().is_empty(),
+                "the final execution must still clean up completed work"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn older_backfill_completion_still_clears_groups_without_new_work() {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let app = MarmotApp::with_relay(dir.path(), "wss://backfill.example")
+            .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+        let mut client = app.client("alice").await.unwrap();
+        let primary = client.create_group("primary rearm", &[]).await.unwrap();
+        let queued = client.create_group("queued rearm", &[]).await.unwrap();
+        let finished = client.create_group("finished", &[]).await.unwrap();
+        let mut completed = armed_backfill(&primary, 0);
+        completed.groups.extend(armed_backfill(&queued, 0).groups);
+        completed.groups.extend(armed_backfill(&finished, 0).groups);
+        client.persist_epoch_backfill_intent(&completed).unwrap();
+        client.pending_epoch_backfill = Some(armed_backfill(&primary, 0));
+        client
+            .queued_epoch_backfills
+            .push_back(armed_backfill(&queued, 0));
+        client.clear_epoch_backfill_intent(&completed).unwrap();
+        let remaining = app.pending_epoch_backfill_intents("alice").unwrap();
+        assert_eq!(remaining.len(), 2);
+        assert!(
+            !remaining
+                .iter()
+                .any(|intent| intent.group_id_hex == hex::encode(finished.as_slice()))
+        );
     }
 
     fn failed_replay_outcome() -> EpochBackfillReplayOutcome {

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -5029,7 +5029,15 @@ mod tests {
             .observe_drained_session_events(&effects)
             .await
             .unwrap();
-        assert_eq!(app.messages("alice").unwrap(), messages);
+        let replayed = app.messages("alice").unwrap();
+        assert_eq!(replayed.len(), messages.len());
+        for (actual, mut expected) in replayed.into_iter().zip(messages) {
+            // Re-observation stamps a fresh local receipt time. Stable message
+            // identity, insertion order and contents must survive replay even
+            // when it crosses a wall-clock second boundary.
+            expected.received_at = actual.received_at;
+            assert_eq!(actual, expected);
+        }
     }
 
     #[tokio::test]

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -639,7 +639,8 @@ impl AppClient {
     ) -> Result<Vec<String>, AppError> {
         let storage = self.app.account_storage(&self.state.label)?;
         let released = storage.consume_released_transport_receipts()?;
-        if released.is_empty() {
+        self.released_backfill_reload_pending |= !released.is_empty();
+        if !self.released_backfill_reload_pending {
             return Ok(Vec::new());
         }
         let released = released
@@ -652,13 +653,23 @@ impl AppClient {
         self.seen_events_index.retain(|id| !released.contains(id));
         self.state.seen_events.retain(|id| !released.contains(id));
         self.pending_seen_event_count = self.state.seen_events.len();
-        tracing::info!(
-            target: "marmot_app::relay_plane",
-            method = "reconcile_released_transport_receipts",
-            released_count = released.len(),
-            "retired released transport receipt claims and restored replay eligibility"
-        );
+        if !released.is_empty() {
+            tracing::info!(
+                target: "marmot_app::relay_plane",
+                method = "reconcile_released_transport_receipts",
+                released_count = released.len(),
+                "retired released transport receipt claims and restored replay eligibility"
+            );
+        }
+        #[cfg(test)]
+        if std::mem::take(&mut self.fail_next_released_backfill_reload) {
+            return Err(cgka_traits::storage::StorageError::Busy(
+                "injected released backfill intent read failure".into(),
+            )
+            .into());
+        }
         self.restore_persisted_epoch_backfill_intents(storage.pending_epoch_backfill_intents()?);
+        self.released_backfill_reload_pending = false;
         Ok(released.into_iter().collect())
     }
 
@@ -5011,6 +5022,77 @@ mod tests {
             crate::client::epoch_stall::PendingEpochBackfillGroup { stalled_epoch },
         );
         pending
+    }
+
+    #[tokio::test]
+    async fn released_backfill_reload_retries_after_consumption_without_reopen() {
+        use cgka_traits::storage::MessageStorage;
+        use cgka_traits::{EpochId, MessageId, MessageRecord, MessageState};
+
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let app = MarmotApp::with_relay(dir.path(), "wss://backfill.example")
+            .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+        let mut client = app.client("alice").await.unwrap();
+        let group = client.create_group("reload failure", &[]).await.unwrap();
+        let storage = app.account_storage("alice").unwrap();
+        let raw = MessageRecord {
+            id: MessageId::new(vec![0xfd; 32]),
+            group_id: group.clone(),
+            epoch: EpochId(client.group_mls_state(&group).unwrap().epoch),
+            state: MessageState::PeelDeferred,
+            payload: Vec::new(),
+            deferred_peel: None,
+        };
+        let id_hex = hex::encode(raw.id.as_slice());
+        client.seen_events_index.insert(id_hex.clone());
+        client.state.seen_events.push(id_hex.clone());
+        storage.put_message(&raw).unwrap();
+        storage.release_message_for_replay(&raw).unwrap();
+        client.fail_next_released_backfill_reload = true;
+        assert!(matches!(
+            client.reconcile_released_transport_receipts(),
+            Err(crate::AppError::Storage(
+                cgka_traits::storage::StorageError::Busy(_)
+            ))
+        ));
+        assert!(client.released_backfill_reload_pending);
+        assert!(!client.seen_events_index.contains(&id_hex));
+        assert!(!client.state.seen_events.contains(&id_hex));
+        assert!(
+            storage
+                .consume_released_transport_receipts()
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(storage.pending_epoch_backfill_intents().unwrap().len(), 1);
+        assert!(!client.has_pending_epoch_backfill());
+
+        // No new release and no reopen: the same client must retry the read
+        // after acknowledgment has already emptied the durable journal.
+        assert!(
+            client
+                .reconcile_released_transport_receipts()
+                .unwrap()
+                .is_empty()
+        );
+        assert!(client.has_pending_epoch_backfill());
+        assert!(!client.released_backfill_reload_pending);
+        let pending = client.pending_epoch_backfill.as_ref().unwrap();
+        assert_eq!(pending.groups[&group].stalled_epoch, raw.epoch.0);
+
+        // Successful reload disarms the flag: steady-state empty reconciles
+        // must not pay for a full pending-intent read on every delivery.
+        client.fail_next_released_backfill_reload = true;
+        assert!(
+            client
+                .reconcile_released_transport_receipts()
+                .unwrap()
+                .is_empty()
+        );
+        assert!(client.fail_next_released_backfill_reload);
     }
 
     #[tokio::test]

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -633,6 +633,29 @@ impl AppClient {
         }
     }
 
+    /// Repair durable release evidence independently of lossy engine effects.
+    pub(crate) fn reconcile_released_transport_receipts(
+        &mut self,
+    ) -> Result<Vec<String>, AppError> {
+        let storage = self.app.account_storage(&self.state.label)?;
+        let released = storage.consume_released_transport_receipts()?;
+        if released.is_empty() {
+            return Ok(Vec::new());
+        }
+        let released = released
+            .into_iter()
+            .map(|id| hex::encode(id.as_slice()))
+            .collect::<HashSet<_>>();
+        // No await or fallible operation between acknowledging the durable
+        // journal and removing its ids from memory. Never checkpoint stale ids
+        // back over the transactional deletion, including unsaved ring entries.
+        self.seen_events_index.retain(|id| !released.contains(id));
+        self.state.seen_events.retain(|id| !released.contains(id));
+        self.pending_seen_event_count = self.state.seen_events.len();
+        self.restore_persisted_epoch_backfill_intents(storage.pending_epoch_backfill_intents()?);
+        Ok(released.into_iter().collect())
+    }
+
     /// Apply the publish gate to `effects`, observing the same batch's
     /// epoch-gap recovery evidence first.
     ///
@@ -658,6 +681,7 @@ impl AppClient {
         &mut self,
         effects: &marmot_account::AccountDeviceEffects,
     ) -> Result<(), AppError> {
+        self.reconcile_released_transport_receipts()?;
         self.observe_recovery_evidence(effects);
         self.remember_pending_convergence_groups(effects);
         let failed_updates = self.invalidate_failed_app_message_projections(effects, None)?;
@@ -721,7 +745,8 @@ impl AppClient {
     /// Each route reconciles against the exact event-id set retained in this
     /// account's SQLCipher database, so traffic in one busy group cannot move
     /// or evict another route's completeness state.
-    async fn reconcile_transport_history(&self, reconcile_until: u64) -> Result<(), AppError> {
+    async fn reconcile_transport_history(&mut self, reconcile_until: u64) -> Result<(), AppError> {
+        self.reconcile_released_transport_receipts()?;
         let storage = self.app.account_storage(&self.state.label)?;
         let routing = self.routing.snapshot();
         let mut work = Vec::with_capacity(routing.group_routes.len().saturating_add(1));
@@ -1113,6 +1138,7 @@ impl AppClient {
         &mut self,
         effects: &marmot_account::AccountDeviceEffects,
     ) -> Result<SyncSummary, AppError> {
+        self.reconcile_released_transport_receipts()?;
         // Session open seeds this list from durable queued/convergence input.
         // Preserve that scheduling edge even when hydration emitted no app
         // events; the worker drains this set immediately after startup sync.
@@ -1455,6 +1481,7 @@ impl AppClient {
                     ));
                 }
             };
+            self.reconcile_released_transport_receipts()?;
             let event_id = hex::encode(delivery.message.id.as_slice());
             if is_own_relay_echo(&delivery, &local_account_id_hex, &self.seen_events_index) {
                 self.record_durable_transport_reconciliation_delivery(&delivery);
@@ -1949,6 +1976,18 @@ impl AppClient {
             // Any delivery proves the stream is alive, including one this drain
             // goes on to skip as an echo or a duplicate.
             silence_started = std::time::Instant::now();
+            if let Err(error) = self.reconcile_released_transport_receipts() {
+                return Err(self
+                    .finish_failed_sync_drain(
+                        summary,
+                        routes_dirty,
+                        counts.clone(),
+                        StagedSyncError::new(error, SyncFailureStage::StatePersist),
+                        drain_started,
+                        cursor_before_secs,
+                    )
+                    .await);
+            }
             let event_id = hex::encode(delivery.message.id.as_slice());
             if is_own_relay_echo(&delivery, &local_account_id_hex, &self.seen_events_index)
                 || self.seen_events_index.contains(&event_id)
@@ -2242,9 +2281,12 @@ impl AppClient {
         let group_id_hint = delivery.group_id_hint.clone();
         let reconciliation_record =
             transport_reconciliation_record(self.adapter.account_id(), &delivery);
+        self.reconcile_released_transport_receipts()?;
         let effects = self.runtime.ingest_delivery(delivery).await?;
+        let released = self.reconcile_released_transport_receipts()?;
         let publish_error = fail_if_publish_failed(&effects.effects).err();
-        let must_stay_fetchable = effects.left_object_unpersisted;
+        let must_stay_fetchable =
+            effects.left_object_unpersisted || released.contains(&source_message_id_hex);
         if !must_stay_fetchable && let Some((route, item)) = &reconciliation_record {
             self.record_transport_reconciliation_item(route, item);
         }
@@ -3876,6 +3918,7 @@ impl AppClient {
         &mut self,
         created_group_id_hex: Option<&str>,
     ) -> Result<Option<crate::ChatListRow>, AppError> {
+        self.reconcile_released_transport_receipts()?;
         let frontiers_to_clear = self
             .pending_local_group_deletion_frontier_clears
             .iter()

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -650,9 +650,17 @@ impl AppClient {
         // No await or fallible operation between acknowledging the durable
         // journal and removing its ids from memory. Never checkpoint stale ids
         // back over the transactional deletion, including unsaved ring entries.
+        let unsaved_start = self
+            .state
+            .seen_events
+            .len()
+            .saturating_sub(self.pending_seen_event_count);
+        self.pending_seen_event_count = self.state.seen_events[unsaved_start..]
+            .iter()
+            .filter(|id| !released.contains(*id))
+            .count();
         self.seen_events_index.retain(|id| !released.contains(id));
         self.state.seen_events.retain(|id| !released.contains(id));
-        self.pending_seen_event_count = self.state.seen_events.len();
         if !released.is_empty() {
             tracing::info!(
                 target: "marmot_app::relay_plane",
@@ -2586,6 +2594,9 @@ impl AppClient {
             });
     }
 
+    /// Merge durable arms into their existing retry owners. Counters describe
+    /// account-wide replay attempts, so new groups get a fresh queued intent
+    /// instead of inheriting another run's EOSE failures or resetting that run.
     pub(crate) fn restore_persisted_epoch_backfill_intents(
         &mut self,
         intents: Vec<storage_sqlite::StoredEpochBackfillIntent>,
@@ -2597,12 +2608,29 @@ impl AppClient {
                 malformed = malformed.saturating_add(1);
                 continue;
             };
-            pending.groups.insert(
-                cgka_traits::GroupId::new(group_id),
-                PendingEpochBackfillGroup {
-                    stalled_epoch: intent.stalled_epoch,
-                },
-            );
+            let group_id = cgka_traits::GroupId::new(group_id);
+            if let Some(existing) = self
+                .pending_epoch_backfill
+                .iter_mut()
+                .chain(self.queued_epoch_backfills.iter_mut())
+                .filter_map(|owner| owner.groups.get_mut(&group_id))
+                .max_by_key(|group| group.stalled_epoch)
+            {
+                // Epoch progress continues the existing recovery run. Its
+                // backoff is capped, and a novel-progress drain resets pacing;
+                // repeated journal loads must not buy a fresh retry ordinal.
+                existing.stalled_epoch = existing.stalled_epoch.max(intent.stalled_epoch);
+            } else {
+                pending
+                    .groups
+                    .entry(group_id)
+                    .and_modify(|group| {
+                        group.stalled_epoch = group.stalled_epoch.max(intent.stalled_epoch)
+                    })
+                    .or_insert(PendingEpochBackfillGroup {
+                        stalled_epoch: intent.stalled_epoch,
+                    });
+            }
         }
         if malformed > 0 {
             tracing::warn!(
@@ -2613,7 +2641,11 @@ impl AppClient {
             );
         }
         if !pending.groups.is_empty() {
-            self.pending_epoch_backfill = Some(pending);
+            if self.pending_epoch_backfill.is_none() && self.queued_epoch_backfills.is_empty() {
+                self.pending_epoch_backfill = Some(pending);
+            } else {
+                self.queued_epoch_backfills.push_back(pending);
+            }
         }
     }
 
@@ -5022,6 +5054,190 @@ mod tests {
             crate::client::epoch_stall::PendingEpochBackfillGroup { stalled_epoch },
         );
         pending
+    }
+
+    #[tokio::test]
+    async fn released_receipts_preserve_only_the_surviving_unsaved_tail() {
+        use cgka_traits::storage::MessageStorage;
+        use cgka_traits::{EpochId, MessageId, MessageRecord, MessageState};
+
+        for (pending_count, released_indices, expected_count) in [
+            (3, vec![0, 3], 2),
+            (0, vec![0], 0),
+            (2, vec![3, 4], 0),
+            (5, vec![0, 3], 3),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            AccountHome::open(dir.path())
+                .create_account("alice")
+                .unwrap();
+            let app = MarmotApp::with_relay(dir.path(), "wss://backfill.example")
+                .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+            let mut client = app.client("alice").await.unwrap();
+            let group = client.create_group("seen tail", &[]).await.unwrap();
+            let storage = app.account_storage("alice").unwrap();
+            let ids = (0..5)
+                .map(|i| MessageId::new(vec![i; 32]))
+                .collect::<Vec<_>>();
+            let ring = ids
+                .iter()
+                .map(|id| hex::encode(id.as_slice()))
+                .collect::<Vec<_>>();
+            client.state.seen_events = ring.clone();
+            client.seen_events_index = ring.iter().cloned().collect();
+            client.pending_seen_event_count = pending_count;
+            let expected_tail = ring[5 - pending_count..]
+                .iter()
+                .filter(|id| !released_indices.iter().any(|index| **id == ring[*index]))
+                .cloned()
+                .collect::<Vec<_>>();
+            for index in &released_indices {
+                let raw = MessageRecord {
+                    id: ids[*index].clone(),
+                    group_id: group.clone(),
+                    epoch: EpochId(0),
+                    state: MessageState::PeelDeferred,
+                    payload: Vec::new(),
+                    deferred_peel: None,
+                };
+                storage.put_message(&raw).unwrap();
+                storage.release_message_for_replay(&raw).unwrap();
+            }
+            client.reconcile_released_transport_receipts().unwrap();
+            assert_eq!(client.pending_seen_event_count, expected_count);
+            let start = client.state.seen_events.len() - client.pending_seen_event_count;
+            assert_eq!(client.state.seen_events[start..], expected_tail);
+            assert_eq!(client.seen_events_index.len(), 5 - released_indices.len());
+        }
+    }
+
+    fn assert_backfill_retry_state_unchanged(
+        actual: &PendingEpochBackfill,
+        before: &PendingEpochBackfill,
+    ) {
+        assert_eq!(actual.attempt_id, before.attempt_id);
+        assert_eq!(actual.execution_attempts, before.execution_attempts);
+        assert_eq!(
+            actual.eose_unconfirmed_attempts,
+            before.eose_unconfirmed_attempts
+        );
+        assert_eq!(actual.no_progress_attempts, before.no_progress_attempts);
+        assert_eq!(actual.last_deferred_audit, before.last_deferred_audit);
+    }
+
+    #[tokio::test]
+    async fn released_backfill_restore_preserves_owned_retry_progress_and_merges_new_work() {
+        use cgka_traits::GroupId;
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let app = MarmotApp::with_relay(dir.path(), "wss://backfill.example")
+            .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+        let mut client = app.client("alice").await.unwrap();
+        let primary_group = GroupId::new(vec![1]);
+        let queued_group = GroupId::new(vec![2]);
+        let memory_only_group = GroupId::new(vec![3]);
+        let new_group = GroupId::new(vec![4]);
+        let mut primary = armed_backfill(&primary_group, 5);
+        primary
+            .groups
+            .extend(armed_backfill(&memory_only_group, 8).groups);
+        primary.execution_attempts = 7;
+        primary.eose_unconfirmed_attempts = 3;
+        primary.no_progress_attempts = 2;
+        primary.last_deferred_audit =
+            Some(crate::client::epoch_stall::EpochBackfillDeferredSnapshot {
+                reason: marmot_forensics::EpochBackfillDeferredReason::GroupEpochUnavailable,
+                retry_ordinal: 7,
+                group_epochs: vec![(primary_group.clone(), Some(5))],
+            });
+        let mut queued = armed_backfill(&queued_group, 7);
+        queued.execution_attempts = 4;
+        queued.eose_unconfirmed_attempts = 2;
+        queued.no_progress_attempts = 1;
+        client.pending_epoch_backfill = Some(primary.clone());
+        client.queued_epoch_backfills.push_back(queued.clone());
+        let paced_until = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        client.epoch_backfill_retry_not_before = Some(paced_until);
+        let intent = |group: &GroupId, stalled_epoch| storage_sqlite::StoredEpochBackfillIntent {
+            group_id_hex: hex::encode(group.as_slice()),
+            stalled_epoch,
+        };
+        client.restore_persisted_epoch_backfill_intents(vec![
+            intent(&primary_group, 5),
+            intent(&queued_group, 7),
+            intent(&new_group, 3),
+        ]);
+        assert_backfill_retry_state_unchanged(
+            client.pending_epoch_backfill.as_ref().unwrap(),
+            &primary,
+        );
+        assert!(
+            client
+                .pending_epoch_backfill
+                .as_ref()
+                .unwrap()
+                .groups
+                .contains_key(&memory_only_group)
+        );
+        assert_eq!(client.queued_epoch_backfills.len(), 2);
+        assert_backfill_retry_state_unchanged(&client.queued_epoch_backfills[0], &queued);
+        let fresh = client.queued_epoch_backfills[1].clone();
+        assert_eq!(fresh.groups.len(), 1);
+        assert_eq!(fresh.groups[&new_group].stalled_epoch, 3);
+        assert_eq!(
+            (
+                fresh.execution_attempts,
+                fresh.eose_unconfirmed_attempts,
+                fresh.no_progress_attempts
+            ),
+            (0, 0, 0)
+        );
+
+        // Same/older markers cannot reset a live run; a later epoch updates its
+        // existing owner, without duplicating queued groups or changing pacing.
+        client.restore_persisted_epoch_backfill_intents(vec![
+            intent(&primary_group, 4),
+            intent(&queued_group, 9),
+            intent(&new_group, 2),
+        ]);
+        assert_eq!(
+            client.pending_epoch_backfill.as_ref().unwrap().groups[&primary_group].stalled_epoch,
+            5
+        );
+        assert_eq!(
+            client.queued_epoch_backfills[0].groups[&queued_group].stalled_epoch,
+            9
+        );
+        assert_eq!(client.queued_epoch_backfills.len(), 2);
+        assert_backfill_retry_state_unchanged(
+            client.pending_epoch_backfill.as_ref().unwrap(),
+            &primary,
+        );
+        assert_backfill_retry_state_unchanged(&client.queued_epoch_backfills[0], &queued);
+        assert_backfill_retry_state_unchanged(&client.queued_epoch_backfills[1], &fresh);
+        assert_eq!(client.epoch_backfill_retry_not_before, Some(paced_until));
+        client.pending_epoch_backfill = None;
+        client.restore_persisted_epoch_backfill_intents(vec![intent(&queued_group, 9)]);
+        assert!(
+            client.pending_epoch_backfill.is_none(),
+            "queued ownership must not be duplicated"
+        );
+        assert_eq!(client.queued_epoch_backfills.len(), 2);
+        let later_group = GroupId::new(vec![5]);
+        client.restore_persisted_epoch_backfill_intents(vec![intent(&later_group, 1)]);
+        assert!(
+            client.pending_epoch_backfill.is_none(),
+            "new work must not jump ahead of queued owners"
+        );
+        assert_eq!(client.queued_epoch_backfills.len(), 3);
+        assert_backfill_retry_state_unchanged(&client.queued_epoch_backfills[0], &queued);
+        assert!(
+            client.queued_epoch_backfills[2]
+                .groups
+                .contains_key(&later_group)
+        );
     }
 
     #[tokio::test]

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1740,6 +1740,9 @@ impl MarmotApp {
                 .with_wedge_rearm_interval_ms(wedge_rearm_interval_ms),
             epoch_backfill_retry_not_before: None,
             pending_epoch_backfill: None,
+            released_backfill_reload_pending: false,
+            #[cfg(test)]
+            fail_next_released_backfill_reload: false,
             queued_epoch_backfills: std::collections::VecDeque::new(),
             post_join_maintenance_subscriptions: HashMap::new(),
             encrypted_media_not_required_epochs: HashMap::new(),

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1745,6 +1745,7 @@ impl MarmotApp {
             encrypted_media_not_required_epochs: HashMap::new(),
             checkpoint_route_refresh_recomputes: 0,
         };
+        client.reconcile_released_transport_receipts()?;
         let persisted_backfills = self.pending_epoch_backfill_intents(&client.state.label)?;
         client.restore_persisted_epoch_backfill_intents(persisted_backfills);
         let persisted_evidence = self.epoch_stall_evidence(&client.state.label)?;

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -1052,106 +1052,131 @@ async fn run_app_runtime_account_worker(
             }
             _ = scheduled_convergence.timer.as_mut() => {
                 let groups = scheduled_convergence.take_ready();
-                match client.sync_runtime_groups().await {
-                    Ok(()) => {
-                        let mut remaining = groups.len();
-                        for group_id in groups {
-                            // Each group's convergence pass is a long blocking
-                            // stretch of synchronous engine + SQLite work with
-                            // no await inside it, so `JoinHandle::abort` cannot
-                            // land there: without this check the shutdown budget
-                            // is spent running the whole batch to completion.
-                            // The group boundary is the only cut point where no
-                            // snapshot guard is live, so it is also the only one
-                            // that cannot leave a group half-rolled-back.
-                            // Undispatched groups need no hand-off — their
-                            // convergence inputs are durable, so the next
-                            // runtime rediscovers them at catch-up.
-                            if lifecycle.is_stopping() {
-                                tracing::debug!(
-                                    target: "marmot_app::runtime",
-                                    method = "scheduled_convergence",
-                                    skipped_groups = remaining,
-                                    "shutdown requested; leaving remaining convergence passes for the next runtime",
-                                );
-                                break;
-                            }
-                            remaining -= 1;
-                            match client.advance_convergence_after_runtime_sync(&group_id).await {
-                                Ok(summary) => {
-                                    publish_app_runtime_summary(&events, &account_id_hex, &account_label, &summary);
-                                    match client.convergence_schedule_state(&group_id) {
-                                        Ok(state) => scheduled_convergence
-                                            .schedule_after_pass(&group_id, state),
+                // Recovery owns the live client, but member/roster reads can
+                // use the last committed snapshot while its relay I/O waits.
+                // Mutations and reads behind them retain worker FIFO order.
+                let read_snapshot = capture_group_read_snapshot(
+                    &client,
+                    &events,
+                    &account_id_hex,
+                    &account_label,
+                    "runtime scheduled convergence snapshot failed",
+                );
+                serve_snapshot_reads_until(
+                    read_snapshot,
+                    async {
+                        #[cfg(any(test, feature = "test-policy-overrides"))]
+                        if let Some(barrier) = shared.take_next_scheduled_convergence_barrier() {
+                            barrier.wait().await;
+                            barrier.wait().await;
+                        }
+                        match client.sync_runtime_groups().await {
+                            Ok(()) => {
+                                let mut remaining = groups.len();
+                                for group_id in groups {
+                                    // Each group's convergence pass is a long blocking
+                                    // stretch of synchronous engine + SQLite work with
+                                    // no await inside it, so `JoinHandle::abort` cannot
+                                    // land there: without this check the shutdown budget
+                                    // is spent running the whole batch to completion.
+                                    // The group boundary is the only cut point where no
+                                    // snapshot guard is live, so it is also the only one
+                                    // that cannot leave a group half-rolled-back.
+                                    // Undispatched groups need no hand-off — their
+                                    // convergence inputs are durable, so the next
+                                    // runtime rediscovers them at catch-up.
+                                    if lifecycle.is_stopping() {
+                                        tracing::debug!(
+                                            target: "marmot_app::runtime",
+                                            method = "scheduled_convergence",
+                                            skipped_groups = remaining,
+                                            "shutdown requested; leaving remaining convergence passes for the next runtime",
+                                        );
+                                        break;
+                                    }
+                                    remaining -= 1;
+                                    match client.advance_convergence_after_runtime_sync(&group_id).await {
+                                        Ok(summary) => {
+                                            publish_app_runtime_summary(&events, &account_id_hex, &account_label, &summary);
+                                            match client.convergence_schedule_state(&group_id) {
+                                                Ok(state) => scheduled_convergence
+                                                    .schedule_after_pass(&group_id, state),
+                                                Err(err) => {
+                                                    scheduled_convergence
+                                                        .schedule_retry_groups([group_id.clone()]);
+                                                    publish_app_runtime_account_error(
+                                                        &events,
+                                                        &account_id_hex,
+                                                        &account_label,
+                                                        account_error_message(
+                                                            "convergence schedule state failed",
+                                                            &err,
+                                                        ),
+                                                    );
+                                                }
+                                            }
+                                            schedule_pending_convergence_groups(
+                                                &mut scheduled_convergence,
+                                                &mut client,
+                                            );
+                                            let _ = run_pending_epoch_backfill_reporting_arm(
+                                                &mut client,
+                                                &events,
+                                                &account_id_hex,
+                                                &account_label,
+                                                &shared,
+                                                EpochBackfillExecutionSeam::Maintenance,
+                                            )
+                                            .await;
+                                            if sync_summary_triggers_audit_tracker_update(&summary) {
+                                                shared.schedule_audit_log_tracker_update("scheduled_convergence");
+                                            }
+                                        }
                                         Err(err) => {
-                                            scheduled_convergence
-                                                .schedule_retry_groups([group_id.clone()]);
+                                            let mut retry_groups = client.take_pending_convergence_groups();
+                                            retry_groups.push(group_id.clone());
+                                            scheduled_convergence.schedule_retry_groups(retry_groups);
                                             publish_app_runtime_account_error(
                                                 &events,
                                                 &account_id_hex,
                                                 &account_label,
-                                                account_error_message(
-                                                    "convergence schedule state failed",
-                                                    &err,
-                                                ),
+                                                account_error_message("scheduled convergence failed", &err),
                                             );
                                         }
                                     }
-                                    schedule_pending_convergence_groups(
-                                        &mut scheduled_convergence,
-                                        &mut client,
-                                    );
-                                    let _ = run_pending_epoch_backfill_reporting_arm(
-                                        &mut client,
-                                        &events,
-                                        &account_id_hex,
-                                        &account_label,
-                                        &shared,
-                                        EpochBackfillExecutionSeam::Maintenance,
-                                    )
-                                    .await;
-                                    if sync_summary_triggers_audit_tracker_update(&summary) {
-                                        shared.schedule_audit_log_tracker_update("scheduled_convergence");
-                                    }
                                 }
-                                Err(err) => {
-                                    let mut retry_groups = client.take_pending_convergence_groups();
-                                    retry_groups.push(group_id.clone());
-                                    scheduled_convergence.schedule_retry_groups(retry_groups);
+                            }
+                            Err(err) => {
+                                let account_inactive = err.is_account_not_active();
+                                scheduled_convergence.schedule_retry_groups(groups);
+                                publish_app_runtime_account_error(
+                                    &events,
+                                    &account_id_hex,
+                                    &account_label,
+                                    account_error_message("scheduled convergence sync failed", &err),
+                                );
+                                if account_inactive
+                                    && let Err(activation_error) = client.prepare_transport().await
+                                {
                                     publish_app_runtime_account_error(
                                         &events,
                                         &account_id_hex,
                                         &account_label,
-                                        account_error_message("scheduled convergence failed", &err),
+                                        account_error_message(
+                                            "scheduled convergence transport reactivation failed",
+                                            &activation_error,
+                                        ),
                                     );
                                 }
                             }
                         }
-                    }
-                    Err(err) => {
-                        let account_inactive = err.is_account_not_active();
-                        scheduled_convergence.schedule_retry_groups(groups);
-                        publish_app_runtime_account_error(
-                            &events,
-                            &account_id_hex,
-                            &account_label,
-                            account_error_message("scheduled convergence sync failed", &err),
-                        );
-                        if account_inactive
-                            && let Err(activation_error) = client.prepare_transport().await
-                        {
-                            publish_app_runtime_account_error(
-                                &events,
-                                &account_id_hex,
-                                &account_label,
-                                account_error_message(
-                                    "scheduled convergence transport reactivation failed",
-                                    &activation_error,
-                                ),
-                            );
-                        }
-                    }
-                }
+                    },
+                    &mut commands,
+                    &mut pending,
+                    &app,
+                    &account_label,
+                )
+                .await;
             }
             command = async {
                 match pending.pop_front() {

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -232,6 +232,8 @@ pub struct RuntimeSharedServices {
     create_group_catch_up_barrier: Arc<StdMutex<Option<Arc<tokio::sync::Notify>>>>,
     #[cfg(any(test, feature = "test-policy-overrides"))]
     next_startup_sync_barrier: Arc<StdMutex<Option<Arc<tokio::sync::Barrier>>>>,
+    #[cfg(any(test, feature = "test-policy-overrides"))]
+    next_scheduled_convergence_barrier: Arc<StdMutex<Option<Arc<tokio::sync::Barrier>>>>,
 }
 
 const MESSAGE_SUBSCRIPTION_SEEN_ID_LIMIT: usize = MAX_SEEN_EVENT_IDS;
@@ -312,6 +314,8 @@ impl Default for RuntimeSharedServices {
             create_group_catch_up_barrier: Arc::new(StdMutex::new(None)),
             #[cfg(any(test, feature = "test-policy-overrides"))]
             next_startup_sync_barrier: Arc::new(StdMutex::new(None)),
+            #[cfg(any(test, feature = "test-policy-overrides"))]
+            next_scheduled_convergence_barrier: Arc::new(StdMutex::new(None)),
         }
     }
 }
@@ -340,6 +344,8 @@ impl RuntimeSharedServices {
             create_group_catch_up_barrier: Arc::new(StdMutex::new(None)),
             #[cfg(any(test, feature = "test-policy-overrides"))]
             next_startup_sync_barrier: Arc::new(StdMutex::new(None)),
+            #[cfg(any(test, feature = "test-policy-overrides"))]
+            next_scheduled_convergence_barrier: Arc::new(StdMutex::new(None)),
         }
     }
 
@@ -380,6 +386,22 @@ impl RuntimeSharedServices {
     #[cfg(any(test, feature = "test-policy-overrides"))]
     fn take_next_startup_sync_barrier(&self) -> Option<Arc<tokio::sync::Barrier>> {
         self.next_startup_sync_barrier.lock().unwrap().take()
+    }
+
+    /// Test-only hook: hold the next scheduled convergence pass between two
+    /// rendezvous so public read responsiveness can be checked deterministically.
+    #[cfg(any(test, feature = "test-policy-overrides"))]
+    #[doc(hidden)]
+    pub fn set_next_scheduled_convergence_barrier(&self, barrier: Arc<tokio::sync::Barrier>) {
+        *self.next_scheduled_convergence_barrier.lock().unwrap() = Some(barrier);
+    }
+
+    #[cfg(any(test, feature = "test-policy-overrides"))]
+    fn take_next_scheduled_convergence_barrier(&self) -> Option<Arc<tokio::sync::Barrier>> {
+        self.next_scheduled_convergence_barrier
+            .lock()
+            .unwrap()
+            .take()
     }
 
     pub(crate) fn lifecycle(&self) -> RuntimeLifecycle {

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -17295,7 +17295,13 @@ fn close_storage_waits_for_legacy_projection_import() {
             SqlcipherDatabaseKind::AccountProjection,
         )
         .unwrap();
-    drop(LegacyAccountProjectionDb::open(legacy_path, &legacy_key).unwrap());
+    let receipt = hex::encode([42_u8; 32]);
+    {
+        let mut legacy = LegacyAccountProjectionDb::open(legacy_path, &legacy_key).unwrap();
+        let mut state = legacy.load_state("legacy-racing").unwrap();
+        state.seen_events.push(receipt.clone());
+        legacy.save_state(&state).unwrap();
+    }
 
     let entered = std::sync::Arc::new(std::sync::Barrier::new(2));
     let release = std::sync::Arc::new(std::sync::Barrier::new(2));
@@ -17307,7 +17313,12 @@ fn close_storage_waits_for_legacy_projection_import() {
     }));
 
     let migrating_app = app.clone();
-    let migration = std::thread::spawn(move || migrating_app.ensure_account_state("legacy-racing"));
+    // Exercise exactly the guarded import. The broader ensure_account_state
+    // performs another storage access after this guard drops; terminal close
+    // may legitimately win that later access and return StorageError::Closed.
+    let migration = std::thread::spawn(move || {
+        migrating_app.migrate_legacy_account_projection_if_needed("legacy-racing")
+    });
     entered.wait();
 
     let closing_app = app.clone();
@@ -17323,24 +17334,54 @@ fn close_storage_waits_for_legacy_projection_import() {
         closed_tx.send(()).unwrap();
         result
     });
-    started_rx
-        .recv()
-        .expect("the closing thread should reach close_storage");
-    assert!(
-        closed_rx
-            .recv_timeout(std::time::Duration::from_millis(250))
-            .is_err(),
-        "terminal close must wait for the legacy database import window",
+    // Do not assert while either thread is outstanding. Even a broken close
+    // must release the importer and join both SQLite users before unwinding.
+    let close_started = started_rx.recv();
+    let close_was_blocked = matches!(
+        closed_rx.recv_timeout(std::time::Duration::from_millis(250)),
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout)
     );
-    assert!(matches!(
+    let lease_was_held = matches!(
         MarmotRootRuntimeLease::try_acquire(root),
         Err(AppError::RuntimeBusy)
-    ));
+    );
 
     release.wait();
-    migration.join().unwrap().unwrap();
-    closer.join().unwrap().unwrap();
+    let migration_result = migration.join();
+    let close_result = closer.join();
+    close_started.expect("the closing thread should reach close_storage");
+    assert!(
+        close_was_blocked,
+        "terminal close must wait for the legacy database import window",
+    );
+    assert!(lease_was_held, "the root lease must cover the import");
+    migration_result
+        .unwrap()
+        .expect("the guarded import must finish");
+    close_result
+        .unwrap()
+        .expect("close must finish after import");
+    assert!(app.storage_is_closed());
     drop(MarmotRootRuntimeLease::try_acquire(root).expect("root lease must be released"));
+
+    // Closing waits for the entire import, including its durable completion
+    // marker. Verify both the imported data and the marker after encrypted reopen.
+    let reopened =
+        MarmotApp::with_relays_and_account_home(root, Vec::new(), AccountHome::open(root));
+    let storage = reopened.account_storage("legacy-racing").unwrap();
+    assert!(
+        storage
+            .account_import_marker(LEGACY_ACCOUNT_PROJECTION_IMPORT_MARKER)
+            .unwrap()
+    );
+    assert_eq!(
+        storage
+            .load_account_projection_state("legacy-racing", MAX_SEEN_EVENT_IDS)
+            .unwrap()
+            .seen_events,
+        vec![receipt]
+    );
+    reopened.close_storage().unwrap();
 }
 
 /// Concurrent `close_storage` callers must serialize: no caller may return

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -18697,7 +18697,7 @@ async fn reconcile_repairs_stale_two_member_count_on_three_member_group_body() {
 fn released_transport_is_replayed_after_lost_effect_and_reopen() {
     run_composed_app_runtime_test("released-transport-replay", || async {
         use cgka_traits::storage::MessageStorage;
-        for handling in ["checkpoint", "reopen", "failed effects"] {
+        for handling in ["checkpoint", "reopen", "failed effects", "unsaved receipts"] {
             let dir = tempfile::tempdir().unwrap();
             let relay = Arc::new(ScriptedPushRelayClient::default());
             let (app, mut client, route) =
@@ -18716,6 +18716,23 @@ fn released_transport_is_replayed_after_lost_effect_and_reopen() {
             // Include a pending in-memory receipt that a later checkpoint would
             // otherwise write back, as well as the already checkpointed receipt.
             client.pending_seen_event_count = client.state.seen_events.len();
+            if handling == "unsaved receipts" {
+                // Construct the state left by a best-effort inventory write
+                // failure and an uncheckpointed seen ring: retained raw bytes,
+                // active in-memory receipt, no durable receipt or old journal.
+                // The storage-only consume deliberately leaves client memory
+                // untouched; this is fixture setup, not the app integration.
+                storage.release_message_for_replay(&record).unwrap();
+                storage.consume_released_transport_receipts().unwrap();
+                storage.put_message(&record).unwrap();
+                assert!(
+                    !app.load_state("alice")
+                        .unwrap()
+                        .seen_events
+                        .contains(&probe.id)
+                );
+                assert!(client.seen_events_index.contains(&probe.id));
+            }
             storage.release_message_for_replay(&record).unwrap();
             if handling == "reopen" {
                 drop(client);

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -826,6 +826,16 @@ pub(crate) fn bounded_epoch_backfill_config() -> MarmotAppConfig {
         .with_dev_epoch_backfill_retry_backoff_ms(0)
 }
 
+/// Queue/correlation tests also run without `test-policy-overrides`, where the
+/// configured zero backoff is correctly ignored. Advance the already-armed
+/// deadline instead of bypassing the automatic seam or waiting in wall-clock.
+fn expire_epoch_backfill_retry_cooldown(client: &mut crate::AppClient) {
+    *client
+        .epoch_backfill_retry_not_before
+        .as_mut()
+        .expect("a failed replay must arm its retry cooldown") = std::time::Instant::now();
+}
+
 /// Open a client on the app's *own* relay plane.
 ///
 /// [`MarmotApp::client`] mints a fresh plane per client, so a test that drives
@@ -1192,6 +1202,7 @@ fn failed_epoch_backfill_activation_retains_one_correlated_retry() {
             "failed activation must retain pending recovery"
         );
 
+        expire_epoch_backfill_retry_cooldown(&mut client);
         let retry = client
             .run_pending_epoch_backfill(marmot_forensics::EpochBackfillExecutionSeam::Maintenance)
             .await
@@ -3811,6 +3822,7 @@ fn in_flight_epoch_backfill_arm_preserves_both_operation_intents_on_failure() {
             "the failed operation must be queued instead of orphaned"
         );
 
+        expire_epoch_backfill_retry_cooldown(&mut client);
         let operation_b_retry = client
             .run_pending_epoch_backfill(marmot_forensics::EpochBackfillExecutionSeam::Maintenance)
             .await
@@ -4147,6 +4159,7 @@ fn deferred_primary_epoch_backfill_rotates_behind_queued_older_operation() {
             "the deferred newer operation must rotate behind the queued older work"
         );
 
+        expire_epoch_backfill_retry_cooldown(&mut client);
         let older_retry = client
             .run_pending_epoch_backfill(marmot_forensics::EpochBackfillExecutionSeam::Maintenance)
             .await

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -18690,3 +18690,95 @@ async fn reconcile_repairs_stale_two_member_count_on_three_member_group_body() {
     );
     runtime.shutdown().await;
 }
+
+/// The storage release is the durable boundary; no engine event is delivered
+/// here, modeling cancellation after engine deletion but before app projection.
+#[test]
+fn released_transport_is_replayed_after_lost_effect_and_reopen() {
+    run_composed_app_runtime_test("released-transport-replay", || async {
+        use cgka_traits::storage::MessageStorage;
+        for handling in ["checkpoint", "reopen", "failed effects"] {
+            let dir = tempfile::tempdir().unwrap();
+            let relay = Arc::new(ScriptedPushRelayClient::default());
+            let (app, mut client, route) =
+                undecryptable_probe_route(&dir, &relay, MarmotAppConfig::default()).await;
+            let created_at = crate::unix_now_seconds() - 1_000;
+            let probe = epoch_gap_probe(&route.nostr_group_id_hex, created_at, "release-replay");
+            let mut delivery = route.probe(created_at, "release-replay");
+            delivery.message = probe.to_transport_message().unwrap();
+            client
+                .ingest_received_delivery(delivery.clone())
+                .await
+                .unwrap();
+            let storage = app.account_storage("alice").unwrap();
+            let record = storage.get_message(&delivery.message.id).unwrap();
+            assert!(client.seen_events_index.contains(&probe.id));
+            // Include a pending in-memory receipt that a later checkpoint would
+            // otherwise write back, as well as the already checkpointed receipt.
+            client.pending_seen_event_count = client.state.seen_events.len();
+            storage.release_message_for_replay(&record).unwrap();
+            if handling == "reopen" {
+                drop(client);
+                client = client_on_app_relay_plane(&app, "alice").await;
+            } else if handling == "failed effects" {
+                let mut effects = marmot_account::AccountDeviceEffects::default();
+                effects.events.push(
+                    cgka_traits::engine::GroupEvent::TransportObjectResourceRefused {
+                        group_id: route.group_id.clone(),
+                        message_id: delivery.message.id.clone(),
+                        resource:
+                            cgka_traits::ingest::InboundResourceLimit::TransportDeferredRetryBudget,
+                    },
+                );
+                effects.failures.push(marmot_account::PublishFailure {
+                    message_id: delivery.message.id.clone(),
+                    reason: "injected".into(),
+                });
+                effects
+                    .pending
+                    .push(marmot_account::PendingResolution::RolledBack {
+                        pending: cgka_traits::engine_state::PendingStateRef::new(7),
+                    });
+                assert!(
+                    client
+                        .observe_drained_session_events(&effects)
+                        .await
+                        .is_err()
+                );
+            } else {
+                client
+                    .save_state_with_pending_local_group_deletion_frontier_clears()
+                    .unwrap();
+            }
+            assert!(!client.seen_events_index.contains(&probe.id));
+            assert!(!client.state.seen_events.contains(&probe.id));
+            assert!(client.has_pending_epoch_backfill());
+            let inventory = storage
+                .transport_reconciliation_inventory(
+                    &storage_sqlite::TransportReconciliationRoute::Group(
+                        hex::decode(&route.nostr_group_id_hex)
+                            .unwrap()
+                            .try_into()
+                            .unwrap(),
+                    ),
+                    crate::unix_now_seconds(),
+                )
+                .unwrap();
+            assert!(
+                !inventory
+                    .items
+                    .iter()
+                    .any(|item| hex::encode(item.event_id) == probe.id)
+            );
+            inject_epoch_gap_probe(&app, probe.clone()).await;
+            client.sync().await.unwrap();
+            assert_eq!(
+                recorded_ingest_outcomes(&app, &probe.id).len(),
+                2,
+                "the exact same transport id must reach engine admission again"
+            );
+            assert!(storage.get_message(&delivery.message.id).is_ok());
+            assert!(client.seen_events_index.contains(&probe.id));
+        }
+    });
+}

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -3084,6 +3084,107 @@ async fn app_runtime_delete_group_local_removes_projection_without_publishing_le
 
 #[tokio::test]
 #[cfg(feature = "test-policy-overrides")]
+async fn app_runtime_serves_member_reads_during_scheduled_convergence() {
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, url) = mock_relay().await;
+    let app = MarmotApp::with_relay_and_config(
+        dir.path(),
+        url.clone(),
+        MarmotAppConfig::default()
+            .with_allow_loopback_relay_endpoints(true)
+            .with_dev_settlement_quiescence_ms(100),
+    );
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let setup = AccountSetupRequest {
+        default_relays: vec![endpoint(&url)],
+        bootstrap_relays: vec![endpoint(&url)],
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+    let alice = create_network_ready_identity(&runtime, setup.relay_options_only()).await;
+    let bob = create_network_ready_identity(&runtime, setup).await;
+    let alice_id = alice.account.account_id_hex;
+    let bob_id = bob.account.account_id_hex;
+    let mut events = runtime.subscribe();
+    let group_id = runtime
+        .create_group(
+            &alice_id,
+            "scheduled reads",
+            std::slice::from_ref(&bob_id),
+            None,
+        )
+        .await
+        .unwrap();
+    wait_for_event(&mut events, |event| {
+        matches!(event, MarmotAppEvent::GroupJoined { account_id_hex, group_id: joined, .. }
+            if account_id_hex == &bob_id && joined == &group_id)
+    })
+    .await;
+    runtime.catch_up_accounts().await.unwrap();
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let mut group_state = runtime
+        .subscribe_group_state(&bob_id, &group_id_hex)
+        .await
+        .unwrap();
+    let barrier = Arc::new(tokio::sync::Barrier::new(2));
+    runtime
+        .shared_services()
+        .set_next_scheduled_convergence_barrier(barrier.clone());
+
+    // A real inbound commit arms the scheduled pass. Its work cannot finish
+    // until every public read below has completed; no sleep creates the window.
+    let rename = runtime.update_group_profile(
+        &alice_id,
+        &group_id,
+        Some("recovered profile".to_owned()),
+        None,
+    );
+    let read_during_recovery = async {
+        timeout(Duration::from_secs(10), barrier.wait())
+            .await
+            .expect("inbound commit must reach scheduled convergence");
+        for account_id in [&alice_id, &bob_id] {
+            let members = timeout(
+                Duration::from_secs(2),
+                runtime.group_members(account_id, &group_id),
+            )
+            .await
+            .expect("member reads must not wait for scheduled recovery")
+            .unwrap();
+            let mut member_ids = members
+                .into_iter()
+                .map(|member| member.member_id_hex)
+                .collect::<Vec<_>>();
+            member_ids.sort();
+            let mut expected = vec![alice_id.clone(), bob_id.clone()];
+            expected.sort();
+            assert_eq!(member_ids, expected);
+            let roster = timeout(
+                Duration::from_secs(2),
+                runtime.group_roster(account_id, &group_id),
+            )
+            .await
+            .expect("roster reads must not wait for scheduled recovery")
+            .unwrap();
+            assert_eq!(roster.roster_revision, roster.epoch.saturating_mul(3));
+            assert_eq!(roster.self_membership, SelfMembership::Member);
+            assert_eq!(roster.members.len(), 2);
+        }
+        timeout(Duration::from_secs(2), barrier.wait())
+            .await
+            .expect("scheduled recovery must remain held throughout the reads");
+    };
+    let (renamed, ()) = tokio::join!(rename, read_during_recovery);
+    renamed.unwrap();
+    wait_for_group_state_update(&mut group_state, |group| {
+        group.profile.name == "recovered profile"
+    })
+    .await;
+    runtime.shutdown_and_close().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "test-policy-overrides")]
 async fn app_runtime_serves_member_reads_before_initial_catch_up_completes() {
     // Regression: the account worker must answer read commands as soon as the
     // session is hydrated, WITHOUT blocking on the initial relay catch-up. On

--- a/crates/storage-sqlite/README.md
+++ b/crates/storage-sqlite/README.md
@@ -123,12 +123,13 @@ The default trait implementation remains compatible with other backends.
 Run the opt-in paired benchmark against encrypted temporary files:
 
 ```sh
-CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=false cargo test --release --locked -p storage-sqlite \
+MDK_DEFERRED_PREPARATION_BENCHMARK_OUT=target/deferred-preparation.json \
+  CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=false cargo test --release --locked -p storage-sqlite \
   --lib deferred_metadata_file_backed_benchmark -- --ignored --nocapture
 ```
 
 It generates 0/4,096 processed rows and 0/64/512/2,048 deferred rows with 4 KiB payloads, varies
-row epochs over 17 values, includes persisted lifecycle fields, alternates query order, and reports ten warmed samples after two warmups.
+row epochs over 17 values, includes persisted lifecycle fields, alternates query order, and writes ten warmed samples after two warmups to the requested private JSON file.
 Reported blob bytes count full-record values materialized in Rust; they exclude SQLite pages,
 metadata values, and filesystem cache effects. This measures storage enumeration, not retained
 MLS context construction or scheduler wake pressure. No timing threshold is asserted.

--- a/crates/storage-sqlite/README.md
+++ b/crates/storage-sqlite/README.md
@@ -111,3 +111,30 @@ cargo test -p storage-sqlite
 ```
 
 See [`AGENTS.md`](AGENTS.md) for module layout and migration rules.
+
+## Deferred recovery preparation benchmark
+
+`MessageStorage::list_deferred_message_metadata` preserves insertion order and exact encoded payload
+lengths while omitting normalized payload blobs. The engine uses it for sweep preparation and readiness,
+then fetches full records only for selected attempts, retirement, or bounded lifecycle normalization.
+Legacy format-1 rows still require their record blob until existing bounded promotion converts them.
+The default trait implementation remains compatible with other backends.
+
+Run the opt-in paired benchmark against encrypted temporary files:
+
+```sh
+CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=false cargo test --release --locked -p storage-sqlite \
+  --lib deferred_metadata_file_backed_benchmark -- --ignored --nocapture
+```
+
+It generates 0/4,096 processed rows and 0/64/512/2,048 deferred rows with 4 KiB payloads, varies
+row epochs over 17 values, includes persisted lifecycle fields, alternates query order, and reports ten warmed samples after two warmups.
+Reported blob bytes count full-record values materialized in Rust; they exclude SQLite pages,
+metadata values, and filesystem cache effects. This measures storage enumeration, not retained
+MLS context construction or scheduler wake pressure. No timing threshold is asserted.
+
+On the September 6, 2026 local run, 4,096 processed plus 2,048 deferred rows took about 29.8 ms
+for the full-row query versus 15.1 ms for metadata, avoiding 8 MiB of full payload copies per query.
+The query still enumerates all deferred metadata so an unattempted row beyond a previously
+attempted prefix remains visible. Candidate-graph cost and repeated zero-attempt wake pacing
+remain follow-up work in [#1715](https://github.com/marmot-protocol/mdk/issues/1715).

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -116,6 +116,8 @@ mod migration_0057_openmls_values_msgpack;
 mod migration_0058_processed_transport_ids;
 #[path = "migrations/0059_chat_list_unread_membership.rs"]
 mod migration_0059_chat_list_unread_membership;
+#[path = "migrations/0060_released_transport_receipts.rs"]
+mod migration_0060_released_transport_receipts;
 #[cfg(test)]
 #[path = "migrations/test_support.rs"]
 mod test_support;
@@ -425,6 +427,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 59,
         name: "0059_chat_list_unread_membership",
         apply: migration_0059_chat_list_unread_membership::apply,
+    },
+    Migration {
+        version: 60,
+        name: "0060_released_transport_receipts",
+        apply: migration_0060_released_transport_receipts::apply,
     },
 ];
 
@@ -953,7 +960,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 59,
+                found: 60,
                 latest_supported: 46,
             }
         ));
@@ -1009,7 +1016,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 59,
+                found: 60,
                 latest_supported: 46,
             }
         ));
@@ -1313,7 +1320,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 59,
+                found: 60,
                 latest_supported: 46,
             }
         ));

--- a/crates/storage-sqlite/src/migrations/0060_released_transport_receipts.rs
+++ b/crates/storage-sqlite/src/migrations/0060_released_transport_receipts.rs
@@ -1,0 +1,20 @@
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE TABLE cgka_released_transport_receipts (
+    id BLOB PRIMARY KEY,
+    group_id BLOB NOT NULL REFERENCES cgka_groups(id) ON DELETE CASCADE,
+    epoch INTEGER NOT NULL CHECK (epoch >= 0)
+);
+CREATE INDEX idx_released_transport_receipts_group
+    ON cgka_released_transport_receipts(group_id);
+CREATE INDEX idx_transport_reconciliation_event
+    ON transport_reconciliation_items(event_id);
+"#,
+    )
+    .storage()
+}

--- a/crates/storage-sqlite/src/storage/messages.rs
+++ b/crates/storage-sqlite/src/storage/messages.rs
@@ -3,7 +3,7 @@ use crate::connection::CachedSql;
 use crate::connection::retry_on_busy;
 use crate::{
     SqliteAccountStorage, SqliteResultExt, deserialize, epoch_to_i64, i64_to_u64,
-    message_state_from_i64, message_state_to_i64, serialize,
+    message_state_from_i64, message_state_to_i64, serialize, unix_now_seconds_i64,
 };
 use cgka_traits::engine::GroupEvent;
 use cgka_traits::message::{
@@ -83,12 +83,12 @@ impl SqliteAccountStorage {
             }
             conn.execute_cached(
                 "INSERT INTO app_epoch_backfill_intents(group_id, stalled_epoch, updated_at)
-                 SELECT group_id, MAX(epoch), unixepoch() FROM cgka_released_transport_receipts
+                 SELECT group_id, MAX(epoch), ?1 FROM cgka_released_transport_receipts
                  GROUP BY group_id
                  ON CONFLICT(group_id) DO UPDATE SET
                     stalled_epoch = MAX(app_epoch_backfill_intents.stalled_epoch, excluded.stalled_epoch),
                     updated_at = excluded.updated_at",
-                [],
+                params![unix_now_seconds_i64()],
             ).storage()?;
             conn.execute_cached("DELETE FROM cgka_released_transport_receipts", [])
                 .storage()?;

--- a/crates/storage-sqlite/src/storage/messages.rs
+++ b/crates/storage-sqlite/src/storage/messages.rs
@@ -266,6 +266,18 @@ impl MessageStorage for SqliteAccountStorage {
     fn release_message_for_replay(&self, record: &MessageRecord) -> StorageResult<()> {
         let release = || {
             let conn = self.lock()?;
+            // App ownership is durable before engine hydration. It must not
+            // depend on individual receipts: the app's active seen ring may
+            // not have checkpointed yet, and inventory writes are best-effort.
+            // A standalone engine has no app consumer and needs only deletion.
+            if !conn
+                .query_row_cached("SELECT EXISTS(SELECT 1 FROM account_state)", [], |row| {
+                    row.get::<_, bool>(0)
+                })
+                .storage()?
+            {
+                return delete_message_on_connection(&conn, &record.id);
+            }
             // Bound journal metadata even if a host never consumes it. At the
             // bound, fail before deleting bytes; never evict replay evidence.
             let recorded = conn
@@ -995,11 +1007,60 @@ mod tests {
     use rusqlite::params;
 
     #[test]
+    fn released_transport_receipt_journal_does_not_limit_standalone_engine_lifetime() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store.put_group(&sample_group(gid(1), 0, 0)).unwrap();
+        // Exercise more distinct releases than the app journal can retain.
+        // This database has no app owner and consequently no journal consumer.
+        store
+            .with_transaction(|storage| -> StorageResult<()> {
+                for id in 0..=super::RELEASED_TRANSPORT_RECEIPT_CAPACITY {
+                    let mut record =
+                        sample_message(MessageId::new(id.to_be_bytes().to_vec()), gid(1), 0);
+                    record.state = MessageState::PeelDeferred;
+                    storage.put_message(&record)?;
+                    storage.release_message_for_replay(&record)?;
+                    assert!(matches!(
+                        storage.get_message(&record.id),
+                        Err(StorageError::NotFound)
+                    ));
+                }
+                Ok(())
+            })
+            .unwrap();
+        assert!(
+            store
+                .consume_released_transport_receipts()
+                .unwrap()
+                .is_empty()
+        );
+        assert!(store.pending_epoch_backfill_intents().unwrap().is_empty());
+    }
+
+    #[test]
+    fn released_transport_receipt_journal_tracks_app_without_persisted_receipts() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store.ensure_account_projection("app-owner").unwrap();
+        store.put_group(&sample_group(gid(1), 0, 0)).unwrap();
+        let mut record = sample_message(mid(1), gid(1), 0);
+        record.state = MessageState::PeelDeferred;
+        store.put_message(&record).unwrap();
+        // Neither receipt table has ever been populated. Ownership alone must
+        // preserve the evidence needed by an app with unsaved seen entries.
+        store.release_message_for_replay(&record).unwrap();
+        assert_eq!(
+            store.consume_released_transport_receipts().unwrap(),
+            vec![record.id]
+        );
+    }
+
+    #[test]
     fn released_transport_receipts_survive_reopen_and_retire_both_receipt_stores() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("release.db");
         let key = crate::SqlCipherKey::new("synthetic release regression").unwrap();
         let store = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+        store.ensure_account_projection("app-owner").unwrap();
         store.put_group(&sample_group(gid(1), 0, 0)).unwrap();
         let mut record = sample_message(MessageId::new(vec![42; 32]), gid(1), 3);
         record.state = MessageState::PeelDeferred;
@@ -1070,6 +1131,7 @@ mod tests {
     #[test]
     fn released_transport_receipt_transaction_rolls_back_with_raw_bytes() {
         let store = SqliteAccountStorage::in_memory().unwrap();
+        store.ensure_account_projection("app-owner").unwrap();
         store.put_group(&sample_group(gid(1), 0, 0)).unwrap();
         let mut record = sample_message(mid(1), gid(1), 0);
         record.state = MessageState::PeelDeferred;
@@ -1111,6 +1173,7 @@ mod tests {
     #[test]
     fn released_transport_receipt_capacity_never_drops_replay_evidence_or_raw_bytes() {
         let store = SqliteAccountStorage::in_memory().unwrap();
+        store.ensure_account_projection("app-owner").unwrap();
         store.put_group(&sample_group(gid(1), 0, 0)).unwrap();
         store
             .with_transaction(|storage| -> StorageResult<()> {

--- a/crates/storage-sqlite/src/storage/messages.rs
+++ b/crates/storage-sqlite/src/storage/messages.rs
@@ -998,6 +998,7 @@ mod tests {
     #[test]
     #[ignore = "explicit encrypted-storage preparation benchmark"]
     fn deferred_metadata_file_backed_benchmark() {
+        let mut measurements = Vec::new();
         for processed in [0, 4096] {
             for deferred in [0, 64, 512, 2048] {
                 let dir = tempfile::tempdir().unwrap();
@@ -1060,18 +1061,25 @@ mod tests {
                         }
                     }
                 }
-                eprintln!(
-                    "deferred_preparation processed={processed} deferred={deferred} payload_bytes=4096 epochs=17 samples=10 full_avg_us={} metadata_avg_us={} full_rows={} full_blob_bytes={} metadata_full_rows={} metadata_full_blob_bytes={}",
-                    timings[0].as_micros() / 10,
-                    timings[1].as_micros() / 10,
-                    full_reads[0].0,
-                    full_reads[0].1,
-                    full_reads[1].0,
-                    full_reads[1].1
-                );
+                measurements.push(serde_json::json!({
+                    "processed": processed, "deferred": deferred,
+                    "payload_bytes": 4096, "epochs": 17, "samples": 10,
+                    "full_avg_us": timings[0].as_micros() / 10,
+                    "metadata_avg_us": timings[1].as_micros() / 10,
+                    "full_rows": full_reads[0].0, "full_blob_bytes": full_reads[0].1,
+                    "metadata_full_rows": full_reads[1].0,
+                    "metadata_full_blob_bytes": full_reads[1].1,
+                }));
                 store.close().unwrap();
                 assert_ne!(&std::fs::read(&path).unwrap()[..16], b"SQLite format 3\0");
             }
+        }
+        if let Some(path) = std::env::var_os("MDK_DEFERRED_PREPARATION_BENCHMARK_OUT") {
+            fs_private::write_private(
+                std::path::Path::new(&path),
+                &serde_json::to_vec_pretty(&measurements).unwrap(),
+            )
+            .unwrap();
         }
     }
 

--- a/crates/storage-sqlite/src/storage/messages.rs
+++ b/crates/storage-sqlite/src/storage/messages.rs
@@ -14,6 +14,7 @@ use cgka_traits::types::{EpochId, GroupId, MessageId};
 use rusqlite::{OptionalExtension, TransactionBehavior, params};
 
 const INGRESS_DEDUP_MARKER_CAPACITY: i64 = 4_096;
+const RELEASED_TRANSPORT_RECEIPT_CAPACITY: i64 = 8_192;
 const NORMALIZED_MESSAGE_STORAGE_FORMAT: i64 = 2;
 const MESSAGE_FORMAT_PROMOTION_BATCH_MAX: usize = 256;
 
@@ -49,6 +50,53 @@ pub struct StorageFormatBenchSizes {
 }
 
 impl SqliteAccountStorage {
+    /// Retire stale host receipts and durably arm backfill before acknowledging
+    /// release evidence. The caller must remove returned ids from its in-memory
+    /// seen ring synchronously, before its next checkpoint or duplicate check.
+    /// A process death after commit is safe: both disk receipt stores are already
+    /// clean and backfill intent survives. An interrupted engine effects batch
+    /// needs no special handling because the release journal is authoritative.
+    pub fn consume_released_transport_receipts(&self) -> StorageResult<Vec<MessageId>> {
+        // Avoid a write transaction on the ordinary no-release hot path.
+        if !self
+            .lock()?
+            .query_row_cached(
+                "SELECT EXISTS(SELECT 1 FROM cgka_released_transport_receipts)",
+                [],
+                |row| row.get::<_, bool>(0),
+            )
+            .storage()?
+        {
+            return Ok(Vec::new());
+        }
+        let consume = || {
+            let conn = self.lock()?;
+            let ids = conn
+                .prepare_cached("SELECT id FROM cgka_released_transport_receipts ORDER BY id")
+                .storage()?
+                .query_map([], |row| row.get::<_, Vec<u8>>(0))
+                .storage()?
+                .collect::<Result<Vec<_>, _>>()
+                .storage()?;
+            for id in &ids {
+                retire_transport_receipts(&conn, &MessageId::new(id.clone()))?;
+            }
+            conn.execute_cached(
+                "INSERT INTO app_epoch_backfill_intents(group_id, stalled_epoch, updated_at)
+                 SELECT group_id, MAX(epoch), unixepoch() FROM cgka_released_transport_receipts
+                 GROUP BY group_id
+                 ON CONFLICT(group_id) DO UPDATE SET
+                    stalled_epoch = MAX(app_epoch_backfill_intents.stalled_epoch, excluded.stalled_epoch),
+                    updated_at = excluded.updated_at",
+                [],
+            ).storage()?;
+            conn.execute_cached("DELETE FROM cgka_released_transport_receipts", [])
+                .storage()?;
+            Ok(ids.into_iter().map(MessageId::new).collect())
+        };
+        retry_on_busy(|| self.connection.with_transaction(consume))
+    }
+
     /// Read aggregate value sizes without returning any stored content.
     #[cfg(feature = "storage-format-benchmarks")]
     pub fn storage_format_bench_sizes(
@@ -212,6 +260,41 @@ impl MessageStorage for SqliteAccountStorage {
                 tx.commit().storage()?;
                 Ok(())
             })
+        }
+    }
+
+    fn release_message_for_replay(&self, record: &MessageRecord) -> StorageResult<()> {
+        let release = || {
+            let conn = self.lock()?;
+            // Bound journal metadata even if a host never consumes it. At the
+            // bound, fail before deleting bytes; never evict replay evidence.
+            let recorded = conn
+                .execute_cached(
+                    "INSERT INTO cgka_released_transport_receipts(id, group_id, epoch)
+                 SELECT ?1, ?2, ?3 WHERE
+                    (SELECT count(*) FROM cgka_released_transport_receipts) < ?4
+                    OR EXISTS(SELECT 1 FROM cgka_released_transport_receipts WHERE id = ?1)
+                 ON CONFLICT(id) DO UPDATE SET epoch = excluded.epoch",
+                    params![
+                        record.id.as_slice(),
+                        record.group_id.as_slice(),
+                        epoch_to_i64(record.epoch)?,
+                        RELEASED_TRANSPORT_RECEIPT_CAPACITY
+                    ],
+                )
+                .storage()?;
+            if recorded == 0 {
+                return Err(StorageError::Backend(
+                    "released transport receipt journal is full".into(),
+                ));
+            }
+            retire_transport_receipts(&conn, &record.id)?;
+            delete_message_on_connection(&conn, &record.id)
+        };
+        if self.connection.is_current_thread_transaction_owner() {
+            release()
+        } else {
+            retry_on_busy(|| self.connection.with_transaction(release))
         }
     }
 
@@ -842,6 +925,20 @@ fn update_message_state_on_connection(
     Ok(())
 }
 
+fn retire_transport_receipts(conn: &rusqlite::Connection, id: &MessageId) -> StorageResult<()> {
+    conn.execute_cached(
+        "DELETE FROM seen_events WHERE event_id = ?1",
+        params![hex::encode(id.as_slice())],
+    )
+    .storage()?;
+    conn.execute_cached(
+        "DELETE FROM transport_reconciliation_items WHERE event_id = ?1",
+        params![id.as_slice()],
+    )
+    .storage()?;
+    Ok(())
+}
+
 /// Delete a protocol message and its not-yet-acknowledged application event on
 /// the same connection/transaction so neither row can outlive the other.
 fn delete_message_on_connection(conn: &rusqlite::Connection, id: &MessageId) -> StorageResult<()> {
@@ -894,7 +991,166 @@ mod tests {
     use cgka_traits::storage::{
         GroupStorage, MessageStorage, StorageError, StorageProvider, StorageResult,
     };
-    use cgka_traits::types::{EpochId, MemberId};
+    use cgka_traits::types::{EpochId, MemberId, MessageId};
+    use rusqlite::params;
+
+    #[test]
+    fn released_transport_receipts_survive_reopen_and_retire_both_receipt_stores() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("release.db");
+        let key = crate::SqlCipherKey::new("synthetic release regression").unwrap();
+        let store = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+        store.put_group(&sample_group(gid(1), 0, 0)).unwrap();
+        let mut record = sample_message(MessageId::new(vec![42; 32]), gid(1), 3);
+        record.state = MessageState::PeelDeferred;
+        store.put_message(&record).unwrap();
+        let seed_receipts = |store: &SqliteAccountStorage| {
+            let conn = store.lock().unwrap();
+            conn.execute(
+                "INSERT INTO seen_events(event_id, seen_at) VALUES (?1, 1)",
+                params![hex::encode(record.id.as_slice())],
+            )
+            .unwrap();
+            conn.execute("INSERT INTO transport_reconciliation_items(route_kind, route_id, event_id, created_at)
+                VALUES(1, ?1, ?2, 1)", params![vec![9_u8; 32], record.id.as_slice()]).unwrap();
+        };
+        seed_receipts(&store);
+        store.release_message_for_replay(&record).unwrap();
+        assert!(matches!(
+            store.get_message(&record.id),
+            Err(StorageError::NotFound)
+        ));
+        for table in ["seen_events", "transport_reconciliation_items"] {
+            assert_eq!(
+                store
+                    .lock()
+                    .unwrap()
+                    .query_row(&format!("SELECT count(*) FROM {table}"), [], |row| row
+                        .get::<_, i64>(0))
+                    .unwrap(),
+                0
+            );
+        }
+        // Model an old app checkpoint before it has consumed the release.
+        seed_receipts(&store);
+        store.close().unwrap();
+        let store = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+        assert_eq!(
+            store.consume_released_transport_receipts().unwrap(),
+            vec![record.id.clone()]
+        );
+        assert!(
+            store
+                .consume_released_transport_receipts()
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(store.pending_epoch_backfill_intents().unwrap().len(), 1);
+        for table in ["seen_events", "transport_reconciliation_items"] {
+            assert_eq!(
+                store
+                    .lock()
+                    .unwrap()
+                    .query_row(&format!("SELECT count(*) FROM {table}"), [], |row| row
+                        .get::<_, i64>(0))
+                    .unwrap(),
+                0
+            );
+        }
+        store.close().unwrap();
+        let store = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+        assert_eq!(
+            store.pending_epoch_backfill_intents().unwrap().len(),
+            1,
+            "death after journal acknowledgement must not lose recovery intent"
+        );
+        store.close().unwrap();
+    }
+
+    #[test]
+    fn released_transport_receipt_transaction_rolls_back_with_raw_bytes() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store.put_group(&sample_group(gid(1), 0, 0)).unwrap();
+        let mut record = sample_message(mid(1), gid(1), 0);
+        record.state = MessageState::PeelDeferred;
+        store.put_message(&record).unwrap();
+        let result: StorageResult<()> = store.with_transaction(|storage| {
+            storage.release_message_for_replay(&record)?;
+            Err(StorageError::Backend("injected interruption".into()))
+        });
+        assert!(result.is_err());
+        assert_eq!(store.get_message(&record.id).unwrap(), record);
+        assert!(
+            store
+                .consume_released_transport_receipts()
+                .unwrap()
+                .is_empty()
+        );
+        store.release_message_for_replay(&record).unwrap();
+        store
+            .lock()
+            .unwrap()
+            .execute_batch(
+                "CREATE TRIGGER fail_release_ack BEFORE DELETE ON
+            cgka_released_transport_receipts BEGIN SELECT RAISE(ABORT, 'injected'); END;",
+            )
+            .unwrap();
+        assert!(store.consume_released_transport_receipts().is_err());
+        assert!(store.pending_epoch_backfill_intents().unwrap().is_empty());
+        store
+            .lock()
+            .unwrap()
+            .execute_batch("DROP TRIGGER fail_release_ack;")
+            .unwrap();
+        assert_eq!(
+            store.consume_released_transport_receipts().unwrap(),
+            vec![record.id]
+        );
+    }
+
+    #[test]
+    fn released_transport_receipt_capacity_never_drops_replay_evidence_or_raw_bytes() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store.put_group(&sample_group(gid(1), 0, 0)).unwrap();
+        store
+            .with_transaction(|storage| -> StorageResult<()> {
+                let conn = storage.lock()?;
+                for id in 0_u64..8192 {
+                    conn.execute(
+                        "INSERT INTO cgka_released_transport_receipts(id, group_id, epoch)
+                    VALUES(?1, ?2, 0)",
+                        params![id.to_be_bytes().as_slice(), gid(1).as_slice()],
+                    )
+                    .unwrap();
+                }
+                Ok(())
+            })
+            .unwrap();
+        let record = sample_message(mid(42), gid(1), 0);
+        store.put_message(&record).unwrap();
+        assert!(store.release_message_for_replay(&record).is_err());
+        assert_eq!(store.get_message(&record.id).unwrap(), record);
+        assert_eq!(
+            store
+                .lock()
+                .unwrap()
+                .query_row(
+                    "SELECT count(*) FROM cgka_released_transport_receipts",
+                    [],
+                    |row| row.get::<_, i64>(0)
+                )
+                .unwrap(),
+            8192
+        );
+        store.delete_group(&gid(1)).unwrap();
+        assert!(
+            store
+                .consume_released_transport_receipts()
+                .unwrap()
+                .is_empty(),
+            "account group deletion must retire its release journal"
+        );
+    }
 
     #[test]
     fn deferred_metadata_does_not_read_normalized_payloads() {

--- a/crates/storage-sqlite/src/storage/messages.rs
+++ b/crates/storage-sqlite/src/storage/messages.rs
@@ -6,7 +6,9 @@ use crate::{
     message_state_from_i64, message_state_to_i64, serialize,
 };
 use cgka_traits::engine::GroupEvent;
-use cgka_traits::message::{DeferredPeelLifecycle, MessageRecord, MessageState};
+use cgka_traits::message::{
+    DeferredMessageMetadata, DeferredPeelLifecycle, MessageRecord, MessageState,
+};
 use cgka_traits::storage::{GroupStateCheckpointRef, MessageStorage, StorageError, StorageResult};
 use cgka_traits::types::{EpochId, GroupId, MessageId};
 use rusqlite::{OptionalExtension, TransactionBehavior, params};
@@ -273,6 +275,81 @@ impl MessageStorage for SqliteAccountStorage {
         .storage()
     }
 
+    fn list_deferred_message_metadata(
+        &self,
+        group_id: &GroupId,
+    ) -> StorageResult<Vec<DeferredMessageMetadata>> {
+        let conn = self.lock()?;
+        // length(BLOB) reads its size without copying it into Rust. Legacy
+        // format 1 has no independent metadata, so only those rows need the
+        // record blob; they promote through the existing bounded migration.
+        let mut stmt = conn
+            .prepare_cached(
+                "SELECT id, group_id, epoch, storage_format,
+                    CASE WHEN storage_format = 1 THEN record END,
+                    CASE WHEN typeof(payload) = 'blob' THEN length(payload) END,
+                    deferred_peel
+             FROM cgka_messages WHERE group_id = ?1 AND state = ?2 AND epoch >= 0
+             ORDER BY insert_order",
+            )
+            .storage()?;
+        let rows = stmt
+            .query_map(
+                params![
+                    group_id.as_slice(),
+                    message_state_to_i64(MessageState::PeelDeferred)
+                ],
+                |row| {
+                    Ok((
+                        row.get::<_, Vec<u8>>(0)?,
+                        row.get::<_, Vec<u8>>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, i64>(3)?,
+                        row.get::<_, Option<Vec<u8>>>(4)?,
+                        row.get::<_, Option<i64>>(5)?,
+                        row.get::<_, Option<Vec<u8>>>(6)?,
+                    ))
+                },
+            )
+            .storage()?;
+        rows.map(|row| {
+            let (id, group_id, epoch, format, record, payload_len, lifecycle) = row.storage()?;
+            match format {
+                1 => {
+                    let record = record.ok_or_else(|| {
+                        StorageError::Serialization(
+                            "legacy message row is missing its record blob".into(),
+                        )
+                    })?;
+                    Ok(DeferredMessageMetadata::from(deserialize::<MessageRecord>(
+                        &record,
+                    )?))
+                }
+                NORMALIZED_MESSAGE_STORAGE_FORMAT => Ok(DeferredMessageMetadata {
+                    id: MessageId::new(id),
+                    group_id: GroupId::new(group_id),
+                    epoch: EpochId(i64_to_u64(epoch)?),
+                    payload_len: usize::try_from(payload_len.ok_or_else(|| {
+                        StorageError::Serialization(
+                            "normalized message row is missing its payload blob".into(),
+                        )
+                    })?)
+                    .map_err(|_| {
+                        StorageError::Serialization("invalid deferred payload length".into())
+                    })?,
+                    deferred_peel: lifecycle
+                        .as_deref()
+                        .map(deserialize::<DeferredPeelLifecycle>)
+                        .transpose()?,
+                }),
+                version => Err(StorageError::Serialization(format!(
+                    "unsupported message storage format {version}"
+                ))),
+            }
+        })
+        .collect()
+    }
+
     fn list_messages_in_states(
         &self,
         group_id: &GroupId,
@@ -522,8 +599,13 @@ impl MessageStorage for SqliteAccountStorage {
     }
 }
 
+#[cfg(test)]
+thread_local! {
+    static FULL_MESSAGE_READS: std::cell::Cell<(usize, usize)> = const { std::cell::Cell::new((0, 0)) };
+}
+
 fn message_columns(row: &rusqlite::Row<'_>) -> rusqlite::Result<MessageColumns> {
-    Ok((
+    let columns: MessageColumns = (
         row.get(0)?,
         row.get(1)?,
         row.get(2)?,
@@ -532,7 +614,16 @@ fn message_columns(row: &rusqlite::Row<'_>) -> rusqlite::Result<MessageColumns> 
         row.get(5)?,
         row.get(6)?,
         row.get(7)?,
-    ))
+    );
+    #[cfg(test)]
+    FULL_MESSAGE_READS.with(|stats| {
+        let (rows, bytes) = stats.get();
+        stats.set((
+            rows + 1,
+            bytes + columns.5.as_ref().map_or(0, Vec::len) + columns.6.as_ref().map_or(0, Vec::len),
+        ));
+    });
+    Ok(columns)
 }
 
 fn decode_message_columns(columns: MessageColumns) -> StorageResult<MessageRecord> {
@@ -804,6 +895,185 @@ mod tests {
         GroupStorage, MessageStorage, StorageError, StorageProvider, StorageResult,
     };
     use cgka_traits::types::{EpochId, MemberId};
+
+    #[test]
+    fn deferred_metadata_does_not_read_normalized_payloads() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store.put_group(&sample_group(gid(1), 0, 0)).unwrap();
+        let mut expected = Vec::new();
+        for id in [9, 2, 7] {
+            let mut message = sample_message(mid(id), gid(1), u64::from(id));
+            message.state = MessageState::PeelDeferred;
+            message.payload = vec![id; 16 * 1024];
+            expected.push(cgka_traits::message::DeferredMessageMetadata::from(
+                message.clone(),
+            ));
+            store.put_message(&message).unwrap();
+        }
+        store
+            .put_message(&sample_message(mid(3), gid(1), 0))
+            .unwrap();
+        super::FULL_MESSAGE_READS.with(|stats| stats.set((0, 0)));
+        assert_eq!(
+            store.list_deferred_message_metadata(&gid(1)).unwrap(),
+            expected
+        );
+        assert_eq!(
+            super::FULL_MESSAGE_READS.with(|stats| stats.get()),
+            (0, 0),
+            "scheduler metadata must not materialize normalized message payloads"
+        );
+    }
+
+    #[test]
+    fn deferred_metadata_preserves_legacy_and_normalized_rows_after_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("metadata.db");
+        let key = crate::SqlCipherKey::new("synthetic metadata regression").unwrap();
+        let store = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+        store.put_group(&sample_group(gid(1), 0, 0)).unwrap();
+        store.put_group(&sample_group(gid(2), 0, 0)).unwrap();
+        let mut expected = Vec::new();
+        for (index, id) in [9, 2, 7].into_iter().enumerate() {
+            let mut message = sample_message(mid(id), gid(1), u64::from(id));
+            message.state = MessageState::PeelDeferred;
+            message.payload = vec![id; 1024 + index];
+            message.deferred_peel = Some(DeferredPeelLifecycle {
+                first_observed_wall_ms: 10_000,
+                wall_high_water_ms: 10_400,
+                clock_instance_id: 7,
+                residence_deadline_monotonic_ms: 2_000,
+                residence_deadline_wall_ms: 11_000,
+                distinct_context_attempts: index as u32,
+                last_context_fingerprint: Some([id; 32]),
+            });
+            if index == 1 {
+                store
+                    .lock()
+                    .unwrap()
+                    .execute(
+                        "INSERT INTO cgka_messages (id, group_id, epoch, state, record)
+                     VALUES (?1, ?2, ?3, ?4, ?5)",
+                        rusqlite::params![
+                            message.id.as_slice(),
+                            message.group_id.as_slice(),
+                            message.epoch.0 as i64,
+                            super::message_state_to_i64(message.state),
+                            serialize(&message).unwrap()
+                        ],
+                    )
+                    .unwrap();
+            } else {
+                store.put_message(&message).unwrap();
+            }
+            expected.push(cgka_traits::message::DeferredMessageMetadata::from(message));
+        }
+        let mut unrelated = sample_message(mid(4), gid(2), 0);
+        unrelated.state = MessageState::PeelDeferred;
+        store.put_message(&unrelated).unwrap();
+        store.close().unwrap();
+        let store = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+        assert_eq!(
+            store.list_deferred_message_metadata(&gid(1)).unwrap(),
+            expected
+        );
+        store.promote_legacy_message_rows(2).unwrap();
+        assert_eq!(
+            store.list_deferred_message_metadata(&gid(1)).unwrap(),
+            expected
+        );
+        store
+            .update_message_state(&mid(2), MessageState::Processed)
+            .unwrap();
+        expected.remove(1);
+        assert_eq!(
+            store.list_deferred_message_metadata(&gid(1)).unwrap(),
+            expected
+        );
+        store.close().unwrap();
+    }
+
+    /// Compare full-row preparation with metadata preparation in the same
+    /// encrypted database. Logical bytes exclude SQLite pages and cache effects.
+    #[test]
+    #[ignore = "explicit encrypted-storage preparation benchmark"]
+    fn deferred_metadata_file_backed_benchmark() {
+        for processed in [0, 4096] {
+            for deferred in [0, 64, 512, 2048] {
+                let dir = tempfile::tempdir().unwrap();
+                let path = dir.path().join("preparation.db");
+                let key = crate::SqlCipherKey::new("synthetic preparation benchmark").unwrap();
+                let store = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+                store.put_group(&sample_group(gid(1), 0, 0)).unwrap();
+                store
+                    .with_transaction(|tx| {
+                        for index in 0..processed + deferred {
+                            let mut message = sample_message(
+                                cgka_traits::MessageId::new((index as u64).to_be_bytes().to_vec()),
+                                gid(1),
+                                (index % 17) as u64,
+                            );
+                            message.state = if index < processed {
+                                MessageState::Processed
+                            } else {
+                                MessageState::PeelDeferred
+                            };
+                            message.payload = vec![0x71; 4096];
+                            if index >= processed {
+                                message.deferred_peel = Some(DeferredPeelLifecycle {
+                                    first_observed_wall_ms: 10_000,
+                                    wall_high_water_ms: 10_400,
+                                    clock_instance_id: 7,
+                                    residence_deadline_monotonic_ms: 2_000,
+                                    residence_deadline_wall_ms: 11_000,
+                                    distinct_context_attempts: 3,
+                                    last_context_fingerprint: Some([0xA5; 32]),
+                                });
+                            }
+                            tx.put_message(&message)?;
+                        }
+                        Ok::<_, StorageError>(())
+                    })
+                    .unwrap();
+                let mut timings = [std::time::Duration::ZERO; 2];
+                let mut full_reads = [(0, 0); 2];
+                for repetition in 0..12 {
+                    for mode in [repetition % 2, 1 - repetition % 2] {
+                        super::FULL_MESSAGE_READS.with(|stats| stats.set((0, 0)));
+                        let start = std::time::Instant::now();
+                        let count = if mode == 0 {
+                            store
+                                .list_messages_in_states(
+                                    &gid(1),
+                                    &[MessageState::PeelDeferred],
+                                    EpochId(0),
+                                )
+                                .unwrap()
+                                .len()
+                        } else {
+                            store.list_deferred_message_metadata(&gid(1)).unwrap().len()
+                        };
+                        assert_eq!(count, deferred);
+                        if repetition >= 2 {
+                            timings[mode] += start.elapsed();
+                            full_reads[mode] = super::FULL_MESSAGE_READS.with(|stats| stats.get());
+                        }
+                    }
+                }
+                eprintln!(
+                    "deferred_preparation processed={processed} deferred={deferred} payload_bytes=4096 epochs=17 samples=10 full_avg_us={} metadata_avg_us={} full_rows={} full_blob_bytes={} metadata_full_rows={} metadata_full_blob_bytes={}",
+                    timings[0].as_micros() / 10,
+                    timings[1].as_micros() / 10,
+                    full_reads[0].0,
+                    full_reads[0].1,
+                    full_reads[1].0,
+                    full_reads[1].1
+                );
+                store.close().unwrap();
+                assert_ne!(&std::fs::read(&path).unwrap()[..16], b"SQLite format 3\0");
+            }
+        }
+    }
 
     fn application_event(message_id: cgka_traits::MessageId) -> GroupEvent {
         GroupEvent::MessageReceived {

--- a/crates/traits/src/message.rs
+++ b/crates/traits/src/message.rs
@@ -726,6 +726,30 @@ pub struct MessageRecord {
     pub deferred_peel: Option<DeferredPeelLifecycle>,
 }
 
+/// Payload-free view of a deferred row for scheduling, resource accounting and
+/// selecting bounded peel work. Payload bytes are fetched only for chosen rows.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DeferredMessageMetadata {
+    pub id: MessageId,
+    pub group_id: GroupId,
+    pub epoch: EpochId,
+    /// Exact byte length of the encoded `MessageRecord::payload`, not a wire estimate.
+    pub payload_len: usize,
+    pub deferred_peel: Option<DeferredPeelLifecycle>,
+}
+
+impl From<MessageRecord> for DeferredMessageMetadata {
+    fn from(record: MessageRecord) -> Self {
+        Self {
+            id: record.id,
+            group_id: record.group_id,
+            epoch: record.epoch,
+            payload_len: record.payload.len(),
+            deferred_peel: record.deferred_peel,
+        }
+    }
+}
+
 /// Per-message state.
 ///
 /// Transitions:

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -17,7 +17,7 @@ use crate::maintenance::{
     DurableGroupEvolution, DurableTransportFanout, GroupMaintenanceState, KeyPackageLifecycleState,
     MaintenanceObligation, PeriodicMaintenancePolicy,
 };
-use crate::message::{MessageRecord, MessageState};
+use crate::message::{DeferredMessageMetadata, MessageRecord, MessageState};
 use crate::transport_adapter::OutboundFanout;
 use crate::types::{Backend, EpochId, GroupId, MemberId, MessageId};
 use crate::welcome::PendingWelcome;
@@ -250,6 +250,21 @@ pub trait MessageStorage {
             .list_messages(group_id, at_or_after_epoch)?
             .into_iter()
             .filter(|record| states.contains(&record.state))
+            .collect())
+    }
+
+    /// Deferred rows in the same stable order as `list_messages_in_states`,
+    /// without copying payload bytes when the backend supports separate metadata.
+    /// This is a complete metadata enumeration: callers must still discover work
+    /// behind an already-attempted prefix. Legacy backends may use the fallback.
+    fn list_deferred_message_metadata(
+        &self,
+        group_id: &GroupId,
+    ) -> StorageResult<Vec<DeferredMessageMetadata>> {
+        Ok(self
+            .list_messages_in_states(group_id, &[MessageState::PeelDeferred], EpochId(0))?
+            .into_iter()
+            .map(DeferredMessageMetadata::from)
             .collect())
     }
 

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -210,6 +210,15 @@ pub trait MessageStorage {
     fn put_message(&self, record: &MessageRecord) -> StorageResult<()>;
     fn get_message(&self, id: &MessageId) -> StorageResult<MessageRecord>;
     fn delete_message(&self, id: &MessageId) -> StorageResult<()>;
+
+    /// Release retained transport bytes without a terminal deduplication verdict.
+    /// Backends with host receipt bookkeeping must atomically retain evidence
+    /// that those receipts are obsolete, so losing the engine event cannot
+    /// prevent exact-id redelivery. Backends without such bookkeeping may delete.
+    fn release_message_for_replay(&self, record: &MessageRecord) -> StorageResult<()> {
+        self.delete_message(&record.id)
+    }
+
     fn update_message_state(&self, id: &MessageId, new_state: MessageState) -> StorageResult<()>;
     fn list_messages(
         &self,

--- a/docs/marmot-architecture/overview/current-state.md
+++ b/docs/marmot-architecture/overview/current-state.md
@@ -19,6 +19,12 @@ status: overview
 
 # Current State — Implementations & Spec
 
+Deferred transport resource release now preserves app replay eligibility across
+lost engine effects and restart. SQLCipher records release evidence atomically
+with raw-byte deletion; app recovery retires both inventory and duplicate
+receipts before readmission. See [released transport receipts](../storage-format-v2.md#released-transport-receipts).
+The production retention and retry limits remain unchanged.
+
 MDK now exposes opt-in durable onboarding for imported identities, with per-step
 validation, repair proposals, explicit approval, and Swift/Kotlin/C bindings.
 It requires single-device acknowledgment before KeyPackage publication and offers

--- a/docs/marmot-architecture/storage-format-v2.md
+++ b/docs/marmot-architecture/storage-format-v2.md
@@ -33,7 +33,11 @@ by MarmotApp before engine hydration. The check shares the release transaction
 and does not require an existing receipt: the app may hold only an unsaved
 in-memory seen entry. A standalone SQLite engine database without app ownership
 uses ordinary deletion and accumulates no journal or app backfill work, so the
-journal bound is not a lifetime limit on standalone engine releases.
+journal bound is not a lifetime limit on standalone engine releases. If an
+app-owned journal fills, the release error aborts that group's current deferred
+sweep, including retries of unrelated rows. Recovery resumes after the app
+consumes the journal; retaining the raw bytes and replay evidence takes priority
+over progress while the journal is full.
 
 The app consumes this evidence on account open and before receipt checkpoints,
 reconciliation, duplicate/echo shortcuts, and after engine ingest. Consumption

--- a/docs/marmot-architecture/storage-format-v2.md
+++ b/docs/marmot-architecture/storage-format-v2.md
@@ -43,8 +43,12 @@ in one transaction. The caller then clears its in-memory seen ring/index
 synchronously, before any await or fallible operation. Process death before
 consumption leaves the journal; death after acknowledgment leaves clean disk
 receipts and durable backfill. Neither case relies on delivery of the engine's
-in-memory `TransportObjectResourceRefused` event. Exact-ID replay still passes
-through the ordinary authentication and engine deduplication paths.
+in-memory `TransportObjectResourceRefused` event. Completing an older backfill
+must retain durable intents for groups rearmed into pending or queued work,
+including a new release at the same epoch. The next execution owns their cleanup;
+otherwise an old completion can erase the restart recovery edge before that
+execution starts. Exact-ID replay still passes through the ordinary authentication
+and engine deduplication paths.
 
 This prevents future release/receipt mismatches. It cannot reconstruct releases
 that happened before this journal existed; bounded repair of historical receipt

--- a/docs/marmot-architecture/storage-format-v2.md
+++ b/docs/marmot-architecture/storage-format-v2.md
@@ -1,7 +1,7 @@
 ---
 title: "Storage Format v2"
 created: 2026-08-13
-updated: 2026-09-03
+updated: 2026-09-06
 tags: [marmot, storage, sqlite, migration, encoding]
 status: current
 ---
@@ -12,6 +12,34 @@ This document owns MDK's local SQLCipher storage-format contract. It is not a
 Marmot wire format and does not constrain other Marmot implementations. The
 canonical protocol specifies which state must be reproducible; this document
 specifies how `storage-sqlite` currently persists that state.
+
+## Released transport receipts
+
+Schema migration `0060_released_transport_receipts` adds a bounded, account-local
+release journal. The engine calls `MessageStorage::release_message_for_replay`
+when resource policy releases retained raw transport bytes. A backend without
+host receipt bookkeeping may use the trait's delete-only default. A backend
+that advertises possession or suppresses delivery must atomically revoke those
+receipts or persist the evidence needed to revoke them after restart.
+
+SQLCipher atomically deletes the raw row, removes its reconciliation inventory
+and persisted seen entry, and records the id and owning group in
+`cgka_released_transport_receipts`. Ordinary message deletion does not create
+replay work. The journal retains no payload or secret, cascades when the group
+is deleted, and refuses a new release before deleting bytes when 8,192 pending
+entries already exist. It never evicts outstanding replay evidence to admit a
+new journal entry.
+
+The app consumes this evidence on account open and before receipt checkpoints,
+reconciliation, duplicate/echo shortcuts, and after engine ingest. Consumption
+again removes both durable receipts (including an intervening stale checkpoint),
+arms the existing durable group backfill intent, and acknowledges the journal
+in one transaction. The caller then clears its in-memory seen ring/index
+synchronously, before any await or fallible operation. Process death before
+consumption leaves the journal; death after acknowledgment leaves clean disk
+receipts and durable backfill. Neither case relies on delivery of the engine's
+in-memory `TransportObjectResourceRefused` event. Exact-ID replay still passes
+through the ordinary authentication and engine deduplication paths.
 
 ## Versioning model
 

--- a/docs/marmot-architecture/storage-format-v2.md
+++ b/docs/marmot-architecture/storage-format-v2.md
@@ -41,6 +41,12 @@ receipts and durable backfill. Neither case relies on delivery of the engine's
 in-memory `TransportObjectResourceRefused` event. Exact-ID replay still passes
 through the ordinary authentication and engine deduplication paths.
 
+This prevents future release/receipt mismatches. It cannot reconstruct releases
+that happened before this journal existed; bounded repair of historical receipt
+claims is tracked in [#1724](https://github.com/marmot-protocol/mdk/issues/1724).
+Missing historical wrapper markers alone do not prove a release, so migration
+0060 does not clear existing receipt history indiscriminately.
+
 ## Versioning model
 
 There is no database-wide `format_version` independent of schema migrations.

--- a/docs/marmot-architecture/storage-format-v2.md
+++ b/docs/marmot-architecture/storage-format-v2.md
@@ -22,6 +22,13 @@ host receipt bookkeeping may use the trait's delete-only default. A backend
 that advertises possession or suppresses delivery must atomically revoke those
 receipts or persist the evidence needed to revoke them after restart.
 
+The app's receipt stores are advisory transport indexes used for duplicate checks
+and bounded reconciliation queries. Engine row absence alone cannot replace
+their possession answer: older databases did not backfill every accepted wrapper
+into the engine's transport markers. The journal records explicit releases while
+preserving these existing query paths; deriving every receipt from engine state
+would also need a migration-compatible mapping for historical transport ids.
+
 For app-owned databases, SQLCipher atomically deletes the raw row, removes its
 reconciliation inventory and persisted seen entry, and records the id and owning group in
 `cgka_released_transport_receipts`. Ordinary message deletion does not create

--- a/docs/marmot-architecture/storage-format-v2.md
+++ b/docs/marmot-architecture/storage-format-v2.md
@@ -1,7 +1,7 @@
 ---
 title: "Storage Format v2"
 created: 2026-08-13
-updated: 2026-09-06
+updated: 2026-09-07
 tags: [marmot, storage, sqlite, migration, encoding]
 status: current
 ---
@@ -22,13 +22,18 @@ host receipt bookkeeping may use the trait's delete-only default. A backend
 that advertises possession or suppresses delivery must atomically revoke those
 receipts or persist the evidence needed to revoke them after restart.
 
-SQLCipher atomically deletes the raw row, removes its reconciliation inventory
-and persisted seen entry, and records the id and owning group in
+For app-owned databases, SQLCipher atomically deletes the raw row, removes its
+reconciliation inventory and persisted seen entry, and records the id and owning group in
 `cgka_released_transport_receipts`. Ordinary message deletion does not create
 replay work. The journal retains no payload or secret, cascades when the group
 is deleted, and refuses a new release before deleting bytes when 8,192 pending
 entries already exist. It never evicts outstanding replay evidence to admit a
-new journal entry.
+new journal entry. App ownership means a durable `account_state` row, established
+by MarmotApp before engine hydration. The check shares the release transaction
+and does not require an existing receipt: the app may hold only an unsaved
+in-memory seen entry. A standalone SQLite engine database without app ownership
+uses ordinary deletion and accumulates no journal or app backfill work, so the
+journal bound is not a lifetime limit on standalone engine releases.
 
 The app consumes this evidence on account open and before receipt checkpoints,
 reconciliation, duplicate/echo shortcuts, and after engine ingest. Consumption


### PR DESCRIPTION
Large offline catch-up could stop making useful progress even after the earlier recovery fixes. Released transport inputs remained deduplicated, queued outbound work reduced background recovery to four rows, and scheduled recovery could keep public reads waiting past their deadline. This PR fixes those boundaries and maintains two complete-recovery app regressions in required CI.

## What changes

- **Durable replay eligibility.** SQLCipher atomically releases raw bytes, retires transport receipts and records a bounded release journal. The app clears its active duplicate index, schedules durable backfill and acknowledges the journal. Lost effects, failed publication and encrypted reopen cannot strand new releases. Reload failures remain retryable on the same client; older replay completion cannot erase newly armed work. Receipt deltas and existing backfill pacing survive restoration.
- **Bounded background recovery.** Queued output now retains the background recovery allowance of 64 rows and the cooperative 500-ms quantum. Foreground sends and individual queued-intent preflights retain their own limits. Generation/fairness barriers still prevent publication before required input processing. If synchronous preparation overruns a slice that started with available budget, one bounded unit of progress can finish before yielding.
- **Less preparation work.** Deferred readiness uses metadata instead of copying payloads, and internal retries omit discarded lineage classifications. Other storage backends retain compatible fallbacks; live ingestion still classifies the current graph.
- **Responsive public reads.** Scheduled recovery serves snapshot reads during asynchronous waits through the existing FIFO-safe mechanism. This cannot preempt a long synchronous engine/SQLite operation.
- **Accurate app-harness correlation.** A chat send can also publish older queued work. The harness resolves its own public timeline transport identity and associates only that event with the action; unrelated relay publications remain present. Exact message/state/reopen oracles remain enforced.

Migration **0060** owns an 8,192-entry release journal only for app-owned databases and retains raw bytes if the journal is full. Standalone engine users do not accumulate app repair work. No retention policy, raw cap, workspace version or cryptographic policy changes are introduced here.

Current head `2b1121d0` is rebased onto master `0c001837`, including the merged audit-upload fix (#1718) and replayed-proposal anchor fix (#1722). Local `just fast-ci`, `actionlint` and focused regression checks passed. Independent review found no actionable code findings. Both final local 1,024-message app journeys passed at this head (215.03s original, 214.08s extra epochs), with complete recovery, fresh messaging, encrypted reopen and clean closure. Exact-head GitHub CI is still running; the earlier full CI was green at `f2ce9381`.

## Evidence and validation

The instrumented Linux plateau showed fast preparation and repeated four-row slices. Slow-preparation starvation is a separately reproduced defect, not the proven cause of that plateau. The queued-output regression fails against the old code and requires 64 deterministic background attempts while preserving the actual foreground send's four-row budget, frozen-generation gating and single publication.

- 157 targeted engine lifecycle, convergence, publication, atomicity and queue-cleanup tests passed.
- 16 app sync tests passed, including receipt restoration, same/new-epoch rearm, reopen and same-client post-acknowledgement retry. Backfill tests passed under both default policy (17) and explicit test overrides (20).
- Four relay-correlation tests passed; all six lighter full-app journeys passed (109.10 seconds).
- Both 1,024-message recovery journeys run through MarmotAppRuntime, encrypted databases, actual local relay sockets and production policy. They require exact payload sets, agreed public state, fresh traffic and persistence after reopen. Their watchdog remains 900 seconds with a three-restart guard. Before the final review corrections and master rebase, both passed locally in 450.57 seconds at a91b00e6 with clean closure; Linux CI at f2ce9381 passed both journeys in 668.47 seconds. The current local runs also passed (215.03s original and 214.08s extra epochs), with zero recovery restarts and two fixed recovery artifact files per journey; the separate exact CI steps are being exercised by the fresh workflow.

The timestamp and cooldown test corrections preserve the original substantive assertions. The concurrent-close test now directly exercises the guarded import, joins both threads before assertions and verifies populated import after encrypted reopen. All five close-storage tests passed with default and override policies; removing the guard makes the corrected test fail. Linux CI recorded SIGSEGV after that test panicked; no native trace identifies its origin, and no general SQLCipher library crash fix is claimed.

## Review follow-up and merged-base validation

- Per-phase recovery logs now use DEBUG; the explicit backlog diagnostic flag enables them in CI. Production INFO logging retains actual release events without idle phase chatter.
- The required app job builds once, then runs the two named journeys in separate `--exact` steps. Each retains its 900-second watchdog and has a 20-minute CI allowance; the second executes after a first-test failure if the build succeeded.
- Recovery evidence uses fixed filenames for compact progress and a sampled/full-success checkpoint, plus terminal observations. A 104-pass regression verifies bounded file count and final snapshot preservation. Watchdog errors retain the active phase, last completed pass/counts and restart count.
- Missing/inconsistent public transport identities after a successful send are classified as protocol/product failures. The receipt timestamp uses the same Rust clock helper as other writers. Docs explain journal-full behavior, transport-index ownership and the type-safe absence of a sweep lineage verdict.
- On the rebased code: both by-reference rival regressions from #1722 passed; 30 deferred-lifecycle and 12 atomicity/budget tests passed with their documented test-policy feature; five journal, three app error-mapping and one bounded-checkpoint tests passed. The public recovery runs continue to use production policy.

Receipt-access boundary consolidation is tracked separately in #1730.

## Boundaries and stack

This prevents new release/receipt mismatches; historical pre-journal repair remains #1724. Remaining preparation/scan optimization remains #1715. Local timings are not end-to-end performance guarantees.

The intended merge order remains **#1719 → #1720 → #1713**. This PR targets master; work on the two follow-up PRs is paused while #1719 is reviewed. #1720 adds account-owned route progress with migration 0061; #1713 expands public scenario families. Signed commits keep the individual fixes and test corrections bisectable.

Fixes #1721. Partially addresses #1715; does not close it.
