### PR TITLE
Make core MDK libraries compile for browser WASM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,43 @@ jobs:
       - name: Check all features
         run: RUSTFLAGS='-D warnings' cargo check --workspace --all-targets --all-features --locked
 
+  rust-wasm-check:
+    name: Rust WASM check
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        run: |
+          set -euo pipefail
+          toolchain="$(sed -n 's/^channel = "\(.*\)"/\1/p' rust-toolchain.toml)"
+          rustup toolchain install "$toolchain" --profile minimal
+          rustup default "$toolchain"
+          rustup target add wasm32-unknown-unknown
+          rustc --version
+          cargo --version
+          clang --version
+          clang --print-targets | grep wasm32
+
+      - name: Cache Cargo artifacts
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      # Compile-only regression gate. Browser runtime behavior belongs in
+      # downstream headless-browser acceptance tests.
+      - name: Build browser WASM libraries
+        env:
+          CC_wasm32_unknown_unknown: clang
+        run: |
+          cargo build --locked --target wasm32-unknown-unknown \
+            -p cgka-traits \
+            -p cgka-engine \
+            -p transport-nostr-peeler
+
   rust-clippy:
     name: Rust clippy
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,7 @@ jobs:
           rustc --version
           cargo --version
           clang --version
+          # Preflight the C toolchain before compiling ring for this target.
           clang --print-targets | grep wasm32
 
       - name: Cache Cargo artifacts
@@ -220,6 +221,7 @@ jobs:
       - name: Build browser WASM libraries
         env:
           CC_wasm32_unknown_unknown: clang
+          RUSTFLAGS: -D warnings
         run: |
           cargo build --locked --target wasm32-unknown-unknown \
             -p cgka-traits \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,8 @@ jobs:
 
   rust-wasm-check:
     name: Rust WASM check
+    needs: changes
+    if: needs.changes.outputs.run_full == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -771,6 +773,7 @@ jobs:
       - rust-audit
       - terminal-harness-installers
       - rust-check
