### PR TITLE
Respect projection timestamps in app and UniFFI durability tests

### DIFF
--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -16,8 +16,8 @@ use cgka_traits::{GroupId, TransportEndpoint};
 use marmot_account::{AccountHome, AccountHomeError, AccountSecretStore, KeychainSecretStore};
 use marmot_app::{
     AccountRelayListBootstrap, AccountSetupRequest, AccountSetupResult, AppError, AppMessageQuery,
-    AuditLogSettings, AuditLogTrackerConfig, AuditLogUploadSource, MarmotApp, MarmotAppConfig,
-    MarmotAppEvent, MarmotAppRuntime, MediaAttachmentReference, MediaLocator,
+    AuditLogSettings, AuditLogTrackerConfig, AuditLogUploadSource, ChatListRow, MarmotApp,
+    MarmotAppConfig, MarmotAppEvent, MarmotAppRuntime, MediaAttachmentReference, MediaLocator,
     MediaUploadAttachmentRequest, MediaUploadRequest, MissingRelayListKind, NotificationTrigger,
     NotificationWakeSource, PushPlatform, RetentionSweepStatus, RuntimeMessageUpdate,
     RuntimeNotificationsSubscription, SelfMembership, SignOutOptions, TimelineMessageQuery,
@@ -10287,7 +10287,28 @@ async fn create_group_detailed_returns_durable_emitted_chat_list_row() {
         .chat_list_row(&alice.account.label, &created.chat_list_row.group_id_hex)
         .unwrap()
         .expect("created chat-list row is queryable immediately");
-    assert_eq!(created.chat_list_row, queried);
+    // Race: `updated_at` is the projection's maintenance stamp, not durable
+    // conversation content. Storage fences it against the source tables'
+    // timestamps in `chat_list_projection_complete_tx`, so every rebuild
+    // re-stamps it to wall-clock now even when the row is otherwise
+    // identical. This is the account's first chat-list query, so
+    // `ensure_chat_list_projection` rebuilds the whole projection (a fresh
+    // database starts at projection version 0, and an earlier account-state
+    // save may already have marked it stale) instead of serving the row the
+    // create tail wrote. When a wall-clock second boundary falls between that
+    // write and this query, the stamp moves forward by one. The durable-row
+    // contract is every other field; the stamp may only advance.
+    assert!(
+        queried.updated_at >= created.chat_list_row.updated_at,
+        "projection maintenance may only advance updated_at"
+    );
+    assert_eq!(
+        ChatListRow {
+            updated_at: queried.updated_at,
+            ..created.chat_list_row.clone()
+        },
+        queried
+    );
 
     let emitted = wait_for_event(&mut events, |event| {
         matches!(

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -10245,7 +10245,8 @@ async fn create_group_returns_before_blocked_founding_welcome() {
 }
 
 /// mdk#1487: the detailed create response carries the exact durable chat-list
-/// row that subscribers and ordinary queries observe at the response boundary.
+/// row emitted to subscribers at the response boundary. Ordinary queries keep
+/// its content, while projection maintenance may advance `updated_at`.
 #[tokio::test]
 async fn create_group_detailed_returns_durable_emitted_chat_list_row() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/marmot-uniffi/src/commands/chat_list.rs
+++ b/crates/marmot-uniffi/src/commands/chat_list.rs
@@ -297,7 +297,10 @@ mod tests {
         assert_eq!(left.last_read_timeline_at, right.last_read_timeline_at);
         assert_eq!(left.conversation_created_at, right.conversation_created_at);
         assert_eq!(left.activity_sort_at, right.activity_sort_at);
-        assert_eq!(left.updated_at, right.updated_at);
+        // The first query can rebuild the projection and advance its
+        // maintenance stamp. Every content field must still match the create
+        // response, and the later query must not move the stamp backwards.
+        assert!(right.updated_at >= left.updated_at);
         assert_eq!(
             std::mem::discriminant(&left.self_membership),
             std::mem::discriminant(&right.self_membership)

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -328,6 +328,12 @@ pub struct ChatListRow {
     /// Durable user-visible activity anchor. Projection maintenance never
     /// advances this value.
     pub activity_sort_at: u64,
+    /// Wall-clock time of the last projection write for this row. Every
+    /// rebuild re-stamps it, even when the derived content is unchanged,
+    /// because `chat_list_projection_complete_tx` fences it against the
+    /// source tables' timestamps to decide whether the row is fresh. Keeping
+    /// an old stamp on a no-op rebuild would make such a row look stale
+    /// forever. Compare durable content, not this stamp.
     pub updated_at: u64,
     /// The local account's membership in this group (active member, left, or
     /// removed). Denormalized from `account_groups.self_membership`.


### PR DESCRIPTION
## Summary

Fixes the pre-existing flake in `create_group_detailed_returns_durable_emitted_chat_list_row`, seen on [this CI run](https://github.com/marmot-protocol/mdk/actions/runs/34122024040/job/101742088768) for #1743 (which did not touch group creation). The two `ChatListRow` values were identical except `updated_at` differed by one second.

**Root cause.** The test compared the row returned by `create_group_detailed` with the row from the immediately following `app.chat_list_row` query using `assert_eq!`. That query is the account's first chat-list read, so `MarmotApp::ensure_chat_list_projection` rebuilds the whole projection: `refresh_chat_list_rows` when an earlier account-state save already marked the projection stale (confirmed locally by instrumenting the gate, which reported `stale=true warmed=false` at that query), or `ensure_chat_list_rows` because a fresh database starts at projection version 0 (migration 0023). Every rebuild goes through `write_chat_list_row_for_group_tx`, which re-stamps `updated_at = unix_now_seconds()` even when the derived row is unchanged. When a wall-clock second boundary falls between the create tail's row write and that query, `updated_at` moves forward by one. The create tail itself does not touch the row after the response is sent.

**Why the test changes rather than the projection.** `updated_at` doubles as the projection freshness fence: `chat_list_projection_complete_tx` reports a row stale when `row.updated_at` is older than `account_groups.updated_at`, `conversation_read_state.updated_at`, the avatar component's `updated_at`, or the newest `message_timeline.received_at`. If a rebuild kept the old stamp whenever the derived content was unchanged, any source change that does not alter the row (a reaction, a description edit, a late-arriving older message) would leave the row failing that fence forever, and every chat-list query would rebuild the whole projection. Decoupling the fence from `updated_at` needs a new column plus migration and changes a host-visible field's meaning, which is out of scope for this flake.

**Change.**
- The test keeps its intent (the returned row is the durable, queryable row): every content field must match exactly, and `updated_at` may only move forward. A comment names the race.
- `ChatListRow::updated_at` gains a doc comment stating that it is the projection maintenance stamp and why rebuilds re-stamp it.

## Verification

- `cargo test -p marmot-app --test relay_runtime --features test-policy-overrides -- --test-threads=1 create_group_detailed`
- `just fast-ci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Takeover follow-up

The same exact-timestamp assumption also failed in master CI's UniFFI `chat_list_row_matches_full_list_and_stays_independent_of_chat_count` test. Apply the same contract there: every content field remains exact and the query's maintenance timestamp may only advance. Clarify the relay test rustdoc accordingly.

Both affected tests and `just fast-ci` passed locally on `54f9c7d0`. Fresh remote CI is running. This PR owns both timestamp assertion fixes; #1746 owns departure scheduling and #1748 owns superseded group-change intents.
