### PR TITLE
Reuse matching timeline FFI conversions

### DIFF
--- a/crates/marmot-uniffi/README.md
+++ b/crates/marmot-uniffi/README.md
@@ -234,3 +234,31 @@ account; they must be restored or opened with a compatible runtime, not silently
 discarded because they may contain approved publication intent. C
 consumers have equivalent methods and subscriptions; external-signer entry
 points retain the C API's existing callback-vtable limitation.
+
+## Live timeline updates
+
+`TimelineMessagesSubscription::next()` returns the complete bounded window on
+every update. Its conversion cache avoids reparsing unchanged rows, but those
+rows still get cloned and serialized across FFI. `next_update()` returns raw
+projection deltas, or a replacement `Page` after a refresh. These methods consume
+the same stream; use only one per subscription. Delta consumers must maintain
+ordering, removals, and window limits themselves; raw projections do not report
+which rows the runtime evicted from its bounded window.
+
+Projection `messages` and upsert `changes` retain their existing wire format.
+When corresponding source records are identical, conversion now parses Markdown
+and resolves media once, then clones the converted record for the second field.
+Different records and removals retain independent conversion.
+
+Run the conversion and wire-serialization benchmark with:
+
+```sh
+cargo test -p marmot-uniffi --release --lib bench_live_timeline_updates -- --ignored --nocapture
+```
+
+It compares cached full pages, current deltas, and the original independent
+conversion of both delta fields. Each window has 25, 100, or 500 rows and one
+edited Markdown message per update. Results include source cloning, conversion,
+and UniFFI serialization: p50/p95 over 100 samples after 10 warm-up iterations,
+plus serialized byte counts. They exclude storage, runtime window application,
+FFI scheduling, and Swift/Kotlin decoding and rendering.

