### PR TITLE
Pip: issue #993 (workflow 3)

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,15 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Non-JSON CLI and daemon human output now sanitizes untrusted remote text
+  with the existing TUI terminal-safety policy, so message bodies, group
+  profile fields, display names, stream previews, and related error text
+  cannot inject ANSI/OSC or Unicode format controls. Human-only `wn daemon
+  start` and `wnd` startup errors use the same helper. `--json` and IPC
+  serialization stay lossless.
+
 ## [0.9.18] - 2026-09-05
 
 ### Changed

--- a/crates/cli/src/commands/account.rs
+++ b/crates/cli/src/commands/account.rs
@@ -11,7 +11,8 @@ use serde_json::{Value, json};
 use crate::{
     AccountCommand, CliRuntimeInfo, CommandOutput, ImportNsec, SecretStoreKind, WnError,
     account_selector_or_default, npub_for_account_id, parse_public_key, profile_display_name,
-    relay_endpoints, relay_lists_json, resolve_account, validate_materialized_secret_identity,
+    relay_endpoints, relay_lists_json, resolve_account, terminal_safe_json_display,
+    terminal_safe_text, validate_materialized_secret_identity,
 };
 
 pub(crate) async fn identity_create_command(
@@ -83,8 +84,10 @@ pub(crate) fn whoami_command(
             )?
         };
         return Ok(CommandOutput {
-            plain: serde_json::to_string_pretty(&status)
-                .expect("JSON response serialization cannot fail"),
+            plain: terminal_safe_json_display(
+                &serde_json::to_string_pretty(&status)
+                    .expect("JSON response serialization cannot fail"),
+            ),
             json: status,
         });
     }
@@ -325,16 +328,20 @@ pub(crate) async fn account_command(
                     app.account_relay_list_status_for_account_id(&account.account_id_hex)?;
                 let json = public_account_status_json(&account, relay_lists)?;
                 return Ok(CommandOutput {
-                    plain: serde_json::to_string_pretty(&json)
-                        .expect("JSON response serialization cannot fail"),
+                    plain: terminal_safe_json_display(
+                        &serde_json::to_string_pretty(&json)
+                            .expect("JSON response serialization cannot fail"),
+                    ),
                     json,
                 });
             }
             let status = app.status(&account.label)?;
             let json = wn_status_json(status, &runtime_info)?;
             Ok(CommandOutput {
-                plain: serde_json::to_string_pretty(&json)
-                    .expect("JSON response serialization cannot fail"),
+                plain: terminal_safe_json_display(
+                    &serde_json::to_string_pretty(&json)
+                        .expect("JSON response serialization cannot fail"),
+                ),
                 json,
             })
         }
@@ -410,13 +417,19 @@ fn account_summary_json(
     }))
 }
 
-fn account_display_name_or_npub(account: &Value) -> &str {
+fn account_display_name_or_npub(account: &Value) -> String {
     account
         .get("display_name")
         .and_then(Value::as_str)
+        .map(terminal_safe_text)
         .filter(|value| !value.trim().is_empty())
-        .or_else(|| account.get("npub").and_then(Value::as_str))
-        .unwrap_or("")
+        .or_else(|| {
+            account
+                .get("npub")
+                .and_then(Value::as_str)
+                .map(terminal_safe_text)
+        })
+        .unwrap_or_default()
 }
 
 fn wn_status_json(status: AppStatus, runtime_info: &CliRuntimeInfo) -> Result<Value, WnError> {
@@ -489,4 +502,38 @@ pub(crate) fn apply_global_relay_defaults(
         applied.bootstrap_relays = true;
     }
     applied
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn account_display_name_falls_back_when_sanitized_label_is_blank() {
+        let named = json!({
+            "display_name": "ali\u{1b}]0;pwn\u{7}ce",
+            "npub": "npub1example"
+        });
+        assert_eq!(account_display_name_or_npub(&named), "ali]0;pwnce");
+
+        let controls_only = json!({
+            "display_name": "\u{1b}\u{7}\u{202e}",
+            "npub": "npub1fallback"
+        });
+        assert_eq!(
+            account_display_name_or_npub(&controls_only),
+            "npub1fallback"
+        );
+    }
+
+    #[test]
+    fn account_pretty_json_plain_dump_uses_terminal_safe_json_display() {
+        let value = json!({"display_name": "a\u{1b}b"});
+        let serialized =
+            serde_json::to_string_pretty(&value).expect("pretty JSON serialization cannot fail");
+        let displayed = terminal_safe_json_display(&serialized);
+        assert_eq!(displayed, serialized);
+        assert!(!displayed.contains('\u{1b}'));
+    }
 }

--- a/crates/cli/src/commands/debug.rs
+++ b/crates/cli/src/commands/debug.rs
@@ -6,6 +6,7 @@ use serde_json::json;
 
 use crate::{
     CommandOutput, DebugCommand, WnError, npub_for_account_id, relay_lists_json, resolve_account,
+    terminal_safe_json_display,
 };
 
 pub(crate) fn debug_command(
@@ -32,8 +33,10 @@ pub(crate) fn debug_command(
                 })
                 .collect::<Result<Vec<_>, WnError>>()?;
             Ok(CommandOutput {
-                plain: serde_json::to_string_pretty(&statuses)
-                    .expect("JSON response serialization cannot fail"),
+                plain: terminal_safe_json_display(
+                    &serde_json::to_string_pretty(&statuses)
+                        .expect("JSON response serialization cannot fail"),
+                ),
                 json: json!({ "accounts": statuses }),
             })
         }

