### PR TITLE
Add a dev-only override for maintenance scheduling windows

### DIFF
--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -448,4 +448,7 @@ Keep these aligned with [`README.md`](README.md), [`SCENARIOS.md`](SCENARIOS.md)
   those windows through `MarmotAppConfig::with_dev_maintenance_timing`, which is honored only when this crate is built
   with `test-policy-overrides` (now also enabling `marmot-app/test-policy-overrides`). Gate any journey that depends
   on it with `cfg_attr(not(feature = "test-policy-overrides"), ignore)` and check
-  `AppRuntimeHarness::honors_maintenance_timing_override()` rather than assuming the knob took effect.
+  `AppRuntimeHarness::honors_maintenance_timing_override()` rather than assuming the knob took effect. That build
+  also switches `AppRuntimeHarness::new()` to marmot-app's instant-settlement test default, so journeys that claim
+  production settlement must use `new_with_pinned_settlement` or `new_with_immediate_maintenance` (both pin the
+  1,000 ms window), and a recipe that enables the feature must select its tests explicitly rather than run the crate.

--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -443,3 +443,9 @@ Keep these aligned with [`README.md`](README.md), [`SCENARIOS.md`](SCENARIOS.md)
   through `transport-nostr-peeler`.
 - **`HarnessClient` exposes only what tests need.** If you need the inner `Engine<S>`, that's a smell — extend the
   harness API instead and keep tests at one abstraction level.
+- **App-runtime maintenance runs on real time unless the build says otherwise.** Own-leaf rotations wait out a
+  60-second quiet window plus up to 30 seconds of jitter. `AppRuntimeHarness::new_with_immediate_maintenance` zeroes
+  those windows through `MarmotAppConfig::with_dev_maintenance_timing`, which is honored only when this crate is built
+  with `test-policy-overrides` (now also enabling `marmot-app/test-policy-overrides`). Gate any journey that depends
+  on it with `cfg_attr(not(feature = "test-policy-overrides"), ignore)` and check
+  `AppRuntimeHarness::honors_maintenance_timing_override()` rather than assuming the knob took effect.

--- a/crates/cgka-conformance-simulator/Cargo.toml
+++ b/crates/cgka-conformance-simulator/Cargo.toml
@@ -12,7 +12,10 @@ description = "In-process multi-client simulator and fixtures for the CGKA engin
 conformance-slow = []
 # Full-engine A/B campaigns that disable only application-message witness
 # admission. This is a simulator experiment, not a supported wire policy.
-test-policy-overrides = ["cgka-engine/test-policy-overrides"]
+test-policy-overrides = [
+    "cgka-engine/test-policy-overrides",
+    "marmot-app/test-policy-overrides",
+]
 
 [dependencies]
 cgka-traits.workspace = true

