### PR TITLE
Persist reconciliation replay progress with account routes

### DIFF
--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use cgka_traits::GroupId;
@@ -66,16 +67,39 @@ fn event_source_message_id_hex(event: &cgka_traits::engine::GroupEvent, fallback
 struct StoredReconciliationProgress<'a> {
     storage: &'a storage_sqlite::SqliteAccountStorage,
     route: &'a TransportReconciliationRoute,
+    retired: AtomicBool,
+}
+
+impl<'a> StoredReconciliationProgress<'a> {
+    fn new(
+        storage: &'a storage_sqlite::SqliteAccountStorage,
+        route: &'a TransportReconciliationRoute,
+    ) -> Self {
+        Self {
+            storage,
+            route,
+            retired: AtomicBool::new(false),
+        }
+    }
+
+    fn map_storage_error(
+        &self,
+        error: cgka_traits::storage::StorageError,
+        operation: &'static str,
+    ) -> cgka_traits::TransportAdapterError {
+        if matches!(error, cgka_traits::storage::StorageError::NotFound) {
+            self.retired.store(true, Ordering::Relaxed);
+        }
+        cgka_traits::TransportAdapterError::Subscription(operation.into())
+    }
 }
 
 impl transport_nostr_adapter::NostrReconciliationProgress for StoredReconciliationProgress<'_> {
     fn load_cursor(&self) -> Result<Option<[u8; 32]>, cgka_traits::TransportAdapterError> {
         self.storage
             .transport_reconciliation_replay_cursor(self.route)
-            .map_err(|_| {
-                cgka_traits::TransportAdapterError::Subscription(
-                    "read durable reconciliation progress failed".into(),
-                )
+            .map_err(|error| {
+                self.map_storage_error(error, "read durable reconciliation progress failed")
             })
     }
 
@@ -85,10 +109,8 @@ impl transport_nostr_adapter::NostrReconciliationProgress for StoredReconciliati
     ) -> Result<(), cgka_traits::TransportAdapterError> {
         self.storage
             .advance_transport_reconciliation_replay_cursor(self.route, cursor)
-            .map_err(|_| {
-                cgka_traits::TransportAdapterError::Subscription(
-                    "save durable reconciliation progress failed".into(),
-                )
+            .map_err(|error| {
+                self.map_storage_error(error, "save durable reconciliation progress failed")
             })
     }
 }
@@ -831,6 +853,7 @@ impl AppClient {
 
         let mut attempted_routes = 0usize;
         let mut routes_failed = 0usize;
+        let mut routes_retired = 0usize;
         let mut relays_succeeded = 0usize;
         let mut relays_failed = 0usize;
         let mut remote_items = 0usize;
@@ -854,10 +877,7 @@ impl AppClient {
                 .map(nostr_reconciliation_item)
                 .collect::<Vec<_>>();
             attempted_routes += 1;
-            let progress = StoredReconciliationProgress {
-                storage: &storage,
-                route: &route,
-            };
+            let progress = StoredReconciliationProgress::new(&storage, &route);
             let result = match route_work {
                 TransportReconciliationWork::Inbox(endpoints) => {
                     self.adapter
@@ -890,6 +910,7 @@ impl AppClient {
                     received_items += summary.received_items;
                 }
                 Ok(None) => {}
+                Err(_) if progress.retired.load(Ordering::Relaxed) => routes_retired += 1,
                 Err(_) => routes_failed += 1,
             }
         }
@@ -899,6 +920,7 @@ impl AppClient {
             method = "reconcile_transport_history",
             attempted_routes,
             routes_failed,
+            routes_retired,
             relays_succeeded,
             relays_failed,
             remote_items,
@@ -4931,7 +4953,7 @@ mod tests {
     use transport_nostr_adapter::AccountSubscriptionEose;
 
     #[test]
-    fn stored_reconciliation_progress_is_scoped_to_owned_routes() {
+    fn stored_reconciliation_progress_resumes_and_reports_closed_storage() {
         use storage_sqlite::{SqliteAccountStorage, TransportReconciliationRoute};
         use transport_nostr_adapter::NostrReconciliationProgress;
         let storage = SqliteAccountStorage::in_memory().unwrap();
@@ -4939,18 +4961,12 @@ mod tests {
         storage
             .transport_reconciliation_inventory(&inbox, 100)
             .unwrap();
-        let progress = super::StoredReconciliationProgress {
-            storage: &storage,
-            route: &inbox,
-        };
+        let progress = super::StoredReconciliationProgress::new(&storage, &inbox);
         assert_eq!(progress.load_cursor().unwrap(), None);
         progress.save_cursor(Some([1; 32])).unwrap();
         // A fresh wrapper, as used after a subscription rebuild, resumes the
         // same owned route without relying on shared SDK cache entries.
-        let rebuilt = super::StoredReconciliationProgress {
-            storage: &storage,
-            route: &inbox,
-        };
+        let rebuilt = super::StoredReconciliationProgress::new(&storage, &inbox);
         assert_eq!(rebuilt.load_cursor().unwrap(), Some([1; 32]));
         assert!(
             storage
@@ -4961,6 +4977,29 @@ mod tests {
         );
         storage.close().unwrap();
         assert!(rebuilt.save_cursor(Some([2; 32])).is_err());
+        assert!(!rebuilt.retired.load(super::Ordering::Relaxed));
+    }
+
+    #[test]
+    fn stored_reconciliation_progress_distinguishes_retired_routes() {
+        use cgka_traits::storage::GroupStorage;
+        use storage_sqlite::TransportReconciliationRoute;
+        use transport_nostr_adapter::NostrReconciliationProgress;
+        let storage = storage_sqlite::SqliteAccountStorage::in_memory().unwrap();
+        let route_id = [7; 32];
+        let route = TransportReconciliationRoute::Group(route_id);
+        storage
+            .transport_reconciliation_inventory(&route, 100)
+            .unwrap();
+        let progress = super::StoredReconciliationProgress::new(&storage, &route);
+        progress.save_cursor(Some([1; 32])).unwrap();
+        storage.delete_transport_group_route(&route_id).unwrap();
+        assert!(progress.load_cursor().is_err());
+        assert!(progress.retired.load(super::Ordering::Relaxed));
+        let late_writer = super::StoredReconciliationProgress::new(&storage, &route);
+        assert!(late_writer.save_cursor(Some([2; 32])).is_err());
+        assert!(late_writer.retired.load(super::Ordering::Relaxed));
+        storage.close().unwrap();
     }
 
     /// A commit or retry can release several retained messages in one effects batch.

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -63,6 +63,36 @@ fn event_source_message_id_hex(event: &cgka_traits::engine::GroupEvent, fallback
     }
 }
 
+struct StoredReconciliationProgress<'a> {
+    storage: &'a storage_sqlite::SqliteAccountStorage,
+    route: &'a TransportReconciliationRoute,
+}
+
+impl transport_nostr_adapter::NostrReconciliationProgress for StoredReconciliationProgress<'_> {
+    fn load_cursor(&self) -> Result<Option<[u8; 32]>, cgka_traits::TransportAdapterError> {
+        self.storage
+            .transport_reconciliation_replay_cursor(self.route)
+            .map_err(|_| {
+                cgka_traits::TransportAdapterError::Subscription(
+                    "read durable reconciliation progress failed".into(),
+                )
+            })
+    }
+
+    fn save_cursor(
+        &self,
+        cursor: Option<[u8; 32]>,
+    ) -> Result<(), cgka_traits::TransportAdapterError> {
+        self.storage
+            .advance_transport_reconciliation_replay_cursor(self.route, cursor)
+            .map_err(|_| {
+                cgka_traits::TransportAdapterError::Subscription(
+                    "save durable reconciliation progress failed".into(),
+                )
+            })
+    }
+}
+
 enum TransportReconciliationWork {
     Inbox(Vec<cgka_traits::TransportEndpoint>),
     Group(cgka_traits::TransportGroupSubscription),
@@ -824,6 +854,10 @@ impl AppClient {
                 .map(nostr_reconciliation_item)
                 .collect::<Vec<_>>();
             attempted_routes += 1;
+            let progress = StoredReconciliationProgress {
+                storage: &storage,
+                route: &route,
+            };
             let result = match route_work {
                 TransportReconciliationWork::Inbox(endpoints) => {
                     self.adapter
@@ -832,6 +866,7 @@ impl AppClient {
                             &local_items,
                             inventory.since,
                             reconcile_until,
+                            &progress,
                         )
                         .await
                 }
@@ -842,6 +877,7 @@ impl AppClient {
                             &local_items,
                             inventory.since,
                             reconcile_until,
+                            &progress,
                         )
                         .await
                 }
@@ -4893,6 +4929,39 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
     use transport_nostr_adapter::AccountSubscriptionEose;
+
+    #[test]
+    fn stored_reconciliation_progress_is_scoped_to_owned_routes() {
+        use storage_sqlite::{SqliteAccountStorage, TransportReconciliationRoute};
+        use transport_nostr_adapter::NostrReconciliationProgress;
+        let storage = SqliteAccountStorage::in_memory().unwrap();
+        let inbox = TransportReconciliationRoute::Inbox;
+        storage
+            .transport_reconciliation_inventory(&inbox, 100)
+            .unwrap();
+        let progress = super::StoredReconciliationProgress {
+            storage: &storage,
+            route: &inbox,
+        };
+        assert_eq!(progress.load_cursor().unwrap(), None);
+        progress.save_cursor(Some([1; 32])).unwrap();
+        // A fresh wrapper, as used after a subscription rebuild, resumes the
+        // same owned route without relying on shared SDK cache entries.
+        let rebuilt = super::StoredReconciliationProgress {
+            storage: &storage,
+            route: &inbox,
+        };
+        assert_eq!(rebuilt.load_cursor().unwrap(), Some([1; 32]));
+        assert!(
+            storage
+                .transport_reconciliation_inventory(&inbox, 100)
+                .unwrap()
+                .items
+                .is_empty()
+        );
+        storage.close().unwrap();
+        assert!(rebuilt.save_cursor(Some([2; 32])).is_err());
+    }
 
     /// A commit or retry can release several retained messages in one effects batch.
     /// Each row needs its own source identity, including when no relay envelope

--- a/crates/marmot-app/src/relay_plane/mod.rs
+++ b/crates/marmot-app/src/relay_plane/mod.rs
@@ -1790,6 +1790,7 @@ impl MarmotRelayPlaneAccountAdapter {
         local_items: &[NostrReconciliationItem],
         reconcile_since: u64,
         reconcile_until: u64,
+        progress: &dyn transport_nostr_adapter::NostrReconciliationProgress,
     ) -> Result<Option<NostrReconciliationSummary>, TransportAdapterError> {
         let Some(client) = &self.relay_plane.inner.transport.sdk_relay_client else {
             return Ok(None);
@@ -1818,6 +1819,7 @@ impl MarmotRelayPlaneAccountAdapter {
                 local_items,
                 reconcile_since,
                 reconcile_until,
+                progress,
             )
             .await;
         let metric = result
@@ -1848,6 +1850,7 @@ impl MarmotRelayPlaneAccountAdapter {
         local_items: &[NostrReconciliationItem],
         reconcile_since: u64,
         reconcile_until: u64,
+        progress: &dyn transport_nostr_adapter::NostrReconciliationProgress,
     ) -> Result<Option<NostrReconciliationSummary>, TransportAdapterError> {
         let Some(client) = &self.relay_plane.inner.transport.sdk_relay_client else {
             return Ok(None);
@@ -1882,6 +1885,7 @@ impl MarmotRelayPlaneAccountAdapter {
                 local_items,
                 reconcile_since,
                 reconcile_until,
+                progress,
             )
             .await;
         let metric = result

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -118,6 +118,8 @@ mod migration_0058_processed_transport_ids;
 mod migration_0059_chat_list_unread_membership;
 #[path = "migrations/0060_released_transport_receipts.rs"]
 mod migration_0060_released_transport_receipts;
+#[path = "migrations/0061_transport_reconciliation_replay_cursor.rs"]
+mod migration_0061_transport_reconciliation_replay_cursor;
 #[cfg(test)]
 #[path = "migrations/test_support.rs"]
 mod test_support;
@@ -432,6 +434,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 60,
         name: "0060_released_transport_receipts",
         apply: migration_0060_released_transport_receipts::apply,
+    },
+    Migration {
+        version: 61,
+        name: "0061_transport_reconciliation_replay_cursor",
+        apply: migration_0061_transport_reconciliation_replay_cursor::apply,
     },
 ];
 
@@ -931,6 +938,65 @@ mod tests {
     }
 
     #[test]
+    fn replay_cursor_migration_preserves_existing_route_inventory() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut conn = keyed_connection(&dir.path().join("replay-upgrade.db"));
+        run(&mut conn, &MIGRATIONS[..60]).unwrap();
+        conn.execute(
+            "INSERT INTO transport_reconciliation_route_state
+            (route_kind, route_id, inventory_since) VALUES (0, X'', 123)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO transport_reconciliation_items
+            (route_kind, route_id, event_id, created_at) VALUES (0, X'', ?1, 124)",
+            params![[7_u8; 32].as_slice()],
+        )
+        .unwrap();
+        run(&mut conn, MIGRATIONS).unwrap();
+        let state: (i64, Option<Vec<u8>>) = conn
+            .query_row(
+                "SELECT inventory_since, replay_after FROM transport_reconciliation_route_state",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(state, (123, None));
+        assert_eq!(
+            conn.query_row(
+                "SELECT count(*) FROM transport_reconciliation_items",
+                [],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+            1
+        );
+        conn.execute(
+            "UPDATE transport_reconciliation_route_state SET replay_after = ?1",
+            params![[8_u8; 32].as_slice()],
+        )
+        .unwrap();
+        run(&mut conn, MIGRATIONS).unwrap();
+        let cursor: Vec<u8> = conn
+            .query_row(
+                "SELECT replay_after FROM transport_reconciliation_route_state",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(cursor, [8; 32]);
+        assert!(
+            conn.execute(
+                "UPDATE transport_reconciliation_route_state SET replay_after = X'01'",
+                []
+            )
+            .is_err()
+        );
+        conn.close().unwrap();
+    }
+
+    #[test]
     fn initial_schema_migration_is_recorded() {
         let store = SqliteAccountStorage::in_memory().unwrap();
         assert_eq!(applied_migrations(&store), expected_migrations());
@@ -960,7 +1026,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 60,
+                found: 61,
                 latest_supported: 46,
             }
         ));
@@ -1016,7 +1082,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 60,
+                found: 61,
                 latest_supported: 46,
             }
         ));
@@ -1320,7 +1386,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 60,
+                found: 61,
                 latest_supported: 46,
             }
         ));

--- a/crates/storage-sqlite/src/migrations/0061_transport_reconciliation_replay_cursor.rs
+++ b/crates/storage-sqlite/src/migrations/0061_transport_reconciliation_replay_cursor.rs
@@ -1,0 +1,10 @@
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        "ALTER TABLE transport_reconciliation_route_state ADD COLUMN replay_after BLOB
+         CHECK (replay_after IS NULL OR (typeof(replay_after) = 'blob' AND length(replay_after) = 32));",
+    ).storage()
+}

--- a/crates/storage-sqlite/src/transport_reconciliation.rs
+++ b/crates/storage-sqlite/src/transport_reconciliation.rs
@@ -207,18 +207,20 @@ impl SqliteAccountStorage {
         cursor: Option<[u8; 32]>,
     ) -> StorageResult<()> {
         let (kind, id) = route.storage_key();
-        let changed = self
-            .lock()?
-            .execute_cached(
-                "UPDATE transport_reconciliation_route_state SET replay_after = ?3
-             WHERE route_kind = ?1 AND route_id = ?2",
-                params![kind, id, cursor.as_ref().map(|id| id.as_slice())],
-            )
-            .storage()?;
-        if changed == 0 {
-            return Err(StorageError::NotFound);
-        }
-        Ok(())
+        retry_on_busy(|| {
+            let changed = self
+                .lock()?
+                .execute_cached(
+                    "UPDATE transport_reconciliation_route_state SET replay_after = ?3
+                 WHERE route_kind = ?1 AND route_id = ?2",
+                    params![kind, id, cursor.as_ref().map(|id| id.as_slice())],
+                )
+                .storage()?;
+            if changed == 0 {
+                return Err(StorageError::NotFound);
+            }
+            Ok(())
+        })
     }
 
     pub fn transport_reconciliation_inventory(
@@ -355,6 +357,68 @@ impl SqliteAccountStorage {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn replay_cursor_retries_observed_writer_contention() {
+        use std::cell::Cell;
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        thread_local! {
+            static BUSY_OBSERVED: Cell<Option<mpsc::Sender<()>>> = const { Cell::new(None) };
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("replay-contention.db");
+        let key = crate::SqlCipherKey::new("synthetic replay contention").unwrap();
+        let store = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+        store
+            .transport_reconciliation_inventory(&TransportReconciliationRoute::Inbox, 100)
+            .unwrap();
+        let blocker = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+        blocker
+            .lock()
+            .unwrap()
+            .execute_batch("BEGIN IMMEDIATE")
+            .unwrap();
+        let (busy_tx, busy_rx) = mpsc::channel();
+        let writer = store.clone();
+        let worker = std::thread::spawn(move || {
+            BUSY_OBSERVED.set(Some(busy_tx));
+            writer
+                .lock()
+                .unwrap()
+                .busy_handler(Some(|_| {
+                    BUSY_OBSERVED.with(|signal| {
+                        if let Some(signal) = signal.take() {
+                            let _ = signal.send(());
+                        }
+                    });
+                    // Force this attempt to return SQLITE_BUSY. Only the outer
+                    // retry can succeed after the blocker is released.
+                    false
+                }))
+                .unwrap();
+            writer.advance_transport_reconciliation_replay_cursor(
+                &TransportReconciliationRoute::Inbox,
+                Some([7; 32]),
+            )
+        });
+        // Release only after SQLite reports real contention, without a sleep.
+        let observed = busy_rx.recv_timeout(Duration::from_secs(5));
+        let released = blocker.lock().unwrap().execute_batch("ROLLBACK");
+        let result = worker.join();
+        released.unwrap();
+        observed.unwrap();
+        result.unwrap().unwrap();
+        assert_eq!(
+            store
+                .transport_reconciliation_replay_cursor(&TransportReconciliationRoute::Inbox)
+                .unwrap(),
+            Some([7; 32])
+        );
+        store.close().unwrap();
+        blocker.close().unwrap();
+    }
 
     #[test]
     fn retired_route_cannot_be_resurrected_by_late_replay_progress() {

--- a/crates/storage-sqlite/src/transport_reconciliation.rs
+++ b/crates/storage-sqlite/src/transport_reconciliation.rs
@@ -169,6 +169,58 @@ impl SqliteAccountStorage {
         })
     }
 
+    /// Read the advisory replay position of an existing account-owned route.
+    /// Inventory initialization establishes ownership; a retired route is not recreated.
+    pub fn transport_reconciliation_replay_cursor(
+        &self,
+        route: &TransportReconciliationRoute,
+    ) -> StorageResult<Option<[u8; 32]>> {
+        let (kind, id) = route.storage_key();
+        let bytes: Option<Vec<u8>> = self
+            .lock()?
+            .query_row_cached(
+                "SELECT replay_after FROM transport_reconciliation_route_state
+             WHERE route_kind = ?1 AND route_id = ?2",
+                params![kind, id],
+                |row| row.get(0),
+            )
+            .optional()
+            .storage()?
+            .ok_or(StorageError::NotFound)?;
+        bytes
+            .map(|bytes| {
+                bytes.try_into().map_err(|_| {
+                    StorageError::Serialization(
+                        "invalid transport reconciliation replay cursor".into(),
+                    )
+                })
+            })
+            .transpose()
+    }
+
+    /// Record selection before replay I/O; this never admits an event.
+    /// Update only an existing route, so a cancelled repair cannot resurrect one
+    /// deleted while its network comparison was in flight.
+    pub fn advance_transport_reconciliation_replay_cursor(
+        &self,
+        route: &TransportReconciliationRoute,
+        cursor: Option<[u8; 32]>,
+    ) -> StorageResult<()> {
+        let (kind, id) = route.storage_key();
+        let changed = self
+            .lock()?
+            .execute_cached(
+                "UPDATE transport_reconciliation_route_state SET replay_after = ?3
+             WHERE route_kind = ?1 AND route_id = ?2",
+                params![kind, id, cursor.as_ref().map(|id| id.as_slice())],
+            )
+            .storage()?;
+        if changed == 0 {
+            return Err(StorageError::NotFound);
+        }
+        Ok(())
+    }
+
     pub fn transport_reconciliation_inventory(
         &self,
         route: &TransportReconciliationRoute,
@@ -303,6 +355,105 @@ impl SqliteAccountStorage {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn retired_route_cannot_be_resurrected_by_late_replay_progress() {
+        use crate::storage::test_support::{gid, sample_group};
+        use cgka_traits::storage::GroupStorage;
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let route_id = [0x44; 32];
+        let route = TransportReconciliationRoute::Group(route_id);
+        store.put_group(&sample_group(gid(1), 0, 0)).unwrap();
+        store
+            .put_transport_group_route(&route_id, &gid(1), cgka_traits::EpochId(0))
+            .unwrap();
+        store
+            .transport_reconciliation_inventory(&route, unix_now_secs().unwrap())
+            .unwrap();
+        store
+            .advance_transport_reconciliation_replay_cursor(&route, Some([1; 32]))
+            .unwrap();
+        store.delete_transport_group_route(&route_id).unwrap();
+        assert!(matches!(
+            store.transport_reconciliation_replay_cursor(&route),
+            Err(StorageError::NotFound)
+        ));
+        assert!(matches!(
+            store.advance_transport_reconciliation_replay_cursor(&route, Some([2; 32])),
+            Err(StorageError::NotFound)
+        ));
+        assert!(matches!(
+            store.transport_reconciliation_replay_cursor(&route),
+            Err(StorageError::NotFound)
+        ));
+    }
+
+    #[test]
+    fn replay_progress_survives_more_than_256_owned_routes_and_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("progress.db");
+        let key = crate::SqlCipherKey::new("synthetic replay progress").unwrap();
+        let store = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+        let now = unix_now_secs().unwrap();
+        let routes = (0_u64..257)
+            .map(|index| {
+                let mut id = [0; 32];
+                id[24..].copy_from_slice(&index.to_be_bytes());
+                TransportReconciliationRoute::Group(id)
+            })
+            .collect::<Vec<_>>();
+        for route in &routes {
+            store
+                .transport_reconciliation_inventory(route, now)
+                .unwrap();
+            store
+                .advance_transport_reconciliation_replay_cursor(route, Some([7; 32]))
+                .unwrap();
+        }
+        store.close().unwrap();
+        let store = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+        for route in &routes {
+            assert_eq!(
+                store.transport_reconciliation_replay_cursor(route).unwrap(),
+                Some([7; 32])
+            );
+            assert!(
+                store
+                    .transport_reconciliation_inventory(route, now)
+                    .unwrap()
+                    .items
+                    .is_empty(),
+                "selecting a replay batch must never manufacture durable admission"
+            );
+        }
+        let other_account = SqliteAccountStorage::in_memory().unwrap();
+        other_account
+            .transport_reconciliation_inventory(&routes[0], now)
+            .unwrap();
+        assert_eq!(
+            other_account
+                .transport_reconciliation_replay_cursor(&routes[0])
+                .unwrap(),
+            None
+        );
+        store
+            .advance_transport_reconciliation_replay_cursor(&routes[0], None)
+            .unwrap();
+        assert_eq!(
+            store
+                .transport_reconciliation_replay_cursor(&routes[0])
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            store
+                .transport_reconciliation_replay_cursor(&routes[1])
+                .unwrap(),
+            Some([7; 32])
+        );
+        store.close().unwrap();
+        other_account.close().unwrap();
+    }
 
     #[test]
     fn reconciliation_items_are_route_scoped_deduplicated_and_ordered() {

--- a/crates/transport-nostr-adapter/README.md
+++ b/crates/transport-nostr-adapter/README.md
@@ -82,7 +82,8 @@ See [`AGENTS.md`](AGENTS.md) for scope, the `sdk` feature, and privacy-safe tele
 that account and route. Hosts serialize reconciliation per route and preserve its cursor across
 subscription rebuilds. Selection saves the next position before fetching, including when the
 caller later cancels. A failed progress read or write stops replay; it must not silently restart
-at a refused prefix. Empty remote sets clear the cursor.
+at a refused prefix. Empty remote sets preserve the cursor: failed relay comparisons can also
+produce an empty set, and the next nonempty set wraps around the saved position.
 
 MarmotApp stores the cursor in its encrypted account database alongside existing route inventory
 (migration 0061). Route retirement deletes it, and a late replay cannot recreate deleted route

--- a/crates/transport-nostr-adapter/README.md
+++ b/crates/transport-nostr-adapter/README.md
@@ -75,3 +75,22 @@ cargo test -p transport-nostr-adapter --features sdk
 ```
 
 See [`AGENTS.md`](AGENTS.md) for scope, the `sdk` feature, and privacy-safe telemetry rules.
+
+## Reconciliation progress ownership
+
+`NostrSdkRelayClient::reconcile_subscription` requires a `NostrReconciliationProgress` store for
+that account and route. Hosts serialize reconciliation per route and preserve its cursor across
+subscription rebuilds. Selection saves the next position before fetching, including when the
+caller later cancels. A failed progress read or write stops replay; it must not silently restart
+at a refused prefix. Empty remote sets clear the cursor.
+
+MarmotApp stores the cursor in its encrypted account database alongside existing route inventory
+(migration 0061). Route retirement deletes it, and a late replay cannot recreate deleted route
+state. The SDK no longer has a shared 256-entry replay cursor cache, so activity on other routes
+cannot evict an active route's progress. State adds at most one 32-byte cursor to each existing
+route row; the 128-event fetch batch and 16,384-ID reconciliation set bounds remain unchanged.
+
+Replay position is advisory, separate from admitted event inventory. Failed or cancelled fetches
+advance position but acknowledge no delivery. Refused events recur on wrap; only durable app
+ingestion removes an event from the missing set. SDK callers must supply this new progress
+argument; no FFI signature changes are required.

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -82,8 +82,8 @@ pub use relay_list::{
 };
 #[cfg(feature = "sdk")]
 pub use sdk_client::{
-    NostrReconciliationItem, NostrReconciliationSummary, NostrSdkRelayClient, NostrSdkRelayHealth,
-    NostrSdkSubscriptionPlan, RelayRegistrationOutcome,
+    NostrReconciliationItem, NostrReconciliationProgress, NostrReconciliationSummary,
+    NostrSdkRelayClient, NostrSdkRelayHealth, NostrSdkSubscriptionPlan, RelayRegistrationOutcome,
 };
 pub use telemetry::{
     DurationHistogramSnapshot, HistogramBucket, RelayDeliverySpread, RelayDeliveryStats,

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -67,7 +67,27 @@ const SDK_RECONCILIATION_REPLAY_BATCH: usize = 128;
 /// Must match the storage inventory ceiling. The relay applies the same limit,
 /// bounding the dry-run result even on first boot with an empty inventory.
 const SDK_RECONCILIATION_SET_LIMIT: usize = 16_384;
-const SDK_RECONCILIATION_CURSOR_LIMIT: usize = 256;
+
+/// Account-owned advisory replay progress, independent of admitted event inventory.
+/// The host must preserve this across routine subscription rebuilds and serialize
+/// calls for one route. Saving must complete before replay fetch I/O starts.
+/// Implementations should return aggregate errors without route or event identifiers.
+pub trait NostrReconciliationProgress: Send + Sync {
+    fn load_cursor(&self) -> Result<Option<[u8; 32]>, TransportAdapterError>;
+    fn save_cursor(&self, cursor: Option<[u8; 32]>) -> Result<(), TransportAdapterError>;
+}
+
+fn select_reconciliation_remote_ids(
+    remote: &HashSet<EventId>,
+    progress: &dyn NostrReconciliationProgress,
+) -> Result<Vec<EventId>, TransportAdapterError> {
+    let after = progress.load_cursor()?.map(EventId::from_byte_array);
+    let ids = bounded_reconciliation_remote_ids(remote, after);
+    // Selection is advisory, including cancellation or fetch failure. Refused
+    // IDs recur on wrap; only durable ingestion changes the admitted inventory.
+    progress.save_cursor(ids.last().map(|id| id.to_bytes()))?;
+    Ok(ids)
+}
 
 fn bounded_reconciliation_remote_ids(
     remote: &HashSet<EventId>,
@@ -158,9 +178,6 @@ pub struct NostrSdkRelayClient {
     /// Relays that explicitly rejected NIP-77 are skipped for the rest of this
     /// process. Transient connection failures are never cached here.
     reconciliation_unsupported_relays: Arc<RwLock<HashSet<RelayUrl>>>,
-    /// Advisory fairness cursors survive subscription rebuilds. Forgetting an
-    /// entry repeats a batch; it never acknowledges delivery or relay coverage.
-    reconciliation_replay_cursors: Arc<Mutex<HashMap<(MemberId, String), EventId>>>,
     /// Per-account, per-relay subscription-registration outcomes accumulated
     /// since that account's last
     /// [`take_subscription_registrations`](Self::take_subscription_registrations)
@@ -246,7 +263,6 @@ impl NostrSdkRelayClient {
             #[cfg(test)]
             publish_relay_pin_failure_stage: Arc::new(AtomicU8::new(0)),
             reconciliation_unsupported_relays: Arc::new(RwLock::new(HashSet::new())),
-            reconciliation_replay_cursors: Arc::new(Mutex::new(HashMap::new())),
             registration_log: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -258,12 +274,14 @@ impl NostrSdkRelayClient {
     /// Reconcile one route's event set against durable account admission.
     /// NIP-77 compares event ids, including SDK-seen events that the account
     /// could not retain. Replay is bounded independently of the set difference.
+    /// `progress` belongs to this account and route and must survive rebuilds.
     pub async fn reconcile_subscription(
         &self,
         subscription: NostrSubscription,
         local_items: &[NostrReconciliationItem],
         reconcile_since: u64,
         reconcile_until: u64,
+        progress: &dyn NostrReconciliationProgress,
     ) -> Result<(NostrReconciliationSummary, Vec<NostrRelayEvent>), TransportAdapterError> {
         let mut plan = Self::plan_subscription(&subscription)?;
         // Startup compares the gap below the subscription floor; explicit
@@ -345,29 +363,7 @@ impl NostrSdkRelayClient {
         // rotating batch so even a completely refused batch cannot starve
         // later dependencies; durable app ingestion shrinks the next diff.
         let remote_item_count = output.val.remote.len();
-        let remote_ids = {
-            let key = (plan.account_id.clone(), subscription_id.clone());
-            let mut cursors = self.reconciliation_replay_cursors.lock().await;
-            let ids =
-                bounded_reconciliation_remote_ids(&output.val.remote, cursors.get(&key).copied());
-            if let Some(last) = ids.last().copied() {
-                // Bound advisory state even across retired accounts/routes.
-                // Subscription rebuilds must not reset an active repair to
-                // the same refused prefix on every pass.
-                if cursors.len() >= SDK_RECONCILIATION_CURSOR_LIMIT
-                    && !cursors.contains_key(&key)
-                    && let Some(retired) = cursors.keys().next().cloned()
-                {
-                    cursors.remove(&retired);
-                }
-                // Advance before I/O so a cancelled or unavailable batch
-                // cannot starve a later dependency. Refused ids recur on wrap.
-                cursors.insert(key, last);
-            } else {
-                cursors.remove(&key);
-            }
-            ids
-        };
+        let remote_ids = select_reconciliation_remote_ids(&output.val.remote, progress)?;
         let mut sdk_events = Vec::new();
         let mut missing_ids = Vec::new();
         for event_id in remote_ids {
@@ -1731,6 +1727,61 @@ mod tests {
     use tokio::time::{Duration, advance, timeout};
     use transport_nostr_peeler::KIND_MARMOT_GROUP_MESSAGE;
 
+    #[derive(Default)]
+    struct TestReconciliationProgress {
+        cursor: std::sync::Mutex<Option<[u8; 32]>>,
+        saved: tokio::sync::Notify,
+    }
+
+    impl NostrReconciliationProgress for TestReconciliationProgress {
+        fn load_cursor(&self) -> Result<Option<[u8; 32]>, TransportAdapterError> {
+            Ok(*self.cursor.lock().unwrap())
+        }
+        fn save_cursor(&self, cursor: Option<[u8; 32]>) -> Result<(), TransportAdapterError> {
+            *self.cursor.lock().unwrap() = cursor;
+            self.saved.notify_one();
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn reconciliation_reaches_tail_for_257_cycling_owned_routes() {
+        let remote = (0..SDK_RECONCILIATION_REPLAY_BATCH + 1)
+            .map(|index| {
+                let mut bytes = [0; 32];
+                bytes[24..].copy_from_slice(&(index as u64).to_be_bytes());
+                EventId::from_byte_array(bytes)
+            })
+            .collect::<HashSet<_>>();
+        let dependency = *remote.iter().max().unwrap();
+        let routes = (0..257)
+            .map(|_| TestReconciliationProgress::default())
+            .collect::<Vec<_>>();
+        for route in &routes {
+            let selected = select_reconciliation_remote_ids(&remote, route).unwrap();
+            assert_eq!(selected.len(), SDK_RECONCILIATION_REPLAY_BATCH);
+            assert!(!selected.contains(&dependency));
+        }
+        // Every batch is refused; nothing shrinks the remote-only set. Routes
+        // above the former shared cache cap must nevertheless reach the tail.
+        for route in &routes {
+            let selected = select_reconciliation_remote_ids(&remote, route).unwrap();
+            assert_eq!(selected.len(), SDK_RECONCILIATION_REPLAY_BATCH);
+            assert!(selected.contains(&dependency));
+        }
+        for route in &routes {
+            assert!(
+                select_reconciliation_remote_ids(&remote, route)
+                    .unwrap()
+                    .contains(remote.iter().min().unwrap()),
+                "refused prefix recurs on wrap"
+            );
+        }
+        select_reconciliation_remote_ids(&HashSet::new(), &routes[0]).unwrap();
+        assert_eq!(routes[0].load_cursor().unwrap(), None);
+        assert!(routes[1].load_cursor().unwrap().is_some());
+    }
+
     /// Build a kind-445 group event DTO pre-signed by a fresh ephemeral key,
     /// matching the production peeler wrap path (spec/transports/nostr.md:64-66).
     /// The publish path rejects unsigned 445s, so publish tests must pre-sign.
@@ -1769,6 +1820,7 @@ mod tests {
         relay.run().await.unwrap();
         let endpoint = relay.url().await;
         let sdk = NostrSdkRelayClient::new(Client::builder().build());
+        let progress = TestReconciliationProgress::default();
         let mut notifications = sdk.client.notifications();
         sdk.client.add_relay(endpoint.clone()).await.unwrap();
         sdk.client.connect().await;
@@ -1781,7 +1833,7 @@ mod tests {
             attempt: SubscriptionAttempt::INITIAL,
         };
         let (_, fetched) = sdk
-            .reconcile_subscription(subscription.clone(), &[], 0, u64::MAX)
+            .reconcile_subscription(subscription.clone(), &[], 0, u64::MAX, &progress)
             .await
             .unwrap();
         assert_eq!(fetched.len(), 1);
@@ -1815,7 +1867,7 @@ mod tests {
             created_at: event.created_at.as_secs(),
         }];
         let (_, after_admission) = sdk
-            .reconcile_subscription(subscription, &inventory, 0, u64::MAX)
+            .reconcile_subscription(subscription, &inventory, 0, u64::MAX, &progress)
             .await
             .unwrap();
         assert!(
@@ -1865,6 +1917,7 @@ mod tests {
         relay.run().await.unwrap();
         let endpoint = relay.url().await;
         let sdk = NostrSdkRelayClient::new(Client::builder().build());
+        let progress = TestReconciliationProgress::default();
         sdk.client.add_relay(endpoint.clone()).await.unwrap();
         sdk.client.connect().await;
         let subscription = NostrSubscription::Group {
@@ -1896,9 +1949,36 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+        tokio::select! {
+            biased;
+            _ = progress.saved.notified() => {}
+            result = sdk.reconcile_subscription(subscription.clone(), &[], 0, u64::MAX, &progress) => {
+                panic!("reconciliation completed before cancellation: {result:?}");
+            }
+        }
+        let after_cancel = progress.load_cursor().unwrap().unwrap();
+        let expected_tail = published
+            .iter()
+            .map(|event| event.id)
+            .filter(|id| id.to_bytes() > after_cancel)
+            .collect::<HashSet<_>>();
+        assert_eq!(expected_tail.len(), 9);
+        let (_, resumed) = sdk
+            .reconcile_subscription(subscription.clone(), &[], 0, u64::MAX, &progress)
+            .await
+            .unwrap();
+        let resumed_ids = resumed
+            .iter()
+            .map(|event| EventId::from_hex(&event.event.id).unwrap())
+            .collect::<HashSet<_>>();
+        assert!(
+            expected_tail.is_subset(&resumed_ids),
+            "cancellation preserves forward replay progress"
+        );
+        progress.save_cursor(None).unwrap();
         let mut notifications = sdk.client.notifications();
         let (_, first) = sdk
-            .reconcile_subscription(subscription.clone(), &[], 0, u64::MAX)
+            .reconcile_subscription(subscription.clone(), &[], 0, u64::MAX, &progress)
             .await
             .unwrap();
         assert_eq!(first.len(), SDK_RECONCILIATION_REPLAY_BATCH);
@@ -1917,7 +1997,7 @@ mod tests {
         // Refusing an entire batch must still expose the remaining history,
         // including a dependency that was outside the first bounded batch.
         let (_, rotated) = sdk
-            .reconcile_subscription(subscription.clone(), &[], 0, u64::MAX)
+            .reconcile_subscription(subscription.clone(), &[], 0, u64::MAX, &progress)
             .await
             .unwrap();
         assert_eq!(rotated.len(), SDK_RECONCILIATION_REPLAY_BATCH);
@@ -1936,7 +2016,7 @@ mod tests {
             })
             .collect::<Vec<_>>();
         let (_, second) = sdk
-            .reconcile_subscription(subscription, &inventory, 0, u64::MAX)
+            .reconcile_subscription(subscription, &inventory, 0, u64::MAX, &progress)
             .await
             .unwrap();
         assert_eq!(second.len(), 10);

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -85,7 +85,11 @@ fn select_reconciliation_remote_ids(
     let ids = bounded_reconciliation_remote_ids(remote, after);
     // Selection is advisory, including cancellation or fetch failure. Refused
     // IDs recur on wrap; only durable ingestion changes the admitted inventory.
-    progress.save_cursor(ids.last().map(|id| id.to_bytes()))?;
+    // Empty comparisons also occur when all relays fail negotiation. Preserve
+    // progress so the next successful comparison does not restart at a refused prefix.
+    if let Some(last) = ids.last() {
+        progress.save_cursor(Some(last.to_bytes()))?;
+    }
     Ok(ids)
 }
 
@@ -1745,7 +1749,7 @@ mod tests {
     }
 
     #[test]
-    fn reconciliation_reaches_tail_for_257_cycling_owned_routes() {
+    fn reconciliation_reaches_tail_for_257_owned_routes_after_empty_comparisons() {
         let remote = (0..SDK_RECONCILIATION_REPLAY_BATCH + 1)
             .map(|index| {
                 let mut bytes = [0; 32];
@@ -1754,6 +1758,8 @@ mod tests {
             })
             .collect::<HashSet<_>>();
         let dependency = *remote.iter().max().unwrap();
+        // 257 tracks #1716's former shared-cache boundary. This tests selection;
+        // encrypted persistence and account isolation are storage-layer tests.
         let routes = (0..257)
             .map(|_| TestReconciliationProgress::default())
             .collect::<Vec<_>>();
@@ -1761,6 +1767,13 @@ mod tests {
             let selected = select_reconciliation_remote_ids(&remote, route).unwrap();
             assert_eq!(selected.len(), SDK_RECONCILIATION_REPLAY_BATCH);
             assert!(!selected.contains(&dependency));
+            let cursor = route.load_cursor().unwrap();
+            assert!(
+                select_reconciliation_remote_ids(&HashSet::new(), route)
+                    .unwrap()
+                    .is_empty()
+            );
+            assert_eq!(route.load_cursor().unwrap(), cursor);
         }
         // Every batch is refused; nothing shrinks the remote-only set. Routes
         // above the former shared cache cap must nevertheless reach the tail.
@@ -1777,9 +1790,15 @@ mod tests {
                 "refused prefix recurs on wrap"
             );
         }
-        select_reconciliation_remote_ids(&HashSet::new(), &routes[0]).unwrap();
-        assert_eq!(routes[0].load_cursor().unwrap(), None);
-        assert!(routes[1].load_cursor().unwrap().is_some());
+        // Even a saved cursor above a changed remote set wraps without clearing.
+        let lower = HashSet::from([*remote.iter().min().unwrap()]);
+        routes[0].save_cursor(Some([0xff; 32])).unwrap();
+        assert_eq!(
+            select_reconciliation_remote_ids(&lower, &routes[0])
+                .unwrap()
+                .len(),
+            1
+        );
     }
 
     /// Build a kind-445 group event DTO pre-signed by a fresh ephemeral key,

--- a/docs/marmot-architecture/overview/current-state.md
+++ b/docs/marmot-architecture/overview/current-state.md
@@ -73,6 +73,11 @@ one-second selection-relevant quiescence window and five-second absolute cap, re
 only its digest-bound membership set, and uses independent runtime deadlines so traffic in one group cannot postpone
 another group.
 
+Relay reconciliation replay progress is owned by each account's encrypted route state. It survives
+subscription rebuilds and advances before fetch I/O, independently of admitted event inventory.
+The SDK requires a route-scoped progress store instead of evicting cursors from a shared cache;
+see [reconciliation progress ownership](../../../crates/transport-nostr-adapter/README.md#reconciliation-progress-ownership).
+
 ## Protocol implementations
 
 ### MDK (this repository)

--- a/docs/marmot-architecture/overview/current-state.md
+++ b/docs/marmot-architecture/overview/current-state.md
@@ -1,7 +1,7 @@
 ---
 title: "Current State — Implementations & Spec"
 created: 2026-04-19
-updated: 2026-09-06
+updated: 2026-09-07
 tags: [marmot, overview, current-state, implementations]
 status: overview
 ---
@@ -74,7 +74,8 @@ only its digest-bound membership set, and uses independent runtime deadlines so 
 another group.
 
 Relay reconciliation replay progress is owned by each account's encrypted route state. It survives
-subscription rebuilds and advances before fetch I/O, independently of admitted event inventory.
+subscription rebuilds and empty or failed comparisons, and advances before fetch I/O independently
+of admitted event inventory. Retired routes are counted separately from reconciliation failures.
 The SDK requires a route-scoped progress store instead of evicting cursors from a shared cache;
 see [reconciliation progress ownership](../../../crates/transport-nostr-adapter/README.md#reconciliation-progress-ownership).
 


### PR DESCRIPTION
The SDK previously kept replay cursors for only 256 account/subscription keys. Cycling through 257 routes could repeatedly evict each route's progress, leaving its next sorted 128-event batch stuck behind refused events. Replay progress now belongs to each account's durable route state.

Migration **0061** adds a nullable 32-byte cursor to each existing encrypted route row. MarmotApp supplies that store to the SDK; the shared cursor cache is removed. Route/account cleanup owns its lifetime, subscription rebuilds preserve it, and late writes cannot recreate a retired route.

The cursor is saved before replay fetch I/O. Cancellation or fetch failure does not acknowledge delivery: refused events recur on wrap, and only durable app ingestion updates possession inventory. Storage errors stop replay. The 128-event batch and 16,384-ID set bounds remain unchanged.

Direct Rust callers of `reconcile_subscription` now supply a `NostrReconciliationProgress` implementation scoped to the account and route and serialize calls for that route. MarmotApp handles this automatically. FFI signatures, workspace versions, inventory retention floors and existing inventory entries remain unchanged.

## Validation

- The 257-route selection test verifies tail reachability after empty comparisons; separate encrypted-reopen tests verify durable per-route progress, account isolation and no fabricated admitted inventory.
- Local-relay cancellation after cursor advancement preserves resumed tail progress and exact-ID redelivery with the default SDK cache.
- Retired routes reject late writes; wrapper reconstruction resumes persisted progress; closed storage returns an error.
- The migration preserves populated inventory and validates cursor shape.
- Review corrections at `5c6b76ed844067aa63926c0b6fb27e5d69117188`: preserve cursors on empty comparisons, retry transient SQLite contention, and count retired routes separately from failures.
- `just fast-ci` passed. Focused storage: 6 passed; SDK reconciliation: 4 passed; app wrapper/retirement: 2 passed. The new contention test forces an observed SQLITE_BUSY before releasing a second encrypted connection's transaction.
- Fresh GitHub CI is pending on this review-fix head. The previous head `d0d3a437637fb2ee893251936d011b0f2c6c3207` passed full CI and all binary builds, including complete recovery of both maintained 1,024-message app journeys; those results do not validate this new head.

## Stack

#1719 is merged. This PR now targets **master** and contains only account-owned route progress. Migration 0061 follows the merged release-journal migration 0060. #1713 remains the following scenario-harness PR in the stack.

Fixes #1716.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added durable, route-specific reconciliation progress that persists across restarts, subscription rebuilds, cancellations, and empty comparisons.
  - Improved recovery of released deliveries and replayed history, including cleanup of obsolete tracking data.
  - Preserved retry ownership when restoring or rearming backfill work.

- **Bug Fixes**
  - Prevented retired routes from being recreated by reconciliation updates.
  - Improved handling of storage and reload failures during reconciliation.

- **Documentation**
  - Documented reconciliation recovery, progress persistence, route retirement, and resource release behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->