--- a/crates/cli/src/commands/groups.rs
+++ b/crates/cli/src/commands/groups.rs
@@ -12,7 +12,7 @@ use serde_json::{Value, json};
 use crate::{
     CommandOutput, GroupCommand, GroupsCommand, MaintenancePolicySetting, WnError,
     ensure_local_signing, group_json, group_list_plain, group_show_output, normalize_group_id_hex,
-    npub_for_account_id, parse_public_key, resolve_account,
+    npub_for_account_id, parse_public_key, resolve_account, terminal_safe_text,
 };
 
 async fn accept_group_invite_retrying_busy(
@@ -431,7 +431,7 @@ pub(crate) async fn groups_command_with_runtime(
                 .group(&account.label, &group_id)?
                 .ok_or_else(|| AppError::UnknownGroup(group_id.clone()))?;
             Ok(CommandOutput {
-                plain: group.endpoint.clone(),
+                plain: terminal_safe_text(&group.endpoint),
                 json: json!({
                     "account_id": account.account_id_hex,
                     "npub": npub_for_account_id(&account.account_id_hex)?,
@@ -813,14 +813,23 @@ fn pending_invites_plain(invites: &[marmot_app::AppGroupRecord]) -> String {
     invites
         .iter()
         .map(|group| {
-            let name = if group.profile.name.trim().is_empty() {
-                "unnamed"
+            let sanitized_name = terminal_safe_text(&group.profile.name);
+            let name = if sanitized_name.trim().is_empty() {
+                "unnamed".to_owned()
             } else {
-                group.profile.name.as_str()
+                sanitized_name
             };
+            let group_id = terminal_safe_text(&group.group_id_hex);
             match group.welcomer_account_id_hex.as_deref() {
-                Some(welcomer) => format!("{} {} from {}", group.group_id_hex, name, welcomer),
-                None => format!("{} {}", group.group_id_hex, name),
+                Some(welcomer) => {
+                    format!(
+                        "{} {} from {}",
+                        group_id,
+                        name,
+                        terminal_safe_text(welcomer)
+                    )
+                }
+                None => format!("{group_id} {name}"),
             }
         })
         .collect::<Vec<_>>()
@@ -922,5 +931,62 @@ mod tests {
                 group_id: "group".into(),
             }
         ));
+    }
+
+    fn sample_group(name: &str, welcomer: Option<&str>) -> marmot_app::AppGroupRecord {
+        let mut group: marmot_app::AppGroupRecord = serde_json::from_value(json!({
+            "group_id_hex": "aa".repeat(16),
+            "endpoint": "wss://relay.example",
+            "nostr_routing": {
+                "component_id": 1,
+                "component": "marmot.transport.nostr.routing.v1",
+                "nostr_group_id_hex": "bb".repeat(16),
+                "relays": ["wss://relay.example"],
+                "data_hex": ""
+            },
+            "profile": {
+                "component_id": 2,
+                "component": "marmot.group.profile.v1",
+                "name": name,
+                "description": "",
+                "data_hex": ""
+            },
+            "image": {
+                "component_id": 3,
+                "component": "marmot.group.blossom-image.v1",
+                "present": false,
+                "image_hash_hex": "",
+                "image_key_hex": "",
+                "image_nonce_hex": "",
+                "image_upload_key_hex": "",
+                "data_hex": ""
+            },
+            "admin_policy": {
+                "component_id": 4,
+                "component": "marmot.group.admin-policy.v1",
+                "admins": [],
+                "data_hex": ""
+            }
+        }))
+        .expect("sample group");
+        group.welcomer_account_id_hex = welcomer.map(str::to_owned);
+        group
+    }
+
+    #[test]
+    fn pending_invites_plain_sanitizes_names_and_keeps_unnamed_fallback() {
+        let named = sample_group("ops\u{1b}]52;c;YXR0YWNr\u{7}", Some("alice\u{202e}"));
+        let blank = sample_group("\u{1b}\u{7}\u{202e}", None);
+        let listed = pending_invites_plain(&[named, blank]);
+        assert_eq!(
+            listed,
+            format!(
+                "{} ops]52;c;YXR0YWNr from alice\n{} unnamed",
+                "aa".repeat(16),
+                "aa".repeat(16)
+            )
+        );
+        assert_eq!(listed.matches('\n').count(), 1);
+        assert!(!listed.contains('\u{1b}'));
     }
 }

--- a/crates/cli/src/commands/key_package.rs
+++ b/crates/cli/src/commands/key_package.rs
@@ -9,6 +9,7 @@ use serde_json::{Value, json};
 use crate::{
     CommandOutput, KeyPackageCommand, WnError, account_selector_or_default, ensure_local_signing,
     npub_for_account_id, parse_public_key, relay_endpoints, relay_lists_json, resolve_account,
+    terminal_safe_text,
 };
 
 pub(crate) async fn key_package_command(
@@ -158,7 +159,12 @@ pub(crate) async fn key_package_command_with_runtime(
                 plain: format!(
                     "fetched key package for {account_id} bytes={} relays={}",
                     fetched.key_package.bytes().len(),
-                    fetched.source_relays.join(",")
+                    fetched
+                        .source_relays
+                        .iter()
+                        .map(|relay| terminal_safe_text(relay))
+                        .collect::<Vec<_>>()
+                        .join(",")
                 ),
                 json: key_package_fetch_json(fetched),
             })

--- a/crates/cli/src/commands/media.rs
+++ b/crates/cli/src/commands/media.rs
@@ -12,7 +12,7 @@ use serde_json::{Value, json};
 
 use crate::{
     CommandOutput, MediaCommand, WnError, ensure_local_signing, normalize_group_id_hex,
-    npub_for_account_id, resolve_account, write_private_file,
+    npub_for_account_id, resolve_account, terminal_safe_text, write_private_file,
 };
 
 pub(crate) async fn media_command(
@@ -73,9 +73,15 @@ pub(crate) async fn media_command_with_runtime(
             })?;
             Ok(CommandOutput {
                 plain: if upload.sent.is_some() {
-                    format!("uploaded and sent {}", first.reference.file_name)
+                    format!(
+                        "uploaded and sent {}",
+                        terminal_safe_text(&first.reference.file_name)
+                    )
                 } else {
-                    format!("uploaded {}", first.reference.file_name)
+                    format!(
+                        "uploaded {}",
+                        terminal_safe_text(&first.reference.file_name)
+                    )
                 },
                 json: json!({
                     "account_id": account.account_id_hex,
@@ -116,7 +122,7 @@ pub(crate) async fn media_command_with_runtime(
                 .await?;
             write_private_file(&output_path, &download.plaintext)?;
             Ok(CommandOutput {
-                plain: output_path.display().to_string(),
+                plain: terminal_safe_text(&output_path.display().to_string()),
                 json: json!({
                     "account_id": account.account_id_hex,
                     "npub": npub_for_account_id(&account.account_id_hex)?,
@@ -148,6 +154,7 @@ pub(crate) async fn media_command_with_runtime(
                     media
                         .iter()
                         .filter_map(|item| item.get("file_name").and_then(Value::as_str))
+                        .map(terminal_safe_text)
                         .collect::<Vec<_>>()
                         .join("\n")
                 },
@@ -462,5 +469,16 @@ mod tests {
         let later = media_attachment_for_hash(vec![message], &hex::encode([0x23; 32]), false)
             .expect("download lookup must reach the later valid sibling");
         assert_eq!(later.file_name, "also-ok.png");
+    }
+
+    #[test]
+    fn media_list_plain_sanitizes_file_names_and_keeps_row_separators() {
+        let names = ["ok\u{1b}[2J.png".to_owned(), "also\nforged.png".to_owned()];
+        let plain = names
+            .iter()
+            .map(|name| crate::terminal_safe_text(name))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert_eq!(plain, "ok[2J.png\nalsoforged.png");
     }
 }

--- a/crates/cli/src/commands/messages.rs
+++ b/crates/cli/src/commands/messages.rs
@@ -21,7 +21,7 @@ use serde_json::{Value, json};
 use crate::{
     CommandOutput, MessageCommand, MessageTimelineCommand, WnError,
     agent_text_stream_payload_value, display_name_for_sender, ensure_local_signing,
-    normalize_group_id_hex, npub_for_account_id, resolve_account,
+    normalize_group_id_hex, npub_for_account_id, resolve_account, terminal_safe_text,
 };
 
 fn message_target_and_text(
@@ -555,7 +555,9 @@ fn message_list_plain(messages: &[AppMessageRecord]) -> String {
         .map(|message| {
             format!(
                 "group={} from={}: {}",
-                message.group_id_hex, message.sender, message.plaintext
+                terminal_safe_text(&message.group_id_hex),
+                terminal_safe_text(&message.sender),
+                terminal_safe_text(&message.plaintext)
             )
         })
         .collect::<Vec<_>>()
@@ -615,14 +617,18 @@ fn timeline_message_list_plain(messages: &[Value]) -> String {
             };
             format!(
                 "group={} from={}: {}{}",
-                message
-                    .get("group_id")
-                    .and_then(Value::as_str)
-                    .unwrap_or("<unknown>"),
-                message
-                    .get("from")
-                    .and_then(Value::as_str)
-                    .unwrap_or("<unknown>"),
+                terminal_safe_text(
+                    message
+                        .get("group_id")
+                        .and_then(Value::as_str)
+                        .unwrap_or("<unknown>")
+                ),
+                terminal_safe_text(
+                    message
+                        .get("from")
+                        .and_then(Value::as_str)
+                        .unwrap_or("<unknown>")
+                ),
                 timeline_message_display_text(message),
                 deleted
             )
@@ -698,13 +704,17 @@ pub(crate) fn timeline_message_display_text(message: &Value) -> String {
             .and_then(Value::as_str)
             .filter(|summary| !summary.trim().is_empty())
     {
-        return summary.to_owned();
+        let sanitized = terminal_safe_text(summary);
+        if !sanitized.trim().is_empty() {
+            return sanitized;
+        }
     }
-    message
-        .get("plaintext")
-        .and_then(Value::as_str)
-        .unwrap_or_default()
-        .to_owned()
+    terminal_safe_text(
+        message
+            .get("plaintext")
+            .and_then(Value::as_str)
+            .unwrap_or_default(),
+    )
 }
 
 fn timeline_group_system_json(
@@ -955,5 +965,58 @@ mod tests {
         });
 
         assert_eq!(timeline_message_display_text(&message), "fallback text");
+    }
+
+    #[test]
+    fn timeline_message_display_text_treats_sanitized_blank_summary_as_absent() {
+        let message = json!({
+            "kind": MARMOT_APP_EVENT_KIND_GROUP_SYSTEM,
+            "plaintext": "fallback\u{1b}[2J text",
+            "group_system": {
+                "summary": "\u{1b}\u{7}\u{202e}"
+            }
+        });
+
+        assert_eq!(timeline_message_display_text(&message), "fallback[2J text");
+    }
+
+    #[test]
+    fn message_and_timeline_plain_rows_sanitize_untrusted_fields() {
+        let hostile = AppMessageRecord {
+            message_id_hex: "11".repeat(32),
+            direction: "received".to_owned(),
+            group_id_hex: "aa\u{1b}]8;;https://evil.example\u{7}bb".to_owned(),
+            sender: "alice\u{202e}eve".to_owned(),
+            plaintext: "hi\u{1b}[2J\nbob\t".to_owned(),
+            kind: 9,
+            tags: Vec::new(),
+            source_epoch: None,
+            retention: None,
+            recorded_at: 1,
+            received_at: 2,
+            insert_order: 0,
+            invalidated: false,
+            moderation_grant: false,
+        };
+        let listed = message_list_plain(&[hostile.clone(), hostile]);
+        assert_eq!(
+            listed,
+            "group=aa]8;;https://evil.examplebb from=aliceeve: hi[2Jbob\ngroup=aa]8;;https://evil.examplebb from=aliceeve: hi[2Jbob"
+        );
+        assert_eq!(listed.matches('\n').count(), 1);
+        assert!(!listed.contains('\u{1b}'));
+        assert!(!listed.contains('\n') || listed == listed.replace('\r', ""));
+
+        let timeline = json!({
+            "group_id": "aa\u{1b}[Hbb",
+            "from": "alice\u{9b}31m",
+            "plaintext": "row\rforged",
+            "deleted": true,
+            "kind": 9
+        });
+        assert_eq!(
+            timeline_message_list_plain(&[timeline.clone(), timeline]),
+            "group=aa[Hbb from=alice31m: rowforged deleted=true\ngroup=aa[Hbb from=alice31m: rowforged deleted=true"
+        );
     }
 }

--- a/crates/cli/src/commands/profile.rs
+++ b/crates/cli/src/commands/profile.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 
 use crate::{
     CommandOutput, ProfileCommand, WnError, ensure_local_signing, npub_for_account_id,
-    resolve_account, unix_now_seconds, validate_relay_url,
+    resolve_account, terminal_safe_json_display, unix_now_seconds, validate_relay_url,
 };
 
 pub(crate) async fn profile_command(
@@ -35,8 +35,10 @@ pub(crate) async fn profile_command_with_runtime(
         ProfileCommand::Show => {
             let entry = app.directory_entry_for_account_id(&account.account_id_hex)?;
             Ok(CommandOutput {
-                plain: serde_json::to_string_pretty(&entry)
-                    .expect("JSON response serialization cannot fail"),
+                plain: terminal_safe_json_display(
+                    &serde_json::to_string_pretty(&entry)
+                        .expect("JSON response serialization cannot fail"),
+                ),
                 json: json!({
                     "account_id": account.account_id_hex,
                     "npub": npub_for_account_id(&account.account_id_hex)?,

--- a/crates/cli/src/commands/relays.rs
+++ b/crates/cli/src/commands/relays.rs
@@ -8,7 +8,7 @@ use serde_json::json;
 use crate::{
     CommandOutput, RelaysCommand, WnError, ensure_local_signing, npub_for_account_id,
     relay_endpoints, relay_lists_json, replaceable_list_inconclusive, resolve_account,
-    validate_relay_url,
+    terminal_safe_text, validate_relay_url,
 };
 
 pub(crate) async fn relays_command(
@@ -37,11 +37,7 @@ pub(crate) async fn relays_command_with_runtime(
             let status = app.account_relay_list_status(&account.label)?;
             let relays = relays_for_type(&status, relay_type.as_deref())?;
             Ok(CommandOutput {
-                plain: if relays.is_empty() {
-                    "no relays".to_owned()
-                } else {
-                    relays.join("\n")
-                },
+                plain: relay_list_plain(&relays),
                 json: json!({
                     "account_id": account.account_id_hex,
                     "npub": npub_for_account_id(&account.account_id_hex)?,
@@ -136,7 +132,7 @@ async fn update_relay_list(
     };
     let relays = relays_for_type(&status, Some(&relay_type))?;
     Ok(CommandOutput {
-        plain: relays.join("\n"),
+        plain: relay_list_plain(&relays),
         json: json!({
             "account_id": account.account_id_hex,
             "npub": npub_for_account_id(&account.account_id_hex)?,
@@ -164,6 +160,17 @@ fn update_relay_values(relays: &mut Vec<String>, url: &str, add: bool) {
     }
     relays.sort();
     relays.dedup();
+}
+
+fn relay_list_plain(relays: &[String]) -> String {
+    if relays.is_empty() {
+        return "no relays".to_owned();
+    }
+    relays
+        .iter()
+        .map(|relay| terminal_safe_text(relay))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn relays_for_type(
@@ -226,6 +233,18 @@ mod tests {
                 "wss://new.example",
                 "wss://write.example",
             ]
+        );
+    }
+
+    #[test]
+    fn relay_list_plain_sanitizes_endpoints_and_keeps_row_separators() {
+        assert_eq!(relay_list_plain(&[]), "no relays");
+        assert_eq!(
+            relay_list_plain(&[
+                "wss://relay.example\u{1b}]8;;https://evil.example\u{7}".to_owned(),
+                "wss://other.example".to_owned()
+            ]),
+            "wss://relay.example]8;;https://evil.example\nwss://other.example"
         );
     }
 }

--- a/crates/cli/src/commands/stream.rs
+++ b/crates/cli/src/commands/stream.rs
@@ -24,7 +24,7 @@ use transport_quic_stream::{
 use crate::{
     AgentStreamDelta, CommandOutput, StreamCommand, WnError, agent_text_stream_payload_value,
     ensure_local_signing, normalize_group_id_hex, npub_for_account_id, resolve_account,
-    resolve_account_ref, stream_route_label, unix_now_seconds,
+    resolve_account_ref, stream_route_label, terminal_safe_text, unix_now_seconds,
 };
 
 const AGENT_STREAM_START_LOOKBACK_LIMIT: usize = 200;
@@ -44,7 +44,8 @@ pub(crate) async fn stream_command_local(command: StreamCommand) -> Result<Comma
             Ok(CommandOutput {
                 plain: format!(
                     "received stream {stream_id} chunks={}\n{}",
-                    received.chunk_count, received.text
+                    received.chunk_count,
+                    terminal_safe_text(&received.text)
                 ),
                 json: json!({
                     "local_addr": local_addr.to_string(),
@@ -618,7 +619,7 @@ where
             "received brokered stream {} chunks={}\n{}",
             hex::encode(&received.stream_id),
             received.chunk_count,
-            received.text
+            terminal_safe_text(&received.text)
         ),
         json: json!({
             "brokered": true,

--- a/crates/cli/src/commands/sync.rs
+++ b/crates/cli/src/commands/sync.rs
@@ -5,7 +5,7 @@ use serde_json::{Value, json};
 
 use crate::{
     CommandOutput, WnError, agent_text_stream_payload_value, display_name_for_sender,
-    error::SyncCommandError, npub_for_account_id,
+    error::SyncCommandError, npub_for_account_id, terminal_safe_text,
 };
 
 pub(crate) async fn sync_command(
@@ -61,8 +61,8 @@ fn sync_plain_with_empty(summary: &SyncSummary, empty: &str) -> String {
         lines.push(format!(
             "received group={} from={}: {}",
             hex::encode(message.group_id.as_slice()),
-            message.sender,
-            message.plaintext
+            terminal_safe_text(&message.sender),
+            terminal_safe_text(&message.plaintext)
         ));
     }
     if !summary.events.is_empty() {
@@ -267,5 +267,52 @@ mod tests {
         assert_eq!(rendered["projection_updates"], 0);
         assert_eq!(rendered["epoch_stall_escalations"], 1);
         assert_eq!(rendered["events"], 0);
+    }
+
+    #[test]
+    fn sync_plain_sanitizes_received_text_and_preserves_row_separators() {
+        let summary = SyncSummary {
+            messages: vec![
+                ReceivedMessage {
+                    message_id_hex: "11".repeat(32),
+                    source_message_id_hex: "22".repeat(32),
+                    sender: "alice\u{1b}[31m".to_owned(),
+                    sender_display_name: None,
+                    group_id: GroupId::new(vec![3; 16]),
+                    source_epoch: 1,
+                    retention: None,
+                    plaintext: "hi\u{1b}[2J\nbob".to_owned(),
+                    kind: 9,
+                    tags: Vec::new(),
+                    recorded_at: 1,
+                    received_at: 2,
+                },
+                ReceivedMessage {
+                    message_id_hex: "33".repeat(32),
+                    source_message_id_hex: "44".repeat(32),
+                    sender: "bob".to_owned(),
+                    sender_display_name: None,
+                    group_id: GroupId::new(vec![5; 16]),
+                    source_epoch: 1,
+                    retention: None,
+                    plaintext: "second".to_owned(),
+                    kind: 9,
+                    tags: Vec::new(),
+                    recorded_at: 3,
+                    received_at: 4,
+                },
+            ],
+            ..Default::default()
+        };
+        let plain = sync_plain(&summary);
+        assert_eq!(
+            plain,
+            format!(
+                "received group={} from=alice[31m: hi[2Jbob\nreceived group={} from=bob: second",
+                hex::encode([3u8; 16]),
+                hex::encode([5u8; 16])
+            )
+        );
+        assert_eq!(plain.matches('\n').count(), 1);
     }
 }

--- a/crates/cli/src/commands/users.rs
+++ b/crates/cli/src/commands/users.rs
@@ -9,6 +9,7 @@ use serde_json::json;
 
 use crate::{
     CommandOutput, UsersCommand, WnError, npub_for_account_id, parse_public_key, resolve_account,
+    terminal_safe_json_display, terminal_safe_text,
 };
 
 /// `users` without a running app runtime.
@@ -55,8 +56,10 @@ async fn run_users_command(
                 .directory_entry_for_account_id(&account_id)?
                 .ok_or_else(|| AppError::MissingDirectoryEntry(account_id.clone()))?;
             Ok(CommandOutput {
-                plain: serde_json::to_string_pretty(&entry)
-                    .expect("JSON response serialization cannot fail"),
+                plain: terminal_safe_json_display(
+                    &serde_json::to_string_pretty(&entry)
+                        .expect("JSON response serialization cannot fail"),
+                ),
                 json: json!({ "user": entry }),
             })
         }
@@ -78,7 +81,7 @@ async fn run_users_command(
             } else {
                 results
                     .iter()
-                    .map(|result| result.npub.clone())
+                    .map(|result| terminal_safe_text(&result.npub))
                     .collect::<Vec<_>>()
                     .join("\n")
             };
@@ -91,7 +94,10 @@ async fn run_users_command(
             });
             if let Some(reason) = completeness.reason() {
                 json["incomplete_reason"] = json!(reason);
-                plain.push_str(&format!("\n(partial results: {reason})"));
+                plain.push_str(&format!(
+                    "\n(partial results: {})",
+                    terminal_safe_text(reason)
+                ));
             }
             Ok(CommandOutput { plain, json })
         }

--- a/crates/cli/src/daemon/lifecycle.rs
+++ b/crates/cli/src/daemon/lifecycle.rs
@@ -504,7 +504,7 @@ pub(crate) fn daemon_error(json: bool, code: &str, message: String) -> CliOutput
     CliOutput {
         code: 1,
         stdout: String::new(),
-        stderr: format!("error: {message}\n"),
+        stderr: format!("error: {}\n", crate::terminal_safe_text(&message)),
     }
 }
 

--- a/crates/cli/src/daemon/mod.rs
+++ b/crates/cli/src/daemon/mod.rs
@@ -117,7 +117,7 @@ fn server_output(
         Err(err) => CliOutput {
             code: 1,
             stdout: String::new(),
-            stderr: format!("{label}: {err}\n"),
+            stderr: format!("{label}: {}\n", crate::terminal_safe_text(&err.to_string())),
         },
     }
 }

--- a/crates/cli/src/daemon/protocol.rs
+++ b/crates/cli/src/daemon/protocol.rs
@@ -612,7 +612,11 @@ pub(crate) fn write_client_stream_response(
 
     if let Some(error) = &response.error {
         let mut stderr = std::io::stderr().lock();
-        writeln!(stderr, "error: {}", error.message)?;
+        writeln!(
+            stderr,
+            "error: {}",
+            crate::terminal_safe_text(&error.message)
+        )?;
         stderr.flush()?;
         return Ok(());
     }
@@ -644,18 +648,24 @@ pub(crate) fn stream_result_plain(result: &serde_json::Value) -> String {
             };
             format!(
                 "{label} group={} from={}: {}",
-                message
-                    .get("group_id")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or("<unknown>"),
-                message
-                    .get("from")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or("<unknown>"),
-                message
-                    .get("plaintext")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or("")
+                crate::terminal_safe_text(
+                    message
+                        .get("group_id")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("<unknown>")
+                ),
+                crate::terminal_safe_text(
+                    message
+                        .get("from")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("<unknown>")
+                ),
+                crate::terminal_safe_text(
+                    message
+                        .get("plaintext")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("")
+                )
             )
         }
         Some("stream_preview") => {
@@ -664,18 +674,24 @@ pub(crate) fn stream_result_plain(result: &serde_json::Value) -> String {
                 .unwrap_or(&serde_json::Value::Null);
             format!(
                 "stream preview {} [{}]: {}",
-                preview
-                    .get("stream_id")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or("<latest>"),
-                preview
-                    .get("status")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or("unknown"),
-                preview
-                    .get("text")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or("")
+                crate::terminal_safe_text(
+                    preview
+                        .get("stream_id")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("<latest>")
+                ),
+                crate::terminal_safe_text(
+                    preview
+                        .get("status")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("unknown")
+                ),
+                crate::terminal_safe_text(
+                    preview
+                        .get("text")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("")
+                )
             )
         }
         Some("agent_stream_delta") => {
@@ -684,18 +700,22 @@ pub(crate) fn stream_result_plain(result: &serde_json::Value) -> String {
                 .unwrap_or(&serde_json::Value::Null);
             format!(
                 "agent stream delta {} #{}: {}",
-                delta
-                    .get("stream_id")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or("<unknown>"),
+                crate::terminal_safe_text(
+                    delta
+                        .get("stream_id")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("<unknown>")
+                ),
                 delta
                     .get("seq")
                     .and_then(serde_json::Value::as_u64)
                     .unwrap_or_default(),
-                delta
-                    .get("text")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or("")
+                crate::terminal_safe_text(
+                    delta
+                        .get("text")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("")
+                )
             )
         }
         Some("timeline_subscription_ready") => {
@@ -703,7 +723,10 @@ pub(crate) fn stream_result_plain(result: &serde_json::Value) -> String {
                 .get("group_id")
                 .and_then(serde_json::Value::as_str)
                 .unwrap_or("<all>");
-            format!("timeline subscription ready group={group_id}")
+            format!(
+                "timeline subscription ready group={}",
+                crate::terminal_safe_text(group_id)
+            )
         }
         Some("initial_timeline_page") | Some("timeline_updated") => {
             timeline_stream_page_plain(result)
@@ -711,7 +734,7 @@ pub(crate) fn stream_result_plain(result: &serde_json::Value) -> String {
         Some("timeline_projection_updated") => timeline_projection_stream_plain(result),
         Some("notification_subscription_ready") => "notification subscription ready".to_owned(),
         Some("notification") => notification_stream_plain(result),
-        _ => result.to_string(),
+        _ => crate::terminal_safe_json_display(&result.to_string()),
     }
 }
 
@@ -742,7 +765,13 @@ pub(crate) fn notification_stream_plain(result: &serde_json::Value) -> String {
         .get("preview_text")
         .and_then(serde_json::Value::as_str)
         .unwrap_or("");
-    format!("notification {trigger} group={group_id} from={sender}: {preview}")
+    format!(
+        "notification {} group={} from={}: {}",
+        crate::terminal_safe_text(trigger),
+        crate::terminal_safe_text(group_id),
+        crate::terminal_safe_text(sender),
+        crate::terminal_safe_text(preview)
+    )
 }
 
 pub(crate) fn timeline_stream_page_plain(result: &serde_json::Value) -> String {
@@ -792,7 +821,9 @@ pub(crate) fn timeline_projection_stream_plain(result: &serde_json::Value) -> St
         .and_then(serde_json::Value::as_str)
         .unwrap_or("SnapshotRefresh");
     format!(
-        "timeline projection updated group={group_id} changes={changes} chat_list_trigger={chat_list_trigger}"
+        "timeline projection updated group={} changes={changes} chat_list_trigger={}",
+        crate::terminal_safe_text(group_id),
+        crate::terminal_safe_text(chat_list_trigger)
     )
 }
 
@@ -808,14 +839,18 @@ pub(crate) fn timeline_stream_message_plain(message: &serde_json::Value) -> Stri
     };
     format!(
         "group={} from={}: {}{}",
-        message
-            .get("group_id")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or("<unknown>"),
-        message
-            .get("from")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or("<unknown>"),
+        crate::terminal_safe_text(
+            message
+                .get("group_id")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("<unknown>")
+        ),
+        crate::terminal_safe_text(
+            message
+                .get("from")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("<unknown>")
+        ),
         crate::commands::messages::timeline_message_display_text(message),
         deleted
     )

--- a/crates/cli/src/daemon/tests.rs
+++ b/crates/cli/src/daemon/tests.rs
@@ -121,6 +121,66 @@ async fn run_server_validates_relays_before_creating_runtime_artifacts() {
     );
 }
 
+const HOSTILE_INVALID_RELAY: &str = "not-a-relay\u{1b}]52;c;YXR0YWNr\u{7}\u{202e}";
+const SANITIZED_INVALID_RELAY: &str = "not-a-relay]52;c;YXR0YWNr";
+
+#[test]
+fn daemon_error_sanitizes_human_message_and_keeps_json_lossless() {
+    let message = format!("invalid relay URL: {HOSTILE_INVALID_RELAY}");
+    let plain = daemon_error(false, "invalid_relay_url", message.clone());
+    assert_eq!(plain.code, 1);
+    assert!(plain.stdout.is_empty());
+    assert_eq!(
+        plain.stderr,
+        format!("error: invalid relay URL: {SANITIZED_INVALID_RELAY}\n")
+    );
+    assert!(!plain.stderr.contains('\u{1b}'));
+    assert!(!plain.stderr.contains('\u{7}'));
+    assert!(!plain.stderr.contains('\u{202e}'));
+
+    let json = daemon_error(true, "invalid_relay_url", message.clone());
+    assert_eq!(json.code, 1);
+    assert!(json.stderr.is_empty());
+    let value: serde_json::Value =
+        serde_json::from_str(json.stdout.trim()).expect("daemon_error JSON");
+    assert_eq!(value["ok"], false);
+    assert_eq!(
+        value["error"],
+        serde_json::json!({
+            "code": "invalid_relay_url",
+            "message": message,
+        })
+    );
+    assert!(
+        value["error"]["message"]
+            .as_str()
+            .expect("message")
+            .contains(HOSTILE_INVALID_RELAY)
+    );
+}
+
+#[tokio::test]
+async fn wnd_startup_sanitizes_hostile_invalid_relay_errors() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let output = run_server_from([
+        "wnd",
+        "--home",
+        home.path().to_str().expect("home utf8"),
+        "--discovery-relays",
+        HOSTILE_INVALID_RELAY,
+    ])
+    .await;
+    assert_eq!(output.code, 1);
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        output.stderr,
+        format!("wnd: invalid relay URL: {SANITIZED_INVALID_RELAY}\n")
+    );
+    assert!(!output.stderr.contains('\u{1b}'));
+    assert!(!output.stderr.contains('\u{7}'));
+    assert!(!output.stderr.contains('\u{202e}'));
+}
+
 #[test]
 #[cfg(unix)]
 fn daemon_pid_and_log_writers_create_private_files() {
@@ -1780,6 +1840,134 @@ fn timeline_stream_plain_output_is_human_readable() {
         stream_result_plain(&projection),
         "timeline projection updated group=aa changes=1 chat_list_trigger=NewLastMessage"
     );
+}
+
+#[test]
+fn stream_plain_output_sanitizes_hostile_remote_fields() {
+    let message = serde_json::json!({
+        "type": "message",
+        "message": {
+            "group_id": "aa\u{1b}[H",
+            "from": "alice\u{9b}31m",
+            "plaintext": "hi\u{1b}[2J\nbob"
+        }
+    });
+    assert_eq!(
+        stream_result_plain(&message),
+        "message group=aa[H from=alice31m: hi[2Jbob"
+    );
+
+    let reaction = serde_json::json!({
+        "type": "reaction",
+        "message": {
+            "group_id": "aa",
+            "from": "bob",
+            "plaintext": "+\u{1b}]52;c;YXR0YWNr\u{7}"
+        }
+    });
+    assert_eq!(
+        stream_result_plain(&reaction),
+        "reaction group=aa from=bob: +]52;c;YXR0YWNr"
+    );
+
+    let preview = serde_json::json!({
+        "type": "stream_preview",
+        "stream_preview": {
+            "stream_id": "s\u{1b}1",
+            "status": "run\u{7}ning",
+            "text": "part\u{9b}ial"
+        }
+    });
+    assert_eq!(
+        stream_result_plain(&preview),
+        "stream preview s1 [running]: partial"
+    );
+
+    let delta = serde_json::json!({
+        "type": "agent_stream_delta",
+        "agent_stream_delta": {
+            "stream_id": "s1",
+            "seq": 3,
+            "text": "chunk\u{202e}text"
+        }
+    });
+    assert_eq!(
+        stream_result_plain(&delta),
+        "agent stream delta s1 #3: chunktext"
+    );
+
+    let page = serde_json::json!({
+        "type": "initial_timeline_page",
+        "has_more_before": true,
+        "has_more_after": false,
+        "messages": [
+            {
+                "kind": 9,
+                "group_id": "aa\r",
+                "from": "alice",
+                "plaintext": "hello\nworld",
+                "deleted": false
+            },
+            {
+                "kind": 1210,
+                "group_id": "aa",
+                "from": "bob",
+                "plaintext": "fallback",
+                "group_system": { "summary": "bob\u{1b}[2J renamed" },
+                "deleted": false
+            }
+        ]
+    });
+    assert_eq!(
+        stream_result_plain(&page),
+        "initial timeline page has_more_before=true has_more_after=false\ngroup=aa from=alice: helloworld\ngroup=aa from=bob: bob[2J renamed"
+    );
+
+    let updated = serde_json::json!({
+        "type": "timeline_updated",
+        "has_more_before": false,
+        "has_more_after": true,
+        "messages": []
+    });
+    assert_eq!(
+        stream_result_plain(&updated),
+        "timeline updated has_more_before=false has_more_after=true: no timeline messages"
+    );
+
+    let notification = serde_json::json!({
+        "type": "notification",
+        "notification": {
+            "trigger": "NewMessage",
+            "group_id_hex": "aa",
+            "preview_text": "hi\u{1b}]8;;https://evil.example\u{7}",
+            "sender": {
+                "display_name": "Ali\u{202e}ce",
+                "account_id_hex": "bb"
+            }
+        }
+    });
+    assert_eq!(
+        stream_result_plain(&notification),
+        "notification NewMessage group=aa from=Alice: hi]8;;https://evil.example"
+    );
+
+    let fallback = serde_json::json!({
+        "type": "unknown_event",
+        "text": "ok"
+    });
+    let rendered = stream_result_plain(&fallback);
+    let serialized = fallback.to_string();
+    assert_eq!(rendered, crate::terminal_safe_json_display(&serialized));
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&serialized).unwrap(),
+        fallback
+    );
+
+    let error = DaemonStreamError {
+        code: "command_failed".to_owned(),
+        message: "boom\u{1b}[2J".to_owned(),
+    };
+    assert_eq!(crate::terminal_safe_text(&error.message), "boom[2J");
 }
 
 #[test]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -25,7 +25,10 @@ pub(crate) mod commands;
 pub mod daemon;
 mod error;
 mod secret;
+mod terminal;
 pub mod tui;
+
+pub(crate) use terminal::{terminal_safe_json_display, terminal_safe_text};
 
 pub use args::SecretStoreKind;
 pub(crate) use args::{
@@ -431,13 +434,14 @@ pub(crate) fn command_output_result(
             // logged by callers and must remain privacy-safe.
             stderr: format!(
                 "error: sync failed; completed prefix:\n{}\nerror: {}\n",
-                sync.partial_plain, sync.source
+                sync.partial_plain,
+                terminal_safe_text(&sync.source.to_string())
             ),
         },
         Err(err) => CliOutput {
             code: 1,
             stdout: String::new(),
-            stderr: format!("error: {err}\n"),
+            stderr: format!("error: {}\n", terminal_safe_text(&err.to_string())),
         },
     }
 }
@@ -747,7 +751,7 @@ fn daemon_client_error_with_code(
     CliOutput {
         code: 1,
         stdout: String::new(),
-        stderr: format!("error: {err}\n"),
+        stderr: format!("error: {}\n", terminal_safe_text(&err.to_string())),
     }
 }
 
@@ -886,18 +890,26 @@ pub(crate) fn group_list_plain(groups: &[AppGroupRecord]) -> String {
         .join("\n")
 }
 
-fn group_plain(group: &AppGroupRecord) -> String {
+pub(crate) fn group_plain(group: &AppGroupRecord) -> String {
     let mut line = format!(
         "{} name={} endpoint={}",
-        group.group_id_hex, group.profile.name, group.endpoint
+        terminal_safe_text(&group.group_id_hex),
+        terminal_safe_text(&group.profile.name),
+        terminal_safe_text(&group.endpoint)
     );
     if group.avatar_url.present {
-        line.push_str(&format!(" avatar_url={}", group.avatar_url.url));
+        line.push_str(&format!(
+            " avatar_url={}",
+            terminal_safe_text(&group.avatar_url.url)
+        ));
         if let Some(dim) = &group.avatar_url.dim {
-            line.push_str(&format!(" avatar_dim={dim}"));
+            line.push_str(&format!(" avatar_dim={}", terminal_safe_text(dim)));
         }
         if let Some(thumbhash) = &group.avatar_url.thumbhash {
-            line.push_str(&format!(" avatar_thumbhash={thumbhash}"));
+            line.push_str(&format!(
+                " avatar_thumbhash={}",
+                terminal_safe_text(thumbhash)
+            ));
         }
     }
     line
@@ -2713,5 +2725,67 @@ mod tests {
             "missing subcommand must be ok:false, got: {value}"
         );
         assert_eq!(value["error"]["code"], "usage");
+    }
+
+    fn sample_group(name: &str) -> marmot_app::AppGroupRecord {
+        serde_json::from_value(json!({
+            "group_id_hex": "aa".repeat(16),
+            "endpoint": "wss://relay.example\u{1b}]8;;https://evil.example\u{7}",
+            "nostr_routing": {
+                "component_id": 1,
+                "component": "marmot.transport.nostr.routing.v1",
+                "nostr_group_id_hex": "bb".repeat(16),
+                "relays": ["wss://relay.example"],
+                "data_hex": ""
+            },
+            "profile": {
+                "component_id": 2,
+                "component": "marmot.group.profile.v1",
+                "name": name,
+                "description": "",
+                "data_hex": ""
+            },
+            "image": {
+                "component_id": 3,
+                "component": "marmot.group.blossom-image.v1",
+                "present": false,
+                "image_hash_hex": "",
+                "image_key_hex": "",
+                "image_nonce_hex": "",
+                "image_upload_key_hex": "",
+                "data_hex": ""
+            },
+            "admin_policy": {
+                "component_id": 4,
+                "component": "marmot.group.admin-policy.v1",
+                "admins": [],
+                "data_hex": ""
+            },
+            "avatar_url": {
+                "component_id": 5,
+                "component": "marmot.group.avatar-url.v1",
+                "present": true,
+                "url": "https://cdn.example/a\u{1b}[2J.png",
+                "dim": "64x64\u{7}",
+                "thumbhash": "thumb\u{202e}",
+                "data_hex": ""
+            }
+        }))
+        .expect("sample group")
+    }
+
+    #[test]
+    fn group_plain_sanitizes_profile_and_avatar_fields() {
+        let group = sample_group("ops\u{1b}]52;c;YXR0YWNr\u{7}\nforged");
+        let listed = crate::group_list_plain(&[group]);
+        assert_eq!(
+            listed,
+            format!(
+                "{} name=ops]52;c;YXR0YWNrforged endpoint=wss://relay.example]8;;https://evil.example avatar_url=https://cdn.example/a[2J.png avatar_dim=64x64 avatar_thumbhash=thumb",
+                "aa".repeat(16)
+            )
+        );
+        assert!(!listed.contains('\n'));
+        assert!(!listed.contains('\u{1b}'));
     }
 }

--- a/crates/cli/src/terminal.rs
+++ b/crates/cli/src/terminal.rs
@@ -1,0 +1,248 @@
+//! Terminal-safe rendering for untrusted human-facing CLI text.
+//!
+//! Shared by TUI render sites and non-JSON CLI/daemon writers. Machine-readable
+//! `--json` and IPC serialization stay lossless.
+
+use unicode_properties::{GeneralCategory, UnicodeGeneralCategory};
+
+pub(crate) fn terminal_safe_text(value: &str) -> String {
+    value.chars().filter(|ch| is_terminal_safe(*ch)).collect()
+}
+
+/// Sanitize freshly serialized JSON for a human-facing dump.
+///
+/// Split on trusted layout LFs, sanitize each line, and rejoin with LF. JSON
+/// encoding already escapes embedded C0/newlines, so only formatter-owned
+/// newlines survive. Never apply this to `--json` or IPC serialization, and
+/// never sanitize a cloned JSON object's keys.
+pub(crate) fn terminal_safe_json_display(serialized: &str) -> String {
+    serialized
+        .split('\n')
+        .map(terminal_safe_text)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Decide whether a single `char` may be rendered in untrusted terminal text
+/// (message bodies, sender names, chat labels, stream previews).
+///
+/// This replaces the earlier hardcoded BiDi/zero-width denylist (see #201 /
+/// PR #459) with a width-aware whitelist, as #201 anticipated. The denylist
+/// inevitably drifted: a residual class of invisible / format characters
+/// (SOFT HYPHEN, the invisible math operators, language-tag characters, the
+/// interlinear-annotation controls, the Hangul fillers, BRAILLE PATTERN BLANK,
+/// ...) still flowed through and enabled the same homograph / hidden-content
+/// spoofing. See #473.
+///
+/// Policy:
+/// - Drop every C0/C1 control (`char::is_control()`), preserving the prior
+///   behavior of stripping ANSI/OSC escapes, newlines, and tabs.
+/// - Drop the entire Unicode `Cf` (Format) general category. This subsumes
+///   every BiDi override, zero-width joiner/space, word joiner, invisible
+///   operator (U+2061–U+2064), deprecated shaping control (U+206A–U+206F),
+///   interlinear-annotation control (U+FFF9–U+FFFB), SOFT HYPHEN, MONGOLIAN
+///   VOWEL SEPARATOR, the musical-beam formatter, the BOM, and the language
+///   tag / tag characters (U+E0001, U+E0020–U+E007F) — now and for any future
+///   `Cf` additions, so the guard no longer drifts as Unicode evolves.
+/// - Drop a small, explicit set of invisible glyphs that render blank but are
+///   *not* `Cf` (so a category-only rule would miss them) and cannot be
+///   distinguished from legitimate text by category alone: the Hangul fillers
+///   (category `Lo`, alongside real CJK) and BRAILLE PATTERN BLANK (category
+///   `So`, alongside real emoji).
+///
+/// Legitimate zero-width characters are intentionally kept: combining marks
+/// (categories `Mn`/`Mc`/`Me`, e.g. accents, the Devanagari virama, Arabic
+/// vowel marks, and emoji variation selectors) render as part of a visible base
+/// glyph and must not be stripped, or accented/Indic/Arabic/emoji text would be
+/// mangled. They are excluded from the `Cf` and explicit-filler rules above.
+fn is_terminal_safe(ch: char) -> bool {
+    if ch.is_control() {
+        return false;
+    }
+    if matches!(ch.general_category(), GeneralCategory::Format) {
+        return false;
+    }
+    !is_invisible_non_format_glyph(ch)
+}
+
+/// Invisible glyphs that are not Unicode `Cf` and therefore are not caught by
+/// the general-category rule, yet render as a blank cell and can be used for
+/// the same name/label spoofing. Enumerated explicitly because their categories
+/// (`Lo`, `So`) also contain legitimate, visible text (CJK, emoji).
+fn is_invisible_non_format_glyph(ch: char) -> bool {
+    matches!(
+        ch,
+        // Hangul fillers (category Lo) — render invisible.
+        '\u{115f}' | '\u{1160}' | '\u{3164}' | '\u{ffa0}'
+        // BRAILLE PATTERN BLANK (category So) — renders as a blank cell.
+            | '\u{2800}'
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{terminal_safe_json_display, terminal_safe_text};
+
+    #[test]
+    fn terminal_safe_text_strips_osc_and_csi_sequences() {
+        assert_eq!(
+            terminal_safe_text("pre\u{1b}]52;c;YXR0YWNr\u{7}post"),
+            "pre]52;c;YXR0YWNrpost"
+        );
+        assert_eq!(
+            terminal_safe_text("\u{1b}]8;;https://evil.example\u{7}click"),
+            "]8;;https://evil.exampleclick"
+        );
+        assert_eq!(
+            terminal_safe_text("\u{1b}]8;;https://evil.example\u{1b}\\click"),
+            "]8;;https://evil.example\\click"
+        );
+        assert_eq!(terminal_safe_text("hi\u{1b}[2Jbob"), "hi[2Jbob");
+        assert_eq!(terminal_safe_text("\u{1b}[Hforged"), "[Hforged");
+        assert_eq!(terminal_safe_text("part\u{9b}31mial\u{7}"), "part31mial");
+    }
+
+    #[test]
+    fn terminal_safe_text_strips_c0_c1_and_del() {
+        let mut input = String::new();
+        let mut expected = String::new();
+        for byte in 0u8..=0x1f {
+            input.push(char::from(byte));
+            input.push('x');
+            expected.push('x');
+        }
+        input.push('\u{7f}');
+        input.push('y');
+        expected.push('y');
+        for code in 0x80u32..=0x9f {
+            input.push(char::from_u32(code).expect("C1 scalar"));
+            input.push('z');
+            expected.push('z');
+        }
+        assert_eq!(terminal_safe_text(&input), expected);
+    }
+
+    #[test]
+    fn terminal_safe_text_strips_bidi_and_zero_width_format_characters() {
+        assert_eq!(
+            terminal_safe_text(
+                "safe\u{202a}name\u{202b}\u{202c}\u{202d}\u{202e}\u{2066}\u{2067}\u{2068}\u{2069}\u{200b}\u{200c}\u{200d}\u{200e}\u{200f}\u{feff}done",
+            ),
+            "safenamedone"
+        );
+    }
+
+    #[test]
+    fn terminal_safe_text_strips_residual_invisible_and_format_spoofing_characters() {
+        let format_class_cf: &[(char, &str)] = &[
+            ('\u{00ad}', "SOFT HYPHEN"),
+            ('\u{2061}', "FUNCTION APPLICATION"),
+            ('\u{2062}', "INVISIBLE TIMES"),
+            ('\u{2063}', "INVISIBLE SEPARATOR"),
+            ('\u{2064}', "INVISIBLE PLUS"),
+            ('\u{206a}', "INHIBIT SYMMETRIC SWAPPING"),
+            ('\u{206f}', "NOMINAL DIGIT SHAPES"),
+            ('\u{fff9}', "INTERLINEAR ANNOTATION ANCHOR"),
+            ('\u{fffa}', "INTERLINEAR ANNOTATION SEPARATOR"),
+            ('\u{fffb}', "INTERLINEAR ANNOTATION TERMINATOR"),
+            ('\u{180e}', "MONGOLIAN VOWEL SEPARATOR"),
+            ('\u{1d173}', "MUSICAL SYMBOL BEGIN BEAM"),
+            ('\u{061c}', "ARABIC LETTER MARK"),
+            ('\u{e0001}', "LANGUAGE TAG"),
+            ('\u{e0020}', "TAG SPACE"),
+            ('\u{e007e}', "TAG TILDE"),
+            ('\u{e007f}', "CANCEL TAG"),
+        ];
+        let invisible_non_cf: &[(char, &str)] = &[
+            ('\u{115f}', "HANGUL CHOSEONG FILLER"),
+            ('\u{1160}', "HANGUL JUNGSEONG FILLER"),
+            ('\u{3164}', "HANGUL FILLER"),
+            ('\u{ffa0}', "HALFWIDTH HANGUL FILLER"),
+            ('\u{2800}', "BRAILLE PATTERN BLANK"),
+        ];
+
+        for (ch, name) in format_class_cf.iter().chain(invisible_non_cf) {
+            let input = format!("a{ch}b");
+            assert_eq!(
+                terminal_safe_text(&input),
+                "ab",
+                "expected {name} (U+{:04X}) to be stripped",
+                *ch as u32
+            );
+        }
+    }
+
+    #[test]
+    fn terminal_safe_text_preserves_legitimate_visible_and_combining_text() {
+        let preserved = [
+            "plain ascii",
+            "中文 日本語 한국어",
+            "café",
+            "cafe\u{0301}",
+            "नमस्ते",
+            "سَلَام",
+            "❤\u{fe0f}",
+            "emoji 😀 ok",
+            "a b\u{00a0}c",
+        ];
+        for sample in preserved {
+            assert_eq!(
+                terminal_safe_text(sample),
+                sample,
+                "expected {sample:?} to pass through unchanged"
+            );
+        }
+        assert_eq!(
+            terminal_safe_text("with\ttab-was-control"),
+            "withtab-was-control"
+        );
+    }
+
+    #[test]
+    fn terminal_safe_text_empty_and_control_only_are_blank() {
+        assert_eq!(terminal_safe_text(""), "");
+        assert_eq!(terminal_safe_text("\u{1b}\u{7}\u{9b}\n\t\u{202e}"), "");
+        // CSI parameters are printable leftovers after the introducer is dropped.
+        assert_eq!(terminal_safe_text("\u{1b}[2J"), "[2J");
+    }
+
+    #[test]
+    fn terminal_safe_text_is_idempotent() {
+        let input = "safe\u{1b}]52;c;YXR0YWNr\u{7}name\u{202e}中文";
+        let once = terminal_safe_text(input);
+        assert_eq!(terminal_safe_text(&once), once);
+        assert_eq!(once, "safe]52;c;YXR0YWNrname中文");
+    }
+
+    #[test]
+    fn terminal_safe_json_display_preserves_layout_and_printable_escapes() {
+        let value = serde_json::json!({
+            "name": "a\u{1b}b\u{202e}c",
+            "nested": { "ok": true }
+        });
+        let serialized =
+            serde_json::to_string_pretty(&value).expect("pretty JSON serialization cannot fail");
+        let displayed = terminal_safe_json_display(&serialized);
+        assert!(displayed.contains('\n'));
+        assert!(displayed.contains("\\u001b") || displayed.contains("\\u001B"));
+        assert!(!displayed.contains('\u{1b}'));
+        assert!(!displayed.contains('\u{202e}'));
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&serialized).expect("serialized JSON"),
+            value
+        );
+        assert_eq!(
+            displayed,
+            "{\n  \"name\": \"a\\u001bbc\",\n  \"nested\": {\n    \"ok\": true\n  }\n}"
+        );
+    }
+
+    #[test]
+    fn terminal_safe_json_display_strips_raw_controls_from_serialized_lines() {
+        let hostile = "{\n  \"name\": \"ok\"\u{9b}\u{202e}\u{2800}\n}";
+        assert_eq!(
+            terminal_safe_json_display(hostile),
+            "{\n  \"name\": \"ok\"\n}"
+        );
+    }
+}

--- a/crates/cli/src/tui/model.rs
+++ b/crates/cli/src/tui/model.rs
@@ -1,7 +1,8 @@
 //! TUI data model: row/view/state types, JSON parsers, and pure helpers.
 
 use super::*;
-use unicode_properties::{GeneralCategory, UnicodeGeneralCategory};
+
+pub(crate) use crate::terminal_safe_text;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum TuiError {
@@ -4877,66 +4878,6 @@ pub(crate) fn group_component_diagnostics(group: &Value) -> Vec<GroupComponentDi
         })
     })
     .collect()
-}
-
-pub(crate) fn terminal_safe_text(value: &str) -> String {
-    value.chars().filter(|ch| is_terminal_safe(*ch)).collect()
-}
-
-/// Decide whether a single `char` may be rendered in untrusted terminal text
-/// (message bodies, sender names, chat labels, stream previews).
-///
-/// This replaces the earlier hardcoded BiDi/zero-width denylist (see #201 /
-/// PR #459) with a width-aware whitelist, as #201 anticipated. The denylist
-/// inevitably drifted: a residual class of invisible / format characters
-/// (SOFT HYPHEN, the invisible math operators, language-tag characters, the
-/// interlinear-annotation controls, the Hangul fillers, BRAILLE PATTERN BLANK,
-/// ...) still flowed through and enabled the same homograph / hidden-content
-/// spoofing. See #473.
-///
-/// Policy:
-/// - Drop every C0/C1 control (`char::is_control()`), preserving the prior
-///   behavior of stripping ANSI/OSC escapes, newlines, and tabs.
-/// - Drop the entire Unicode `Cf` (Format) general category. This subsumes
-///   every BiDi override, zero-width joiner/space, word joiner, invisible
-///   operator (U+2061–U+2064), deprecated shaping control (U+206A–U+206F),
-///   interlinear-annotation control (U+FFF9–U+FFFB), SOFT HYPHEN, MONGOLIAN
-///   VOWEL SEPARATOR, the musical-beam formatter, the BOM, and the language
-///   tag / tag characters (U+E0001, U+E0020–U+E007F) — now and for any future
-///   `Cf` additions, so the guard no longer drifts as Unicode evolves.
-/// - Drop a small, explicit set of invisible glyphs that render blank but are
-///   *not* `Cf` (so a category-only rule would miss them) and cannot be
-///   distinguished from legitimate text by category alone: the Hangul fillers
-///   (category `Lo`, alongside real CJK) and BRAILLE PATTERN BLANK (category
-///   `So`, alongside real emoji).
-///
-/// Legitimate zero-width characters are intentionally kept: combining marks
-/// (categories `Mn`/`Mc`/`Me`, e.g. accents, the Devanagari virama, Arabic
-/// vowel marks, and emoji variation selectors) render as part of a visible base
-/// glyph and must not be stripped, or accented/Indic/Arabic/emoji text would be
-/// mangled. They are excluded from the `Cf` and explicit-filler rules above.
-fn is_terminal_safe(ch: char) -> bool {
-    if ch.is_control() {
-        return false;
-    }
-    if matches!(ch.general_category(), GeneralCategory::Format) {
-        return false;
-    }
-    !is_invisible_non_format_glyph(ch)
-}
-
-/// Invisible glyphs that are not Unicode `Cf` and therefore are not caught by
-/// the general-category rule, yet render as a blank cell and can be used for
-/// the same name/label spoofing. Enumerated explicitly because their categories
-/// (`Lo`, `So`) also contain legitimate, visible text (CJK, emoji).
-fn is_invisible_non_format_glyph(ch: char) -> bool {
-    matches!(
-        ch,
-        // Hangul fillers (category Lo) — render invisible.
-        '\u{115f}' | '\u{1160}' | '\u{3164}' | '\u{ffa0}'
-        // BRAILLE PATTERN BLANK (category So) — renders as a blank cell.
-            | '\u{2800}'
-    )
 }
 
 pub(crate) fn shorten(value: &str, max_len: usize) -> String {

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -261,8 +261,14 @@ fn relay_pair_json(first: &TestRelay, second: &TestRelay) -> Value {
 }
 
 fn wn(home: &std::path::Path) -> Command {
+    let mut command = wn_plain(home);
+    command.arg("--json");
+    command
+}
+
+fn wn_plain(home: &std::path::Path) -> Command {
     let mut command = Command::new(env!("CARGO_BIN_EXE_wn"));
-    command.arg("--home").arg(home).arg("--json");
+    command.arg("--home").arg(home);
     command.env("WN_SECRET_STORE", "file");
     command.env("WN_RELAY", test_relay_url());
     // CLI tests exercise encrypted media against a loopback Blossom server,
@@ -276,6 +282,19 @@ fn wn(home: &std::path::Path) -> Command {
         command.env("WN_DEV_SETTLEMENT_QUIESCENCE_MS", "0");
     }
     command
+}
+
+fn run_plain(home: &std::path::Path, args: &[&str]) -> String {
+    let output = wn_plain(home)
+        .args(args)
+        .output()
+        .expect("wn command should start");
+    assert!(
+        output.status.success(),
+        "wn failed\nargs={args:?}\n{}",
+        command_output_summary(&output)
+    );
+    String::from_utf8(output.stdout).expect("plain stdout should be UTF-8")
 }
 
 fn wn_without_relay(home: &std::path::Path) -> Command {
@@ -7080,4 +7099,391 @@ fn daemon_real_relay_keeps_live_subscriptions_without_polling_knobs() {
     assert_message_plaintexts(&messages, &[&body]);
 
     let _ = wn(home.path()).args(["daemon", "stop"]).output();
+}
+
+#[test]
+fn plain_human_output_sanitizes_untrusted_remote_text_without_mutating_json_or_storage() {
+    let home = tempfile::tempdir().expect("tempdir");
+    const HOSTILE_TEXT: &str = "hello\u{1b}]52;c;YXR0YWNr\u{7}world\u{1b}[2J";
+    const SANITIZED_TEXT: &str = "hello]52;c;YXR0YWNrworld[2J";
+    const HOSTILE_NAME: &str = "ops\u{202e}chat";
+    const SANITIZED_NAME: &str = "opschat";
+    const HOSTILE_DISPLAY: &str = "Ali\u{202e}ce";
+    const SANITIZED_DISPLAY: &str = "Alice";
+
+    let alice = create_account(home.path());
+    let bob = create_account(home.path());
+    run_json(home.path(), &["--account", &bob, "keys", "publish"]);
+    run_json_with_relay(
+        home.path(),
+        test_relay_url(),
+        &[
+            "--account",
+            &alice,
+            "profile",
+            "update",
+            "--display-name",
+            HOSTILE_DISPLAY,
+        ],
+    );
+
+    let created_group = run_json(
+        home.path(),
+        &["--account", &alice, "group", "create", HOSTILE_NAME, &bob],
+    );
+    let group_id = created_group["group_id"].as_str().expect("group id");
+    assert_eq!(created_group["name"], HOSTILE_NAME);
+    assert_eq!(created_group["profile"]["name"], HOSTILE_NAME);
+    sync_until_joined(home.path(), test_relay_url(), &bob, group_id);
+
+    let invites_json = run_json(home.path(), &["--account", &bob, "groups", "invites"]);
+    assert_eq!(invites_json["invites"][0]["profile"]["name"], HOSTILE_NAME);
+    let invites_plain = run_plain(home.path(), &["--account", &bob, "groups", "invites"]);
+    assert!(
+        invites_plain.contains(SANITIZED_NAME),
+        "pending invite plain output should sanitize the group name: {invites_plain:?}"
+    );
+    assert!(
+        !invites_plain.contains('\u{202e}'),
+        "pending invite plain output must drop BiDi controls: {invites_plain:?}"
+    );
+
+    run_json(
+        home.path(),
+        &[
+            "--account",
+            &alice,
+            "messages",
+            "send",
+            group_id,
+            HOSTILE_TEXT,
+        ],
+    );
+    sync_until_message(home.path(), test_relay_url(), &bob, HOSTILE_TEXT);
+
+    let listed_plain = run_plain(
+        home.path(),
+        &[
+            "--account",
+            &bob,
+            "messages",
+            "list",
+            group_id,
+            "--limit",
+            "20",
+        ],
+    );
+    assert!(
+        listed_plain.contains(SANITIZED_TEXT),
+        "message list plain output should sanitize the body: {listed_plain:?}"
+    );
+    assert!(
+        !listed_plain.contains('\u{1b}'),
+        "message list plain output must drop ESC: {listed_plain:?}"
+    );
+    assert!(
+        listed_plain.ends_with('\n'),
+        "formatter-owned trailing newline must remain: {listed_plain:?}"
+    );
+    assert_eq!(
+        listed_plain.matches('\n').count(),
+        listed_plain.trim_end_matches('\n').matches('\n').count() + 1,
+        "formatter-owned trailing newline must remain"
+    );
+
+    let timeline_plain = run_plain(
+        home.path(),
+        &[
+            "--account",
+            &bob,
+            "messages",
+            "timeline",
+            "list",
+            group_id,
+            "--limit",
+            "20",
+        ],
+    );
+    assert!(timeline_plain.contains(SANITIZED_TEXT));
+    assert!(!timeline_plain.contains('\u{1b}'));
+
+    let search_plain = run_plain(
+        home.path(),
+        &["--account", &bob, "messages", "search", group_id, "hello"],
+    );
+    assert!(search_plain.contains(SANITIZED_TEXT));
+
+    let groups_plain = run_plain(home.path(), &["--account", &alice, "groups", "list"]);
+    assert!(
+        groups_plain.contains(SANITIZED_NAME),
+        "groups list should sanitize the profile name: {groups_plain:?}"
+    );
+    assert!(!groups_plain.contains('\u{202e}'));
+
+    let chats_plain = run_plain(home.path(), &["--account", &alice, "chats", "list"]);
+    assert!(chats_plain.contains(SANITIZED_NAME));
+
+    let accounts_plain = run_plain(home.path(), &["account", "list"]);
+    assert!(
+        accounts_plain.contains(SANITIZED_DISPLAY),
+        "accounts list should sanitize the display name: {accounts_plain:?}"
+    );
+    assert!(!accounts_plain.contains('\u{1b}'));
+    let whoami_plain = run_plain(home.path(), &["--account", &alice, "whoami"]);
+    let whoami_json = run_json(home.path(), &["--account", &alice, "whoami"]);
+    assert!(
+        !whoami_plain.contains('\u{1b}'),
+        "whoami pretty dump must not emit raw ESC: {whoami_plain:?}"
+    );
+    assert_eq!(whoami_json["account_id"], alice);
+
+    let listed_json = run_json(
+        home.path(),
+        &[
+            "--account",
+            &bob,
+            "messages",
+            "list",
+            group_id,
+            "--limit",
+            "20",
+        ],
+    );
+    assert_message_plaintexts(&listed_json, &[HOSTILE_TEXT]);
+    let reread = run_json(
+        home.path(),
+        &[
+            "--account",
+            &bob,
+            "messages",
+            "list",
+            group_id,
+            "--limit",
+            "20",
+        ],
+    );
+    assert_eq!(reread, listed_json);
+
+    let groups_json = run_json(home.path(), &["--account", &alice, "groups", "list"]);
+    assert_eq!(groups_json["groups"][0]["profile"]["name"], HOSTILE_NAME);
+
+    let socket = home.path().join("dev").join("wnd.sock");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_wnd"))
+        .arg("--home")
+        .arg(home.path())
+        .arg("--socket")
+        .arg(&socket)
+        .arg("--discovery-relays")
+        .arg(test_relay_url())
+        .arg("--default-account-relays")
+        .arg(test_relay_url())
+        .arg("--secret-store")
+        .arg("file")
+        .env("WN_ALLOW_LOOPBACK_RELAYS", "1")
+        .env("WN_DEV_SETTLEMENT_QUIESCENCE_MS", "0")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("wnd should start");
+    wait_for_daemon(&socket);
+
+    let daemon_list = {
+        let output = wn_plain(home.path())
+            .arg("--socket")
+            .arg(&socket)
+            .args([
+                "--account",
+                &bob,
+                "messages",
+                "list",
+                group_id,
+                "--limit",
+                "20",
+            ])
+            .output()
+            .expect("daemon-backed list should start");
+        assert!(
+            output.status.success(),
+            "daemon-backed list failed\n{}",
+            command_output_summary(&output)
+        );
+        String::from_utf8(output.stdout).expect("plain stdout")
+    };
+    assert!(daemon_list.contains(SANITIZED_TEXT));
+    assert!(!daemon_list.contains('\u{1b}'));
+
+    let json_subscription = spawn_json_subscription(
+        home.path(),
+        &[
+            "--socket",
+            socket.to_str().expect("socket utf8"),
+            "--account",
+            &bob,
+            "messages",
+            "subscribe",
+            group_id,
+            "--limit",
+            "20",
+        ],
+    );
+    let json_event = json_subscription.wait_for(Duration::from_secs(20), |line| {
+        line["result"]["type"] == "message"
+            && line["result"]["message"]["plaintext"] == HOSTILE_TEXT
+    });
+    assert_eq!(json_event["result"]["message"]["plaintext"], HOSTILE_TEXT);
+
+    let mut plain_child = wn_plain(home.path())
+        .arg("--socket")
+        .arg(&socket)
+        .args([
+            "--account",
+            &bob,
+            "messages",
+            "subscribe",
+            group_id,
+            "--limit",
+            "20",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("plain subscription should start");
+    let stdout = plain_child.stdout.take().expect("subscription stdout");
+    let (tx, rx) = std_mpsc::channel();
+    let reader = std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            let Ok(line) = line else {
+                break;
+            };
+            if tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let mut saw_sanitized = false;
+    while Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        match rx.recv_timeout(remaining) {
+            Ok(line) if line.contains(SANITIZED_TEXT) => {
+                saw_sanitized = true;
+                assert!(!line.contains('\u{1b}'));
+                break;
+            }
+            Ok(_) => {}
+            Err(std_mpsc::RecvTimeoutError::Timeout | std_mpsc::RecvTimeoutError::Disconnected) => {
+                break;
+            }
+        }
+    }
+    let _ = plain_child.kill();
+    let _ = plain_child.wait();
+    let _ = reader.join();
+    assert!(
+        saw_sanitized,
+        "plain subscription should emit sanitized text"
+    );
+
+    drop(json_subscription);
+    stop_daemon(&socket, &mut child);
+}
+
+#[test]
+fn daemon_human_startup_errors_sanitize_hostile_relays_without_changing_json() {
+    let home = tempfile::tempdir().expect("tempdir");
+    const HOSTILE_RELAY: &str = "not-a-relay\u{1b}]52;c;YXR0YWNr\u{7}\u{202e}";
+    const SANITIZED_WN: &str = "error: invalid relay URL: not-a-relay]52;c;YXR0YWNr\n";
+    const SANITIZED_WND: &str = "wnd: invalid relay URL: not-a-relay]52;c;YXR0YWNr\n";
+
+    let ordinary = Command::new(env!("CARGO_BIN_EXE_wn"))
+        .arg("--home")
+        .arg(home.path())
+        .arg("--relay")
+        .arg(HOSTILE_RELAY)
+        .arg("--secret-store")
+        .arg("file")
+        .env_remove("WN_RELAY")
+        .args(["account", "list"])
+        .output()
+        .expect("ordinary wn should run");
+    assert_eq!(ordinary.status.code(), Some(1));
+    assert_eq!(
+        String::from_utf8_lossy(&ordinary.stderr),
+        SANITIZED_WN,
+        "ordinary wn errors must stay sanitized"
+    );
+
+    let start = Command::new(env!("CARGO_BIN_EXE_wn"))
+        .arg("--home")
+        .arg(home.path())
+        .arg("--secret-store")
+        .arg("file")
+        .env_remove("WN_RELAY")
+        .args(["daemon", "start", "--discovery-relays", HOSTILE_RELAY])
+        .output()
+        .expect("wn daemon start should run");
+    assert_eq!(
+        start.status.code(),
+        Some(1),
+        "{}",
+        command_output_summary(&start)
+    );
+    assert_eq!(String::from_utf8_lossy(&start.stderr), SANITIZED_WN);
+    assert!(!String::from_utf8_lossy(&start.stderr).contains('\u{1b}'));
+    assert!(!String::from_utf8_lossy(&start.stderr).contains('\u{7}'));
+    assert!(!String::from_utf8_lossy(&start.stderr).contains('\u{202e}'));
+    assert!(start.stdout.is_empty());
+
+    let wnd = Command::new(env!("CARGO_BIN_EXE_wnd"))
+        .arg("--home")
+        .arg(home.path())
+        .arg("--discovery-relays")
+        .arg(HOSTILE_RELAY)
+        .env_remove("WN_RELAY")
+        .output()
+        .expect("wnd should run");
+    assert_eq!(
+        wnd.status.code(),
+        Some(1),
+        "{}",
+        command_output_summary(&wnd)
+    );
+    assert_eq!(String::from_utf8_lossy(&wnd.stderr), SANITIZED_WND);
+    assert!(!String::from_utf8_lossy(&wnd.stderr).contains('\u{1b}'));
+    assert!(!String::from_utf8_lossy(&wnd.stderr).contains('\u{7}'));
+    assert!(!String::from_utf8_lossy(&wnd.stderr).contains('\u{202e}'));
+    assert!(wnd.stdout.is_empty());
+
+    let start_json = Command::new(env!("CARGO_BIN_EXE_wn"))
+        .arg("--home")
+        .arg(home.path())
+        .arg("--secret-store")
+        .arg("file")
+        .arg("--json")
+        .env_remove("WN_RELAY")
+        .args(["daemon", "start", "--discovery-relays", HOSTILE_RELAY])
+        .output()
+        .expect("wn daemon start --json should run");
+    assert_eq!(
+        start_json.status.code(),
+        Some(1),
+        "{}",
+        command_output_summary(&start_json)
+    );
+    assert!(start_json.stderr.is_empty());
+    let value: Value =
+        serde_json::from_slice(&start_json.stdout).expect("daemon start JSON should parse");
+    assert_eq!(value["ok"], false);
+    assert_eq!(
+        value["error"],
+        serde_json::json!({
+            "code": "invalid_relay_url",
+            "message": format!("invalid relay URL: {HOSTILE_RELAY}"),
+        })
+    );
+    let message = value["error"]["message"].as_str().expect("error message");
+    assert!(message.contains(HOSTILE_RELAY));
+    assert!(message.contains('\u{1b}'));
+    assert!(message.contains('\u{7}'));
+    assert!(message.contains('\u{202e}'));
 }


### PR DESCRIPTION
<!-- pip-control:v1 effect=repo:1055628515#993@3:draft-pr sha256=f6fc18af4408a3a1fc2b5c2aa065f7028b227de09cda2edb6849259ad47151b4 -->
## Pip implementation for #993

Plan version: 1 · Remediation round: 1

Commit: `53ac3d8f8143ea9f186bf677f59c3a16f2632fca`

### Local checks

- cargo test -p wn-cli --lib --locked: 611 passed
- cargo test -p wn-cli --lib --locked daemon_error_sanitizes_human_message_and_keeps_json_lossless wnd_startup_sanitizes_hostile_invalid_relay_errors terminal_safe_text: 12 passed
- cargo test -p wn-cli --test cli --locked daemon_human_startup_errors_sanitize_hostile_relays_without_changing_json: 1 passed
- cargo test -p wn-cli --features test-policy-overrides --locked: 611 lib + 91 cli passed
- cargo test -p marmot-app --features test-policy-overrides --locked: 982 passed under parallel load, 1 unrelated flake (account_reconcile_returns_local_readiness_before_relay_subscription_registration timeout); isolated rerun passed
- just fast-ci: passed (fmt-check, naming, c-parity, convergence ledger, campaign toolchain, agent-install docs, install-example sha256, cargo-audit policy, ci-path classifier, check, clippy, convergence_policy_pin 5 passed)

### Findings addressed

- **general-sol-daemon-error-sanitization:** Applied the shared terminal_safe_text helper to the human-only daemon_error and wnd server_output writers, keeping trusted prefixes, trailing newlines, exit code 1, and lossless --json error values. Reused the already-clean retained remediation commit after source and test verification.

  Checks: daemon::tests::daemon_error_sanitizes_human_message_and_keeps_json_lossless passed; daemon::tests::wnd_startup_sanitizes_hostile_invalid_relay_errors passed; cli::daemon_human_startup_errors_sanitize_hostile_relays_without_changing_json passed; cargo test -p wn-cli --lib --locked: 611 passed; cargo test -p wn-cli --features test-policy-overrides --locked: 611 lib + 91 cli passed

Checks are builder-reported; required CI and independent reviews are evaluated separately. Full structured build evidence is retained by Pip.