--- a/crates/cgka-conformance-simulator/src/app_runtime.rs
+++ b/crates/cgka-conformance-simulator/src/app_runtime.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use cgka_traits::{GroupId, TransportEndpoint};
+use marmot_account::MaintenanceTiming;
 use marmot_app::{
     AccountSetupRequest, AppError, AppMessageQuery, MarmotApp, MarmotAppConfig, MarmotAppEvent,
     MarmotAppRuntime,
@@ -133,22 +134,40 @@ pub struct AppRuntimeHarness {
     accepted_publications: BTreeMap<String, BTreeSet<String>>,
     relay_action_events: RelayActionEvents,
     settlement_quiescence_ms: Option<u64>,
+    maintenance_timing: Option<MaintenanceTiming>,
 }
 
 impl AppRuntimeHarness {
     pub async fn new(clients: &[String]) -> Result<Self, SubjectError> {
-        Self::new_with_settlement_quiescence(clients, None).await
+        Self::new_with_policy(clients, None, None).await
     }
 
     /// Build the retained-history regression harness with the protocol-pinned
     /// settlement window even when the workspace enables test-policy overrides.
     pub async fn new_with_pinned_settlement(clients: &[String]) -> Result<Self, SubjectError> {
-        Self::new_with_settlement_quiescence(clients, Some(1_000)).await
+        Self::new_with_policy(clients, Some(1_000), None).await
     }
 
-    async fn new_with_settlement_quiescence(
+    /// Build a harness whose participants run own-leaf maintenance with every
+    /// scheduling window set to zero, so a manual or post-join self-update
+    /// publishes within a few explicit [`Self::run_due_maintenance`] sweeps.
+    /// The protocol-pinned settlement window is kept. The override is honored
+    /// only when this crate is built with `test-policy-overrides`; in any other
+    /// build the runtimes keep production maintenance windows and report the
+    /// ignored knob through tracing.
+    pub async fn new_with_immediate_maintenance(clients: &[String]) -> Result<Self, SubjectError> {
+        Self::new_with_policy(clients, Some(1_000), Some(MaintenanceTiming::immediate())).await
+    }
+
+    /// Whether this build can honor maintenance timing overrides at all.
+    pub const fn honors_maintenance_timing_override() -> bool {
+        cfg!(feature = "test-policy-overrides")
+    }
+
+    async fn new_with_policy(
         clients: &[String],
         settlement_quiescence_ms: Option<u64>,
+        maintenance_timing: Option<MaintenanceTiming>,
     ) -> Result<Self, SubjectError> {
         let relay_control = RelayControl::new();
         let relay = LocalRelay::new(relay_control.relay_builder());
@@ -162,7 +181,12 @@ impl AppRuntimeHarness {
                 .tempdir()
                 .map_err(environment_error)?;
             fs_private::create_dir_all_private(root.path()).map_err(environment_error)?;
-            let app = app_for_root(root.path(), &relay_url, settlement_quiescence_ms);
+            let app = app_for_root(
+                root.path(),
+                &relay_url,
+                settlement_quiescence_ms,
+                maintenance_timing,
+            );
             let runtime = MarmotAppRuntime::new(app.clone());
             runtime.start().await.map_err(app_error)?;
             let setup = runtime
@@ -208,6 +232,7 @@ impl AppRuntimeHarness {
             accepted_publications: BTreeMap::new(),
             relay_action_events: BTreeMap::new(),
             settlement_quiescence_ms,
+            maintenance_timing,
         })
     }
 
@@ -411,13 +436,19 @@ impl AppRuntimeHarness {
     pub async fn reopen(&mut self, client: &str) -> Result<(), SubjectError> {
         let relay_url = self.relay_url.clone();
         let settlement_quiescence_ms = self.settlement_quiescence_ms;
+        let maintenance_timing = self.maintenance_timing;
         let participant = self.participant_mut(client)?;
         if participant.online
             && let Some(runtime) = participant.runtime.take()
         {
             runtime.shutdown_and_close().await.map_err(app_error)?;
         }
-        participant.app = app_for_root(participant.root(), &relay_url, settlement_quiescence_ms);
+        participant.app = app_for_root(
+            participant.root(),
+            &relay_url,
+            settlement_quiescence_ms,
+            maintenance_timing,
+        );
         let runtime = MarmotAppRuntime::new(participant.app.clone());
         runtime.start().await.map_err(app_error)?;
         participant.events = Some(runtime.subscribe());
@@ -1422,10 +1453,18 @@ async fn compensate_admin_changes(
     app_error(original)
 }
 
-fn app_for_root(root: &Path, relay_url: &str, settlement_quiescence_ms: Option<u64>) -> MarmotApp {
+fn app_for_root(
+    root: &Path,
+    relay_url: &str,
+    settlement_quiescence_ms: Option<u64>,
+    maintenance_timing: Option<MaintenanceTiming>,
+) -> MarmotApp {
     let mut config = MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true);
     if let Some(ms) = settlement_quiescence_ms {
         config = config.with_dev_settlement_quiescence_ms(ms);
+    }
+    if let Some(timing) = maintenance_timing {
+        config = config.with_dev_maintenance_timing(timing);
     }
     MarmotApp::with_relay_and_config(root, relay_url.to_owned(), config)
 }

--- a/crates/marmot-account/src/lib.rs
+++ b/crates/marmot-account/src/lib.rs
@@ -27,8 +27,8 @@ pub use key_package::{
 pub use routing::{StaticTransportRouting, TransportRoutingError, TransportRoutingPolicy};
 pub use runtime::{
     AccountDeviceEffects, AccountDeviceRuntime, AccountIngestEffects, CompletedWelcomePublishTask,
-    FailedApplicationMessage, PendingResolution, PreparedSessionCommit, PreparedSessionSend,
-    PreparedWelcomePublishTask, PublishFailure, PublishedApplicationMessage,
+    FailedApplicationMessage, MaintenanceTiming, PendingResolution, PreparedSessionCommit,
+    PreparedSessionSend, PreparedWelcomePublishTask, PublishFailure, PublishedApplicationMessage,
     UnresolvedApplicationMessage, UnresolvedPublish, UnresolvedPublishReason,
     WelcomeDeliveryFailure,
 };

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -66,6 +66,64 @@ const FROZEN_FANOUT_AMBIGUOUS_RETRY_MAX_MS: u64 = 60 * 60 * 1_000;
 /// connectivity does not leave a user send behind the ambiguity backoff.
 const FROZEN_FANOUT_UNAVAILABLE_RETRY_DELAY_MS: u64 = 5 * 1_000;
 
+/// Local scheduling windows for own-leaf maintenance rotations.
+///
+/// These are anti-contention and catch-up delays, not protocol policy. A
+/// rotation waits until the group has been free of valid state-bearing input
+/// for `quiet`, then a sampled delay of up to `contention_jitter_max` spreads
+/// simultaneous rotations apart so freshly joined devices do not all commit in
+/// the same second. Production always runs the defaults. Test harnesses that
+/// drive [`AccountDeviceRuntime::run_due_maintenance`] explicitly may shorten
+/// them through [`AccountDeviceRuntime::with_maintenance_timing`]. Periodic
+/// rotation scheduling, its 24 to 36 day cadence and 15 minute jitter, is not
+/// covered by this type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MaintenanceTiming {
+    /// Minimum time a group must stay free of valid commits and proposals
+    /// before an obligation may rotate.
+    pub quiet: Duration,
+    /// Upper bound of the sampled post-quiet delay for post-join and manual
+    /// rotations. Persisted deadlines have whole-second granularity.
+    pub contention_jitter_max: Duration,
+    /// How long a post-join obligation waits for the retained-history
+    /// subscription's end-of-stored-events marker before giving up on it.
+    pub eose_timeout: Duration,
+    /// Grace after end-of-stored-events, or its timeout, before the quiet
+    /// window starts.
+    pub post_eose_grace: Duration,
+}
+
+impl MaintenanceTiming {
+    /// Every window zero: a manual or post-join rotation publishes within a
+    /// few consecutive maintenance sweeps. For harnesses that call
+    /// `run_due_maintenance` directly, never for production runtimes.
+    pub const fn immediate() -> Self {
+        Self {
+            quiet: Duration::ZERO,
+            contention_jitter_max: Duration::ZERO,
+            eose_timeout: Duration::ZERO,
+            post_eose_grace: Duration::ZERO,
+        }
+    }
+
+    fn contention_jitter_max_ms(self) -> u64 {
+        u64::try_from(self.contention_jitter_max.as_millis()).unwrap_or(u64::MAX)
+    }
+}
+
+impl Default for MaintenanceTiming {
+    fn default() -> Self {
+        Self {
+            quiet: Duration::from_secs(MAINTENANCE_QUIET_SECS),
+            contention_jitter_max: Duration::from_millis(
+                cgka_traits::maintenance::POST_JOIN_CONTENTION_JITTER_MAX_MS,
+            ),
+            eose_timeout: Duration::from_secs(MAINTENANCE_EOSE_TIMEOUT_SECS),
+            post_eose_grace: Duration::from_secs(MAINTENANCE_POST_EOSE_GRACE_SECS),
+        }
+    }
+}
+
 /// Run independent async work with fixed fan-out while returning results in
 /// input order. Completion order therefore cannot reorder reports or select a
 /// different caller-visible error.
@@ -270,6 +328,7 @@ pub struct AccountDeviceRuntime<A, R = StaticTransportRouting, K = NoopKeyPackag
     wall_clock: Arc<dyn WallClock>,
     monotonic_clock: Arc<dyn MonotonicClock>,
     maintenance_random: Arc<dyn MaintenanceRandom>,
+    maintenance_timing: MaintenanceTiming,
     maintenance_paused: bool,
     maintenance_quiet_monotonic: HashMap<cgka_traits::MessageId, Duration>,
     /// Exact Welcome events whose relay-only publish phase currently runs
@@ -298,6 +357,7 @@ where
             wall_clock: Arc::new(SystemWallClock),
             monotonic_clock: Arc::new(SystemMonotonicClock::default()),
             maintenance_random: Arc::new(OsMaintenanceRandom),
+            maintenance_timing: MaintenanceTiming::default(),
             maintenance_paused: false,
             maintenance_quiet_monotonic: HashMap::new(),
             detached_welcome_publishes: HashSet::new(),
@@ -323,6 +383,17 @@ where
         self.monotonic_clock = monotonic_clock;
         self.maintenance_random = maintenance_random;
         self
+    }
+
+    /// Replace the maintenance scheduling windows. Production runtimes keep
+    /// [`MaintenanceTiming::default`]; this exists for test harnesses only.
+    pub fn with_maintenance_timing(mut self, timing: MaintenanceTiming) -> Self {
+        self.maintenance_timing = timing;
+        self
+    }
+
+    pub fn maintenance_timing(&self) -> MaintenanceTiming {
+        self.maintenance_timing
     }
 
     pub fn session(&self) -> &AccountDeviceSession {
@@ -1181,10 +1252,9 @@ where
             grace_until: None,
             quiet_since: Some(now),
             own_leaf_baseline_hash: Some(self.session.own_leaf_hash(group_id)?),
-            sampled_jitter_ms: self.maintenance_random.sample_inclusive(
-                0,
-                cgka_traits::maintenance::POST_JOIN_CONTENTION_JITTER_MAX_MS,
-            ),
+            sampled_jitter_ms: self
+                .maintenance_random
+                .sample_inclusive(0, self.maintenance_timing.contention_jitter_max_ms()),
             not_before: None,
             attempt_count: 0,
             semantic_rearm_count: 0,
@@ -1206,7 +1276,8 @@ where
                 && obligation.eose_deadline_at.is_none()
             {
                 obligation.eose_deadline_at = Some(Timestamp(
-                    now.0.saturating_add(MAINTENANCE_EOSE_TIMEOUT_SECS),
+                    now.0
+                        .saturating_add(self.maintenance_timing.eose_timeout.as_secs()),
                 ));
                 self.session.put_maintenance_obligation(&obligation)?;
             }
@@ -1225,7 +1296,8 @@ where
             {
                 obligation.phase = MaintenancePhase::Grace;
                 obligation.grace_until = Some(Timestamp(
-                    now.0.saturating_add(MAINTENANCE_POST_EOSE_GRACE_SECS),
+                    now.0
+                        .saturating_add(self.maintenance_timing.post_eose_grace.as_secs()),
                 ));
                 self.session.put_maintenance_obligation(&obligation)?;
             }
@@ -1441,7 +1513,8 @@ where
                     {
                         obligation.phase = MaintenancePhase::EoseTimeout;
                         obligation.grace_until = Some(Timestamp(
-                            now.0.saturating_add(MAINTENANCE_POST_EOSE_GRACE_SECS),
+                            now.0
+                                .saturating_add(self.maintenance_timing.post_eose_grace.as_secs()),
                         ));
                     }
                     self.put_maintenance_obligation_if_changed(&original_obligation, &obligation)?;
@@ -1468,11 +1541,12 @@ where
                         .get(&obligation.id)
                         .map(|started| {
                             self.monotonic_clock.elapsed().saturating_sub(*started)
-                                >= Duration::from_secs(MAINTENANCE_QUIET_SECS)
+                                >= self.maintenance_timing.quiet
                         })
                         .unwrap_or_else(|| {
                             obligation.quiet_since.is_some_and(|started| {
-                                now.0.saturating_sub(started.0) >= MAINTENANCE_QUIET_SECS
+                                now.0.saturating_sub(started.0)
+                                    >= self.maintenance_timing.quiet.as_secs()
                             })
                         });
                     if !quiet_long_enough {
@@ -1482,7 +1556,17 @@ where
                         )?;
                         continue;
                     }
-                    let jitter_secs = obligation.sampled_jitter_ms.saturating_add(999) / 1_000;
+                    // Periodic rotations keep their own wide spread; only the
+                    // contention jitter of post-join and manual rotations is
+                    // bounded by the configured window.
+                    let jitter_ms = if obligation.trigger == MaintenanceTrigger::Periodic {
+                        obligation.sampled_jitter_ms
+                    } else {
+                        obligation
+                            .sampled_jitter_ms
+                            .min(self.maintenance_timing.contention_jitter_max_ms())
+                    };
+                    let jitter_secs = jitter_ms.saturating_add(999) / 1_000;
                     obligation.phase = MaintenancePhase::Jitter;
                     obligation.not_before = Some(Timestamp(now.0.saturating_add(jitter_secs)));
                     self.put_maintenance_obligation_if_changed(&original_obligation, &obligation)?;

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -37,8 +37,8 @@ use cgka_traits::{
 };
 use marmot_account::{
     AccountDeviceRuntime, AccountError, KeyPackagePublication, KeyPackagePublishError,
-    KeyPackagePublishReceipt, KeyPackagePublisher, MaintenanceRandom, MonotonicClock,
-    NoopKeyPackagePublisher, PendingResolution, PublishedApplicationMessage,
+    KeyPackagePublishReceipt, KeyPackagePublisher, MaintenanceRandom, MaintenanceTiming,
+    MonotonicClock, NoopKeyPackagePublisher, PendingResolution, PublishedApplicationMessage,
     StaticTransportRouting, TransportRoutingError, TransportRoutingPolicy, WallClock,
 };
 use storage_sqlite::{SqlCipherKey, SqliteAccountStorage};
@@ -4589,4 +4589,152 @@ async fn maintenance_supersession_leaves_a_failed_obligation_terminal() {
         publishes_before,
         "no self-update may be attempted in a group this device has left"
     );
+}
+
+#[tokio::test]
+async fn maintenance_timing_defaults_match_production_windows() {
+    let timing = MaintenanceTiming::default();
+    assert_eq!(timing.quiet, Duration::from_secs(60));
+    assert_eq!(timing.contention_jitter_max, Duration::from_millis(30_000));
+    assert_eq!(timing.eose_timeout, Duration::from_secs(5 * 60));
+    assert_eq!(timing.post_eose_grace, Duration::from_secs(15));
+    assert_eq!(MaintenanceTiming::immediate().quiet, Duration::ZERO);
+
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot maintenance timing key").unwrap();
+    let runtime = AccountDeviceRuntime::new(
+        current_session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        RecordingKeyPackages::default(),
+    );
+    assert_eq!(
+        runtime.maintenance_timing(),
+        MaintenanceTiming::default(),
+        "a runtime built without an override runs production maintenance windows"
+    );
+}
+
+/// One single-member group with periodic rotation disabled, reopened under
+/// `timing` with clocks that never advance. Returns the reopened runtime, the
+/// group, and its epoch before any maintenance.
+async fn manual_only_group_runtime(
+    timing: MaintenanceTiming,
+) -> (
+    tempfile::TempDir,
+    AccountDeviceRuntime<RecordingAdapter, StaticTransportRouting, RecordingKeyPackages>,
+    cgka_traits::GroupId,
+    cgka_traits::EpochId,
+) {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot maintenance timing group key").unwrap();
+    let mut initial_runtime = AccountDeviceRuntime::new(
+        current_session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]),
+        RecordingKeyPackages::default(),
+    );
+    let (group_id, created) = initial_runtime
+        .create_group(CreateGroupRequest {
+            name: "timing group".into(),
+            description: String::new(),
+            members: Vec::new(),
+            required_features: Vec::new(),
+            app_components: Vec::new(),
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    assert!(created.failures.is_empty());
+    let mut maintenance_state = initial_runtime
+        .session()
+        .group_maintenance(&group_id)
+        .unwrap()
+        .unwrap();
+    maintenance_state.periodic_enrolled = false;
+    maintenance_state.next_periodic_rotation_at = None;
+    initial_runtime
+        .session()
+        .put_group_maintenance(&maintenance_state)
+        .unwrap();
+    let source_epoch = initial_runtime.session().epoch(&group_id).unwrap();
+    drop(initial_runtime);
+
+    let runtime = AccountDeviceRuntime::new(
+        current_session(database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![])
+            .required_acks(1)
+            .with_group_route(
+                group_id.clone(),
+                group_id.as_slice().to_vec(),
+                vec![TransportEndpoint("wss://group-a.example".into())],
+            ),
+        RecordingKeyPackages::default(),
+    )
+    .with_maintenance_sources(
+        Arc::new(TestWallClock::new(100_000)),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(0)),
+    )
+    .with_maintenance_timing(timing);
+    (dir, runtime, group_id, source_epoch)
+}
+
+#[tokio::test]
+async fn immediate_maintenance_timing_publishes_a_manual_self_update_without_waiting() {
+    let (_dir, mut runtime, group_id, source_epoch) =
+        manual_only_group_runtime(MaintenanceTiming::immediate()).await;
+    let obligation_id = runtime.schedule_manual_self_update(&group_id).unwrap();
+
+    // Sweep one: the zero quiet window is already satisfied, so the
+    // obligation moves straight to its zero-length jitter.
+    runtime.run_due_maintenance().await.unwrap();
+    assert_eq!(
+        runtime
+            .session()
+            .maintenance_obligation(&obligation_id)
+            .unwrap()
+            .unwrap()
+            .phase,
+        cgka_traits::MaintenancePhase::Jitter
+    );
+    assert_eq!(runtime.session().epoch(&group_id).unwrap(), source_epoch);
+
+    // Sweep two: the jitter deadline is already due, so the rotation publishes
+    // and confirms without either clock having moved.
+    let effects = runtime.run_due_maintenance().await.unwrap();
+    assert!(
+        effects
+            .pending
+            .iter()
+            .any(|resolution| matches!(resolution, PendingResolution::Confirmed { .. })),
+        "{effects:?}"
+    );
+    assert_eq!(
+        runtime.session().epoch(&group_id).unwrap().0,
+        source_epoch.0 + 1
+    );
+}
+
+#[tokio::test]
+async fn default_maintenance_timing_holds_a_manual_self_update_in_its_quiet_window() {
+    let (_dir, mut runtime, group_id, source_epoch) =
+        manual_only_group_runtime(MaintenanceTiming::default()).await;
+    let obligation_id = runtime.schedule_manual_self_update(&group_id).unwrap();
+    for _ in 0..3 {
+        runtime.run_due_maintenance().await.unwrap();
+    }
+    assert_eq!(
+        runtime
+            .session()
+            .maintenance_obligation(&obligation_id)
+            .unwrap()
+            .unwrap()
+            .phase,
+        cgka_traits::MaintenancePhase::Quiet,
+        "sixty seconds of quiet have not elapsed, so nothing may rotate"
+    );
+    assert_eq!(runtime.session().epoch(&group_id).unwrap(), source_epoch);
 }

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -4738,3 +4738,72 @@ async fn default_maintenance_timing_holds_a_manual_self_update_in_its_quiet_wind
     );
     assert_eq!(runtime.session().epoch(&group_id).unwrap(), source_epoch);
 }