--- a/crates/marmot-uniffi/src/conversions/timeline.rs
+++ b/crates/marmot-uniffi/src/conversions/timeline.rs
@@ -366,14 +366,39 @@ pub struct TimelineProjectionUpdateFfi {
 
 impl From<AppProjectionUpdate> for TimelineProjectionUpdateFfi {
     fn from(value: AppProjectionUpdate) -> Self {
+        let mut source_changes = value.timeline_changes.into_iter();
+        let mut changes = Vec::with_capacity(source_changes.len());
+        let messages = value
+            .timeline_messages
+            .into_iter()
+            .map(|record| {
+                // Storage emits the same rows in both compatibility messages
+                // and ordered upserts. Parse matching rows only once; preserve
+                // independent conversion for removals or differing records.
+                let change = source_changes.next();
+                let matching = matches!(
+                    &change,
+                    Some(TimelineMessageChange::Upsert { message, .. }) if **message == record
+                );
+                let message = TimelineMessageRecordFfi::from(record);
+                match change {
+                    Some(TimelineMessageChange::Upsert { trigger, .. }) if matching => {
+                        changes.push(TimelineMessageChangeFfi::Upsert {
+                            trigger: trigger.into(),
+                            message: message.clone(),
+                        });
+                    }
+                    Some(change) => changes.push(change.into()),
+                    None => {}
+                }
+                message
+            })
+            .collect();
+        changes.extend(source_changes.map(Into::into));
         Self {
             group_id_hex: value.group_id_hex,
-            messages: value
-                .timeline_messages
-                .into_iter()
-                .map(Into::into)
-                .collect(),
-            changes: value.timeline_changes.into_iter().map(Into::into).collect(),
+            messages,
+            changes,
             chat_list_row: value.chat_list_row.map(Into::into),
             chat_list_trigger: value.chat_list_trigger.into(),
         }
@@ -454,6 +479,74 @@ mod tests {
                 .iter()
                 .all(|entry| entry.count as usize == entry.senders.len())
         );
+    }
+
+    #[test]
+    fn projection_wire_is_unchanged() {
+        let mut first = record_with_media(Some(7), None, None);
+        first.plaintext = "hello **world**".into();
+        let mut second = first.clone();
+        second.plaintext = "edited *text*".into();
+        let upsert = |message| TimelineMessageChange::Upsert {
+            trigger: TimelineUpdateTrigger::MessageEditedOrReprojected,
+            message: Box::new(message),
+        };
+        let remove = TimelineMessageChange::Remove {
+            message_id_hex: "removed".into(),
+            reason: TimelineRemoveReason::Pruned,
+        };
+        // Matching records, same-id edits, removals, unequal lengths, and
+        // changes-only updates must keep the independently encoded wire bytes.
+        for (records, changes) in [
+            (vec![first.clone()], vec![upsert(first.clone())]),
+            (vec![first.clone()], vec![upsert(second.clone())]),
+            (
+                vec![first.clone()],
+                vec![remove.clone(), upsert(second.clone())],
+            ),
+            (
+                vec![first.clone(), second.clone()],
+                vec![upsert(first.clone())],
+            ),
+            (vec![first.clone()], Vec::new()),
+            (Vec::new(), vec![upsert(second), remove]),
+        ] {
+            let source = AppProjectionUpdate {
+                group_id_hex: "group".into(),
+                timeline_messages: records,
+                timeline_changes: changes,
+                chat_list_row: None,
+                chat_list_trigger: Default::default(),
+            };
+            let expected = TimelineProjectionUpdateFfi {
+                group_id_hex: source.group_id_hex.clone(),
+                messages: source
+                    .timeline_messages
+                    .iter()
+                    .cloned()
+                    .map(Into::into)
+                    .collect(),
+                changes: source
+                    .timeline_changes
+                    .iter()
+                    .cloned()
+                    .map(Into::into)
+                    .collect(),
+                chat_list_row: None,
+                chat_list_trigger: source.chat_list_trigger.into(),
+            };
+            let mut expected_bytes = Vec::new();
+            let mut actual_bytes = Vec::new();
+            <TimelineProjectionUpdateFfi as uniffi::Lower<crate::UniFfiTag>>::write(
+                expected,
+                &mut expected_bytes,
+            );
+            <TimelineProjectionUpdateFfi as uniffi::Lower<crate::UniFfiTag>>::write(
+                source.into(),
+                &mut actual_bytes,
+            );
+            assert_eq!(actual_bytes, expected_bytes);
+        }
     }
 
     fn imeta_tag(byte: u8, media_type: &str, file_name: &str) -> Vec<String> {

--- a/crates/marmot-uniffi/src/conversions/timeline.rs
+++ b/crates/marmot-uniffi/src/conversions/timeline.rs
@@ -375,7 +375,15 @@ impl From<AppProjectionUpdate> for TimelineProjectionUpdateFfi {
                 // Storage emits the same rows in both compatibility messages
                 // and ordered upserts. Parse matching rows only once; preserve
                 // independent conversion for removals or differing records.
-                let change = source_changes.next();
+                // Removals have no corresponding compatibility message.
+                let change = loop {
+                    match source_changes.next() {
+                        Some(change @ TimelineMessageChange::Remove { .. }) => {
+                            changes.push(change.into());
+                        }
+                        change => break change,
+                    }
+                };
                 let matching = matches!(
                     &change,
                     Some(TimelineMessageChange::Upsert { message, .. }) if **message == record
@@ -500,6 +508,20 @@ mod tests {
         for (records, changes) in [
             (vec![first.clone()], vec![upsert(first.clone())]),
             (vec![first.clone()], vec![upsert(second.clone())]),
+            (
+                vec![first.clone()],
+                vec![remove.clone(), remove.clone(), upsert(first.clone())],
+            ),
+            (
+                vec![first.clone(), second.clone()],
+                vec![
+                    upsert(first.clone()),
+                    remove.clone(),
+                    upsert(second.clone()),
+                    remove.clone(),
+                ],
+            ),
+            (vec![first.clone()], vec![remove.clone(), remove.clone()]),
             (
                 vec![first.clone()],
                 vec![remove.clone(), upsert(second.clone())],

--- a/crates/marmot-uniffi/src/subscriptions.rs
+++ b/crates/marmot-uniffi/src/subscriptions.rs
@@ -413,37 +413,34 @@ mod tests {
         assert_eq!(take_snapshot(&snapshot), None);
     }
 
+    fn record(id: &str, plaintext: &str) -> TimelineMessageRecord {
+        TimelineMessageRecord {
+            message_id_hex: id.to_string(),
+            source_message_id_hex: None,
+            source_epoch: None,
+            retention_seconds: None,
+            retention_expires_at: None,
+            direction: "received".to_string(),
+            group_id_hex: "aa".to_string(),
+            sender: "bb".to_string(),
+            plaintext: plaintext.to_string(),
+            kind: cgka_traits::app_event::MARMOT_APP_EVENT_KIND_CHAT,
+            tags: Vec::new(),
+            timeline_at: 1,
+            received_at: 1,
+            reply_to_message_id_hex: None,
+            reply_preview: None,
+            media: None,
+            agent_text_stream: None,
+            reactions: marmot_app::TimelineReactionSummary::default(),
+            deleted: false,
+            deleted_by_message_id_hex: None,
+            invalidation_status: None,
+        }
+    }
+
     #[test]
     fn cached_conversion_reuses_unchanged_rows_and_never_serves_stale_content() {
-        use cgka_traits::app_event::MARMOT_APP_EVENT_KIND_CHAT;
-        use marmot_app::TimelineReactionSummary;
-
-        fn record(id: &str, plaintext: &str) -> TimelineMessageRecord {
-            TimelineMessageRecord {
-                message_id_hex: id.to_string(),
-                source_message_id_hex: None,
-                source_epoch: None,
-                retention_seconds: None,
-                retention_expires_at: None,
-                direction: "received".to_string(),
-                group_id_hex: "aa".to_string(),
-                sender: "bb".to_string(),
-                plaintext: plaintext.to_string(),
-                kind: MARMOT_APP_EVENT_KIND_CHAT,
-                tags: Vec::new(),
-                timeline_at: 1,
-                received_at: 1,
-                reply_to_message_id_hex: None,
-                reply_preview: None,
-                media: None,
-                agent_text_stream: None,
-                reactions: TimelineReactionSummary::default(),
-                deleted: false,
-                deleted_by_message_id_hex: None,
-                invalidation_status: None,
-            }
-        }
-
         fn page(messages: Vec<TimelineMessageRecord>) -> TimelinePage {
             TimelinePage {
                 messages,
@@ -485,6 +482,140 @@ mod tests {
         let cache = cache.lock().unwrap();
         assert_eq!(cache.len(), 1);
         assert!(cache.contains_key("m2"));
+    }
+
+    /// Measures Rust conversion and UniFFI wire serialization, excluding storage
+    /// and Swift/Kotlin decoding or rendering. Both paths change one row.
+    #[test]
+    #[ignore = "release-mode live timeline conversion benchmark"]
+    fn bench_live_timeline_updates() {
+        use std::hint::black_box;
+        use std::time::Instant;
+
+        use marmot_app::{AppProjectionUpdate, TimelineMessageChange, TimelineUpdateTrigger};
+
+        for count in [25, 100, 500] {
+            let text =
+                "A **bold** update with [a link](https://example.com) and `code`. ".repeat(16);
+            let mut page = TimelinePage {
+                messages: (0..count)
+                    .map(|id| record(&id.to_string(), &text))
+                    .collect(),
+                has_more_before: true,
+                has_more_after: false,
+            };
+            let cache = StdMutex::new(HashMap::new());
+            black_box(convert_timeline_page_cached(&cache, page.clone()));
+            let mut full_times = Vec::new();
+            let mut delta_times = Vec::new();
+            let mut original_times = Vec::new();
+            let mut sizes = [0; 3];
+            // Full-page allocation churn is not part of a delta-only consumer.
+            for paths in [&[0][..], &[1, 2][..]] {
+                for sample in 0..110 {
+                    let message = page.messages.last_mut().unwrap();
+                    message.plaintext = format!("{text}{sample}");
+                    let update = marmot_app::RuntimeTimelineMessageUpdate::Projection(
+                        marmot_app::RuntimeProjectionUpdate {
+                            account_id_hex: "account".into(),
+                            account_label: "account".into(),
+                            update: AppProjectionUpdate {
+                                group_id_hex: message.group_id_hex.clone(),
+                                timeline_messages: vec![message.clone()],
+                                timeline_changes: vec![TimelineMessageChange::Upsert {
+                                    trigger: TimelineUpdateTrigger::MessageEditedOrReprojected,
+                                    message: Box::new(message.clone()),
+                                }],
+                                chat_list_row: None,
+                                chat_list_trigger: Default::default(),
+                            },
+                        },
+                    );
+                    // Alternate old/new delta order; discard warm-up samples.
+                    for offset in 0..paths.len() {
+                        let path = paths[(sample + offset) % paths.len()];
+                        let start = Instant::now();
+                        let mut bytes = Vec::new();
+                        if path == 0 {
+                            let ffi = convert_timeline_page_cached(&cache, black_box(page.clone()));
+                            <TimelinePageFfi as uniffi::Lower<crate::UniFfiTag>>::write(
+                                ffi, &mut bytes,
+                            );
+                        } else {
+                            let source = black_box(update.clone());
+                            let ffi = if path == 1 {
+                                TimelineSubscriptionUpdateFfi::from(source)
+                            } else {
+                                // Original independent conversion of both fields.
+                                let marmot_app::RuntimeTimelineMessageUpdate::Projection(source) =
+                                    source
+                                else {
+                                    unreachable!();
+                                };
+                                TimelineSubscriptionUpdateFfi::Projection {
+                                    update: crate::conversions::RuntimeProjectionUpdateFfi {
+                                        account_id_hex: source.account_id_hex,
+                                        account_label: source.account_label,
+                                        update: crate::conversions::TimelineProjectionUpdateFfi {
+                                            group_id_hex: source.update.group_id_hex,
+                                            messages: source
+                                                .update
+                                                .timeline_messages
+                                                .into_iter()
+                                                .map(Into::into)
+                                                .collect(),
+                                            changes: source
+                                                .update
+                                                .timeline_changes
+                                                .into_iter()
+                                                .map(Into::into)
+                                                .collect(),
+                                            chat_list_row: source
+                                                .update
+                                                .chat_list_row
+                                                .map(Into::into),
+                                            chat_list_trigger: source
+                                                .update
+                                                .chat_list_trigger
+                                                .into(),
+                                        },
+                                    },
+                                }
+                            };
+                            <TimelineSubscriptionUpdateFfi as uniffi::Lower<crate::UniFfiTag>>::write(
+                            ffi, &mut bytes,
+                        );
+                        }
+                        sizes[path] = black_box(bytes).len();
+                        let elapsed = start.elapsed().as_nanos();
+                        if sample >= 10 {
+                            if path == 0 {
+                                full_times.push(elapsed);
+                            } else if path == 1 {
+                                delta_times.push(elapsed);
+                            } else {
+                                original_times.push(elapsed);
+                            }
+                        }
+                    }
+                }
+            }
+            full_times.sort_unstable();
+            delta_times.sort_unstable();
+            original_times.sort_unstable();
+            assert_eq!(sizes[1], sizes[2]);
+            eprintln!(
+                "rows={count} full_p50_ns={} full_p95_ns={} delta_p50_ns={} delta_p95_ns={} original_p50_ns={} original_p95_ns={} full_bytes={} delta_bytes={}",
+                full_times[49],
+                full_times[94],
+                delta_times[49],
+                delta_times[94],
+                original_times[49],
+                original_times[94],
+                sizes[0],
+                sizes[1],
+            );
+        }
     }
 
     // The timeline window's projection/cap/anchoring contract now lives and is


### PR DESCRIPTION
Live timeline projections carry matching records in both `messages` and upsert `changes`. Both previously parsed Markdown and resolved media independently. This change converts identical corresponding records once and clones the result for the second field. Differing records, removals, and unequal list lengths preserve independent conversion.

### Measurement

The included release benchmark measures one edited Markdown message, including source cloning, Rust conversion, and UniFFI serialization. It uses 100 measured samples after 10 warm-up samples and alternates the original/current delta paths separately from full-page allocation churn.

| Window rows | Original delta p50 | Current delta p50 | Original delta p95 | Current delta p95 |
| --- | ---: | ---: | ---: | ---: |
| 25 | 27.97 us | 19.22 us | 30.07 us | 20.04 us |
| 100 | 27.36 us | 19.07 us | 27.81 us | 19.40 us |
| 500 | 29.04 us | 20.83 us | 30.33 us | 21.48 us |

This is approximately 1.4x for this conversion/serialization workload. Serialized size is unchanged. These measurements exclude storage, runtime window application, FFI scheduling, and Swift/Kotlin decoding and rendering; they are not an end-to-end app speedup claim.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved live timeline updates so inserted, edited, removed, and unmatched records remain correctly aligned.
  - Fixed handling of leading, interleaved, and removal-only updates.
  - Prevented stale record content from being reused during timeline updates.
  - Improved handling of updates with differing numbers of records and changes.

- **Documentation**
  - Added guidance for full-window and delta timeline subscriptions, shared-stream usage, bounded windows, conversion caching, and performance benchmarking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->