+      - rust-wasm-check
       - rust-clippy
       - c-smoke
       - ios-account-clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,7 +908,6 @@ dependencies = [
  "chacha20poly1305",
  "criterion",
  "futures",
- "getrandom 0.4.3",
  "gloo-timers",
  "hex",
  "insta",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,6 +908,7 @@ dependencies = [
  "chacha20poly1305",
  "criterion",
  "futures",
+ "getrandom 0.4.3",
  "gloo-timers",
  "hex",
  "insta",
@@ -1437,7 +1438,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hybrid-array",
  "rand_core 0.10.1",
 ]
@@ -1960,12 +1961,6 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -2143,16 +2138,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2234,22 +2229,13 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -2260,7 +2246,7 @@ checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -2669,12 +2655,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "id-set"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2756,8 +2736,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -2993,12 +2971,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -3447,7 +3419,7 @@ dependencies = [
  "agent-control",
  "async-trait",
  "fs-private",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "hex",
  "hmac 0.12.1",
  "libc",
@@ -3874,6 +3846,7 @@ name = "openmls"
 version = "0.8.1"
 source = "git+https://github.com/erskingardner/openmls.git?rev=59e7d3b27a7e95237879dd5478de1fd90eff7ada#59e7d3b27a7e95237879dd5478de1fd90eff7ada"
 dependencies = [
+ "getrandom 0.4.3",
  "log",
  "openmls_serialization_helpers",
  "openmls_traits",
@@ -3882,6 +3855,7 @@ dependencies = [
  "serde_bytes",
  "thiserror 2.0.18",
  "tls_codec",
+ "web-time",
  "zeroize",
 ]
 
@@ -4679,7 +4653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.1",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -5819,7 +5793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -6491,12 +6465,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "uniffi"
 version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6678,7 +6646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "atomic",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -6757,16 +6725,7 @@ version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -6825,28 +6784,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6857,18 +6794,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.13.0",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -6888,6 +6813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 
@@ -7350,97 +7276,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.13.0",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "wn-cli"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,6 +930,7 @@ dependencies = [
  "tls_codec",
  "tokio",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
@@ -3428,6 +3429,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "web-time",
 ]
 
 [[package]]
@@ -6351,6 +6353,7 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 hex = "0.4"
 httpdate = "1.0"
 getrandom = "0.3"
+web-time = "1.1"
 hmac = "0.12"
 libc = "0.2"
 hkdf = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 hex = "0.4"
 httpdate = "1.0"
-getrandom = "0.4.3"
+getrandom = "0.4"
 web-time = "1.1"
 hmac = "0.12"
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 hex = "0.4"
 httpdate = "1.0"
-getrandom = "0.3"
+getrandom = "0.4.3"
 web-time = "1.1"
 hmac = "0.12"
 libc = "0.2"

--- a/Justfile
+++ b/Justfile
@@ -38,6 +38,12 @@ clippy-default:
 clippy-otlp:
     cargo clippy --workspace --all-targets --features {{otlp-features}} -- -D warnings
 
+# Compile the browser-capable library boundary. The target and a WASM-capable
+# C compiler must already be installed; override CC_wasm32_unknown_unknown
+# when the system clang does not advertise a wasm32 backend.
+wasm-check:
+    RUSTFLAGS='-D warnings' CC_wasm32_unknown_unknown="${CC_wasm32_unknown_unknown:-clang}" cargo build --locked --target wasm32-unknown-unknown -p cgka-traits -p cgka-engine -p transport-nostr-peeler
+
 test: test-default test-otlp
 
 test-default:

--- a/README.md
+++ b/README.md
@@ -94,6 +94,19 @@ just clippy
 just test
 ```
 
+MDK also maintains a compile-only browser WASM boundary for `cgka-traits`,
+`cgka-engine`, and `transport-nostr-peeler`. Install the Rust target, ensure
+`CC_wasm32_unknown_unknown` names a Clang binary with a `wasm32` backend when
+the system Clang lacks one, and run:
+
+```sh
+rustup target add wasm32-unknown-unknown
+just wasm-check
+```
+
+This gate does not run browser acceptance tests and does not claim browser
+support for SQLCipher storage, the app runtime, bindings, CLI, or daemon.
+
 The repository's [`.cargo/config.toml`](.cargo/config.toml) supplies a 4 MiB
 `RUST_MIN_STACK` for Cargo-launched tests and debug binaries. Unoptimized
 OpenMLS group construction and tree deserialization can exceed Rust's

--- a/crates/cgka-engine/Cargo.toml
+++ b/crates/cgka-engine/Cargo.toml
@@ -37,6 +37,7 @@ marmot-forensics.workspace = true
 nostr.workspace = true
 rand.workspace = true
 sha2.workspace = true
+web-time.workspace = true
 # Pure-Rust secp256k1 used only to validate that a Marmot credential identity
 # is a well-formed BIP-340 x-only public key (foundation/identity.md). Already
 # resolved transitively via openmls_rust_crypto -> hpke-rs-rust-crypto -> k256;

--- a/crates/cgka-engine/Cargo.toml
+++ b/crates/cgka-engine/Cargo.toml
@@ -47,13 +47,10 @@ k256 = { version = "0.13", default-features = false, features = ["schnorr"] }
 [target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dependencies]
 tokio = { workspace = true, features = ["time"] }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { workspace = true, features = ["wasm_js"] }
-openmls = { workspace = true, features = ["js"] }
-
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 futures.workspace = true
 gloo-timers = { version = "0.3", features = ["futures"] }
+openmls = { workspace = true, features = ["js"] }
 
 [dev-dependencies]
 storage-sqlite = { workspace = true, features = ["storage-format-benchmarks"] }

--- a/crates/cgka-engine/Cargo.toml
+++ b/crates/cgka-engine/Cargo.toml
@@ -47,6 +47,10 @@ k256 = { version = "0.13", default-features = false, features = ["schnorr"] }
 [target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dependencies]
 tokio = { workspace = true, features = ["time"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { workspace = true, features = ["wasm_js"] }
+openmls = { workspace = true, features = ["js"] }
+
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 futures.workspace = true
 gloo-timers = { version = "0.3", features = ["futures"] }

--- a/crates/cgka-engine/src/convergence_clock.rs
+++ b/crates/cgka-engine/src/convergence_clock.rs
@@ -7,7 +7,7 @@
 //! their existing clocks.
 
 use std::sync::{Arc, Mutex};
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use web_time::{Instant, SystemTime, UNIX_EPOCH};
 
 /// One paired convergence-clock observation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -43,7 +43,7 @@ use rand::RngCore;
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
-use tls_codec::{Deserialize as _, Serialize as _};
+use tls_codec::Serialize as _;
 use web_time::{SystemTime, UNIX_EPOCH};
 
 /// Default ciphersuite. MLS-1.0 mandatory-to-implement; TLS-ish naming.

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -43,8 +43,8 @@ use rand::RngCore;
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
-use tls_codec::Serialize as _;
+use tls_codec::{Deserialize as _, Serialize as _};
+use web_time::{SystemTime, UNIX_EPOCH};
 
 /// Default ciphersuite. MLS-1.0 mandatory-to-implement; TLS-ish naming.
 pub const DEFAULT_CIPHERSUITE: Ciphersuite =

--- a/crates/cgka-engine/src/identity.rs
+++ b/crates/cgka-engine/src/identity.rs
@@ -18,6 +18,7 @@ use openmls::prelude::{
 };
 use openmls_basic_credential::SignatureKeyPair;
 use openmls_traits::types::Ciphersuite;
+use web_time::{SystemTime, UNIX_EPOCH};
 
 /// Bundle of everything needed to sign + identify the local client.
 pub struct Identity {
@@ -102,8 +103,8 @@ impl Identity {
             credential: credential.into(),
             signature_key: signer.public().into(),
         };
-        let created_at = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
+        let created_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
             .map_err(|error| format!("system clock precedes Unix epoch: {error}"))?
             .as_secs();
         let account_identity_proof =

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -37,7 +37,8 @@ use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use web_time::Instant;
 
 pub(crate) const MAX_CONVERGENCE_REPROCESSING_PASSES: usize = 16;
 pub(crate) const SELF_REMOVE_AUTO_COMMIT_JITTER_MIN_MS: u64 = 10;

--- a/crates/fs-private/src/lib.rs
+++ b/crates/fs-private/src/lib.rs
@@ -11,7 +11,9 @@
 
 use std::fs::OpenOptions;
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(unix)]
+use std::path::PathBuf;
 
 /// Owner-only mode for files holding private data.
 pub const PRIVATE_FILE_MODE: u32 = 0o600;
@@ -717,6 +719,7 @@ fn resolve_platform_directory_aliases(
     Ok(Some(resolved))
 }
 
+#[cfg(unix)]
 fn io_context(operation: &str, path: &Path, error: io::Error) -> io::Error {
     io::Error::new(
         error.kind(),
@@ -857,17 +860,10 @@ fn set_handle_private(file: &std::fs::File) -> io::Result<()> {
     }
 }
 
+#[cfg(unix)]
 fn set_directory_handle_private(directory: &std::fs::File) -> io::Result<()> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        directory.set_permissions(std::fs::Permissions::from_mode(PRIVATE_DIR_MODE))
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = directory;
-        Ok(())
-    }
+    use std::os::unix::fs::PermissionsExt;
+    directory.set_permissions(std::fs::Permissions::from_mode(PRIVATE_DIR_MODE))
 }
 
 /// The workspace's one octal permission-mode parser.

--- a/crates/marmot-forensics/Cargo.toml
+++ b/crates/marmot-forensics/Cargo.toml
@@ -9,6 +9,7 @@ publish.workspace = true
 fs-private.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+web-time.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -24,9 +24,9 @@ use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
-use web_time::{SystemTime, UNIX_EPOCH};
+use web_time::{Instant, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -24,7 +24,9 @@ use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
+
+use web_time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/transport-nostr-peeler/Cargo.toml
+++ b/crates/transport-nostr-peeler/Cargo.toml
@@ -17,6 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
+web-time.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros"] }

--- a/crates/transport-nostr-peeler/src/event.rs
+++ b/crates/transport-nostr-peeler/src/event.rs
@@ -8,7 +8,7 @@ use nostr::{Event, JsonUtil};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use std::time::{SystemTime, UNIX_EPOCH};
+use web_time::{SystemTime, UNIX_EPOCH};
 
 /// Nostr event shape consumed and produced at the peeler boundary.
 ///

--- a/crates/transport-nostr-peeler/src/peeler.rs
+++ b/crates/transport-nostr-peeler/src/peeler.rs
@@ -20,6 +20,8 @@ use nostr::base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use nostr::{EventBuilder, Keys, Kind, NostrSigner, PublicKey, RelayUrl, Tag, UnsignedEvent};
 use rand::RngCore;
 use std::sync::Arc;
+#[cfg(test)]
+use web_time::{SystemTime, UNIX_EPOCH};
 
 const NONCE_LEN: usize = 12;
 const WELCOME_SIGNER_CONTEXT: &str = "nostr_welcome_signer";
@@ -750,8 +752,8 @@ mod tests {
             HashMap::from([(DEFAULT_EXPORTER_LABEL.to_string(), vec![0x7a; 32])]),
             Some(group_id),
         );
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
 

--- a/crates/transport-nostr-peeler/src/peeler.rs
+++ b/crates/transport-nostr-peeler/src/peeler.rs
@@ -20,8 +20,6 @@ use nostr::base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use nostr::{EventBuilder, Keys, Kind, NostrSigner, PublicKey, RelayUrl, Tag, UnsignedEvent};
 use rand::RngCore;
 use std::sync::Arc;
-#[cfg(test)]
-use web_time::{SystemTime, UNIX_EPOCH};
 
 const NONCE_LEN: usize = 12;
 const WELCOME_SIGNER_CONTEXT: &str = "nostr_welcome_signer";
@@ -752,8 +750,8 @@ mod tests {
             HashMap::from([(DEFAULT_EXPORTER_LABEL.to_string(), vec![0x7a; 32])]),
             Some(group_id),
         );
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
 

--- a/docs/marmot-architecture/overview/current-state.md
+++ b/docs/marmot-architecture/overview/current-state.md
@@ -1,7 +1,7 @@
 ---
 title: "Current State — Implementations & Spec"
 created: 2026-04-19
-updated: 2026-09-06
+updated: 2026-09-07
 tags: [marmot, overview, current-state, implementations]
 status: overview
 ---
@@ -80,6 +80,12 @@ idempotent Blossom upload, and canonical group creation are separate host-visibl
 uploaded founding metadata and performs no media transfer; the older all-in-one founding-image API keeps its existing
 uploaded-before-success semantics while also enforcing the new group-image byte, dimension, pixel, and format limits
 before canonical creation.
+
+The workspace maintains a compile-only browser WASM boundary for `cgka-traits`, `cgka-engine`, and
+`transport-nostr-peeler` on `wasm32-unknown-unknown`. Required CI keeps those three libraries compiling with
+warnings denied, and `just wasm-check` provides the matching local gate. This is a portability boundary, not a
+browser-runtime acceptance claim: SQLCipher storage, `marmot-app`, UniFFI/C bindings, the CLI, and daemons remain
+outside its scope, and browser execution still requires downstream acceptance coverage.
 
 Hosts can also send app-defined custom events: any non-reserved application event kind with verbatim tags and content,
 through `marmot-app`, the MarmotKit bindings, or `wn messages send-event`. Stored events are queryable by kind on


### PR DESCRIPTION
## Summary

Complete the remaining browser-WASM portability work for MDK’s core libraries:

- replace browser-reachable clock reads with `web-time`;
- enable the required `getrandom` and OpenMLS JavaScript features on WASM;
- compile `cgka-traits`, `cgka-engine`, and `transport-nostr-peeler` for
  `wasm32-unknown-unknown` in CI;
- make that WASM compilation job part of Required CI.

## Provenance

This maintainer integration is intended to supersede #1610, #1613, and #1627
after it merges.

#1611 and #1612 are already merged and are not duplicated here.

The four imported commits retain Liam Helmer as their author. Rebasing and
conflict resolution necessarily created new commit hashes; those rewritten
commits are committed and signed by Jeff Gardner.

## Integration notes

- Preserved #1611’s native Tokio/browser deadline dependency partition.
- Preserved the newer native `Duration` and `Instant` audit-rotation behavior
  while moving wall-clock reads to `web-time`.
- Regenerated `Cargo.lock` against the current dependency graph.
- Reduced #1627 to its unique CI change.
- Added `rust-wasm-check` to the aggregate Required CI gate.
- Connected the WASM job to the current changed-path classifier.

## Scope

This establishes a native-first, browser-capable compilation boundary for:

- `cgka-traits`
- `cgka-engine`
- `transport-nostr-peeler`

It does not claim that the full MDK workspace, SQLCipher storage, app runtime,
bindings, CLI, or daemon run in a browser. The new gate is compile-only;
browser-runtime acceptance remains separate work.

## Validation

- `actionlint .github/workflows/ci.yml`
- locked Cargo metadata
- `just fast-ci`
- `cargo test -p cgka-traits`
- `cargo test -p cgka-engine --features test-policy-overrides`
- `cargo test -p transport-nostr-peeler -p marmot-forensics`
- locked `wasm32-unknown-unknown` build of the three supported crates
