### PR TITLE
Route the live timeline benchmark output through tracing

### DIFF
--- a/crates/marmot-uniffi/src/subscriptions.rs
+++ b/crates/marmot-uniffi/src/subscriptions.rs
@@ -604,16 +604,22 @@ mod tests {
             delta_times.sort_unstable();
             original_times.sort_unstable();
             assert_eq!(sizes[1], sizes[2]);
-            eprintln!(
-                "rows={count} full_p50_ns={} full_p95_ns={} delta_p50_ns={} delta_p95_ns={} original_p50_ns={} original_p95_ns={} full_bytes={} delta_bytes={}",
-                full_times[49],
-                full_times[94],
-                delta_times[49],
-                delta_times[94],
-                original_times[49],
-                original_times[94],
-                sizes[0],
-                sizes[1],
+            // Structured tracing rather than direct output: the repo-wide
+            // audit forbids `eprintln!` in library sources, tests included.
+            // Run with a subscriber (for example `RUST_LOG=info`) to read it.
+            tracing::info!(
+                target: "marmot_uniffi::benchmark",
+                method = "live_timeline_conversion_benchmark",
+                rows = count,
+                full_p50_ns = full_times[49],
+                full_p95_ns = full_times[94],
+                delta_p50_ns = delta_times[49],
+                delta_p95_ns = delta_times[94],
+                original_p50_ns = original_times[49],
+                original_p95_ns = original_times[94],
+                full_bytes = sizes[0],
+                delta_bytes = sizes[1],
+                "live timeline conversion benchmark"
             );
         }
     }


### PR DESCRIPTION
## Problem

Master is red on **Simulator and vectors** since #1732: `crates/marmot-uniffi/src/subscriptions.rs:607` prints benchmark percentiles with `eprintln!` inside the ignored release-mode live timeline conversion benchmark. The conformance simulator's `production_library_sources_do_not_write_direct_output` audit scans whole library source files, test modules included, and #1732 touched only `marmot-uniffi`, so the conformance job did not run on that PR and the break landed on master. Every PR since (for example #1743) fails that job through the merge ref.

## Fix

The benchmark reports through a structured `tracing::info!` with an explicit target and method and one field per percentile, which is what the audit and the tracing conventions ask for. Run the benchmark with a subscriber (`RUST_LOG=info`) to read the numbers.

## Validation

`cargo test -p cgka-conformance-simulator --test tracing_audit`: all four audits pass. `cargo check -p marmot-uniffi --all-targets` and `cargo fmt --all --check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
