### PR TITLE
Add app-layer interaction journeys and concurrent-mutation harness support

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -33,6 +33,10 @@ cli-e2e = { max-threads = 2 }
 # admission long enough to trip the action-correlation timeout even though the
 # same scenario is stable in isolation.
 process-orchestrator = { max-threads = 1 }
+# Every public app journey starts a local relay and several SQLCipher runtimes
+# and then waits on real settlement windows. Two at a time keeps the smoke lane
+# moving without letting eleven of them starve each other's relay admission.
+app-runtime-journeys = { max-threads = 2 }
 
 [[profile.default.overrides]]
 filter = 'package(wn-cli) & binary(cli)'
@@ -41,6 +45,10 @@ test-group = 'cli-e2e'
 [[profile.default.overrides]]
 filter = 'package(cgka-conformance-simulator) & binary(process_orchestrator)'
 test-group = 'process-orchestrator'
+
+[[profile.default.overrides]]
+filter = 'package(cgka-conformance-simulator) & (binary(app_runtime_journeys) | binary(app_runtime_interaction_journeys))'
+test-group = 'app-runtime-journeys'
 
 # These cross-process recovery cases each launch several runtimes and local
 # relays. Reserve the full nextest worker budget so CPU pressure cannot turn a

--- a/crates/cgka-conformance-simulator/APP_PATH_COVERAGE.md
+++ b/crates/cgka-conformance-simulator/APP_PATH_COVERAGE.md
@@ -70,6 +70,67 @@ multiple groups, duplicate/reordered retained history, partitions, competing com
 catalog. Capability-preflight failures must stay visible as coverage gaps; do not discard incompatible assertions
 and call the original scenario covered.
 
+## Interaction journeys
+
+`tests/app_runtime_interaction_journeys.rs` uses the same harness and evidence layout and covers interactions the
+serialized generated families cannot express. `AppRuntimeHarness::race_mutations` issues several public commands from
+different participants at the same instant, so each device commits against its own current epoch; a rejected command
+may already have reached the relay, so only accepted publications are correlated strictly in that case.
+`AppRuntimeHarness::run_due_maintenance` drives the maintenance sweep instead of the worker's fifteen-second timer.
+
+| Test suffix | Public contract |
+| --- | --- |
+| `07_two_groups_stay_isolated` | Work and pair groups on one device; the second invite of Bob needs a fresh KeyPackage; a non-member has no projection; a removal and a reopen leave the other group's exact history untouched |
+| `08_concurrent_admin_profile_edits_converge` | Two admins save name and description at the same instant; members settle on one state containing at least one edit; fresh traffic and reopen persistence hold; dropped edits are recorded |
+| `08_strict_concurrent_admin_profile_edits_are_never_lost` (ignored) | As above, and every edit the runtime reported as saved is present in the settled state |
+| `09_concurrent_invite_and_rename_converge` | An invite races a rename; founders settle; the invitee is either a full member who sends and receives or holds no membership; at least one edit landed |
+| `09_strict_concurrent_invite_and_rename_are_never_lost` (ignored) | As above, and an invite or rename reported as saved is not lost |
+| `10_member_removed_while_offline_learns_removal` | A closed device is removed; on reconnect it learns the removal from relay history, never decrypts post-removal traffic, keeps its exact pre-removal history across reopen, and its sends are refused as `group_removed` |
+| `12_leave_with_several_remaining_members_converges` | David leaves a four-member group; within three minutes the survivors apply it, settle, exchange decryptable traffic in every direction, and persist across reopen; the leaver keeps exactly its pre-departure history and nothing it sends afterwards reaches them |
+| `12_strict_leave_is_applied_by_survivors_promptly` (ignored) | As above, but the survivors must apply the leave within 30 seconds |
+| `11_manual_self_update_advances_every_member` (ignored) | A manual self-update advances the shared epoch with no loss; waits out the real-time 60-second quiet window plus up to 30 seconds of jitter (passed locally in about 150 seconds on 2026-09-06) |
+
+On 2026-09-06 the four default race, group, and removal journeys passed locally in debug mode in about 80 seconds
+total, the default leave journey passed in about two minutes, and the strict variants failed only on the documented
+contracts below. The default concurrent journeys accept either race outcome. They fail when members do not settle, when neither edit
+reached the settled state, or when fresh traffic or reopen persistence breaks. They do not prove that a same-epoch
+fork occurred on a given run; real socket timing is not seed-controlled.
+
+### Known gap: a losing admin edit is dropped after its caller was told it saved
+
+The first run of the strict profile-edit journey (2026-09-06) showed both `update_group_profile` calls returning
+success, every member settling at the next epoch with Bob's description, and Alice's rename absent everywhere, with
+no error event on any device. This matches the account layer: when convergence parks an own commit, only a
+`SelfUpdate` evolution re-arms its maintenance obligation; `Invite`, `RemoveMembers`, and `UpdateAppComponents`
+evolutions are marked superseded and their intent is not re-issued or reported. The engine vectors
+(`group-data-fork-recovery/v1`) specify only that both clients converge, so the engine oracle cannot see this.
+The strict journeys stay ignored until the runtime either re-issues a parked intent or reports the loss to the
+caller; the default journeys keep the convergence, delivery, and persistence contract green in the ordinary run.
+
+### Known gap: survivors apply a voluntary leave only when something else runs convergence
+
+The engine schedules a peer's SelfRemove auto-commit 10 to 50 ms after the proposal and marks the group as one the
+app should feed through its convergence timer. The app worker's schedule state, however, is derived from open
+convergence passes, unresolved convergence rows, queued outbound intents, pending fanouts, and deferred peels; a
+scheduled auto-commit is none of those, so the group reads `Idle` and no timer is armed. On 2026-09-06 four
+instrumented runs showed the proposal admitted by the relay immediately and the three survivors unchanged at epoch 1
+for 50 to 80 seconds, until their post-join rotations happened to run convergence and carried the removal with them
+(epoch 1 to 4 across three commits). The existing send-leave family canary shows the same shape: its post-leave
+checkpoint took 82 seconds. In a settled group with no rotation due, a departed member would stay on the roster and
+keep the current epoch secret until the next unrelated commit. The strict journey stays ignored until the worker
+arms a wakeup for scheduled auto-commits; the default journey allows three minutes so the eventual contract stays
+green. Neither run needed a manual `retry_group_convergence`.
+
+The invite-versus-rename race decides differently from run to run. When the invite won, the rename was dropped and
+the invitee joined normally. When the rename won (strict run, same day), `invite_members` had still returned
+success, the founders settled at the next epoch with three members and the new name, and the invitee's device had
+accepted the Welcome from the parked branch: it reported itself a full member at the same epoch number with four
+members and the old name, with no pending confirmation and no error event. That device cannot decrypt the real
+group's traffic and its own sends are undecryptable to the members. This is the stale-Welcome incident archetype
+reaching the public app with no repair; the engine family `membership-reentry/v1` covers the shape only after an
+explicit remove and fresh re-invite. The default journey records the invitee's view in `after-race.json` whenever
+the founders' settled roster excludes it.
+
 ## Running and preserving evidence
 
 The later consolidation applies the 2,048-row mitigation to the broader WIP checkout. Evidence for this combination

--- a/crates/cgka-conformance-simulator/APP_PATH_COVERAGE.md
+++ b/crates/cgka-conformance-simulator/APP_PATH_COVERAGE.md
@@ -81,22 +81,40 @@ may already have reached the relay, so only accepted publications are correlated
 | Test suffix | Public contract |
 | --- | --- |
 | `07_two_groups_stay_isolated` | Work and pair groups on one device; the second invite of Bob needs a fresh KeyPackage; a non-member has no projection; a removal and a reopen leave the other group's exact history untouched |