+
+#[tokio::test]
+async fn immediate_maintenance_timing_walks_a_post_join_obligation_without_waiting() {
+    let (_dir, mut runtime, group_id, source_epoch) =
+        manual_only_group_runtime(MaintenanceTiming::immediate()).await;
+    // A post-join obligation as the engine creates it at join: waiting on the
+    // retained-history subscription, with the full 30-second jitter sampled.
+    let obligation_id = cgka_traits::MessageId::new(vec![7; 32]);
+    runtime
+        .session()
+        .put_maintenance_obligation(&cgka_traits::maintenance::MaintenanceObligation {
+            id: obligation_id.clone(),
+            group_id: group_id.clone(),
+            trigger: cgka_traits::MaintenanceTrigger::PostJoin,
+            phase: cgka_traits::MaintenancePhase::CatchUp,
+            created_at: cgka_traits::Timestamp(100_000),
+            operational_target_at: None,
+            overdue: false,
+            eose_deadline_at: None,
+            grace_until: None,
+            quiet_since: None,
+            own_leaf_baseline_hash: Some(runtime.session().own_leaf_hash(&group_id).unwrap()),
+            sampled_jitter_ms: 30_000,
+            not_before: None,
+            attempt_count: 0,
+            semantic_rearm_count: 0,
+            last_failure_code: None,
+        })
+        .unwrap();
+    runtime
+        .mark_post_join_subscription_installed(&group_id)
+        .unwrap();
+
+    let mut phases = Vec::new();
+    for _ in 0..3 {
+        runtime.run_due_maintenance().await.unwrap();
+        phases.push(
+            runtime
+                .session()
+                .maintenance_obligation(&obligation_id)
+                .unwrap()
+                .unwrap()
+                .phase,
+        );
+    }
+    assert_eq!(
+        phases,
+        [
+            cgka_traits::MaintenancePhase::EoseTimeout,
+            cgka_traits::MaintenancePhase::Quiet,
+            cgka_traits::MaintenancePhase::Jitter,
+        ],
+        "zero EOSE timeout, grace, and quiet windows advance one phase per sweep"
+    );
+    assert_eq!(runtime.session().epoch(&group_id).unwrap(), source_epoch);
+
+    let effects = runtime.run_due_maintenance().await.unwrap();
+    assert!(
+        effects
+            .pending
+            .iter()
+            .any(|resolution| matches!(resolution, PendingResolution::Confirmed { .. })),
+        "the sampled 30-second jitter is bounded by the zero window: {effects:?}"
+    );
+    assert_eq!(
+        runtime.session().epoch(&group_id).unwrap().0,
+        source_epoch.0 + 1
+    );
+}