-| `08_concurrent_admin_profile_edits_converge` | Two admins save name and description at the same instant; members settle on one state containing at least one edit; fresh traffic and reopen persistence hold; dropped edits are recorded |
-| `08_strict_concurrent_admin_profile_edits_are_never_lost` (ignored) | As above, and every edit the runtime reported as saved is present in the settled state |
-| `09_concurrent_invite_and_rename_converge` | An invite races a rename; founders settle; the invitee is either a full member who sends and receives or holds no membership; at least one edit landed |
-| `09_strict_concurrent_invite_and_rename_are_never_lost` (ignored) | As above, and an invite or rename reported as saved is not lost |
+| `08_concurrent_admin_profile_edits_converge` | Two admins save name and description at the same instant; members settle on one state in which at least one edit is present (measured on the settled projection, not on the commands' return values); fresh traffic and reopen persistence hold; dropped accepted edits are recorded |
+| `08_strict_concurrent_admin_profile_edits_are_never_lost` (ignored, #1734) | As above, and every edit the runtime reported as saved is present in the settled state |
+| `09_concurrent_invite_and_rename_converge` | An invite races a rename; founders settle with at least one edit present; an invitee the founders admitted sends and receives; an excluded invitee's device state is recorded as `no_projection` or `stranded` |
+| `09_strict_concurrent_invite_and_rename_are_never_lost` (ignored, #1734, #1735) | As above, an excluded invitee holds no projection, and an invite or rename reported as saved is not lost |
 | `10_member_removed_while_offline_learns_removal` | A closed device is removed; on reconnect it learns the removal from relay history, never decrypts post-removal traffic, keeps its exact pre-removal history across reopen, and its sends are refused as `group_removed` |
 | `12_leave_with_several_remaining_members_converges` | David leaves a four-member group; within three minutes the survivors apply it, settle, exchange decryptable traffic in every direction, and persist across reopen; the leaver keeps exactly its pre-departure history and nothing it sends afterwards reaches them |
-| `12_strict_leave_is_applied_by_survivors_promptly` (ignored) | As above, but the survivors must apply the leave within 30 seconds |
+| `12_strict_leave_is_applied_by_survivors_promptly` (ignored, #1736) | As above, but the survivors must apply the leave within 30 seconds |
 | `11_manual_self_update_advances_every_member` (ignored) | A manual self-update advances the shared epoch with no loss; waits out the real-time 60-second quiet window plus up to 30 seconds of jitter (passed locally in about 150 seconds on 2026-09-06) |
 
 On 2026-09-06 the four default race, group, and removal journeys passed locally in debug mode in about 80 seconds
 total, the default leave journey passed in about two minutes, and the strict variants failed only on the documented
 contracts below. The default concurrent journeys accept either race outcome. They fail when members do not settle, when neither edit
-reached the settled state, or when fresh traffic or reopen persistence breaks. They do not prove that a same-epoch
-fork occurred on a given run; real socket timing is not seed-controlled.
+is present in the settled state, or when fresh traffic or reopen persistence breaks. They do not prove that a same-epoch
+fork occurred on a given run; real socket timing is not seed-controlled. The three gaps below are tracked in
+[#1734](https://github.com/marmot-protocol/mdk/issues/1734), [#1735](https://github.com/marmot-protocol/mdk/issues/1735),
+and [#1736](https://github.com/marmot-protocol/mdk/issues/1736); the ignored strict journeys are their regressions.
 
-### Known gap: a losing admin edit is dropped after its caller was told it saved
+Run the default journeys the way the conformance CI job does, or serially with retained evidence:
+
+```sh
+cargo nextest run -p cgka-conformance-simulator --locked --profile ci --test app_runtime_interaction_journeys
+```
+
+```sh
+MDK_APP_JOURNEY_ARTIFACTS="$PWD/target/app-interaction-evidence" \
+cargo test --release --locked -p cgka-conformance-simulator --test app_runtime_interaction_journeys -- \
+  --test-threads=1 --nocapture
+```
+
+Add `--include-ignored` to also run the strict regressions and the manual self-update journey. Under nextest the
+`app-runtime-journeys` test group in `.config/nextest.toml` runs at most two public journeys at a time, because each
+one starts a local relay and several SQLCipher runtimes and then waits on real settlement windows.
+
+### Known gap: a losing admin edit is dropped after its caller was told it saved (#1734)
 
 The first run of the strict profile-edit journey (2026-09-06) showed both `update_group_profile` calls returning
 success, every member settling at the next epoch with Bob's description, and Alice's rename absent everywhere, with
@@ -107,7 +125,7 @@ evolutions are marked superseded and their intent is not re-issued or reported. 
 The strict journeys stay ignored until the runtime either re-issues a parked intent or reports the loss to the
 caller; the default journeys keep the convergence, delivery, and persistence contract green in the ordinary run.
 
-### Known gap: survivors apply a voluntary leave only when something else runs convergence
+### Known gap: survivors apply a voluntary leave only when something else runs convergence (#1736)
 
 The engine schedules a peer's SelfRemove auto-commit 10 to 50 ms after the proposal and marks the group as one the
 app should feed through its convergence timer. The app worker's schedule state, however, is derived from open
@@ -121,7 +139,7 @@ keep the current epoch secret until the next unrelated commit. The strict journe
 arms a wakeup for scheduled auto-commits; the default journey allows three minutes so the eventual contract stays
 green. Neither run needed a manual `retry_group_convergence`.
 
-The invite-versus-rename race decides differently from run to run. When the invite won, the rename was dropped and
+The invite-versus-rename race decides differently from run to run (#1735). When the invite won, the rename was dropped and
 the invitee joined normally. When the rename won (strict run, same day), `invite_members` had still returned
 success, the founders settled at the next epoch with three members and the new name, and the invitee's device had
 accepted the Welcome from the parked branch: it reported itself a full member at the same epoch number with four

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -1067,11 +1067,16 @@ it is not a passing catch-up result. Commands, limits, and remaining coverage ga
 two groups on one device (traffic, a removal, and a reopen must not leak across groups, and the second invitation of the
 same member exercises a fresh KeyPackage), two admins saving different profile fields at the same instant, an invite
 racing a rename, a member removed while its device is closed (it must learn the removal from relay history, keep
-its pre-removal history exactly, and have its own sends refused), and a voluntary leave from a four-member group, where
-the remaining devices must apply the removal and still exchange decryptable traffic (the strict form requires them to
-do so within 30 seconds and stays ignored while the worker only reaches the auto-commit through unrelated commits). `AppRuntimeHarness::race_mutations` issues the
-concurrent commands; the oracle is that members settle on one public state and that no edit reported as saved is lost.
-The manual self-update journey is explicitly ignored because the protocol's quiet window and jitter run on real time.
+its pre-removal history exactly, and have its own sends refused), and a voluntary leave from a four-member group.
+`AppRuntimeHarness::race_mutations` issues the concurrent commands.
+
+The default forms run in the ordinary crate test and gate only what the product delivers today: members settle on one
+public state, at least one racing edit is present in that settled state (measured on the projection, never on the
+command's return value), fresh traffic flows in every direction, history survives reopen, and survivors apply a leave
+within three minutes. The strict forms are ignored regressions for three tracked gaps: an edit or invite the runtime
+reported as saved is never lost (#1734), an invitee the founders exclude holds no projection rather than a stranded
+parked-branch membership (#1735), and survivors apply a leave within 30 seconds (#1736). The manual self-update journey
+is explicitly ignored because the protocol's quiet window and jitter run on real time.
 
 `cgka-conformance-app-inventory` inventories unchanged generated inputs against the actual public adapter's action
 capabilities before spending runtime budget. Its first bounded selection covers twelve families and records

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -1063,6 +1063,16 @@ relay order and public app operations, not the engine fixture's forced reverse s
 it is not a passing catch-up result. Commands, limits, and remaining coverage gaps are in
 [`APP_PATH_COVERAGE.md`](APP_PATH_COVERAGE.md).
 
+`tests/app_runtime_interaction_journeys.rs` adds interaction journeys the serialized public families cannot express:
+two groups on one device (traffic, a removal, and a reopen must not leak across groups, and the second invitation of the
+same member exercises a fresh KeyPackage), two admins saving different profile fields at the same instant, an invite
+racing a rename, a member removed while its device is closed (it must learn the removal from relay history, keep
+its pre-removal history exactly, and have its own sends refused), and a voluntary leave from a four-member group, where
+the remaining devices must apply the removal and still exchange decryptable traffic (the strict form requires them to
+do so within 30 seconds and stays ignored while the worker only reaches the auto-commit through unrelated commits). `AppRuntimeHarness::race_mutations` issues the
+concurrent commands; the oracle is that members settle on one public state and that no edit reported as saved is lost.
+The manual self-update journey is explicitly ignored because the protocol's quiet window and jitter run on real time.
+
 `cgka-conformance-app-inventory` inventories unchanged generated inputs against the actual public adapter's action
 capabilities before spending runtime budget. Its first bounded selection covers twelve families and records
 unsupported cases explicitly; it does not create new families, remove assertions, or count preflight as a pass.

--- a/crates/cgka-conformance-simulator/src/app_runtime.rs
+++ b/crates/cgka-conformance-simulator/src/app_runtime.rs
@@ -87,6 +87,55 @@ pub struct AppRuntimeObservationV1 {
     pub local: AppRuntimeLocalDiagnosticsV1,
 }
 
+/// One public group mutation issued at the same instant as its siblings by
+/// [`AppRuntimeHarness::race_mutations`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ConcurrentMutation<'a> {
+    UpdateGroupProfile {
+        client: &'a str,
+        name: Option<&'a str>,
+        description: Option<&'a str>,
+    },
+    InviteMembers {
+        inviter: &'a str,
+        invitees: &'a [String],
+    },
+}
+
+impl ConcurrentMutation<'_> {
+    pub fn client(&self) -> &str {
+        match self {
+            Self::UpdateGroupProfile { client, .. } => client,
+            Self::InviteMembers { inviter, .. } => inviter,
+        }
+    }
+}
+
+/// Public result of one concurrently issued mutation. `accepted` means the
+/// runtime reported the command as saved to its caller; a rejected command
+/// carries only a privacy-safe error classification.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConcurrentMutationOutcome {
+    pub client: String,
+    pub accepted: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_kind: Option<String>,
+}
+
+/// Everything [`AppRuntimeHarness::race_mutations`] learned at the command
+/// boundary. Relay events admitted beyond the accepted commands' own
+/// publications are counted, not rejected: they are how convergence recovery
+/// or a rejected command's early publication become visible to a scenario.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConcurrentMutationReport {
+    pub outcomes: Vec<ConcurrentMutationOutcome>,
+    /// Retained relay events the accepted commands reported publishing.
+    pub expected_publications: usize,
+    /// Retained relay events admitted after the race started, once every
+    /// accepted publication had appeared.
+    pub admitted_publications: usize,
+}
+
 struct Participant {
     root: TempDir,
     app: MarmotApp,
@@ -213,6 +262,13 @@ impl AppRuntimeHarness {
 
     async fn relay_publication_cursor(&self) -> usize {
         self.relay_control.publication_cursor().await
+    }
+
+    /// Number of events the shared relay has admitted so far. A scenario can
+    /// difference two readings to prove that a command reached the relay at
+    /// all, independently of any participant's projection.
+    pub async fn relay_admitted_events(&self) -> usize {
+        self.relay_publication_cursor().await
     }
 
     async fn set_all_maintenance_paused(&self, paused: bool) -> Result<(), SubjectError> {
@@ -475,6 +531,143 @@ impl AppRuntimeHarness {
             }
             participant.online = false;
         }
+    }
+
+    /// Advance every named online participant's durable maintenance state once
+    /// through the public runtime, publishing work whose safety windows have
+    /// elapsed. Scenarios poll this instead of waiting for the worker's own
+    /// fifteen-second timer; deadlines and jitter still run on real time.
+    pub async fn run_due_maintenance(&mut self, clients: &[String]) -> Result<(), SubjectError> {
+        for label in clients {
+            let participant = self.participant_mut(label)?;
+            if !participant.online {
+                continue;
+            }
+            let account_id = participant.account_id.clone();
+            if let Err(error) = participant
+                .runtime()?
+                .run_due_maintenance(&account_id)
+                .await
+            {
+                record_failure(participant, &error);
+                return Err(app_error(error));
+            }
+        }
+        self.refresh_cached_members(clients).await
+    }
+
+    /// Issue several mutations from different participants at the same instant
+    /// against the active scenario group, then wait until the shared relay has
+    /// admitted every accepted publication. Each participant commits against
+    /// its own current epoch, so accepted siblings may compete for one epoch;
+    /// the caller asserts the public outcome. Convergence may publish recovery
+    /// commits inside the window and a rejected command may have reached the
+    /// relay before failing, so additional admitted events are reported rather
+    /// than treated as a correlation failure.
+    pub async fn race_mutations(
+        &mut self,
+        action_id: &str,
+        mutations: &[ConcurrentMutation<'_>],
+    ) -> Result<ConcurrentMutationReport, SubjectError> {
+        if mutations.is_empty() {
+            return Err(SubjectError::classified(
+                SubjectFailureCategory::ExpectedRefusal,
+                "empty_concurrent_mutation_set",
+                "a concurrent mutation set needs at least one mutation",
+            ));
+        }
+        let group_id = self.active_group()?;
+        let before = self.relay_publication_cursor().await;
+        let include_welcomes = mutations
+            .iter()
+            .any(|mutation| matches!(mutation, ConcurrentMutation::InviteMembers { .. }));
+        let mut tasks = tokio::task::JoinSet::new();
+        for (index, mutation) in mutations.iter().enumerate() {
+            let participant = self.participant(mutation.client())?;
+            let runtime = participant.runtime()?.clone();
+            let account_id = participant.account_id.clone();
+            let group_id = group_id.clone();
+            match mutation {
+                ConcurrentMutation::UpdateGroupProfile {
+                    name, description, ..
+                } => {
+                    let name = name.map(str::to_owned);
+                    let description = description.map(str::to_owned);
+                    tasks.spawn(async move {
+                        let result = runtime
+                            .update_group_profile(&account_id, &group_id, name, description)
+                            .await;
+                        (index, result)
+                    });
+                }
+                ConcurrentMutation::InviteMembers { invitees, .. } => {
+                    let invitees = self.account_ids(invitees)?;
+                    tasks.spawn(async move {
+                        let result = runtime
+                            .invite_members(&account_id, &group_id, &invitees)
+                            .await;
+                        (index, result)
+                    });
+                }
+            }
+        }
+        let mut results = (0..mutations.len()).map(|_| None).collect::<Vec<_>>();
+        while let Some(joined) = tasks.join_next().await {
+            let (index, result) = joined.map_err(|_| {
+                SubjectError::classified(
+                    SubjectFailureCategory::Environment,
+                    "concurrent_mutation_task_failed",
+                    "a concurrently issued app-runtime mutation did not complete",
+                )
+            })?;
+            results[index] = Some(result);
+        }
+        let mut outcomes = Vec::with_capacity(mutations.len());
+        let mut expected_publications = 0;
+        let mut expected_event_ids = Vec::new();
+        for (mutation, result) in mutations.iter().zip(results) {
+            let result = result.expect("every spawned mutation reports exactly once");
+            let client = mutation.client().to_owned();
+            outcomes.push(match result {
+                Ok(summary) => {
+                    expected_publications += summary.published;
+                    expected_event_ids.extend(summary.message_ids);
+                    ConcurrentMutationOutcome {
+                        client,
+                        accepted: true,
+                        error_kind: None,
+                    }
+                }
+                Err(error) => ConcurrentMutationOutcome {
+                    client,
+                    accepted: false,
+                    error_kind: Some(app_error_kind(&error).to_owned()),
+                },
+            });
+        }
+        let admitted_publications = self
+            .relay_control
+            .wait_for_at_least_action_events(
+                &mut self.relay_action_events,
+                action_id,
+                before,
+                RelayActionExpectation {
+                    include_welcomes,
+                    expected_publications,
+                    expected_event_ids: &expected_event_ids,
+                    timeout: RELAY_ACTION_PUBLICATION_TIMEOUT,
+                },
+            )
+            .await
+            .map_err(relay_control_error)?;
+        for outcome in outcomes.iter().filter(|outcome| outcome.accepted) {
+            self.record_accepted_publication(&outcome.client, action_id);
+        }
+        Ok(ConcurrentMutationReport {
+            outcomes,
+            expected_publications,
+            admitted_publications,
+        })
     }
 
     fn active_group(&self) -> Result<GroupId, SubjectError> {
@@ -1488,8 +1681,10 @@ pub(crate) async fn accept_group_invite_retrying_busy(
     Err(last_retryable)
 }
 
-fn record_failure(participant: &mut Participant, error: &AppError) {
-    let kind = match error {
+/// Privacy-safe classification of a public runtime error: a fixed label per
+/// variant family, never the variant's inner details.
+fn app_error_kind(error: &AppError) -> &'static str {
+    match error {
         AppError::AccountSessionBusy => "account_session_busy",
         AppError::AccountWorkerBusy => "account_worker_busy",
         AppError::AccountWorkerResponseTimedOut => "account_worker_response_timed_out",
@@ -1502,10 +1697,18 @@ fn record_failure(participant: &mut Participant, error: &AppError) {
         AppError::Storage(_) | AppError::Sqlite(_) | AppError::SqlcipherKeyDerivation(_) => {
             "storage"
         }
+        AppError::UnknownGroup(_) => "unknown_group",
+        AppError::GroupRemoved(_) => "group_removed",
+        AppError::GroupDisbanding(_) => "group_disbanding",
+        AppError::GroupInviteNotPending => "group_invite_not_pending",
+        AppError::MissingKeyPackage(_) => "missing_key_package",
+        AppError::MissingMemberInboxRoute(_) => "missing_member_inbox_route",
         _ => "app_runtime_operation",
     }
-    .to_owned();
-    participant.last_error_kind = Some(kind);
+}
+
+fn record_failure(participant: &mut Participant, error: &AppError) {
+    participant.last_error_kind = Some(app_error_kind(error).to_owned());
     if matches!(
         error,
         AppError::AccountSessionBusy
@@ -1598,7 +1801,10 @@ fn app_error(error: AppError) -> SubjectError {
     SubjectError::classified(
         category,
         "app_runtime_operation_failed",
-        "application runtime operation failed",
+        format!(
+            "application runtime operation failed: {}",
+            app_error_kind(&error)
+        ),
     )
 }
 

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -65,6 +65,7 @@ pub mod vector;
 pub use app_runtime::{
     APP_RUNTIME_OBSERVATION_SCHEMA_VERSION, AppRuntimeApplicationProjectionV1, AppRuntimeHarness,
     AppRuntimeLocalDiagnosticsV1, AppRuntimeObservationV1, AppRuntimeProtocolProjectionV1,
+    ConcurrentMutation, ConcurrentMutationOutcome, ConcurrentMutationReport,
 };
 pub use bus::{ClientId, DeliveryPolicy, TransportBus};
 pub use campaign_metrics::{

--- a/crates/cgka-conformance-simulator/src/relay_control.rs
+++ b/crates/cgka-conformance-simulator/src/relay_control.rs
@@ -263,6 +263,12 @@ impl RelayControl {
             expected_event_ids,
             timeout,
         } = expectation;
+        if expected_event_ids.len() > expected_publications {
+            return Err(RelayControlError {
+                code: "relay_action_publication_identity_count_mismatch",
+                message: "the action's expected relay event ids do not match its publication count",
+            });
+        }
         let expected_event_ids = expected_event_ids.iter().cloned().collect::<BTreeSet<_>>();
         let deadline = Instant::now() + timeout;
         loop {
@@ -527,5 +533,82 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(error.code, "relay_action_publication_identity_mismatch");
+    }
+
+    #[tokio::test]
+    async fn at_least_waiter_requires_accepted_ids_but_tolerates_additional_admissions() {
+        let control = RelayControl::new();
+        let database = RecordingRelayDatabase {
+            inner: MemoryDatabase::with_opts(MemoryDatabaseOptions {
+                events: true,
+                max_events: None,
+            }),
+            publication_log: Arc::clone(&control.publication_log),
+            hidden_event_ids: Arc::clone(&control.hidden_event_ids),
+        };
+        let keys = nostr::Keys::generate();
+        let accepted = nostr::EventBuilder::new(Kind::MlsGroupMessage, "accepted commit")
+            .sign_with_keys(&keys)
+            .unwrap();
+        let recovery = nostr::EventBuilder::new(Kind::MlsGroupMessage, "convergence recovery")
+            .sign_with_keys(&keys)
+            .unwrap();
+        let welcome = nostr::EventBuilder::new(Kind::GiftWrap, "early welcome")
+            .sign_with_keys(&keys)
+            .unwrap();
+        for event in [&recovery, &welcome] {
+            assert!(database.save_event(event).await.unwrap().is_success());
+        }
+        let accepted_ids = [accepted.id.to_hex()];
+        let expectation = || RelayActionExpectation {
+            include_welcomes: true,
+            expected_publications: 1,
+            expected_event_ids: &accepted_ids,
+            timeout: Duration::from_millis(200),
+        };
+
+        // Two unrelated admissions do not satisfy the wait: the accepted
+        // command's own event must appear.
+        let mut action_events = RelayActionEvents::new();
+        let missing = control
+            .wait_for_at_least_action_events(&mut action_events, "race", 0, expectation())
+            .await
+            .unwrap_err();
+        assert_eq!(missing.code, "relay_action_publication_timeout");
+
+        // Once it does, the additional admissions are counted, not rejected,
+        // where the exact waiter would report a count mismatch.
+        assert!(database.save_event(&accepted).await.unwrap().is_success());
+        let admitted = control
+            .wait_for_at_least_action_events(&mut action_events, "race", 0, expectation())
+            .await
+            .unwrap();
+        assert_eq!(admitted, 3);
+        let exact = control
+            .wait_for_action_events(&mut action_events, "race-exact", 0, expectation())
+            .await
+            .unwrap_err();
+        assert_eq!(exact.code, "relay_action_publication_identity_mismatch");
+
+        // Both waiters refuse an id list longer than the publication count.
+        let two_ids = [accepted.id.to_hex(), recovery.id.to_hex()];
+        let inconsistent = control
+            .wait_for_at_least_action_events(
+                &mut action_events,
+                "race-inconsistent",
+                0,
+                RelayActionExpectation {
+                    include_welcomes: true,
+                    expected_publications: 1,
+                    expected_event_ids: &two_ids,
+                    timeout: Duration::from_millis(50),
+                },
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(
+            inconsistent.code,
+            "relay_action_publication_identity_count_mismatch"
+        );
     }
 }

--- a/crates/cgka-conformance-simulator/src/relay_control.rs
+++ b/crates/cgka-conformance-simulator/src/relay_control.rs
@@ -244,6 +244,52 @@ impl RelayControl {
         }
     }
 
+    /// Like [`Self::wait_for_action_events`], but admitted events beyond the
+    /// expected count are tolerated and the admitted count is returned. Use it
+    /// for concurrently issued commands: convergence may legitimately publish
+    /// recovery commits inside the window, and a rejected command may have
+    /// reached the relay before failing, so an exact count is not a meaningful
+    /// correlation there. The accepted publications must still all appear.
+    pub async fn wait_for_at_least_action_events(
+        &self,
+        action_events: &mut RelayActionEvents,
+        action_id: &str,
+        before: usize,
+        expectation: RelayActionExpectation<'_>,
+    ) -> Result<usize, RelayControlError> {
+        let RelayActionExpectation {
+            include_welcomes,
+            expected_publications,
+            expected_event_ids,
+            timeout,
+        } = expectation;
+        let expected_event_ids = expected_event_ids.iter().cloned().collect::<BTreeSet<_>>();
+        let deadline = Instant::now() + timeout;
+        loop {
+            let recorded = self
+                .record_action_events(action_events, action_id, before, include_welcomes)
+                .await?;
+            let observed_event_ids = action_events
+                .get(action_id)
+                .into_iter()
+                .flatten()
+                .map(|event| event.event.id.to_hex())
+                .collect::<BTreeSet<_>>();
+            if recorded >= expected_publications
+                && expected_event_ids.is_subset(&observed_event_ids)
+            {
+                return Ok(recorded);
+            }
+            if Instant::now() >= deadline {
+                return Err(RelayControlError {
+                    code: "relay_action_publication_timeout",
+                    message: "the action's expected retained relay publications were not admitted before the deadline",
+                });
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    }
+
     pub async fn set_action_event_visibility(
         &self,
         action_events: &RelayActionEvents,

--- a/crates/cgka-conformance-simulator/tests/AGENTS.md
+++ b/crates/cgka-conformance-simulator/tests/AGENTS.md
@@ -22,6 +22,12 @@ determinism, reachability, interaction-coverage, and promotion checks when addin
     Real local relay, SQLCipher roots, exact public payload/state checks, post-change messaging, and restart
     persistence. See `../APP_PATH_COVERAGE.md` for replay and evidence commands.
 
+- **File:** `app_runtime_interaction_journeys.rs`
+  - **Owns:** Public app interaction journeys that the serialized generated families do not reach: two groups on
+    one device with a removal and reopen, two admins editing different profile fields at the same instant, a
+    concurrent invite plus rename, a member removed while its device is closed, a voluntary leave with three
+    remaining auto-committers, and the explicit slow manual self-update. Same harness and evidence layout as `app_runtime_journeys.rs`; see `../APP_PATH_COVERAGE.md`.
+
 - **File:** `agent_text_stream_vectors.rs`
   - **Owns:** Byte-level conformance vectors for the agent text stream QUIC feature: `AgentTextStreamKeyContextV1`
     encoding, HKDF-SHA256 record key / nonce derivation, record AEAD AAD, transcript hashes, and the

--- a/crates/cgka-conformance-simulator/tests/app_runtime_interaction_journeys.rs
+++ b/crates/cgka-conformance-simulator/tests/app_runtime_interaction_journeys.rs
@@ -8,8 +8,8 @@ use std::{collections::BTreeMap, error::Error, path::Path, time::Duration};
 
 use cgka_conformance_simulator::{
     AppRuntimeHarness, AppRuntimeObservationV1, ConcurrentMutation, ConcurrentMutationReport,
-    ConvergenceSubject, SubjectCreateGroup, SubjectFailureCategory, SubjectRemoveMembers,
-    SubjectSelfUpdate, SubjectSendApplication,
+    ConvergenceSubject, SubjectCreateGroup, SubjectError, SubjectFailureCategory,
+    SubjectRemoveMembers, SubjectSelfUpdate, SubjectSendApplication,
 };
 use serde_json::json;
 
@@ -107,6 +107,17 @@ async fn send(
     sender: &str,
     payload: &str,
 ) -> TestResult {
+    try_send(subject, group, sender, payload).await?;
+    Ok(())
+}
+
+/// A send whose refusal the journey wants to classify rather than fail on.
+async fn try_send(
+    subject: &mut AppRuntimeHarness,
+    group: &str,
+    sender: &str,
+    payload: &str,
+) -> Result<(), SubjectError> {
     subject.select_scenario_group(group, false)?;
     subject
         .send_application(SubjectSendApplication {
@@ -114,8 +125,23 @@ async fn send(
             sender,
             payload,
         })
-        .await?;
-    Ok(())
+        .await
+}
+
+/// The harness reports a group this device holds no projection of either as
+/// an expected refusal from the public member read (`unknown_group` in the
+/// classified message) or, when that read passes but the projection is
+/// missing, as its own `unknown_group` code.
+fn is_unknown_group(error: &SubjectError) -> bool {
+    error.code == "unknown_group"
+        || (error.category == SubjectFailureCategory::ExpectedRefusal
+            && error.message.ends_with("unknown_group"))
+}
+
+/// An expected public refusal whose privacy-safe kind is `kind`.
+fn refused_as(error: &SubjectError, kind: &str) -> bool {
+    error.category == SubjectFailureCategory::ExpectedRefusal
+        && error.message.ends_with(&format!(": {kind}"))
 }
 
 /// Drive public catch-up until the named group's members all expose the
@@ -252,9 +278,7 @@ async fn two_groups(subject: &mut AppRuntimeHarness, out: &Path) -> TestResult {
             save(out, "carol-pair-leak.json", &observation)?;
             return Err("non-member carol holds a projection of the pair group".into());
         }
-        Err(error)
-            if error.category == SubjectFailureCategory::ExpectedRefusal
-                && error.message.contains("unknown_group") => {}
+        Err(error) if is_unknown_group(&error) => {}
         Err(error) => {
             return Err(format!("unexpected pair-group read failure for carol: {error}").into());
         }
@@ -299,11 +323,33 @@ async fn two_groups(subject: &mut AppRuntimeHarness, out: &Path) -> TestResult {
         .map(|_| ())
 }
 
+/// Whether every settled observation carries the edit.
+fn edit_applied(observations: &[AppRuntimeObservationV1], field: &str, value: &str) -> bool {
+    !observations.is_empty()
+        && observations.iter().all(|o| match field {
+            "name" => o.protocol.group_name == value,
+            _ => o.protocol.group_description == value,
+        })
+}
+
+/// Which racing profile edits are present in the settled public state,
+/// regardless of what the runtime told the caller.
+fn settled_edits(
+    observations: &[AppRuntimeObservationV1],
+    edits: &[(&str, &str, &str)],
+) -> Vec<String> {
+    edits
+        .iter()
+        .filter(|(_, field, value)| edit_applied(observations, field, value))
+        .map(|(client, field, _)| format!("{client}:{field}"))
+        .collect()
+}
+
 /// Which racing profile edits the runtime reported as saved but the settled
 /// public state does not contain. Convergence keeps one branch and parks the
 /// other; the parked committer's intent is not re-issued today, so a losing
-/// admin edit is dropped after its caller was told it succeeded. The strict
-/// journeys fail on this; the default journeys record it as evidence.
+/// admin edit is dropped after its caller was told it succeeded (#1734). The
+/// strict journeys fail on this; the default journeys record it as evidence.
 fn dropped_accepted_edits(
     report: &ConcurrentMutationReport,
     observations: &[AppRuntimeObservationV1],
@@ -317,12 +363,7 @@ fn dropped_accepted_edits(
                 .iter()
                 .any(|outcome| outcome.client == *client && outcome.accepted)
         })
-        .filter(|(_, field, value)| {
-            !observations.iter().all(|o| match *field {
-                "name" => o.protocol.group_name == *value,
-                _ => o.protocol.group_description == *value,
-            })
-        })
+        .filter(|(_, field, value)| !edit_applied(observations, field, value))
         .map(|(client, field, _)| format!("{client}:{field}"))
         .collect()
 }
@@ -387,14 +428,19 @@ async fn concurrent_profile_edits(
         ("alice", "name", "alice renamed it"),
         ("bob", "description", "bob described it"),
     ];
+    let settled = settled_edits(&observations, &edits);
     let dropped = dropped_accepted_edits(&report, &observations, &edits);
     save(
         out,
         "after-race.json",
-        &json!({ "dropped_accepted_edits": dropped, "observations": observations }),
+        &json!({
+            "settled_edits": settled, "dropped_accepted_edits": dropped,
+            "observations": observations,
+        }),
     )?;
-    let landed = edits.len() - dropped.len();
-    if landed == 0 {
+    // Presence is measured on the settled projection itself, so a command the
+    // runtime rejected before publishing never counts as landed.
+    if settled.is_empty() {
         return Err("neither concurrent profile edit reached the settled public state".into());
     }
     require_edits_retained(&dropped, strict)?;
@@ -402,10 +448,12 @@ async fn concurrent_profile_edits(
 }
 
 /// One admin invites a fourth member while another admin renames the group at
-/// the same instant. The founders must settle on one state, the invitee must
-/// either become a full member who sends and receives or hold no membership
-/// at all, and at least one of the two edits must have landed. The strict form
-/// also requires that an invite or rename reported as saved is not lost.
+/// the same instant. The founders must settle on one state with at least one
+/// of the two edits present, and an invitee the founders admitted must send
+/// and receive. When the founders exclude the invitee, the default form records
+/// its device state (no projection, or a stranded parked-branch membership);
+/// the strict form requires no projection and that an invite or rename
+/// reported as saved is not lost (#1734, #1735).
 async fn concurrent_invite_and_rename(
     subject: &mut AppRuntimeHarness,
     out: &Path,
@@ -470,27 +518,47 @@ async fn concurrent_invite_and_rename(
     let observations = subject
         .await_observable_settlement(&members, SETTLEMENT)
         .await?;
-    let mut dropped = dropped_accepted_edits(
-        &report,
-        &observations,
-        &[("bob", "name", "renamed during invite")],
-    );
-    if invite_accepted && !david_joined {
+    let edits = [("bob", "name", "renamed during invite")];
+    let mut settled = settled_edits(&observations, &edits);
+    let mut dropped = dropped_accepted_edits(&report, &observations, &edits);
+    if david_joined {
+        settled.push("alice:invite".into());
+    } else if invite_accepted {
         dropped.push("alice:invite".into());
     }
-    let david_stranded = subject.observations(&labels(&["david"])).await.ok();
+    // An invitee the founders exclude must hold no projection of the group. A
+    // device that still reports membership joined a parked branch through a
+    // stale Welcome: the stranded-invitee gap (#1735).
+    let invitee_state = if david_joined {
+        "member"
+    } else {
+        match subject.observations(&labels(&["david"])).await {
+            Ok(view) => {
+                save(out, "stranded-invitee.json", &view)?;
+                "stranded"
+            }
+            Err(error) if is_unknown_group(&error) => "no_projection",
+            Err(error) => {
+                return Err(format!("unexpected invitee read failure: {error}").into());
+            }
+        }
+    };
     save(
         out,
         "after-race.json",
         &json!({
-            "dropped_accepted_edits": dropped, "david_joined": david_joined,
-            "observations": observations,
-            "david_when_not_a_member": if david_joined { None } else { david_stranded },
+            "settled_edits": settled, "dropped_accepted_edits": dropped,
+            "invitee_state": invitee_state, "observations": observations,
         }),
     )?;
-    if dropped.len() == 2 {
+    if settled.is_empty() {
         return Err(
             "neither the concurrent invite nor the rename reached the settled state".into(),
+        );
+    }
+    if strict && invitee_state == "stranded" {
+        return Err(
+            "invitee excluded by the founders still reports membership on a parked branch".into(),
         );
     }
     require_edits_retained(&dropped, strict)?;
@@ -579,7 +647,7 @@ async fn removed_while_offline(subject: &mut AppRuntimeHarness, out: &Path) -> T
 
     // A removed device must be refused when it tries to send, and nothing it
     // attempts may reach the remaining members.
-    let refusal = send(subject, "main", "carol", "stale-from-carol").await;
+    let refusal = try_send(subject, "main", "carol", "stale-from-carol").await;
     save(
         out,
         "carol-send-refusal.json",
@@ -587,7 +655,7 @@ async fn removed_while_offline(subject: &mut AppRuntimeHarness, out: &Path) -> T
     )?;
     match refusal {
         Ok(()) => return Err("removed member's send was accepted by its own runtime".into()),
-        Err(error) if error.to_string().contains("group_removed") => {}
+        Err(error) if refused_as(&error, "group_removed") => {}
         Err(error) => {
             return Err(
                 format!("removed member's send failed for the wrong reason: {error}").into(),
@@ -698,7 +766,7 @@ async fn leave_with_several_remaining(
     // attempts afterwards may reach the survivors. Whether its own runtime
     // refuses the send is recorded, not asserted: a voluntary leave is a
     // different terminal state from an administrative removal.
-    let attempt = send(subject, "main", "david", "stale-from-david").await;
+    let attempt = try_send(subject, "main", "david", "stale-from-david").await;
     subject.catch_up(&labels(&["david"])).await?;
     let david = subject.observations(&labels(&["david"])).await?.remove(0);
     save(
@@ -817,9 +885,11 @@ async fn check(journey: Journey) {
             Journey::ManualSelfUpdate => manual_self_update(&mut subject, artifacts.path()).await,
         }
     };
-    let result = match tokio::time::timeout(Duration::from_secs(600), exercise).await {
+    // Same budget as the basic public journeys: the leave journey alone stacks
+    // several sixty-second settlement deadlines around its three-minute wait.
+    let result = match tokio::time::timeout(Duration::from_secs(900), exercise).await {
         Ok(result) => result,
-        Err(_) => Err("public interaction journey exceeded its 600-second watchdog".into()),
+        Err(_) => Err("public interaction journey exceeded its 900-second watchdog".into()),
     };
     // Close every runtime before asserting. Never exit the process while a
     // SQLCipher worker may still be writing (see APP_PATH_COVERAGE.md).

--- a/crates/cgka-conformance-simulator/tests/app_runtime_interaction_journeys.rs
+++ b/crates/cgka-conformance-simulator/tests/app_runtime_interaction_journeys.rs
@@ -144,6 +144,18 @@ fn refused_as(error: &SubjectError, kind: &str) -> bool {
         && error.message.ends_with(&format!(": {kind}"))
 }
 
+/// Tick a device that may legitimately hold no projection of the active group
+/// yet: its Welcome is still in flight, or the invite never published one. The
+/// harness reports that state through its public member read as
+/// `unknown_group`, which is an expected outcome here, not a failure.
+async fn tick_possible_non_member(subject: &mut AppRuntimeHarness, client: &str) -> TestResult {
+    match subject.tick(&labels(&[client])).await {
+        Ok(()) => Ok(()),
+        Err(error) if is_unknown_group(&error) => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
 /// Drive public catch-up until the named group's members all expose the
 /// expected timeline and shared state, or fail with the last observations.
 async fn expect_timeline(
@@ -495,12 +507,12 @@ async fn concurrent_invite_and_rename(
         .outcomes
         .iter()
         .any(|outcome| outcome.client == "alice" && outcome.accepted);
-    // Ticks accept the pending Welcome on the invitee's device once it arrives.
     // Membership is decided by the founders' settled roster, not by the
-    // inviter's success report.
-    subject
-        .tick(&labels(&["alice", "bob", "carol", "david"]))
-        .await?;
+    // inviter's success report. The invitee is progressed separately: until a
+    // Welcome reaches it, or if the rejected invite never published one, its
+    // device holds no group at all, which must not abort the journey.
+    subject.tick(&founders).await?;
+    tick_possible_non_member(subject, "david").await?;
     let founders_state = subject
         .await_observable_settlement(&founders, SETTLEMENT)
         .await?;
@@ -514,6 +526,25 @@ async fn concurrent_invite_and_rename(
         members.push("david".to_owned());
         // A late joiner is entitled to messages sent after admission only.
         expected.insert("david".into(), Vec::new());
+        // The founders can commit the add before the Welcome lands on the
+        // invitee's device; keep ticking it until it holds the group.
+        let deadline = tokio::time::Instant::now() + SETTLEMENT;
+        loop {
+            tick_possible_non_member(subject, "david").await?;
+            match subject.observations(&labels(&["david"])).await {
+                Ok(_) => break,
+                Err(error)
+                    if is_unknown_group(&error) && tokio::time::Instant::now() < deadline =>
+                {
+                    tokio::time::sleep(Duration::from_millis(250)).await;
+                }
+                Err(error) => {
+                    return Err(
+                        format!("admitted invitee never received its Welcome: {error}").into(),
+                    );
+                }
+            }
+        }
     }
     let observations = subject
         .await_observable_settlement(&members, SETTLEMENT)

--- a/crates/cgka-conformance-simulator/tests/app_runtime_interaction_journeys.rs
+++ b/crates/cgka-conformance-simulator/tests/app_runtime_interaction_journeys.rs
@@ -1,0 +1,909 @@
+//! Public-runtime interaction journeys: several groups, concurrent admins, a
+//! member removed while offline, a voluntary leave with several remaining
+//! auto-committers, and a manual self-update. Same production shape as
+//! `app_runtime_journeys.rs`: real local Nostr relay, one SQLCipher database
+//! per participant, public app commands and projections only.
+
+use std::{collections::BTreeMap, error::Error, path::Path, time::Duration};
+
+use cgka_conformance_simulator::{
+    AppRuntimeHarness, AppRuntimeObservationV1, ConcurrentMutation, ConcurrentMutationReport,
+    ConvergenceSubject, SubjectCreateGroup, SubjectFailureCategory, SubjectRemoveMembers,
+    SubjectSelfUpdate, SubjectSendApplication,
+};
+use serde_json::json;
+
+type TestResult<T = ()> = Result<T, Box<dyn Error>>;
+const SETTLEMENT: Duration = Duration::from_secs(60);
+/// A manual self-update publishes only after the protocol's real-time quiet
+/// window and sampled jitter (60 s plus up to 30 s); the public runtime has no
+/// virtual clock, so this budget is wall-clock by necessity.
+const MAINTENANCE_PUBLICATION_BUDGET: Duration = Duration::from_secs(150);
+/// How long the survivors of a voluntary leave may take to apply it. The
+/// engine schedules the SelfRemove auto-commit within 50 ms of the proposal,
+/// so the strict form allows a generous 30 s. The default form allows three
+/// minutes because today the app worker only reaches that auto-commit when
+/// some other commit or timer runs convergence for the group; see
+/// APP_PATH_COVERAGE.md.
+const STRICT_LEAVE_APPLICATION_BUDGET: Duration = Duration::from_secs(30);
+const EVENTUAL_LEAVE_APPLICATION_BUDGET: Duration = Duration::from_secs(180);
+
+type Timeline = BTreeMap<String, Vec<String>>;
+
+#[derive(Clone, Copy, Debug)]
+enum Journey {
+    TwoGroups,
+    ConcurrentProfileEdits { strict: bool },
+    ConcurrentInviteAndRename { strict: bool },
+    RemovedWhileOffline,
+    LeaveWithSeveralRemaining { strict: bool },
+    ManualSelfUpdate,
+}
+
+impl Journey {
+    fn label(self) -> &'static str {
+        match self {
+            Self::TwoGroups => "two_groups",
+            Self::LeaveWithSeveralRemaining { strict: false } => "leave_with_several_remaining",
+            Self::LeaveWithSeveralRemaining { strict: true } => {
+                "leave_with_several_remaining_strict"
+            }
+            Self::ConcurrentProfileEdits { strict: false } => "concurrent_profile_edits",
+            Self::ConcurrentProfileEdits { strict: true } => "concurrent_profile_edits_strict",
+            Self::ConcurrentInviteAndRename { strict: false } => "concurrent_invite_and_rename",
+            Self::ConcurrentInviteAndRename { strict: true } => {
+                "concurrent_invite_and_rename_strict"
+            }
+            Self::RemovedWhileOffline => "removed_while_offline",
+            Self::ManualSelfUpdate => "manual_self_update",
+        }
+    }
+}
+
+fn save(out: &Path, name: &str, value: &impl serde::Serialize) -> TestResult {
+    fs_private::write_private(&out.join(name), &serde_json::to_vec_pretty(value)?)?;
+    Ok(())
+}
+
+fn multiset(payloads: &[String]) -> BTreeMap<String, usize> {
+    let mut counts = BTreeMap::new();
+    for payload in payloads {
+        *counts.entry(payload.clone()).or_default() += 1;
+    }
+    counts
+}
+
+fn labels(clients: &[&str]) -> Vec<String> {
+    clients.iter().map(|client| (*client).to_owned()).collect()
+}
+
+fn push_all(expected: &mut Timeline, payload: &str) {
+    for payloads in expected.values_mut() {
+        payloads.push(payload.to_owned());
+    }
+}
+
+/// Every named participant exposes exactly the expected visible chat history,
+/// the same public group commitment, the expected roster size, no pending
+/// confirmation, and an encrypted on-disk database.
+fn complete(observations: &[AppRuntimeObservationV1], expected: &Timeline, members: usize) -> bool {
+    observations.len() == expected.len()
+        && !observations.is_empty()
+        && observations.iter().all(|o| {
+            expected.get(&o.participant).is_some_and(|payloads| {
+                multiset(&o.application.visible_plaintexts) == multiset(payloads)
+            }) && !o.application.pending_confirmation
+                && o.protocol.member_count == members
+                && o.protocol.state_commitment_sha256
+                    == observations[0].protocol.state_commitment_sha256
+                && o.local.database_exists
+                && o.local.database_encrypted
+        })
+}
+
+async fn send(
+    subject: &mut AppRuntimeHarness,
+    group: &str,
+    sender: &str,
+    payload: &str,
+) -> TestResult {
+    subject.select_scenario_group(group, false)?;
+    subject
+        .send_application(SubjectSendApplication {
+            action_id: payload,
+            sender,
+            payload,
+        })
+        .await?;
+    Ok(())
+}
+
+/// Drive public catch-up until the named group's members all expose the
+/// expected timeline and shared state, or fail with the last observations.
+async fn expect_timeline(
+    subject: &mut AppRuntimeHarness,
+    group: &str,
+    expected: &Timeline,
+    out: &Path,
+    checkpoint: &str,
+) -> TestResult<Vec<AppRuntimeObservationV1>> {
+    let clients = expected.keys().cloned().collect::<Vec<_>>();
+    let deadline = tokio::time::Instant::now() + SETTLEMENT;
+    loop {
+        subject.select_scenario_group(group, false)?;
+        subject.catch_up(&clients).await?;
+        let observations = subject.observations(&clients).await?;
+        if complete(&observations, expected, clients.len()) {
+            save(out, checkpoint, &observations)?;
+            return Ok(observations);
+        }
+        if tokio::time::Instant::now() >= deadline {
+            save(out, checkpoint, &observations)?;
+            return Err(
+                format!("public payload/state mismatch at {checkpoint} in group {group}").into(),
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn create_group(
+    subject: &mut AppRuntimeHarness,
+    group: &str,
+    invitees: &[String],
+    admins: &[String],
+) -> TestResult {
+    subject.select_scenario_group(group, true)?;
+    subject
+        .create_group(SubjectCreateGroup {
+            action_id: group,
+            creator: "alice",
+            name: &format!("{group} group"),
+            invitees,
+            required_features: &[],
+            initial_admins: admins,
+            pending: group,
+        })
+        .await?;
+    let mut members = vec!["alice".to_owned()];
+    members.extend(invitees.iter().cloned());
+    subject.tick(&members).await?;
+    subject
+        .await_observable_settlement(&members, SETTLEMENT)
+        .await?;
+    Ok(())
+}
+
+/// Every remaining member both sends and receives in the current epoch, then
+/// one recipient reopens and must still hold the complete history.
+async fn fresh_traffic_and_reopen(
+    subject: &mut AppRuntimeHarness,
+    group: &str,
+    expected: &mut Timeline,
+    reopen: &str,
+    out: &Path,
+    prefix: &str,
+) -> TestResult {
+    let members = expected.keys().cloned().collect::<Vec<_>>();
+    for member in &members {
+        let payload = format!("{prefix}-fresh-from-{member}");
+        send(subject, group, member, &payload).await?;
+        push_all(expected, &payload);
+    }
+    expect_timeline(
+        subject,
+        group,
+        expected,
+        out,
+        &format!("{prefix}-fresh.json"),
+    )
+    .await?;
+    subject.reopen(reopen).await?;
+    expect_timeline(
+        subject,
+        group,
+        expected,
+        out,
+        &format!("{prefix}-after-reopen.json"),
+    )
+    .await?;
+    Ok(())
+}
+
+/// Alice runs a three-member work group and a two-member pair group with the
+/// same device. Traffic, a removal in one group, and a reopen must never leak
+/// history or membership across groups. Inviting Bob into the second group
+/// also exercises fetching a fresh KeyPackage after the first one was used.
+async fn two_groups(subject: &mut AppRuntimeHarness, out: &Path) -> TestResult {
+    create_group(
+        subject,
+        "work",
+        &labels(&["bob", "carol"]),
+        &labels(&["alice"]),
+    )
+    .await?;
+    create_group(subject, "pair", &labels(&["bob"]), &labels(&["alice"])).await?;
+
+    let mut work = labels(&["alice", "bob", "carol"])
+        .into_iter()
+        .map(|client| (client, Vec::new()))
+        .collect::<Timeline>();
+    let mut pair = labels(&["alice", "bob"])
+        .into_iter()
+        .map(|client| (client, Vec::new()))
+        .collect::<Timeline>();
+    send(subject, "work", "alice", "work-1").await?;
+    push_all(&mut work, "work-1");
+    send(subject, "pair", "bob", "pair-1").await?;
+    push_all(&mut pair, "pair-1");
+    send(subject, "work", "carol", "work-2").await?;
+    push_all(&mut work, "work-2");
+    expect_timeline(subject, "work", &work, out, "work-initial.json").await?;
+    expect_timeline(subject, "pair", &pair, out, "pair-initial.json").await?;
+
+    // Carol was never invited to the pair group: after catching up on
+    // everything the relay holds for her, her device must have no projection
+    // of it at all, not an empty one.
+    subject.select_scenario_group("work", false)?;
+    subject.catch_up(&labels(&["carol"])).await?;
+    subject.select_scenario_group("pair", false)?;
+    match subject.observations(&labels(&["carol"])).await {
+        Ok(observation) => {
+            save(out, "carol-pair-leak.json", &observation)?;
+            return Err("non-member carol holds a projection of the pair group".into());
+        }
+        Err(error)
+            if error.category == SubjectFailureCategory::ExpectedRefusal
+                && error.message.contains("unknown_group") => {}
+        Err(error) => {
+            return Err(format!("unexpected pair-group read failure for carol: {error}").into());
+        }
+    }
+
+    subject.select_scenario_group("work", false)?;
+    subject
+        .remove_members(SubjectRemoveMembers {
+            action_id: "remove-carol",
+            remover: "alice",
+            members: &labels(&["carol"]),
+            pending: "remove-carol",
+        })
+        .await?;
+    subject.tick(&labels(&["alice", "bob", "carol"])).await?;
+    subject
+        .await_observable_settlement(&labels(&["alice", "bob"]), SETTLEMENT)
+        .await?;
+    let carol_history = work.remove("carol").expect("carol was a work member");
+
+    send(subject, "work", "alice", "work-after-remove").await?;
+    push_all(&mut work, "work-after-remove");
+    send(subject, "pair", "bob", "pair-after-remove").await?;
+    push_all(&mut pair, "pair-after-remove");
+    expect_timeline(subject, "work", &work, out, "work-after-remove.json").await?;
+    expect_timeline(subject, "pair", &pair, out, "pair-after-remove.json").await?;
+
+    subject.select_scenario_group("work", false)?;
+    subject.catch_up(&labels(&["carol"])).await?;
+    let carol = subject.observations(&labels(&["carol"])).await?;
+    save(out, "carol-after-remove.json", &carol)?;
+    if multiset(&carol[0].application.visible_plaintexts) != multiset(&carol_history) {
+        return Err("removed member's work history changed after removal".into());
+    }
+
+    fresh_traffic_and_reopen(subject, "work", &mut work, "bob", out, "work").await?;
+    // Bob's reopen must also have preserved the other group completely.
+    expect_timeline(subject, "pair", &pair, out, "pair-after-reopen.json").await?;
+    fresh_traffic_and_reopen(subject, "pair", &mut pair, "alice", out, "pair").await?;
+    expect_timeline(subject, "work", &work, out, "work-terminal.json")
+        .await
+        .map(|_| ())
+}
+
+/// Which racing profile edits the runtime reported as saved but the settled
+/// public state does not contain. Convergence keeps one branch and parks the
+/// other; the parked committer's intent is not re-issued today, so a losing
+/// admin edit is dropped after its caller was told it succeeded. The strict
+/// journeys fail on this; the default journeys record it as evidence.
+fn dropped_accepted_edits(
+    report: &ConcurrentMutationReport,
+    observations: &[AppRuntimeObservationV1],
+    edits: &[(&str, &str, &str)],
+) -> Vec<String> {
+    edits
+        .iter()
+        .filter(|(client, _, _)| {
+            report
+                .outcomes
+                .iter()
+                .any(|outcome| outcome.client == *client && outcome.accepted)
+        })
+        .filter(|(_, field, value)| {
+            !observations.iter().all(|o| match *field {
+                "name" => o.protocol.group_name == *value,
+                _ => o.protocol.group_description == *value,
+            })
+        })
+        .map(|(client, field, _)| format!("{client}:{field}"))
+        .collect()
+}
+
+fn require_edits_retained(dropped: &[String], strict: bool) -> TestResult {
+    if strict && !dropped.is_empty() {
+        return Err(format!(
+            "edits reported as saved are missing from the settled public state: {dropped:?}"
+        )
+        .into());
+    }
+    Ok(())
+}
+
+/// Two admins save different profile fields at the same instant. Whatever the
+/// commit race decides, every member must settle on one state that contains at
+/// least one of the edits, and messaging plus reopen persistence must hold.
+/// The strict form also requires that no edit reported as saved is lost.
+async fn concurrent_profile_edits(
+    subject: &mut AppRuntimeHarness,
+    out: &Path,
+    strict: bool,
+) -> TestResult {
+    let clients = labels(&["alice", "bob", "carol"]);
+    create_group(
+        subject,
+        "main",
+        &labels(&["bob", "carol"]),
+        &labels(&["alice", "bob"]),
+    )
+    .await?;
+    let mut expected = clients
+        .iter()
+        .map(|client| (client.clone(), vec!["before".to_owned()]))
+        .collect::<Timeline>();
+    send(subject, "main", "alice", "before").await?;
+    expect_timeline(subject, "main", &expected, out, "before.json").await?;
+
+    let report = subject
+        .race_mutations(
+            "race-profile",
+            &[
+                ConcurrentMutation::UpdateGroupProfile {
+                    client: "alice",
+                    name: Some("alice renamed it"),
+                    description: None,
+                },
+                ConcurrentMutation::UpdateGroupProfile {
+                    client: "bob",
+                    name: None,
+                    description: Some("bob described it"),
+                },
+            ],
+        )
+        .await?;
+    save(out, "race-report.json", &report)?;
+    subject.tick(&clients).await?;
+    let observations = subject
+        .await_observable_settlement(&clients, SETTLEMENT)
+        .await?;
+    let edits = [
+        ("alice", "name", "alice renamed it"),
+        ("bob", "description", "bob described it"),
+    ];
+    let dropped = dropped_accepted_edits(&report, &observations, &edits);
+    save(
+        out,
+        "after-race.json",
+        &json!({ "dropped_accepted_edits": dropped, "observations": observations }),
+    )?;
+    let landed = edits.len() - dropped.len();
+    if landed == 0 {
+        return Err("neither concurrent profile edit reached the settled public state".into());
+    }
+    require_edits_retained(&dropped, strict)?;
+    fresh_traffic_and_reopen(subject, "main", &mut expected, "carol", out, "main").await
+}
+
+/// One admin invites a fourth member while another admin renames the group at
+/// the same instant. The founders must settle on one state, the invitee must
+/// either become a full member who sends and receives or hold no membership
+/// at all, and at least one of the two edits must have landed. The strict form
+/// also requires that an invite or rename reported as saved is not lost.
+async fn concurrent_invite_and_rename(
+    subject: &mut AppRuntimeHarness,
+    out: &Path,
+    strict: bool,
+) -> TestResult {
+    let founders = labels(&["alice", "bob", "carol"]);
+    create_group(
+        subject,
+        "main",
+        &labels(&["bob", "carol"]),
+        &labels(&["alice", "bob"]),
+    )
+    .await?;
+    let mut expected = founders
+        .iter()
+        .map(|client| (client.clone(), vec!["before".to_owned()]))
+        .collect::<Timeline>();
+    send(subject, "main", "alice", "before").await?;
+    expect_timeline(subject, "main", &expected, out, "before.json").await?;
+
+    let report = subject
+        .race_mutations(
+            "race-invite-rename",
+            &[
+                ConcurrentMutation::InviteMembers {
+                    inviter: "alice",
+                    invitees: &labels(&["david"]),
+                },
+                ConcurrentMutation::UpdateGroupProfile {
+                    client: "bob",
+                    name: Some("renamed during invite"),
+                    description: None,
+                },
+            ],
+        )
+        .await?;
+    save(out, "race-report.json", &report)?;
+    let invite_accepted = report
+        .outcomes
+        .iter()
+        .any(|outcome| outcome.client == "alice" && outcome.accepted);
+    // Ticks accept the pending Welcome on the invitee's device once it arrives.
+    // Membership is decided by the founders' settled roster, not by the
+    // inviter's success report.
+    subject
+        .tick(&labels(&["alice", "bob", "carol", "david"]))
+        .await?;
+    let founders_state = subject
+        .await_observable_settlement(&founders, SETTLEMENT)
+        .await?;
+    let david_joined = founders_state[0]
+        .protocol
+        .member_identities
+        .iter()
+        .any(|member| member == "david");
+    let mut members = founders.clone();
+    if david_joined {
+        members.push("david".to_owned());
+        // A late joiner is entitled to messages sent after admission only.
+        expected.insert("david".into(), Vec::new());
+    }
+    let observations = subject
+        .await_observable_settlement(&members, SETTLEMENT)
+        .await?;
+    let mut dropped = dropped_accepted_edits(
+        &report,
+        &observations,
+        &[("bob", "name", "renamed during invite")],
+    );
+    if invite_accepted && !david_joined {
+        dropped.push("alice:invite".into());
+    }
+    let david_stranded = subject.observations(&labels(&["david"])).await.ok();
+    save(
+        out,
+        "after-race.json",
+        &json!({
+            "dropped_accepted_edits": dropped, "david_joined": david_joined,
+            "observations": observations,
+            "david_when_not_a_member": if david_joined { None } else { david_stranded },
+        }),
+    )?;
+    if dropped.len() == 2 {
+        return Err(
+            "neither the concurrent invite nor the rename reached the settled state".into(),
+        );
+    }
+    require_edits_retained(&dropped, strict)?;
+    let reopen = if david_joined { "david" } else { "carol" };
+    fresh_traffic_and_reopen(subject, "main", &mut expected, reopen, out, "main").await
+}
+
+/// Carol's device is closed when the admin removes her. When it comes back it
+/// must learn the removal from relay history alone: no post-removal plaintext
+/// may ever appear on it, its own sends must be refused, and the remaining
+/// members' timelines must stay exact.
+async fn removed_while_offline(subject: &mut AppRuntimeHarness, out: &Path) -> TestResult {
+    let clients = labels(&["alice", "bob", "carol"]);
+    create_group(
+        subject,
+        "main",
+        &labels(&["bob", "carol"]),
+        &labels(&["alice"]),
+    )
+    .await?;
+    let mut expected = clients
+        .iter()
+        .map(|client| (client.clone(), vec!["before".to_owned()]))
+        .collect::<Timeline>();
+    send(subject, "main", "alice", "before").await?;
+    expect_timeline(subject, "main", &expected, out, "before.json").await?;
+
+    subject.set_online("carol", false).await?;
+    subject
+        .remove_members(SubjectRemoveMembers {
+            action_id: "remove-carol",
+            remover: "alice",
+            members: &labels(&["carol"]),
+            pending: "remove-carol",
+        })
+        .await?;
+    let remaining = labels(&["alice", "bob"]);
+    subject.tick(&remaining).await?;
+    subject
+        .await_observable_settlement(&remaining, SETTLEMENT)
+        .await?;
+    let carol_history = expected.remove("carol").expect("carol was a member");
+    send(subject, "main", "alice", "after-removal-1").await?;
+    push_all(&mut expected, "after-removal-1");
+    send(subject, "main", "bob", "after-removal-2").await?;
+    push_all(&mut expected, "after-removal-2");
+    expect_timeline(subject, "main", &expected, out, "after-removal.json").await?;
+
+    // Carol reconnects and repairs from the retained relay history.
+    subject.set_online("carol", true).await?;
+    let deadline = tokio::time::Instant::now() + SETTLEMENT;
+    let carol = loop {
+        subject.repair_full_history(&labels(&["carol"])).await?;
+        subject.catch_up(&labels(&["carol"])).await?;
+        let carol = subject.observations(&labels(&["carol"])).await?.remove(0);
+        if carol
+            .application
+            .visible_plaintexts
+            .iter()
+            .any(|payload| payload.starts_with("after-removal"))
+        {
+            save(out, "carol-leak.json", &carol)?;
+            return Err("member removed while offline decrypted post-removal traffic".into());
+        }
+        // Public evidence that the device processed its own removal: it no
+        // longer counts itself among the group's members.
+        let knows_removed = !carol
+            .protocol
+            .member_identities
+            .iter()
+            .any(|m| m == "carol")
+            && carol.protocol.member_count == remaining.len();
+        if knows_removed {
+            break carol;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            save(out, "carol-stale.json", &carol)?;
+            return Err("reconnected member never learned it had been removed".into());
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    };
+    save(out, "carol-after-reconnect.json", &carol)?;
+    if multiset(&carol.application.visible_plaintexts) != multiset(&carol_history) {
+        return Err("removed member's pre-removal history changed".into());
+    }
+
+    // A removed device must be refused when it tries to send, and nothing it
+    // attempts may reach the remaining members.
+    let refusal = send(subject, "main", "carol", "stale-from-carol").await;
+    save(
+        out,
+        "carol-send-refusal.json",
+        &json!({ "refused": refusal.is_err(), "error": refusal.as_ref().err().map(ToString::to_string) }),
+    )?;
+    match refusal {
+        Ok(()) => return Err("removed member's send was accepted by its own runtime".into()),
+        Err(error) if error.to_string().contains("group_removed") => {}
+        Err(error) => {
+            return Err(
+                format!("removed member's send failed for the wrong reason: {error}").into(),
+            );
+        }
+    }
+    fresh_traffic_and_reopen(subject, "main", &mut expected, "bob", out, "main").await?;
+    subject.reopen("carol").await?;
+    subject.catch_up(&labels(&["carol"])).await?;
+    let carol = subject.observations(&labels(&["carol"])).await?.remove(0);
+    save(out, "carol-after-reopen.json", &carol)?;
+    if multiset(&carol.application.visible_plaintexts) != multiset(&carol_history) {
+        return Err("removed member's history changed after reopen".into());
+    }
+    Ok(())
+}
+
+/// David leaves a four-member group. Every remaining device is entitled to
+/// auto-commit the same `Leave` proposal by reference, so rival commits can
+/// race for one epoch on a real-world departure. The survivors must settle on
+/// one state and keep exchanging decryptable traffic in both directions, and
+/// the leaver's device must keep exactly its pre-departure history. The strict
+/// form also requires the survivors to apply the leave promptly.
+async fn leave_with_several_remaining(
+    subject: &mut AppRuntimeHarness,
+    out: &Path,
+    strict: bool,
+) -> TestResult {
+    let clients = labels(&["alice", "bob", "carol", "david"]);
+    create_group(
+        subject,
+        "main",
+        &labels(&["bob", "carol", "david"]),
+        &labels(&["alice"]),
+    )
+    .await?;
+    let mut expected = clients
+        .iter()
+        .map(|client| (client.clone(), vec!["before".to_owned()]))
+        .collect::<Timeline>();
+    send(subject, "main", "alice", "before").await?;
+    send(subject, "main", "david", "before-from-david").await?;
+    push_all(&mut expected, "before-from-david");
+    expect_timeline(subject, "main", &expected, out, "before.json").await?;
+
+    subject.select_scenario_group("main", false)?;
+    let admitted_before_leave = subject.relay_admitted_events().await;
+    subject.leave("leave-david", "david").await?;
+    let admitted_after_leave = subject.relay_admitted_events().await;
+    let remaining = labels(&["alice", "bob", "carol"]);
+    // The survivors' runtimes learn the proposal from their live subscriptions;
+    // the engine schedules the auto-commit within 50 ms. Poll slowly so the
+    // harness itself is not what keeps the worker busy.
+    let budget = if strict {
+        STRICT_LEAVE_APPLICATION_BUDGET
+    } else {
+        EVENTUAL_LEAVE_APPLICATION_BUDGET
+    };
+    let left_at = tokio::time::Instant::now();
+    let deadline = left_at + budget;
+    let mut rounds = 0_u32;
+    let settled = loop {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        subject.tick(&remaining).await?;
+        let observations = subject.observations(&remaining).await?;
+        let leaver = subject.observations(&labels(&["david"])).await.ok();
+        save(
+            out,
+            &format!("after-leave-round-{rounds:02}.json"),
+            &json!({
+                "seconds_since_leave": left_at.elapsed().as_secs(),
+                "admitted_before_leave": admitted_before_leave,
+                "admitted_after_leave": admitted_after_leave,
+                "admitted_now": subject.relay_admitted_events().await,
+                "survivors": observations,
+                "leaver": leaver,
+            }),
+        )?;
+        if observations
+            .iter()
+            .all(|o| o.protocol.member_count == remaining.len())
+        {
+            eprintln!(
+                "survivors applied the leave after {}s",
+                left_at.elapsed().as_secs()
+            );
+            break subject
+                .await_observable_settlement(&remaining, SETTLEMENT)
+                .await?;
+        }
+        rounds += 1;
+        if tokio::time::Instant::now() >= deadline {
+            return Err(format!(
+                "survivors had not applied the leave {}s after it was published",
+                left_at.elapsed().as_secs()
+            )
+            .into());
+        }
+    };
+    save(out, "after-leave.json", &settled)?;
+    let david_history = expected.remove("david").expect("david was a member");
+
+    // Decryptable traffic in every direction is the real convergence check:
+    // public epoch numbers can agree while devices sit on different branches.
+    fresh_traffic_and_reopen(subject, "main", &mut expected, "bob", out, "main").await?;
+
+    // The leaver's device keeps its pre-departure history and nothing it
+    // attempts afterwards may reach the survivors. Whether its own runtime
+    // refuses the send is recorded, not asserted: a voluntary leave is a
+    // different terminal state from an administrative removal.
+    let attempt = send(subject, "main", "david", "stale-from-david").await;
+    subject.catch_up(&labels(&["david"])).await?;
+    let david = subject.observations(&labels(&["david"])).await?.remove(0);
+    save(
+        out,
+        "leaver.json",
+        &json!({
+            "send_refused": attempt.is_err(),
+            "send_error": attempt.as_ref().err().map(ToString::to_string),
+            "observation": david,
+        }),
+    )?;
+    if multiset(&david.application.visible_plaintexts) != multiset(&david_history) {
+        return Err("leaver's history changed after leaving".into());
+    }
+    expect_timeline(
+        subject,
+        "main",
+        &expected,
+        out,
+        "survivors-after-stale-send.json",
+    )
+    .await?;
+    Ok(())
+}
+
+/// Bob asks for a manual self-update, the same operation periodic maintenance
+/// performs in production. The public epoch must advance for every member
+/// without any message loss, and messaging must continue afterwards.
+async fn manual_self_update(subject: &mut AppRuntimeHarness, out: &Path) -> TestResult {
+    let clients = labels(&["alice", "bob"]);
+    create_group(subject, "main", &labels(&["bob"]), &labels(&["alice"])).await?;
+    let mut expected = clients
+        .iter()
+        .map(|client| (client.clone(), vec!["before".to_owned()]))
+        .collect::<Timeline>();
+    send(subject, "main", "alice", "before").await?;
+    let before = expect_timeline(subject, "main", &expected, out, "before.json").await?;
+    let epoch_before = before[0].protocol.epoch;
+
+    subject
+        .self_update(SubjectSelfUpdate {
+            action_id: "bob-self-update",
+            client: "bob",
+            pending: "bob-self-update",
+        })
+        .await?;
+    let deadline = tokio::time::Instant::now() + MAINTENANCE_PUBLICATION_BUDGET;
+    let observations = loop {
+        subject.run_due_maintenance(&labels(&["bob"])).await?;
+        subject.catch_up(&clients).await?;
+        let observations = subject.observations(&clients).await?;
+        let advanced = observations.iter().all(|o| o.protocol.epoch > epoch_before);
+        if advanced && complete(&observations, &expected, clients.len()) {
+            break observations;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            save(out, "self-update-stalled.json", &observations)?;
+            return Err(
+                "manual self-update did not advance the shared public epoch in time".into(),
+            );
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    };
+    save(out, "after-self-update.json", &observations)?;
+    fresh_traffic_and_reopen(subject, "main", &mut expected, "bob", out, "main").await
+}
+
+async fn check(journey: Journey) {
+    let label = journey.label();
+    let mut builder = tempfile::Builder::new();
+    let prefix = format!("app-interaction-{label}-");
+    builder.prefix(&prefix);
+    let artifacts = if let Some(root) = std::env::var_os("MDK_APP_JOURNEY_ARTIFACTS") {
+        fs_private::create_dir_all_private(Path::new(&root)).unwrap();
+        builder.tempdir_in(root).unwrap()
+    } else {
+        builder.tempdir().unwrap()
+    };
+    fs_private::create_dir_all_private(artifacts.path()).unwrap();
+    let clients = match journey {
+        Journey::ConcurrentInviteAndRename { .. } | Journey::LeaveWithSeveralRemaining { .. } => {
+            labels(&["alice", "bob", "carol", "david"])
+        }
+        Journey::ManualSelfUpdate => labels(&["alice", "bob"]),
+        _ => labels(&["alice", "bob", "carol"]),
+    };
+    save(
+        artifacts.path(),
+        "input.json",
+        &json!({
+            "journey": label, "version": 1, "clients": clients,
+            "adapter": "marmot_app_runtime", "storage": "sqlcipher_per_participant",
+            "relay_order": "native local Nostr relay", "debug_assertions": cfg!(debug_assertions),
+            "settlement_policy": "default production policy; no test override requested",
+        }),
+    )
+    .unwrap();
+    let mut subject = AppRuntimeHarness::new(&clients)
+        .await
+        .expect("public runtime setup");
+    let exercise = async {
+        match journey {
+            Journey::TwoGroups => two_groups(&mut subject, artifacts.path()).await,
+            Journey::ConcurrentProfileEdits { strict } => {
+                concurrent_profile_edits(&mut subject, artifacts.path(), strict).await
+            }
+            Journey::ConcurrentInviteAndRename { strict } => {
+                concurrent_invite_and_rename(&mut subject, artifacts.path(), strict).await
+            }
+            Journey::RemovedWhileOffline => {
+                removed_while_offline(&mut subject, artifacts.path()).await
+            }
+            Journey::LeaveWithSeveralRemaining { strict } => {
+                leave_with_several_remaining(&mut subject, artifacts.path(), strict).await
+            }
+            Journey::ManualSelfUpdate => manual_self_update(&mut subject, artifacts.path()).await,
+        }
+    };
+    let result = match tokio::time::timeout(Duration::from_secs(600), exercise).await {
+        Ok(result) => result,
+        Err(_) => Err("public interaction journey exceeded its 600-second watchdog".into()),
+    };
+    // Close every runtime before asserting. Never exit the process while a
+    // SQLCipher worker may still be writing (see APP_PATH_COVERAGE.md).
+    let mut close_errors = Vec::new();
+    for client in &clients {
+        if let Err(error) = subject.set_online(client, false).await {
+            close_errors.push(error.to_string());
+        }
+    }
+    subject.shutdown().await;
+    drop(subject);
+    save(
+        artifacts.path(),
+        "result.json",
+        &json!({
+            "passed": result.is_ok() && close_errors.is_empty(),
+            "error": result.as_ref().err().map(ToString::to_string), "close_errors": close_errors,
+        }),
+    )
+    .unwrap();
+    if result.is_err() || std::env::var_os("MDK_APP_JOURNEY_ARTIFACTS").is_some() {
+        eprintln!("public journey evidence: {}", artifacts.keep().display());
+    }
+    assert!(
+        close_errors.is_empty(),
+        "runtime close failed: {close_errors:?}"
+    );
+    assert!(result.is_ok(), "{label}: {}", result.unwrap_err());
+}
+
+macro_rules! journey_test {
+    ($name:ident, $journey:expr) => {
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn $name() {
+            check($journey).await;
+        }
+    };
+}
+
+journey_test!(public_app_07_two_groups_stay_isolated, Journey::TwoGroups);
+journey_test!(
+    public_app_08_concurrent_admin_profile_edits_converge,
+    Journey::ConcurrentProfileEdits { strict: false }
+);
+journey_test!(
+    public_app_09_concurrent_invite_and_rename_converge,
+    Journey::ConcurrentInviteAndRename { strict: false }
+);
+journey_test!(
+    public_app_10_member_removed_while_offline_learns_removal,
+    Journey::RemovedWhileOffline
+);
+journey_test!(
+    public_app_12_leave_with_several_remaining_members_converges,
+    Journey::LeaveWithSeveralRemaining { strict: false }
+);
+
+// The strict forms additionally require that an edit the runtime reported as
+// saved reaches the settled public state. Convergence currently parks the
+// losing committer's intent without re-issuing it, so they document a known
+// product gap rather than gating CI; see APP_PATH_COVERAGE.md.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "known gap: a losing admin edit is dropped after its caller was told it saved"]
+async fn public_app_08_strict_concurrent_admin_profile_edits_are_never_lost() {
+    check(Journey::ConcurrentProfileEdits { strict: true }).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "known gap: a losing invite or rename is dropped after its caller was told it saved"]
+async fn public_app_09_strict_concurrent_invite_and_rename_are_never_lost() {
+    check(Journey::ConcurrentInviteAndRename { strict: true }).await;
+}
+
+// The engine schedules a peer's SelfRemove auto-commit within 50 ms, but the
+// app worker's convergence schedule has no arm for it, so survivors apply a
+// leave only when some other commit or timer runs convergence for the group.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "known gap: survivors apply a voluntary leave only when another commit runs convergence"]
+async fn public_app_12_strict_leave_is_applied_by_survivors_promptly() {
+    check(Journey::LeaveWithSeveralRemaining { strict: true }).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "waits out the real-time maintenance quiet window and jitter; run explicitly"]
+async fn public_app_11_manual_self_update_advances_every_member() {
+    check(Journey::ManualSelfUpdate).await;
+}


### PR DESCRIPTION
## Why

The public app scenarios covered one mutation at a time, one group per device, and a member that was online when it was removed. Real groups have two admins saving at once, several groups on one phone, members whose devices are closed when the group changes, and members who simply leave. This PR adds those shapes on the existing `AppRuntimeHarness` (real local Nostr relay, one SQLCipher database per participant, public commands and projections only) and records what they found. Test and doc changes only; no product code changes.

## New journeys (`tests/app_runtime_interaction_journeys.rs`)

| Journey | Contract |
| --- | --- |
| `07_two_groups_stay_isolated` | Work and pair groups on one device; the second invite of the same member needs a fresh KeyPackage; a non-member has no projection; a removal and a reopen leave the other group's exact history untouched |
| `08_concurrent_admin_profile_edits_converge` | Two admins save name and description at the same instant; members settle on one state with at least one edit; fresh traffic and reopen persistence hold; dropped edits are recorded |
| `09_concurrent_invite_and_rename_converge` | An invite races a rename; founders settle; the invitee is a full member who sends and receives or holds no membership; at least one edit landed |
| `10_member_removed_while_offline_learns_removal` | A closed device is removed; on reconnect it learns the removal from relay history, never decrypts post-removal traffic, keeps its exact history across reopen, and its sends are refused as `group_removed` |
| `12_leave_with_several_remaining_members_converges` | A member leaves a four-member group; within three minutes the survivors apply it, settle, exchange decryptable traffic in every direction, and persist across reopen; the leaver keeps exactly its pre-departure history |
| `08_strict`, `09_strict`, `12_strict` (ignored) | As above, plus: an edit reported as saved is never lost; the leave is applied within 30 seconds |
| `11_manual_self_update_advances_every_member` (ignored) | A manual self-update advances every member; waits out the real-time maintenance quiet window and jitter (#1729 makes it fast) |

Harness additions in `app_runtime.rs`: `race_mutations` issues commands from several devices at the same instant and reports accepted/rejected outcomes plus relay admissions; `run_due_maintenance` drives the maintenance sweep; `relay_admitted_events` exposes the shared relay's admission count; subject errors now carry a privacy-safe error kind so a scenario can tell `group_removed` from `unknown_group`.

## Findings (evidence and mechanism in `APP_PATH_COVERAGE.md`)

1. **A losing admin edit is dropped after its caller was told it saved.** Both `update_group_profile` calls return `Ok`; convergence parks the loser and only `SelfUpdate` evolutions re-arm, so the intent is neither re-issued nor reported.
2. **A losing invite strands the invitee.** The inviter gets `Ok`, the invitee's device accepts the parked-branch Welcome and reports itself a full member at the same epoch number with the stale roster and name, while the real group excludes it.
3. **Survivors apply a voluntary leave only when something else runs convergence.** The engine schedules the SelfRemove auto-commit within 50 ms, but the worker's convergence schedule state derives `Idle` for a group whose only pending work is that schedule, so no timer is armed. Observed: the proposal on the relay immediately, survivors unchanged for 50 to 80 seconds until their post-join rotations carried the removal. The existing send-leave canary shows the same 82-second checkpoint.

The strict journeys stay ignored until those are fixed; the default journeys keep the convergence, delivery, and persistence contracts green.

## Validation

- Five default journeys pass locally (about six minutes serially in debug mode; the leave journey alone about two).
- The three strict forms fail only on the documented contracts (evidence retained locally).
- The six existing public journeys, the public family contract tests, the adapter tests, and the engine smoke lane (416 tests) pass.
- `cargo clippy -p cgka-conformance-simulator --all-targets -- -D warnings` and `cargo fmt --all --check` are clean; dependent crates check.

Rebased on master after #1722. Follow-up: #1729 adds the dev maintenance timing override; once both land, journey 11 switches to `new_with_immediate_maintenance` behind `cfg_attr(not(feature = "test-policy-overrides"), ignore)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