--- a/crates/marmot-app/src/config.rs
+++ b/crates/marmot-app/src/config.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use marmot_account::MaintenanceTiming;
 use serde::{Deserialize, Serialize};
 
 const DEFAULT_DIRECTORY_MAX_FUTURE_SKEW: Duration = Duration::from_secs(5 * 60);
@@ -97,6 +98,12 @@ pub struct MarmotAppConfig {
     /// lets integration tests hold the precise post-cutoff/pre-scheduler state
     /// without changing protocol timing in normal builds.
     pub dev_scheduled_convergence_delay_ms: Option<u64>,
+    /// Dev/test override for own-leaf maintenance scheduling: the quiet window,
+    /// post-join and manual contention jitter, end-of-stored-events timeout,
+    /// and post-EOSE grace. `None` (the default) keeps the production windows.
+    /// Honored only with `test-policy-overrides`; normal debug and release
+    /// builds ignore it so hosts cannot shorten the anti-contention delays.
+    pub dev_maintenance_timing: Option<MaintenanceTiming>,
     /// Dev/test-only delay applied before each startup hydration-pipeline
     /// batch (mdk#1161). `None` (the default) adds no delay. Honored only
     /// with `test-policy-overrides`; this lets integration tests hold groups
@@ -226,6 +233,7 @@ impl Default for MarmotAppConfig {
             allow_loopback_relay_endpoints: false,
             dev_settlement_quiescence_ms: None,
             dev_scheduled_convergence_delay_ms: None,
+            dev_maintenance_timing: None,
             dev_startup_hydration_batch_delay_ms: None,
             dev_force_group_read_snapshot_failure: false,
             dev_fail_invite_welcome_intent: false,
@@ -323,6 +331,14 @@ impl MarmotAppConfig {
     /// worker's scheduled convergence pass. Normal builds ignore this field.
     pub fn with_dev_scheduled_convergence_delay_ms(mut self, ms: u64) -> Self {
         self.dev_scheduled_convergence_delay_ms = Some(ms);
+        self
+    }
+
+    /// Test-only override for own-leaf maintenance scheduling windows, for
+    /// harnesses that drive maintenance sweeps explicitly. Normal builds
+    /// ignore this field and keep the production quiet window and jitter.
+    pub fn with_dev_maintenance_timing(mut self, timing: MaintenanceTiming) -> Self {
+        self.dev_maintenance_timing = Some(timing);
         self
     }
 

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -49,8 +49,8 @@ use cgka_traits::{
 };
 use marmot_account::{
     AccountDeviceRuntime, AccountHome, AccountHomeError, AccountSummary, KeyPackagePublication,
-    KeyPackagePublishError, KeyPackagePublishReceipt, KeyPackagePublisher, MaintenanceTiming,
-    TransportRoutingError, TransportRoutingPolicy,
+    KeyPackagePublishError, KeyPackagePublishReceipt, KeyPackagePublisher, TransportRoutingError,
+    TransportRoutingPolicy,
 };
 use nostr_sdk::prelude::{
     Client as NostrSdkClient, EventBuilder, Kind, PublicKey, Tag, Timestamp as NostrTimestamp,
@@ -105,6 +105,7 @@ mod sqlcipher;
 use external_signer::{AccountSigner, RegisteredExternalSigner};
 pub use external_signer::{EXTERNAL_SIGNER_REJECTED, ExternalAccountSigner};
 pub(crate) use groups::AppGroupImageInput;
+pub use marmot_account::MaintenanceTiming;
 pub use root_runtime_lease::{MARMOT_ROOT_RUNTIME_LOCK_FILE, MarmotRootRuntimeLease};
 pub(crate) use runtime::blocking_app_task;
 pub use runtime::{

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -49,8 +49,8 @@ use cgka_traits::{
 };
 use marmot_account::{
     AccountDeviceRuntime, AccountHome, AccountHomeError, AccountSummary, KeyPackagePublication,
-    KeyPackagePublishError, KeyPackagePublishReceipt, KeyPackagePublisher, TransportRoutingError,
-    TransportRoutingPolicy,
+    KeyPackagePublishError, KeyPackagePublishReceipt, KeyPackagePublisher, MaintenanceTiming,
+    TransportRoutingError, TransportRoutingPolicy,
 };
 use nostr_sdk::prelude::{
     Client as NostrSdkClient, EventBuilder, Kind, PublicKey, Tag, Timestamp as NostrTimestamp,
@@ -3655,8 +3655,11 @@ impl MarmotApp {
             signer: signer.clone(),
         };
         let routing = self.routing_for(&state)?;
-        let runtime =
+        let mut runtime =
             AccountDeviceRuntime::new(session, adapter.clone(), routing.clone(), key_packages);
+        if let Some(timing) = dev_maintenance_timing(&self.config) {
+            runtime = runtime.with_maintenance_timing(timing);
+        }
         Ok(OpenAppAccount {
             runtime,
             session_guard,
@@ -5925,6 +5928,24 @@ pub(crate) fn external_signer_session_error(error: cgka_session::SessionError) -
         AppError::ExternalSignerRejected
     } else {
         AppError::from(error)
+    }
+}
+
+/// The maintenance scheduling override a runtime should apply, if any.
+/// Production always runs [`MaintenanceTiming::default`]: the knob is honored
+/// only in explicit `test-policy-overrides` builds, and a configured value in
+/// any other build is reported and ignored.
+fn dev_maintenance_timing(config: &MarmotAppConfig) -> Option<MaintenanceTiming> {
+    let timing = config.dev_maintenance_timing?;
+    if cfg!(feature = "test-policy-overrides") {
+        Some(timing)
+    } else {
+        tracing::warn!(
+            target: "marmot_app",
+            method = "open_account",
+            "ignoring dev_maintenance_timing without test-policy-overrides; production maintenance windows required"
+        );
+        None
     }
 }
 

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -18853,3 +18853,20 @@ fn released_transport_is_replayed_after_lost_effect_and_reopen() {
         }
     });
 }
+
+#[test]
+fn dev_maintenance_timing_is_honored_only_in_test_policy_builds() {
+    assert_eq!(dev_maintenance_timing(&MarmotAppConfig::default()), None);
+    let configured =
+        MarmotAppConfig::default().with_dev_maintenance_timing(MaintenanceTiming::immediate());
+    let expected = if cfg!(feature = "test-policy-overrides") {
+        Some(MaintenanceTiming::immediate())
+    } else {
+        None
+    };
+    assert_eq!(
+        dev_maintenance_timing(&configured),
+        expected,
+        "production builds must keep the anti-contention maintenance windows"
+    );
+}

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -18870,3 +18870,27 @@ fn dev_maintenance_timing_is_honored_only_in_test_policy_builds() {
         "production builds must keep the anti-contention maintenance windows"
     );
 }
+
+#[tokio::test]
+async fn dev_maintenance_timing_reaches_the_account_runtime_only_in_test_policy_builds() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let app = MarmotApp::with_relay_and_config(
+        dir.path(),
+        "wss://relay.example".to_owned(),
+        MarmotAppConfig::default().with_dev_maintenance_timing(MaintenanceTiming::immediate()),
+    );
+    let client = app.client("alice").await.unwrap();
+    let expected = if cfg!(feature = "test-policy-overrides") {
+        MaintenanceTiming::immediate()
+    } else {
+        MaintenanceTiming::default()
+    };
+    assert_eq!(
+        client.runtime.maintenance_timing(),
+        expected,
+        "the override must reach the runtime that schedules rotations only in test-policy builds"
+    );
+}


### PR DESCRIPTION
## Problem

Own-leaf maintenance rotations wait out a fixed 60-second quiet window, up to 30 seconds of contention jitter, a five-minute end-of-stored-events timeout and a 15-second post-EOSE grace, all on real clocks. Those windows are correct for production: they keep freshly joined devices from committing rival self-updates in the same second. But test harnesses that drive maintenance sweeps explicitly had no way to shorten them, so app-layer self-update coverage had to sit ignored behind a two-and-a-half-minute wall-clock wait, and maintenance interleaving with sends and commits could not be tested at the app layer at all.

## Change

- `marmot-account`: `MaintenanceTiming` carries the four windows with the production defaults and an `immediate()` preset. `AccountDeviceRuntime::with_maintenance_timing` replaces them; runtimes built without it are unchanged. Periodic rotation scheduling keeps its own 24 to 36 day cadence and 15 minute jitter; only post-join and manual contention jitter is bounded by the configured window, so production behaviour is identical.
- `marmot-app`: `MarmotAppConfig::with_dev_maintenance_timing`, honored only in `test-policy-overrides` builds exactly like the settlement-quiescence override, and reported through tracing and ignored in every other build.
- `cgka-conformance-simulator`: the crate's `test-policy-overrides` feature now also enables `marmot-app/test-policy-overrides`, and `AppRuntimeHarness::new_with_immediate_maintenance` applies the preset while keeping the protocol-pinned settlement window. `honors_maintenance_timing_override()` lets a journey check the build instead of assuming.

## Tests

- `maintenance_timing_defaults_match_production_windows` pins the four defaults and that a runtime built without an override reports them.
- `immediate_maintenance_timing_publishes_a_manual_self_update_without_waiting`: two sweeps, neither clock moves, the rotation publishes and confirms.
- `default_maintenance_timing_holds_a_manual_self_update_in_its_quiet_window`: the same sweeps leave the obligation in `Quiet` at the same epoch.
- `dev_maintenance_timing_is_honored_only_in_test_policy_builds`: `None` without the feature, the configured timing with it (run both ways locally).

`cargo check --workspace --all-targets --locked`, `cargo fmt --all --check`, and `cargo clippy -D warnings` for the three touched crates (with and without the simulator feature) are clean locally.

## Follow-up

Once the app-layer interaction journeys PR lands, the manual self-update journey there switches to `new_with_immediate_maintenance` and `cfg_attr(not(feature = "test-policy-overrides"), ignore)`, with a nightly recipe that runs it under the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable maintenance timing, including production-style and immediate timing profiles.
  * Added support for applying maintenance timing overrides in development and testing environments.
  * Exposed maintenance timing configuration for runtime setup and inspection.

* **Bug Fixes**
  * Improved consistency of maintenance scheduling when participants are created or reopened.

* **Tests**
  * Added coverage for timing defaults, immediate maintenance, quiet-window enforcement, and policy-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->