### PR TITLE
Re-issue or report a device's own group change when convergence supersedes it

### DIFF
--- a/crates/cgka-conformance-simulator/APP_PATH_COVERAGE.md
+++ b/crates/cgka-conformance-simulator/APP_PATH_COVERAGE.md
@@ -98,8 +98,7 @@ may already have reached the relay, so only accepted publications are correlated
 | Test suffix | Public contract |
 | --- | --- |
 | `07_two_groups_stay_isolated` | Work and pair groups on one device; the second invite of Bob needs a fresh KeyPackage; a non-member has no projection; a removal and a reopen leave the other group's exact history untouched |
-| `08_concurrent_admin_profile_edits_converge` | Two admins save name and description at the same instant; members settle on one state in which at least one edit is present (measured on the settled projection, not on the commands' return values); fresh traffic and reopen persistence hold; dropped accepted edits are recorded |
-| `08_strict_concurrent_admin_profile_edits_are_never_lost` (ignored, #1734) | As above, and every edit the runtime reported as saved is present in the settled state |
+| `08_concurrent_admin_profile_edits_are_never_lost` | Two admins save name and description at the same instant; members settle on one state in which both edits are present, because the losing commit's edit is re-issued when the winner left its field untouched (#1734; measured on the settled projection, not on the commands' return values); fresh traffic and reopen persistence hold; dropped accepted edits are recorded |
 | `09_concurrent_invite_and_rename_converge` | An invite races a rename; founders settle with at least one edit present; an invitee the founders admitted sends and receives; an excluded invitee's device state is recorded as `no_projection` or `stranded` |
 | `09_strict_concurrent_invite_and_rename_are_never_lost` (ignored, #1734, #1735) | As above, an excluded invitee holds no projection, and an invite or rename reported as saved is not lost |
 | `10_member_removed_while_offline_learns_removal` | A closed device is removed; on reconnect it learns the removal from relay history, never decrypts post-removal traffic, keeps its exact pre-removal history across reopen, and its sends are refused as `group_removed` |
@@ -113,7 +112,9 @@ contracts below. The default concurrent journeys accept either race outcome. The
 is present in the settled state, or when fresh traffic or reopen persistence breaks. They do not prove that a same-epoch
 fork occurred on a given run; real socket timing is not seed-controlled. The three gaps below are tracked in
 [#1734](https://github.com/marmot-protocol/mdk/issues/1734), [#1735](https://github.com/marmot-protocol/mdk/issues/1735),
-and [#1736](https://github.com/marmot-protocol/mdk/issues/1736); the ignored strict journeys are their regressions.
+and [#1736](https://github.com/marmot-protocol/mdk/issues/1736); the ignored strict journeys are their regressions. The
+dropped-edit gap ([#1734](https://github.com/marmot-protocol/mdk/issues/1734)) is fixed for profile edits, and its
+never-lost contract is now the default journey 08; the strict journey 09 stays ignored for the invite half (#1735).
 
 Run the default journeys the way the conformance CI job does, or serially with retained evidence:
 
@@ -132,16 +133,23 @@ self-update journey; `just simulator-fast-maintenance` runs that journey with ze
 `app-runtime-journeys` test group in `.config/nextest.toml` runs at most two public journeys at a time, because each
 one starts a local relay and several SQLCipher runtimes and then waits on real settlement windows.
 
-### Known gap: a losing admin edit is dropped after its caller was told it saved (#1734)
+### Fixed: a losing admin edit is re-issued or reported, never silently dropped (#1734)
 
 The first run of the strict profile-edit journey (2026-09-06) showed both `update_group_profile` calls returning
 success, every member settling at the next epoch with Bob's description, and Alice's rename absent everywhere, with
-no error event on any device. This matches the account layer: when convergence parks an own commit, only a
-`SelfUpdate` evolution re-arms its maintenance obligation; `Invite`, `RemoveMembers`, and `UpdateAppComponents`
-evolutions are marked superseded and their intent is not re-issued or reported. The engine vectors
-(`group-data-fork-recovery/v1`) specify only that both clients converge, so the engine oracle cannot see this.
-The strict journeys stay ignored until the runtime either re-issues a parked intent or reports the loss to the
-caller; the default journeys keep the convergence, delivery, and persistence contract green in the ordinary run.
+no error event on any device. Until #1734 that matched the account layer: when convergence parked an own commit,
+only a `SelfUpdate` evolution re-armed its maintenance obligation; `Invite`, `RemoveMembers`, `UpdateGroupData`, and
+`UpdateAppComponents` evolutions were marked superseded and their intent was neither re-issued nor reported. The
+engine now retains the intent behind every own group evolution together with the authoring baseline
+(`cgka_own_commit_intents`, kept until the group has advanced past the rewind horizon), and when a pass withdraws
+that commit it decides per kind: a profile or component edit is re-queued when the winning branch left the edited
+field untouched and reported as a conflict when it changed it; a removal is re-queued for targets that are still
+members; an invite is reported as needing a fresh invitation (#1735 owns the invitee's side). Re-issue is bounded to
+two attempts. Every decision reaches the host as `MarmotAppEvent::GroupChangeSuperseded { kind, outcome, reason }`
+(UniFFI and C ABI mirrors), and `run_due_maintenance` re-derives a missed announcement from the stored disposition.
+Journey 08 now requires both edits in the settled state; `crates/marmot-app/tests/relay_runtime.rs` races two admins
+on a real relay for the re-issued and the conflict outcome, and `crates/cgka-engine/tests/distributed_convergence.rs`
+pins the field rule, the bounded re-issue, and the horizon garbage collection.
 
 ### Known gap: survivors apply a voluntary leave only when something else runs convergence (#1736)
 

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -1086,9 +1086,11 @@ its pre-removal history exactly, and have its own sends refused), and a voluntar
 The default forms run in the ordinary crate test and gate only what the product delivers today: members settle on one
 public state, at least one racing edit is present in that settled state (measured on the projection, never on the
 command's return value), fresh traffic flows in every direction, history survives reopen, and survivors apply a leave
-within three minutes. The strict forms are ignored regressions for three tracked gaps: an edit or invite the runtime
-reported as saved is never lost (#1734), an invitee the founders exclude holds no projection rather than a stranded
-parked-branch membership (#1735), and survivors apply a leave within 30 seconds (#1736). The manual self-update journey
+within three minutes. Journey 08 is strict by default since #1734: a profile edit the runtime reported as saved is never
+lost, because the losing commit is re-issued when the winner left its field untouched (a same-field race is reported to
+the host as a conflict instead). The strict forms of journeys 09 and 12 are ignored regressions for two tracked gaps: an
+invitee the founders exclude holds no projection rather than a stranded parked-branch membership, and a losing invite is
+re-issued rather than only reported (#1735); and survivors apply a leave within 30 seconds (#1736). The manual self-update journey
 runs with zeroed maintenance windows when the crate is built with `test-policy-overrides`
 (`just simulator-fast-maintenance`) and is ignored in ordinary builds, where the protocol's quiet window and jitter run
 on real time.

--- a/crates/cgka-conformance-simulator/tests/app_runtime_interaction_journeys.rs
+++ b/crates/cgka-conformance-simulator/tests/app_runtime_interaction_journeys.rs
@@ -1012,9 +1012,12 @@ macro_rules! journey_test {
 }
 
 journey_test!(public_app_07_two_groups_stay_isolated, Journey::TwoGroups);
+// Strict since #1734: a losing profile edit is re-issued when the winning
+// commit left its field untouched, so an edit the runtime reported as saved
+// reaches the settled public state.
 journey_test!(
-    public_app_08_concurrent_admin_profile_edits_converge,
-    Journey::ConcurrentProfileEdits { strict: false }
+    public_app_08_concurrent_admin_profile_edits_are_never_lost,
+    Journey::ConcurrentProfileEdits { strict: true }
 );
 journey_test!(
     public_app_09_concurrent_invite_and_rename_converge,
@@ -1029,16 +1032,12 @@ journey_test!(
     Journey::LeaveWithSeveralRemaining { strict: false }
 );
 
-// The strict forms additionally require that an edit the runtime reported as
-// saved reaches the settled public state. Convergence currently parks the
-// losing committer's intent without re-issuing it, so they document a known
-// product gap rather than gating CI; see APP_PATH_COVERAGE.md.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[ignore = "known gap: a losing admin edit is dropped after its caller was told it saved"]
-async fn public_app_08_strict_concurrent_admin_profile_edits_are_never_lost() {
-    check(Journey::ConcurrentProfileEdits { strict: true }).await;
-}
-
+// The strict form additionally requires that an invite or rename the runtime
+// reported as saved reaches the settled public state and that an excluded
+// invitee holds no projection. A losing rename is re-issued since #1734; a
+// losing invite still strands its invitee on a parked branch (#1735), so this
+// documents a known product gap rather than gating CI; see
+// APP_PATH_COVERAGE.md.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore = "known gap: a losing invite or rename is dropped after its caller was told it saved"]
 async fn public_app_09_strict_concurrent_invite_and_rename_are_never_lost() {

--- a/crates/cgka-engine/AGENTS.md
+++ b/crates/cgka-engine/AGENTS.md
@@ -515,6 +515,18 @@ epoch visibility through `support::epoch_sealed_peeler`), plus the `convergence-
   announced once — it durably flips its record to `EpochInvalidated`, so a later pass no longer sees it as previously
   applied. That half of the hole predates announce-once. Both repairs flip forward only; `GroupStateRevalidated` has no
   account-layer consumer and neither reconciler un-marks a supersession.
+- **Every own group evolution keeps its intent until the commit is beyond the rewind horizon.** `do_send_ready`
+  records an `OwnCommitIntent` (kind, the pre-staging baseline of the edited fields, source epoch, attempt count) for
+  `Invite`, `RemoveMembers`, `UpdateGroupData`, and `UpdateAppComponents` before dispatch, keyed by the commit's
+  message id; `publish_failed` deletes it, confirmation does not, and
+  `reissue_superseded_own_commits_from_state` garbage-collects a `Processed` record once `group.epoch` exceeds
+  `source_epoch + max_rewind_commits`. When branch selection withdraws the commit, `reissue_superseded_own_commit`
+  (event path: the account layer's `GroupStateInvalidated` reconciler; derived path: `run_due_maintenance`) decides
+  from the record, never from the losing branch's bytes: re-queue an edit only when the canonical value of every field
+  the intent changed still equals the baseline, report `Conflict` otherwise; re-queue a removal for targets still on
+  the roster; an invite is `ReinviteRequired` (mdk#1735 owns the invitee); at most `MAX_OWN_COMMIT_REISSUE_ATTEMPTS`
+  re-issues, then `Abandoned`. The decision is returned as a `SupersededIntentReport` so the runtime can announce it
+  (mdk#1734). Tests: `tests/distributed_convergence.rs::superseded_profile_edit_*`.
 - **A retained anchor for epoch E is the state of E as the device *left* E.** `retain_current_group_epoch_snapshot`
   therefore runs both before an advance past E and immediately after a replayed proposal enters the store at E
   (`openmls_projection::process_openmls_messages_inner`, the `ProposalMessage` arm, under the same

--- a/crates/cgka-engine/src/lib.rs
+++ b/crates/cgka-engine/src/lib.rs
@@ -63,6 +63,7 @@ pub(crate) mod message_disposition;
 pub mod message_processor;
 pub(crate) mod mls_group_cache;
 pub mod openmls_projection;
+pub mod own_commit_intent;
 pub mod pending_commit_guard;
 pub mod provider;
 pub mod publish;

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -644,7 +644,7 @@ impl<S: StorageProvider> Engine<S> {
             .should_queue_outbound_intent(&group_id, &intent)
             .await?
         {
-            return self.queue_outbound_intent(group_id, intent);
+            return self.queue_outbound_intent(group_id, intent, 0);
         }
 
         let prepare_started = Instant::now();
@@ -691,7 +691,7 @@ impl<S: StorageProvider> Engine<S> {
                 },
             ));
         }
-        self.queue_outbound_intent(group_id, intent)
+        self.queue_outbound_intent(group_id, intent, 0)
     }
 
     fn validate_send_acceptance(&mut self, intent: &SendIntent) -> Result<GroupId, EngineError> {
@@ -876,7 +876,9 @@ impl<S: StorageProvider> Engine<S> {
             self.engine_metrics
                 .note_queued_outbound_wait_ms(now_ms.saturating_sub(record.created_at_ms));
             let prepare_started = Instant::now();
-            let prepared = self.do_send_ready(record.intent.clone()).await;
+            let prepared = self
+                .do_send_ready_with_reissue_attempts(record.intent.clone(), record.reissue_attempts)
+                .await;
             self.engine_metrics.note_outbound_wire_prepare_ms(
                 prepare_started
                     .elapsed()
@@ -2951,10 +2953,11 @@ impl<S: StorageProvider> Engine<S> {
         Ok(queued.len())
     }
 
-    fn queue_outbound_intent(
+    pub(crate) fn queue_outbound_intent(
         &mut self,
         group_id: GroupId,
         intent: SendIntent,
+        reissue_attempts: u32,
     ) -> Result<SendResult, EngineError> {
         let queue_started = Instant::now();
         let created_at_ms = self.convergence_now_ms();
@@ -2981,6 +2984,7 @@ impl<S: StorageProvider> Engine<S> {
                 group_id: group_id.clone(),
                 intent,
                 created_at_ms,
+                reissue_attempts,
             })?;
         // The drain is what releases this row, so writing it and arming the
         // drain are one step — see `has_queued_outbound_intents`. `Stable` is

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -28,6 +28,16 @@ impl<S: StorageProvider> Engine<S> {
         &mut self,
         intent: SendIntent,
     ) -> Result<SendResult, EngineError> {
+        self.do_send_ready_with_reissue_attempts(intent, 0).await
+    }
+
+    /// `do_send_ready` for an intent that has already been re-queued
+    /// `reissue_attempts` times after losing same-epoch races (mdk#1734).
+    pub(crate) async fn do_send_ready_with_reissue_attempts(
+        &mut self,
+        intent: SendIntent,
+        reissue_attempts: u32,
+    ) -> Result<SendResult, EngineError> {
         let group_id = super::send_intent_group_id(&intent).clone();
         if self.storage.disband_tombstone(&group_id)?.is_some() {
             return Err(EngineError::InvalidTransition(
@@ -76,7 +86,14 @@ impl<S: StorageProvider> Engine<S> {
                 },
             ));
         }
-        match intent {
+        // Retain the intent behind every own group evolution until the commit
+        // is confirmed or rolled back, so a supersession can re-issue it
+        // (mdk#1734). The baseline is read before staging so it describes the
+        // state the caller was looking at.
+        let recording = self.own_commit_recording(&intent)?;
+        let retained_intent = recording.as_ref().map(|_| intent.clone());
+        let source_epoch = group.as_ref().map(|group| group.epoch).unwrap_or_default();
+        let result = match intent {
             SendIntent::AppMessage { group_id, payload } => {
                 self.do_send_app_message(group_id, payload).await
             }
@@ -108,7 +125,23 @@ impl<S: StorageProvider> Engine<S> {
                 self.do_enable_group_disbanding(group_id).await
             }
             SendIntent::Disband { group_id } => self.do_request_disband(group_id),
+        };
+        if let (
+            Some((_, baseline)),
+            Some(retained_intent),
+            Ok(SendResult::GroupEvolution { msg, .. }),
+        ) = (recording, retained_intent, &result)
+        {
+            self.record_own_commit_intent(
+                msg.id.clone(),
+                group_id,
+                source_epoch,
+                retained_intent,
+                baseline,
+                reissue_attempts,
+            )?;
         }
+        result
     }
 
     async fn do_send_invite(

--- a/crates/cgka-engine/src/own_commit_intent.rs
+++ b/crates/cgka-engine/src/own_commit_intent.rs
@@ -1,0 +1,321 @@
+//! Re-issuing the intent behind an own commit that convergence superseded
+//! (mdk#1734).
+//!
+//! When two devices commit at the same epoch, branch selection keeps one and
+//! parks the other. The parked committer already told its caller the change
+//! saved, so dropping the intent silently is a product defect. The send path
+//! records every own group-evolution commit's intent, together with the state
+//! it was authored against, from staging until the commit is confirmed or
+//! rolled back. When a supersession is announced or later derived from stored
+//! dispositions, [`Engine::reissue_superseded_own_commit`] decides:
+//!
+//! - a profile edit or component update is re-queued only when the winning
+//!   branch left every field it touches exactly as the author saw it, and is
+//!   otherwise reported as a conflict so the winner's value stands;
+//! - a removal is re-queued for the targets that are still members, or
+//!   reported as already satisfied when none remain;
+//! - a lost invite is never replayed, because its KeyPackages were consumed
+//!   by the parked Welcome; the inviter is told to re-invite with fresh
+//!   material (mdk#1735);
+//! - re-issue is bounded by [`MAX_OWN_COMMIT_REISSUE_ATTEMPTS`].
+//!
+//! Re-queued intents flow through the ordinary queued-intent drain, so they
+//! are regenerated against the canonical state with every existing gate.
+
+use crate::engine::Engine;
+use crate::provider::EngineOpenMlsProvider;
+use cgka_traits::app_components::AppComponentData;
+use cgka_traits::engine::{
+    SendIntent, SupersededIntentKind, SupersededIntentOutcome, SupersededIntentReport,
+};
+use cgka_traits::error::EngineError;
+use cgka_traits::message::MessageState;
+use cgka_traits::storage::{OwnCommitBaseline, OwnCommitIntent, StorageProvider};
+use cgka_traits::types::{GroupId, MessageId};
+use openmls::group::MlsGroup;
+use openmls_traits::OpenMlsProvider;
+
+/// How many times one intent may be re-queued after losing a same-epoch race.
+pub const MAX_OWN_COMMIT_REISSUE_ATTEMPTS: u32 = 2;
+
+impl<S: StorageProvider> Engine<S> {
+    /// The kind and authoring baseline to retain for an intent that is about
+    /// to stage a group evolution, or `None` for intents that never need
+    /// re-issue (application messages, leaves, self-updates, disband).
+    pub(crate) fn own_commit_recording(
+        &self,
+        intent: &SendIntent,
+    ) -> Result<Option<(SupersededIntentKind, OwnCommitBaseline)>, EngineError> {
+        Ok(match intent {
+            SendIntent::Invite { .. } => {
+                Some((SupersededIntentKind::Invite, OwnCommitBaseline::None))
+            }
+            SendIntent::RemoveMembers { .. } => {
+                Some((SupersededIntentKind::RemoveMembers, OwnCommitBaseline::None))
+            }
+            SendIntent::UpdateGroupData { group_id, .. } => {
+                let mls_group = self.load_mls_group(group_id)?;
+                let (name, description) =
+                    crate::app_components::group_profile_of_group(&mls_group)?.unwrap_or_default();
+                Some((
+                    SupersededIntentKind::GroupProfile,
+                    OwnCommitBaseline::GroupProfile { name, description },
+                ))
+            }
+            SendIntent::UpdateAppComponents { group_id, updates } => {
+                let mls_group = self.load_mls_group(group_id)?;
+                let components = updates
+                    .iter()
+                    .map(|update| AppComponentData {
+                        component_id: update.component_id,
+                        data: crate::app_components::app_component_data_of_group(
+                            &mls_group,
+                            update.component_id,
+                        )
+                        .unwrap_or_default(),
+                    })
+                    .collect();
+                Some((
+                    SupersededIntentKind::AppComponents,
+                    OwnCommitBaseline::AppComponents { components },
+                ))
+            }
+            SendIntent::AppMessage { .. }
+            | SendIntent::Leave { .. }
+            | SendIntent::SelfUpdate { .. }
+            | SendIntent::EnableDisbanding { .. }
+            | SendIntent::Disband { .. } => None,
+        })
+    }
+
+    fn load_mls_group(&self, group_id: &GroupId) -> Result<MlsGroup, EngineError> {
+        let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
+        let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+        MlsGroup::load(provider.storage(), &mls_gid)
+            .map_err(|error| EngineError::Backend(format!("load group: {error:?}")))?
+            .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))
+    }
+
+    /// Decide what becomes of the intent behind `commit_id` now that
+    /// convergence has superseded that commit. Returns `None` when this device
+    /// recorded no intent for it (a peer's commit, a self-update, or a record
+    /// already consumed). The record is always removed; a re-queued intent
+    /// lives on as an ordinary queued outbound intent.
+    pub fn reissue_superseded_own_commit(
+        &mut self,
+        commit_id: &MessageId,
+    ) -> Result<Option<SupersededIntentReport>, EngineError> {
+        let Some(record) = self.storage.own_commit_intent(commit_id)? else {
+            return Ok(None);
+        };
+        self.storage.delete_own_commit_intent(commit_id)?;
+        let kind = match &record.intent {
+            SendIntent::Invite { .. } => SupersededIntentKind::Invite,
+            SendIntent::RemoveMembers { .. } => SupersededIntentKind::RemoveMembers,
+            SendIntent::UpdateGroupData { .. } => SupersededIntentKind::GroupProfile,
+            SendIntent::UpdateAppComponents { .. } => SupersededIntentKind::AppComponents,
+            _ => return Ok(None),
+        };
+        let report = |outcome, reason| SupersededIntentReport {
+            group_id: record.group_id.clone(),
+            commit_id: commit_id.clone(),
+            kind,
+            outcome,
+            reason,
+        };
+
+        let group = self.stored_group_record(&record.group_id)?;
+        let Some(group) = group else {
+            return Ok(Some(report(
+                SupersededIntentOutcome::NotMember,
+                "the group no longer exists on this device",
+            )));
+        };
+        if group.removed || group.disbanded.is_some() {
+            return Ok(Some(report(
+                SupersededIntentOutcome::NotMember,
+                "this device is no longer a member of the group",
+            )));
+        }
+        if record.reissue_attempts >= MAX_OWN_COMMIT_REISSUE_ATTEMPTS {
+            return Ok(Some(report(
+                SupersededIntentOutcome::Abandoned,
+                "the change lost more concurrent commits than the engine retries",
+            )));
+        }
+
+        let intent = match &record.intent {
+            SendIntent::Invite { .. } => {
+                return Ok(Some(report(
+                    SupersededIntentOutcome::ReinviteRequired,
+                    "the invite's KeyPackages were consumed by the parked Welcome; re-invite with fresh material",
+                )));
+            }
+            SendIntent::RemoveMembers { group_id, members } => {
+                let remaining = members
+                    .iter()
+                    .filter(|member| group.members.iter().any(|current| current.id == **member))
+                    .cloned()
+                    .collect::<Vec<_>>();
+                if remaining.is_empty() {
+                    return Ok(Some(report(
+                        SupersededIntentOutcome::AlreadySatisfied,
+                        "the winning branch already removed every requested member",
+                    )));
+                }
+                SendIntent::RemoveMembers {
+                    group_id: group_id.clone(),
+                    members: remaining,
+                }
+            }
+            SendIntent::UpdateGroupData {
+                group_id,
+                name,
+                description,
+            } => {
+                let OwnCommitBaseline::GroupProfile {
+                    name: baseline_name,
+                    description: baseline_description,
+                } = &record.baseline
+                else {
+                    return Ok(Some(report(
+                        SupersededIntentOutcome::Conflict,
+                        "the profile edit carried no authoring baseline to compare against",
+                    )));
+                };
+                let mls_group = self.load_mls_group(group_id)?;
+                let (current_name, current_description) =
+                    crate::app_components::group_profile_of_group(&mls_group)?.unwrap_or_default();
+                let name_untouched = name.is_none() || current_name == *baseline_name;
+                let description_untouched =
+                    description.is_none() || current_description == *baseline_description;
+                if !(name_untouched && description_untouched) {
+                    return Ok(Some(report(
+                        SupersededIntentOutcome::Conflict,
+                        "the winning branch changed the same profile field; its value stands",
+                    )));
+                }
+                record.intent.clone()
+            }
+            SendIntent::UpdateAppComponents { group_id, updates } => {
+                let OwnCommitBaseline::AppComponents { components } = &record.baseline else {
+                    return Ok(Some(report(
+                        SupersededIntentOutcome::Conflict,
+                        "the component update carried no authoring baseline to compare against",
+                    )));
+                };
+                let mls_group = self.load_mls_group(group_id)?;
+                let untouched = updates.iter().all(|update| {
+                    let baseline = components
+                        .iter()
+                        .find(|component| component.component_id == update.component_id)
+                        .map(|component| component.data.as_slice())
+                        .unwrap_or_default();
+                    crate::app_components::app_component_data_of_group(
+                        &mls_group,
+                        update.component_id,
+                    )
+                    .unwrap_or_default()
+                        == baseline
+                });
+                if !untouched {
+                    return Ok(Some(report(
+                        SupersededIntentOutcome::Conflict,
+                        "the winning branch changed the same component; its value stands",
+                    )));
+                }
+                record.intent.clone()
+            }
+            _ => return Ok(None),
+        };
+
+        match self.queue_outbound_intent(
+            record.group_id.clone(),
+            intent,
+            record.reissue_attempts.saturating_add(1),
+        ) {
+            Ok(_) => Ok(Some(report(
+                SupersededIntentOutcome::Reissued,
+                "the change is still valid against the canonical state and has been queued again",
+            ))),
+            Err(EngineError::QueuedOutboundAtCapacity { .. }) => Ok(Some(report(
+                SupersededIntentOutcome::Abandoned,
+                "the group's outbound queue is full",
+            ))),
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Re-derive supersessions from stored dispositions for every retained
+    /// own-commit intent, for reconcilers that may have missed the
+    /// announcement, and garbage-collect records whose commit can no longer
+    /// be superseded. A confirmed commit stays reconsiderable while its
+    /// source epoch is within the group's rewind horizon, so its record is
+    /// kept until the group has advanced past that horizon. Live or in-flight
+    /// commits are left alone.
+    pub fn reissue_superseded_own_commits_from_state(
+        &mut self,
+    ) -> Result<Vec<SupersededIntentReport>, EngineError> {
+        let mut reports = Vec::new();
+        for record in self.storage.list_own_commit_intents(None)? {
+            let state = match self.storage.get_message(&record.commit_id) {
+                Ok(message) => message.state,
+                Err(cgka_traits::storage::StorageError::NotFound) => continue,
+                Err(error) => return Err(error.into()),
+            };
+            match state {
+                MessageState::ConvergenceDeferred | MessageState::EpochInvalidated => {
+                    if let Some(report) = self.reissue_superseded_own_commit(&record.commit_id)? {
+                        reports.push(report);
+                    }
+                }
+                MessageState::Processed if self.own_commit_is_beyond_rewind_horizon(&record)? => {
+                    self.storage.delete_own_commit_intent(&record.commit_id)?;
+                }
+                _ => {}
+            }
+        }
+        Ok(reports)
+    }
+
+    /// Whether a confirmed commit staged from `record.source_epoch` can no
+    /// longer be rolled back by a late rival: the group has advanced more than
+    /// `max_rewind_commits` epochs past it.
+    fn own_commit_is_beyond_rewind_horizon(
+        &self,
+        record: &OwnCommitIntent,
+    ) -> Result<bool, EngineError> {
+        let Some(group) = self.stored_group_record(&record.group_id)? else {
+            return Ok(true);
+        };
+        let max_rewind = self
+            .convergence_policy_for_group(&record.group_id)
+            .map_err(|error| EngineError::Backend(format!("convergence policy: {error:?}")))?
+            .convergence
+            .max_rewind_commits;
+        Ok(group.epoch.0 > record.source_epoch.0.saturating_add(max_rewind))
+    }
+
+    /// Retain the intent behind a commit this device just staged.
+    pub(crate) fn record_own_commit_intent(
+        &mut self,
+        commit_id: MessageId,
+        group_id: GroupId,
+        source_epoch: cgka_traits::types::EpochId,
+        intent: SendIntent,
+        baseline: OwnCommitBaseline,
+        reissue_attempts: u32,
+    ) -> Result<(), EngineError> {
+        let created_at_ms = self.convergence_now_ms();
+        self.storage.put_own_commit_intent(&OwnCommitIntent {
+            commit_id,
+            group_id,
+            source_epoch,
+            intent,
+            baseline,
+            reissue_attempts,
+            created_at_ms,
+        })?;
+        Ok(())
+    }
+}

--- a/crates/cgka-engine/src/publish.rs
+++ b/crates/cgka-engine/src/publish.rs
@@ -420,6 +420,12 @@ impl<S: StorageProvider> Engine<S> {
         });
         self.storage
             .with_transaction(|storage| -> Result<(), EngineError> {
+                // No endpoint accepted the commit, so nothing can supersede it
+                // later: the caller already learned the failure directly and
+                // the retained intent must not be re-issued behind its back.
+                if let Some(origin_commit_id) = origin_commit_id.as_ref() {
+                    storage.delete_own_commit_intent(origin_commit_id)?;
+                }
                 if has_pending_commit {
                     let source_epoch = EpochId(mls_group.epoch().as_u64());
                     // No endpoint accepted this staged evolution. Retire its

--- a/crates/cgka-engine/src/snapshot_guard.rs
+++ b/crates/cgka-engine/src/snapshot_guard.rs
@@ -157,6 +157,7 @@ mod tests {
                 payload: vec![id],
             },
             created_at_ms: u64::from(id),
+            reissue_attempts: 0,
         }
     }
 

--- a/crates/cgka-engine/tests/crash_recovery_sqlite.rs
+++ b/crates/cgka-engine/tests/crash_recovery_sqlite.rs
@@ -601,6 +601,7 @@ async fn run_child_case(database: &Path) {
                 payload: app_payload_for(&carol, b"queued across crash"),
             },
             created_at_ms: 2_100,
+            reissue_attempts: 0,
         })
         .expect("persist queued work");
     // Persist the independent outbound obligation before admitting the late

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -16,7 +16,7 @@ use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MarmotAppEvent};
 use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
 use cgka_traits::engine::{
     AppMessageInvalidationReason, CgkaEngine, CreateGroupRequest, GroupEvent, SendIntent,
-    SendResult,
+    SendResult, SupersededIntentKind, SupersededIntentOutcome,
 };
 use cgka_traits::error::PeelerError;
 use cgka_traits::group_context::GroupContextSnapshot;
@@ -2865,6 +2865,7 @@ async fn engine_defers_child_commit_until_parent_arrives() {
                 description: None,
             },
             created_at_ms: 1_001,
+            reissue_attempts: 0,
         })
         .expect("persist already-queued admin group-state intent");
 
@@ -3138,6 +3139,7 @@ fn queue_intent(
             group_id: group_id.clone(),
             intent,
             created_at_ms,
+            reissue_attempts: 0,
         })
         .expect("persist queued outbound intent");
 }
@@ -4427,6 +4429,7 @@ async fn durable_unrecoverable_halt_blocks_queued_drain_without_rehydration() {
                 payload: app_payload_for(&alice, b"must remain queued"),
             },
             created_at_ms: 1,
+            reissue_attempts: 0,
         })
         .unwrap();
     let mut stored_group = storage.get_group(&group_id).unwrap();
@@ -9070,6 +9073,7 @@ async fn advance_convergence_retains_queued_intent_when_regeneration_fails() {
                 description: None,
             },
             created_at_ms: 0,
+            reissue_attempts: 0,
         })
         .unwrap();
 
@@ -9114,6 +9118,7 @@ async fn restart_schedules_groups_with_durable_queued_intents() {
                 payload: app_payload_for(&alice, b"send after restart"),
             },
             created_at_ms: 1,
+            reissue_attempts: 0,
         })
         .unwrap();
     drop(alice);
@@ -9165,6 +9170,7 @@ async fn queued_group_evolution_pauses_later_queued_intents_until_publish_resolv
                 initial_admins: vec![],
             },
             created_at_ms: 0,
+            reissue_attempts: 0,
         })
         .unwrap();
     let app_intent_id = MessageId::new(b"later-app".to_vec());
@@ -9177,6 +9183,7 @@ async fn queued_group_evolution_pauses_later_queued_intents_until_publish_resolv
                 payload: app_payload_for(&alice, b"after invite publish resolves"),
             },
             created_at_ms: 1,
+            reissue_attempts: 0,
         })
         .unwrap();
 
@@ -10197,4 +10204,270 @@ async fn live_deferral_reclassifies_graph_after_a_retry_sweep_and_new_rival() {
         },
         "live recovery evidence must use the current stored graph"
     );
+}
+
+/// Two admins commit a profile change from the same epoch; branch selection
+/// keeps one and parks the other. The parked committer already told its caller
+/// the change saved, so its intent must be re-issued when the winner left the
+/// edited field alone, and reported as a conflict when the winner changed the
+/// same field (mdk#1734).
+async fn race_profile_edits(
+    alice_edit: (Option<&str>, Option<&str>),
+    bob_edit: (Option<&str>, Option<&str>),
+) -> (
+    Engine<SqliteAccountStorage>,
+    SqliteAccountStorage,
+    Engine<SqliteAccountStorage>,
+    SqliteAccountStorage,
+    GroupId,
+    MessageId,
+    MessageId,
+) {
+    let (mut alice, alice_storage) = build_client(b"alice");
+    let (mut bob, bob_storage) = build_client(b"bob");
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "before".into(),
+            description: "before".into(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![bob.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcome_for(&welcomes, b"bob"))
+        .await
+        .unwrap();
+
+    let edit = |(name, description): (Option<&str>, Option<&str>)| SendIntent::UpdateGroupData {
+        group_id: group_id.clone(),
+        name: name.map(str::to_owned),
+        description: description.map(str::to_owned),
+    };
+    let (alice_commit, alice_pending) = evolution(alice.send(edit(alice_edit)).await.unwrap());
+    let (bob_commit, bob_pending) = evolution(bob.send(edit(bob_edit)).await.unwrap());
+    let alice_commit_id = alice_commit.id.clone();
+    let bob_commit_id = bob_commit.id.clone();
+    assert!(
+        alice_storage
+            .own_commit_intent(&alice_commit_id)
+            .unwrap()
+            .is_some(),
+        "staging an own profile commit retains its intent"
+    );
+    alice.confirm_published(alice_pending).await.unwrap();
+    bob.confirm_published(bob_pending).await.unwrap();
+    assert!(
+        alice_storage
+            .own_commit_intent(&alice_commit_id)
+            .unwrap()
+            .is_some(),
+        "confirming a publish keeps the intent until the branch is decided"
+    );
+
+    // Each side receives the rival from the same source epoch and adjudicates.
+    for (engine, rival) in [(&mut alice, &bob_commit), (&mut bob, &alice_commit)] {
+        engine
+            .buffer_openmls_convergence_message_at(&group_id, route(rival.clone(), &group_id), 500)
+            .unwrap();
+        let result = engine
+            .converge_stored_openmls_messages_at(&group_id, 1_000_000)
+            .unwrap();
+        assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
+    }
+    (
+        alice,
+        alice_storage,
+        bob,
+        bob_storage,
+        group_id,
+        alice_commit_id,
+        bob_commit_id,
+    )
+}
+
+#[tokio::test]
+async fn superseded_profile_edit_is_reissued_when_the_winner_left_the_field_alone() {
+    let (mut alice, alice_storage, mut bob, bob_storage, group_id, alice_commit_id, bob_commit_id) =
+        race_profile_edits(
+            (Some("alice renamed it"), None),
+            (None, Some("bob described it")),
+        )
+        .await;
+    let alice_wins = committer_wins(&alice.self_id(), &bob.self_id());
+    let (loser, loser_storage, loser_commit_id, winner, winner_storage) = if alice_wins {
+        (
+            &mut bob,
+            &bob_storage,
+            &bob_commit_id,
+            &mut alice,
+            &alice_storage,
+        )
+    } else {
+        (
+            &mut alice,
+            &alice_storage,
+            &alice_commit_id,
+            &mut bob,
+            &bob_storage,
+        )
+    };
+
+    // The winner's own commit is live; nothing to re-issue there.
+    assert!(
+        winner
+            .reissue_superseded_own_commits_from_state()
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        winner_storage
+            .list_queued_outbound_intents(&group_id)
+            .unwrap()
+            .is_empty()
+    );
+
+    // The loser's commit was parked; the winner touched the other field, so
+    // the edit is still valid and gets queued again with one attempt spent.
+    let reports = loser.reissue_superseded_own_commits_from_state().unwrap();
+    assert_eq!(reports.len(), 1, "{reports:?}");
+    assert_eq!(reports[0].commit_id, *loser_commit_id);
+    assert_eq!(reports[0].kind, SupersededIntentKind::GroupProfile);
+    assert_eq!(reports[0].outcome, SupersededIntentOutcome::Reissued);
+    assert!(
+        loser_storage
+            .own_commit_intent(loser_commit_id)
+            .unwrap()
+            .is_none(),
+        "a decided record is consumed"
+    );
+    let queued = loser_storage
+        .list_queued_outbound_intents(&group_id)
+        .unwrap();
+    assert_eq!(queued.len(), 1);
+    assert_eq!(queued[0].reissue_attempts, 1);
+    assert!(
+        loser
+            .reissue_superseded_own_commits_from_state()
+            .unwrap()
+            .is_empty(),
+        "re-issue is decided exactly once"
+    );
+
+    // The ordinary drain regenerates the edit against the canonical state and
+    // the winner applies it, so both fields end up everywhere.
+    let drained = loser
+        .converge_and_drain_queued_outbound_intents(&group_id, 2_000_000)
+        .await
+        .unwrap();
+    let (reissued_commit, reissued_pending) = evolution(
+        drained
+            .into_iter()
+            .next()
+            .expect("the re-queued edit regenerates into a commit"),
+    );
+    loser.confirm_published(reissued_pending).await.unwrap();
+    assert!(
+        loser_storage
+            .own_commit_intent(&reissued_commit.id)
+            .unwrap()
+            .is_some(),
+        "a confirmed commit stays reconsiderable inside the rewind horizon, so its record is kept"
+    );
+    winner
+        .buffer_openmls_convergence_message_at(
+            &group_id,
+            route(reissued_commit.clone(), &group_id),
+            3_000_000,
+        )
+        .unwrap();
+    let applied = winner
+        .converge_stored_openmls_messages_at(&group_id, 4_000_000)
+        .unwrap();
+    assert_eq!(applied.convergence_status, ConvergenceStatus::Settled);
+    for storage in [&alice_storage, &bob_storage] {
+        let group = storage.get_group(&group_id).unwrap();
+        assert_eq!(group.name, "alice renamed it");
+        assert_eq!(group.description, "bob described it");
+    }
+
+    // Records are garbage-collected once the group has advanced past the
+    // rewind horizon, and never before: with a one-commit horizon, two further
+    // commits retire the re-issued commit's record while the newest stays.
+    loser
+        .set_convergence_policy(CanonicalizationPolicy {
+            convergence: ConvergencePolicy {
+                max_rewind_commits: 1,
+                ..ConvergencePolicy::default()
+            },
+            ..CanonicalizationPolicy::default()
+        })
+        .unwrap();
+    let mut newest = None;
+    for index in 0..2 {
+        let (commit, pending) = evolution(
+            loser
+                .send(SendIntent::UpdateGroupData {
+                    group_id: group_id.clone(),
+                    name: Some(format!("later edit {index}")),
+                    description: None,
+                })
+                .await
+                .unwrap(),
+        );
+        loser.confirm_published(pending).await.unwrap();
+        newest = Some(commit.id.clone());
+    }
+    loser.reissue_superseded_own_commits_from_state().unwrap();
+    let remaining = loser_storage
+        .list_own_commit_intents(Some(&group_id))
+        .unwrap()
+        .into_iter()
+        .map(|record| record.commit_id)
+        .collect::<Vec<_>>();
+    assert!(
+        !remaining.contains(&reissued_commit.id),
+        "a confirmed commit below the rewind horizon no longer needs its intent"
+    );
+    assert!(
+        remaining.contains(&newest.expect("two later commits")),
+        "a commit still inside the horizon keeps its intent"
+    );
+}
+
+#[tokio::test]
+async fn superseded_profile_edit_on_the_same_field_is_reported_as_a_conflict() {
+    let (mut alice, alice_storage, mut bob, bob_storage, group_id, alice_commit_id, bob_commit_id) =
+        race_profile_edits((Some("alice's name"), None), (Some("bob's name"), None)).await;
+    let alice_wins = committer_wins(&alice.self_id(), &bob.self_id());
+    let (loser, loser_storage, loser_commit_id, winner_name) = if alice_wins {
+        (&mut bob, &bob_storage, &bob_commit_id, "alice's name")
+    } else {
+        (&mut alice, &alice_storage, &alice_commit_id, "bob's name")
+    };
+    let reports = loser.reissue_superseded_own_commits_from_state().unwrap();
+    assert_eq!(reports.len(), 1, "{reports:?}");
+    assert_eq!(reports[0].commit_id, *loser_commit_id);
+    assert_eq!(reports[0].outcome, SupersededIntentOutcome::Conflict);
+    assert!(
+        loser_storage
+            .list_queued_outbound_intents(&group_id)
+            .unwrap()
+            .is_empty(),
+        "a conflicting edit is dropped, never re-queued"
+    );
+    for storage in [&alice_storage, &bob_storage] {
+        assert_eq!(
+            storage.get_group(&group_id).unwrap().name,
+            winner_name,
+            "the winner's value stands on both devices"
+        );
+    }
 }

--- a/crates/cgka-engine/tests/hydration_quarantine.rs
+++ b/crates/cgka-engine/tests/hydration_quarantine.rs
@@ -214,6 +214,7 @@ fn seed_probe_work_rows(
             payload: vec![0x73, suffix],
         },
         created_at_ms: u64::from(suffix),
+        reissue_attempts: 0,
     };
     storage
         .put_queued_outbound_intent(&queued)
@@ -559,6 +560,27 @@ impl OutboundIntentStorage for FlakyGroupRecordStorage {
     }
     fn delete_queued_outbound_intent(&self, id: &MessageId) -> StorageResult<()> {
         self.inner.delete_queued_outbound_intent(id)
+    }
+    fn put_own_commit_intent(
+        &self,
+        record: &cgka_traits::storage::OwnCommitIntent,
+    ) -> StorageResult<()> {
+        self.inner.put_own_commit_intent(record)
+    }
+    fn own_commit_intent(
+        &self,
+        commit_id: &MessageId,
+    ) -> StorageResult<Option<cgka_traits::storage::OwnCommitIntent>> {
+        self.inner.own_commit_intent(commit_id)
+    }
+    fn list_own_commit_intents(
+        &self,
+        group_id: Option<&GroupId>,
+    ) -> StorageResult<Vec<cgka_traits::storage::OwnCommitIntent>> {
+        self.inner.list_own_commit_intents(group_id)
+    }
+    fn delete_own_commit_intent(&self, commit_id: &MessageId) -> StorageResult<()> {
+        self.inner.delete_own_commit_intent(commit_id)
     }
 }
 

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -1445,6 +1445,7 @@ fn queue_app_message_intent(
                 payload: app_payload_for(engine, b"queued before removal"),
             },
             created_at_ms: 1,
+            reissue_attempts: 0,
         })
         .expect("queue outbound intent");
     id

--- a/crates/cgka-engine/tests/publish_lifecycle.rs
+++ b/crates/cgka-engine/tests/publish_lifecycle.rs
@@ -1129,6 +1129,27 @@ impl OutboundIntentStorage for FaultStorage {
     fn delete_queued_outbound_intent(&self, id: &MessageId) -> StorageResult<()> {
         self.inner.delete_queued_outbound_intent(id)
     }
+    fn put_own_commit_intent(
+        &self,
+        record: &cgka_traits::storage::OwnCommitIntent,
+    ) -> StorageResult<()> {
+        self.inner.put_own_commit_intent(record)
+    }
+    fn own_commit_intent(
+        &self,
+        commit_id: &MessageId,
+    ) -> StorageResult<Option<cgka_traits::storage::OwnCommitIntent>> {
+        self.inner.own_commit_intent(commit_id)
+    }
+    fn list_own_commit_intents(
+        &self,
+        group_id: Option<&GroupId>,
+    ) -> StorageResult<Vec<cgka_traits::storage::OwnCommitIntent>> {
+        self.inner.list_own_commit_intents(group_id)
+    }
+    fn delete_own_commit_intent(&self, commit_id: &MessageId) -> StorageResult<()> {
+        self.inner.delete_own_commit_intent(commit_id)
+    }
 }
 
 impl OutboundFanoutStorage for FaultStorage {

--- a/crates/cgka-engine/tests/record_write_atomicity.rs
+++ b/crates/cgka-engine/tests/record_write_atomicity.rs
@@ -461,6 +461,27 @@ impl OutboundIntentStorage for FaultStorage {
     fn delete_queued_outbound_intent(&self, id: &MessageId) -> StorageResult<()> {
         self.inner.delete_queued_outbound_intent(id)
     }
+    fn put_own_commit_intent(
+        &self,
+        record: &cgka_traits::storage::OwnCommitIntent,
+    ) -> StorageResult<()> {
+        self.inner.put_own_commit_intent(record)
+    }
+    fn own_commit_intent(
+        &self,
+        commit_id: &MessageId,
+    ) -> StorageResult<Option<cgka_traits::storage::OwnCommitIntent>> {
+        self.inner.own_commit_intent(commit_id)
+    }
+    fn list_own_commit_intents(
+        &self,
+        group_id: Option<&GroupId>,
+    ) -> StorageResult<Vec<cgka_traits::storage::OwnCommitIntent>> {
+        self.inner.list_own_commit_intents(group_id)
+    }
+    fn delete_own_commit_intent(&self, commit_id: &MessageId) -> StorageResult<()> {
+        self.inner.delete_own_commit_intent(commit_id)
+    }
 }
 
 impl OutboundFanoutStorage for FaultStorage {

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -14,7 +14,7 @@ use cgka_engine::{Engine, EngineBuilder};
 use cgka_traits::app_components::{AppComponentId, AppComponentSet, default_group_components};
 use cgka_traits::engine::{
     CgkaEngine, CreateGroupRequest, GroupEvent, GroupHydrationQuarantineReason, KeyPackage,
-    SendIntent, SendResult,
+    SendIntent, SendResult, SupersededIntentReport,
 };
 use cgka_traits::engine_state::PendingStateRef;
 use cgka_traits::error::EngineError;
@@ -1067,6 +1067,21 @@ impl AccountDeviceSession {
         group_id: &GroupId,
     ) -> SessionResult<Option<u64>> {
         Ok(self.engine.deferred_peel_cutoff_delay_ms(group_id)?)
+    }
+
+    /// See `Engine::reissue_superseded_own_commit` (mdk#1734).
+    pub fn reissue_superseded_own_commit(
+        &mut self,
+        commit_id: &MessageId,
+    ) -> SessionResult<Option<SupersededIntentReport>> {
+        Ok(self.engine.reissue_superseded_own_commit(commit_id)?)
+    }
+
+    /// See `Engine::reissue_superseded_own_commits_from_state` (mdk#1734).
+    pub fn reissue_superseded_own_commits_from_state(
+        &mut self,
+    ) -> SessionResult<Vec<SupersededIntentReport>> {
+        Ok(self.engine.reissue_superseded_own_commits_from_state()?)
     }
 
     pub fn confirm_regenerated_queued_intent(

--- a/crates/cli/src/daemon/runtime_host.rs
+++ b/crates/cli/src/daemon/runtime_host.rs
@@ -703,6 +703,11 @@ pub(crate) async fn handle_app_runtime_event(
         // operators through the runtime event stream and the group's forensic
         // `epoch_stall_backfill_escalated` row.
         marmot_app::MarmotAppEvent::EpochStallEscalated { .. } => {}
+        // A same-epoch race withdrew one of this device's own group changes.
+        // The runtime already re-issued it or classified why it cannot; the
+        // report reaches operators through the runtime event stream, and
+        // there is no activity summary shape for it.
+        marmot_app::MarmotAppEvent::GroupChangeSuperseded { .. } => {}
     }
 }
 

--- a/crates/marmot-account/AGENTS.md
+++ b/crates/marmot-account/AGENTS.md
@@ -54,6 +54,12 @@ relay auth, or transport-specific relay discovery.
   is a terminal verdict (`local_member_removed` is the live one), and re-arming it would send a `SelfUpdate` into a group
   the device has left, once per tick, uncounted by `MaintenanceRunSummary.failures`. `Complete` is deliberately not
   guarded — a withdrawn commit un-completing the obligation it satisfied is the PCS re-arm this layer owes.
+- The same two reconcilers also hand a withdrawn own commit's intent back to the engine
+  (`reissue_superseded_own_commit` on the event path, `reissue_superseded_own_commits_from_state` in
+  `run_due_maintenance`) and return the engine's `SupersededIntentReport`s in `AccountDeviceEffects::superseded_intents`.
+  Every seam that produces effects must carry them through (`extend`/`absorb`); `marmot-app` turns each report into one
+  `MarmotAppEvent::GroupChangeSuperseded`, so a report dropped here is a saved change the user is never told was lost
+  (mdk#1734).
 - Roll back pending work when publication fails before any external exposure is possible. Once publication intent is durable and a relay may have accepted work, retain the journaled state and retry the exact or replaceable publication instead.
 - Do not log account ids, group ids, relay URLs, message ids, pubkeys, payloads, ciphertext, plaintext, or key material.
 

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -12,6 +12,7 @@ use cgka_session::{
 use cgka_traits::AppComponentId;
 use cgka_traits::engine::{
     CreateGroupRequest, GroupEvent, GroupHydrationQuarantineReason, KeyPackage, SendIntent,
+    SupersededIntentReport,
 };
 use cgka_traits::engine_state::PendingStateRef;
 use cgka_traits::group::{Group, Member};
@@ -1354,7 +1355,8 @@ where
         // supersessions whose announcement never reached
         // `reconcile_superseded_maintenance`. This is the maintenance sweep, so
         // it is where a stranded evolution would otherwise do its damage.
-        self.reconcile_superseded_maintenance_from_state(now)?;
+        let superseded = self.reconcile_superseded_maintenance_from_state(now)?;
+        output.superseded_intents.extend(superseded);
         // Fanout of an already-acknowledged exact event is publication
         // recovery, not a new preparation, so it continues while paused.
         if self.key_package_has_pending_fanout()?
@@ -1951,7 +1953,8 @@ where
         output.absorb_session_effects(rollback_effects, &mut queue);
         self.publish_queue(&mut output, &mut queue, None).await?;
         self.reconcile_confirmed_own_leaf_rotations(&output.events)?;
-        self.reconcile_superseded_maintenance(&output.events)?;
+        let superseded = self.reconcile_superseded_maintenance(&output.events)?;
+        output.superseded_intents.extend(superseded);
         Ok(output)
     }
 
@@ -2290,7 +2293,8 @@ where
         output.absorb_session_effects(effects, &mut queue);
         self.publish_queue(&mut output, &mut queue, context).await?;
         self.reconcile_confirmed_own_leaf_rotations(&output.events)?;
-        self.reconcile_superseded_maintenance(&output.events)?;
+        let superseded = self.reconcile_superseded_maintenance(&output.events)?;
+        output.superseded_intents.extend(superseded);
         Ok(output)
     }
 
@@ -2464,7 +2468,8 @@ where
         }
         self.publish_queue(&mut output, &mut queue, None).await?;
         self.reconcile_confirmed_own_leaf_rotations(&output.events)?;
-        self.reconcile_superseded_maintenance(&output.events)?;
+        let superseded = self.reconcile_superseded_maintenance(&output.events)?;
+        output.superseded_intents.extend(superseded);
         Ok((output, blocked_groups))
     }
 
@@ -2532,7 +2537,13 @@ where
         Ok(())
     }
 
-    fn reconcile_superseded_maintenance(&mut self, events: &[GroupEvent]) -> AccountResult<()> {
+    /// Retire the evolutions behind commits this batch announced as
+    /// superseded, and decide what becomes of the intent behind each own
+    /// commit (mdk#1734). Returns the per-commit decisions for the effects.
+    fn reconcile_superseded_maintenance(
+        &mut self,
+        events: &[GroupEvent],
+    ) -> AccountResult<Vec<SupersededIntentReport>> {
         let superseded = events
             .iter()
             .filter_map(|event| match event {
@@ -2545,10 +2556,11 @@ where
             })
             .collect::<Vec<_>>();
         if superseded.is_empty() {
-            return Ok(());
+            return Ok(Vec::new());
         }
 
         let now = self.wall_clock.now();
+        let mut reports = Vec::new();
         for (group_id, invalidated_commit_id) in superseded {
             let evolutions = self.session.group_evolutions_for_group(&group_id)?;
             for evolution in evolutions.into_iter().filter(|evolution| {
@@ -2557,8 +2569,14 @@ where
             }) {
                 self.mark_evolution_superseded(evolution, now)?;
             }
+            if let Some(report) = self
+                .session
+                .reissue_superseded_own_commit(&invalidated_commit_id)?
+            {
+                reports.push(report);
+            }
         }
-        Ok(())
+        Ok(reports)
     }
 
     /// Re-derive a supersession whose `GroupStateInvalidated` announcement was
@@ -2596,7 +2614,10 @@ where
     /// here — and the event path never un-marks a superseded evolution, so
     /// neither does this. It is therefore a fixed point: a converged account
     /// writes nothing, and a flipped evolution is skipped on every later run.
-    fn reconcile_superseded_maintenance_from_state(&mut self, now: Timestamp) -> AccountResult<()> {
+    fn reconcile_superseded_maintenance_from_state(
+        &mut self,
+        now: Timestamp,
+    ) -> AccountResult<Vec<SupersededIntentReport>> {
         for evolution in self.session.group_evolutions()? {
             if evolution.phase == GroupEvolutionPhase::SupersededByConvergence {
                 continue;
@@ -2612,7 +2633,9 @@ where
             }
             self.mark_evolution_superseded(evolution, now)?;
         }
-        Ok(())
+        // Own commits carry their intent separately from evolutions; derive
+        // their supersession from the same stored dispositions (mdk#1734).
+        Ok(self.session.reissue_superseded_own_commits_from_state()?)
     }
 
     /// Retire an evolution that branch selection superseded, and settle the
@@ -4537,6 +4560,11 @@ pub struct AccountDeviceEffects {
     /// group so the caller can re-deliver the stored welcome via
     /// [`AccountDeviceRuntime::redeliver_welcome`] without re-committing.
     pub welcome_failures: Vec<WelcomeDeliveryFailure>,
+    /// Own commits that convergence superseded during this batch, with what
+    /// became of the intent behind each: re-queued for the next drain, or
+    /// dropped with a stated reason (mdk#1734). Hosts surface these to the
+    /// user; the original command already returned success.
+    pub superseded_intents: Vec<SupersededIntentReport>,
     pub pending: Vec<PendingResolution>,
     pub maintenance_disposition: SendMaintenanceDisposition,
 }
@@ -4591,6 +4619,8 @@ impl AccountDeviceEffects {
         self.published_app_messages
             .append(&mut other.published_app_messages);
         self.welcome_failures.append(&mut other.welcome_failures);
+        self.superseded_intents
+            .append(&mut other.superseded_intents);
         self.pending.append(&mut other.pending);
         if other.maintenance_disposition
             == SendMaintenanceDisposition::PostJoinRotationPendingRetryable

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -386,6 +386,9 @@ pub struct AppClient {
     /// `WelcomeDeliveryPending` event so callers learn a member is unjoinable
     /// without polling (mdk#352).
     pub(crate) pending_welcome_delivery_events: Vec<PendingWelcomeDelivery>,
+    /// Superseded own commits awaiting a `GroupChangeSuperseded` runtime event
+    /// (mdk#1734). Deduplicated by commit id across effect batches.
+    pub(crate) pending_superseded_change_events: Vec<cgka_traits::engine::SupersededIntentReport>,
     /// Canonical create/invite work whose Welcome fanout has not run yet.
     /// The managed account worker replies first, then drives this delivery.
     pub(crate) unpublished_welcome_delivery: Option<UnpublishedWelcomeDelivery>,
@@ -4490,7 +4493,39 @@ impl AppClient {
         Ok(())
     }
 
+    /// Queue this batch's superseded own commits for the runtime worker to
+    /// broadcast as `GroupChangeSuperseded` events (mdk#1734).
+    pub(crate) fn note_superseded_intent_reports(
+        &mut self,
+        effects: &marmot_account::AccountDeviceEffects,
+    ) {
+        for report in &effects.superseded_intents {
+            if self
+                .pending_superseded_change_events
+                .iter()
+                .any(|pending| pending.commit_id == report.commit_id)
+            {
+                continue;
+            }
+            tracing::info!(
+                target: "marmot_app::client",
+                method = "note_superseded_intent_reports",
+                kind = report.kind.as_str(),
+                outcome = report.outcome.as_str(),
+                "convergence superseded an own commit"
+            );
+            self.pending_superseded_change_events.push(report.clone());
+        }
+    }
+
+    pub(crate) fn take_pending_superseded_change_events(
+        &mut self,
+    ) -> Vec<cgka_traits::engine::SupersededIntentReport> {
+        std::mem::take(&mut self.pending_superseded_change_events)
+    }
+
     fn remember_published_reports(&mut self, effects: &marmot_account::AccountDeviceEffects) {
+        self.note_superseded_intent_reports(effects);
         self.pending_convergence_groups
             .extend(effects.pending_convergence.iter().cloned());
         if effects.reports.is_empty() {

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -4247,6 +4247,7 @@ impl AppClient {
         source_message_id_hex: &str,
         source_received_at: u64,
     ) -> Result<bool, AppError> {
+        self.note_superseded_intent_reports(effects);
         // MLS member ids in this design are the Nostr account pubkey hex, so a
         // membership change whose subject matches the local account id hex is
         // the local account leaving / being removed (or, for joins, returning).

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -102,6 +102,9 @@ mod root_runtime_lease;
 mod runtime;
 mod sqlcipher;
 
+pub use cgka_traits::engine::{
+    SupersededIntentKind, SupersededIntentOutcome, SupersededIntentReport,
+};
 use external_signer::{AccountSigner, RegisteredExternalSigner};
 pub use external_signer::{EXTERNAL_SIGNER_REJECTED, ExternalAccountSigner};
 pub(crate) use groups::AppGroupImageInput;
@@ -1736,6 +1739,7 @@ impl MarmotApp {
             #[cfg(test)]
             force_event_group_projection_unavailable: false,
             pending_welcome_delivery_events: Vec::new(),
+            pending_superseded_change_events: Vec::new(),
             unpublished_welcome_delivery: None,
             epoch_stall: crate::client::epoch_stall::EpochStallDetector::default()
                 .with_wedge_rearm_interval_ms(wedge_rearm_interval_ms),

--- a/crates/marmot-app/src/notifications.rs
+++ b/crates/marmot-app/src/notifications.rs
@@ -1602,6 +1602,7 @@ pub(crate) fn notification_update_from_event_cached(
         | MarmotAppEvent::AgentStreamStarted(_)
         | MarmotAppEvent::WelcomeDeliveryPending { .. }
         | MarmotAppEvent::EpochStallEscalated { .. }
+        | MarmotAppEvent::GroupChangeSuperseded { .. }
         | MarmotAppEvent::AccountError(_) => Ok(None),
     }
 }

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -1098,6 +1098,19 @@ async fn run_app_runtime_account_worker(
                                     match client.advance_convergence_after_runtime_sync(&group_id).await {
                                         Ok(summary) => {
                                             publish_app_runtime_summary(&events, &account_id_hex, &account_label, &summary);
+                                            // A pass that superseded one of this
+                                            // device's own commits reports it
+                                            // through the client's pending
+                                            // buffer; this arm is the only seam
+                                            // that can observe such a pass
+                                            // without a later command to drain
+                                            // it (mdk#1734).
+                                            publish_client_pending_projection_updates(
+                                                &mut client,
+                                                &events,
+                                                &account_id_hex,
+                                                &account_label,
+                                            );
                                             match client.convergence_schedule_state(&group_id) {
                                                 Ok(state) => scheduled_convergence
                                                     .schedule_after_pass(&group_id, state),
@@ -1311,6 +1324,16 @@ async fn run_app_runtime_account_worker(
                     Ok(summary) => {
                         reconnect_backoff.reset();
                         publish_app_runtime_summary(&events, &account_id_hex, &account_label, &summary);
+                        // An inline convergence pass on a delivered rival can
+                        // supersede one of this device's own commits; the
+                        // report waits in the client's pending buffer and this
+                        // arm has no later command to drain it (mdk#1734).
+                        publish_client_pending_projection_updates(
+                            &mut client,
+                            &events,
+                            &account_id_hex,
+                            &account_label,
+                        );
                         start_post_join_history_after_visibility(
                             &mut client,
                             &summary,
@@ -2640,6 +2663,12 @@ async fn handle_account_worker_command(
             let result = match client.sync_with_classified_partial_progress().await {
                 Ok(summary) => {
                     publish_app_runtime_summary(events, account_id_hex, account_label, &summary);
+                    publish_client_pending_projection_updates(
+                        client,
+                        events,
+                        account_id_hex,
+                        account_label,
+                    );
                     let backfill_result = run_pending_epoch_backfill_reporting_arm(
                         client,
                         events,
@@ -2697,6 +2726,12 @@ async fn handle_account_worker_command(
             let result = match client.repair_full_history().await {
                 Ok(summary) => {
                     publish_app_runtime_summary(events, account_id_hex, account_label, &summary);
+                    publish_client_pending_projection_updates(
+                        client,
+                        events,
+                        account_id_hex,
+                        account_label,
+                    );
                     if sync_summary_triggers_audit_tracker_update(&summary) {
                         shared.schedule_audit_log_tracker_update("repair_full_history");
                     }
@@ -4622,6 +4657,19 @@ fn publish_client_pending_projection_updates(
 ) {
     for update in client.take_pending_projection_updates() {
         publish_app_runtime_projection_update(events, account_id_hex, account_label, update);
+    }
+    // Superseded own commits ride the same drain: every worker seam that can
+    // observe convergence effects already flushes projection updates here.
+    for report in client.take_pending_superseded_change_events() {
+        let _ = events.send(MarmotAppEvent::GroupChangeSuperseded {
+            account_id_hex: account_id_hex.to_owned(),
+            account_label: account_label.to_owned(),
+            group_id: report.group_id,
+            commit_id_hex: hex::encode(report.commit_id.as_slice()),
+            kind: report.kind,
+            outcome: report.outcome,
+            reason: report.reason,
+        });
     }
 }
 

--- a/crates/marmot-app/src/runtime/event_routing.rs
+++ b/crates/marmot-app/src/runtime/event_routing.rs
@@ -24,6 +24,7 @@ pub(crate) fn runtime_message_update_from_event(
         | MarmotAppEvent::GroupEvent(_)
         | MarmotAppEvent::WelcomeDeliveryPending { .. }
         | MarmotAppEvent::EpochStallEscalated { .. }
+        | MarmotAppEvent::GroupChangeSuperseded { .. }
         | MarmotAppEvent::AccountError(_) => None,
     }
 }
@@ -40,6 +41,7 @@ pub(crate) fn projection_update_from_event(
         | MarmotAppEvent::GroupEvent(_)
         | MarmotAppEvent::WelcomeDeliveryPending { .. }
         | MarmotAppEvent::EpochStallEscalated { .. }
+        | MarmotAppEvent::GroupChangeSuperseded { .. }
         | MarmotAppEvent::AccountError(_) => None,
     }
 }
@@ -89,6 +91,7 @@ pub(crate) fn runtime_group_event_route(event: &MarmotAppEvent) -> Option<(&str,
         | MarmotAppEvent::AgentStreamStarted(_)
         | MarmotAppEvent::WelcomeDeliveryPending { .. }
         | MarmotAppEvent::EpochStallEscalated { .. }
+        | MarmotAppEvent::GroupChangeSuperseded { .. }
         | MarmotAppEvent::AccountError(_) => None,
     }
 }
@@ -114,6 +117,7 @@ pub(crate) fn chat_list_event_route(event: &MarmotAppEvent) -> Option<(&str, &Gr
         | MarmotAppEvent::AgentStreamStarted(_)
         | MarmotAppEvent::WelcomeDeliveryPending { .. }
         | MarmotAppEvent::EpochStallEscalated { .. }
+        | MarmotAppEvent::GroupChangeSuperseded { .. }
         | MarmotAppEvent::AccountError(_) => None,
     }
 }
@@ -150,6 +154,7 @@ pub(crate) fn chat_list_trigger_from_event(event: &MarmotAppEvent) -> ChatListUp
         // A stalled group's escalation reports a repair need, not a state
         // change: the chat list has nothing new to show for it.
         | MarmotAppEvent::EpochStallEscalated { .. }
+        | MarmotAppEvent::GroupChangeSuperseded { .. }
         | MarmotAppEvent::AccountError(_) => ChatListUpdateTrigger::SnapshotRefresh,
     }
 }

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -1158,6 +1158,22 @@ pub enum MarmotAppEvent {
         stalled_epoch: u64,
         arms: u32,
     },
+    /// Convergence superseded a commit this device authored after its command
+    /// had already returned success (mdk#1734). `outcome` says what became of
+    /// the change: re-queued and about to be re-issued, or dropped for the
+    /// stated `reason` (the winner changed the same field, the request is
+    /// already satisfied, an invite needs fresh material, or the engine gave
+    /// up). Hosts should tell the user when a change they saw saved was not
+    /// re-applied.
+    GroupChangeSuperseded {
+        account_id_hex: String,
+        account_label: String,
+        group_id: GroupId,
+        commit_id_hex: String,
+        kind: cgka_traits::engine::SupersededIntentKind,
+        outcome: cgka_traits::engine::SupersededIntentOutcome,
+        reason: &'static str,
+    },
 }
 
 impl MarmotAppRuntime {

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -5933,12 +5933,23 @@ async fn app_runtime_message_subscription_kinds_filter_applies_to_live_updates()
 
 async fn wait_for_event<F>(
     events: &mut tokio::sync::broadcast::Receiver<MarmotAppEvent>,
+    matches_event: F,
+) -> MarmotAppEvent
+where
+    F: FnMut(&MarmotAppEvent) -> bool,
+{
+    wait_for_event_within(events, Duration::from_secs(5), matches_event).await
+}
+
+async fn wait_for_event_within<F>(
+    events: &mut tokio::sync::broadcast::Receiver<MarmotAppEvent>,
+    budget: Duration,
     mut matches_event: F,
 ) -> MarmotAppEvent
 where
     F: FnMut(&MarmotAppEvent) -> bool,
 {
-    timeout(Duration::from_secs(5), async {
+    timeout(budget, async {
         loop {
             let event = events.recv().await.unwrap();
             if matches_event(&event) {
@@ -13390,4 +13401,254 @@ async fn onboarding_cancelled_new_identity_can_resume_through_legacy_login() {
         marmot_app::AccountSetupReadiness::NetworkReady
     );
     runtime.shutdown_and_close().await.unwrap();
+}
+
+/// Two admins commit different profile fields at the same instant. The loser's
+/// runtime already told its caller the edit saved, so once convergence parks
+/// that commit the intent must be re-issued against the canonical state and
+/// every member must end up with both fields; the runtime announces the
+/// re-issue as a `GroupChangeSuperseded` event (mdk#1734).
+async fn race_two_admin_profile_edits(
+    alice_edit: (Option<&str>, Option<&str>),
+    bob_edit: (Option<&str>, Option<&str>),
+) -> (
+    RaceFixture,
+    MarmotAppRuntime,
+    MarmotApp,
+    tokio::sync::broadcast::Receiver<MarmotAppEvent>,
+    GroupId,
+    Vec<(String, String)>,
+) {
+    // Both returned to the caller: dropping the account home mid-test makes
+    // every later account-home read fail with `account_home_unknown_account`,
+    // and dropping the relay handle stops the relay the loser still needs.
+    let dir = tempfile::tempdir().unwrap();
+    let gate = BlockNextGroupMessages::new();
+    let (relay, app, url) = group_message_blocking_app(&dir, gate.clone()).await;
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let setup = || AccountSetupRequest {
+        default_relays: vec![endpoint(&url)],
+        bootstrap_relays: vec![endpoint(&url)],
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+    let alice = create_network_ready_identity(&runtime, setup().relay_options_only()).await;
+    let bob = create_network_ready_identity(&runtime, setup()).await;
+    let carol = create_network_ready_identity(&runtime, setup()).await;
+    let alice_id = alice.account.account_id_hex.clone();
+    let bob_id = bob.account.account_id_hex.clone();
+    let carol_id = carol.account.account_id_hex.clone();
+    let mut events = runtime.subscribe();
+    let group_id = runtime
+        .create_group(
+            &alice_id,
+            "before",
+            &[bob_id.clone(), carol_id.clone()],
+            None,
+        )
+        .await
+        .unwrap();
+    // Both invitees join concurrently, in either order: waiting for one at a
+    // time would consume and drop the other's `GroupJoined`.
+    let mut awaiting_join: std::collections::HashSet<String> =
+        [bob_id.clone(), carol_id.clone()].into_iter().collect();
+    while !awaiting_join.is_empty() {
+        let joined_event = wait_for_event_within(&mut events, Duration::from_secs(20), |event| {
+            matches!(
+                event,
+                MarmotAppEvent::GroupJoined { account_id_hex, group_id: joined, .. }
+                    if awaiting_join.contains(account_id_hex) && joined == &group_id
+            )
+        })
+        .await;
+        if let MarmotAppEvent::GroupJoined { account_id_hex, .. } = joined_event {
+            awaiting_join.remove(&account_id_hex);
+        }
+    }
+    for member in [&bob_id, &carol_id] {
+        accept_group_invite_retrying_busy(&runtime, member, &group_id)
+            .await
+            .unwrap();
+    }
+    runtime
+        .promote_admin(&alice_id, &group_id, &bob_id)
+        .await
+        .unwrap();
+    // Let the promotion settle everywhere before racing, so both commits fork
+    // from the same epoch.
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    loop {
+        let mut epochs = Vec::new();
+        for id in [&alice_id, &bob_id, &carol_id] {
+            epochs.push(runtime.group_mls_state(id, &group_id).await.unwrap().epoch);
+        }
+        if epochs.iter().all(|epoch| *epoch == epochs[0]) && epochs[0] >= 2 {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "members did not settle after the admin promotion: {epochs:?}"
+        );
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    // A fresh subscription for the race itself: the settle loop above does not
+    // drain events, and a lagged receiver would drop the announcement.
+    let events = runtime.subscribe();
+    gate.arm(2);
+    let (alice_runtime, bob_runtime) = (runtime.clone(), runtime.clone());
+    let (alice_gid, bob_gid) = (group_id.clone(), group_id.clone());
+    let (alice_for, bob_for) = (alice_id.clone(), bob_id.clone());
+    let (alice_name, alice_description) = (
+        alice_edit.0.map(str::to_owned),
+        alice_edit.1.map(str::to_owned),
+    );
+    let (bob_name, bob_description) =
+        (bob_edit.0.map(str::to_owned), bob_edit.1.map(str::to_owned));
+    let alice_edit = tokio::spawn(async move {
+        alice_runtime
+            .update_group_profile(&alice_for, &alice_gid, alice_name, alice_description)
+            .await
+    });
+    let bob_edit = tokio::spawn(async move {
+        bob_runtime
+            .update_group_profile(&bob_for, &bob_gid, bob_name, bob_description)
+            .await
+    });
+    timeout(Duration::from_secs(10), gate.wait_for_blocked(2))
+        .await
+        .expect("both profile edits should overlap at commit publication");
+    gate.release();
+    alice_edit.await.unwrap().expect("alice's edit is accepted");
+    bob_edit.await.unwrap().expect("bob's edit is accepted");
+
+    let labels = vec![
+        (alice.account.label.clone(), alice_id),
+        (bob.account.label.clone(), bob_id),
+        (carol.account.label.clone(), carol_id),
+    ];
+    (
+        RaceFixture {
+            _dir: dir,
+            _relay: relay,
+        },
+        runtime,
+        app,
+        events,
+        group_id,
+        labels,
+    )
+}
+
+/// Keeps the account home and the local relay alive for the whole test.
+struct RaceFixture {
+    _dir: tempfile::TempDir,
+    _relay: LocalRelay,
+}
+
+async fn wait_for_profile_everywhere(
+    app: &MarmotApp,
+    labels: &[(String, String)],
+    group_id: &GroupId,
+    expected: (&str, &str),
+) {
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        let profiles = labels
+            .iter()
+            .map(|(label, _)| {
+                let group = app.group(label, &group_id_hex).unwrap().unwrap();
+                (group.profile.name, group.profile.description)
+            })
+            .collect::<Vec<_>>();
+        if profiles
+            .iter()
+            .all(|(name, description)| name == expected.0 && description == expected.1)
+        {
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "members did not converge on the expected profile {expected:?}; got {profiles:?}"
+        );
+        sleep(Duration::from_millis(100)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn superseded_profile_edit_on_a_different_field_is_reissued_and_announced() {
+    let (_fixture, runtime, app, mut events, group_id, labels) = race_two_admin_profile_edits(
+        (Some("alice renamed it"), None),
+        (None, Some("bob described it")),
+    )
+    .await;
+    // Whichever commit lost, its edit touched a field the winner left alone,
+    // so the loser announces the re-issue and both fields land on every device.
+    wait_for_event_within(&mut events, Duration::from_secs(30), |event| {
+        matches!(
+            event,
+            MarmotAppEvent::GroupChangeSuperseded { group_id: changed, kind, outcome, .. }
+                if changed == &group_id
+                    && *kind == marmot_app::SupersededIntentKind::GroupProfile
+                    && *outcome == marmot_app::SupersededIntentOutcome::Reissued
+        )
+    })
+    .await;
+    wait_for_profile_everywhere(
+        &app,
+        &labels,
+        &group_id,
+        ("alice renamed it", "bob described it"),
+    )
+    .await;
+    runtime.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn superseded_profile_edit_on_the_same_field_is_reported_as_a_conflict() {
+    let (_fixture, runtime, app, mut events, group_id, labels) =
+        race_two_admin_profile_edits((Some("alice's name"), None), (Some("bob's name"), None))
+            .await;
+    // The loser learns of the race only when the winning commit reaches it and
+    // a convergence pass adjudicates, on real relay timing.
+    let conflict = wait_for_event_within(&mut events, Duration::from_secs(30), |event| {
+        matches!(
+            event,
+            MarmotAppEvent::GroupChangeSuperseded { group_id: changed, kind, outcome, .. }
+                if changed == &group_id
+                    && *kind == marmot_app::SupersededIntentKind::GroupProfile
+                    && *outcome == marmot_app::SupersededIntentOutcome::Conflict
+        )
+    })
+    .await;
+    // The winner's name stands everywhere; the loser's is dropped, not replayed.
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    let winner_name = loop {
+        let names = labels
+            .iter()
+            .map(|(label, _)| {
+                app.group(label, &group_id_hex)
+                    .unwrap()
+                    .unwrap()
+                    .profile
+                    .name
+            })
+            .collect::<Vec<_>>();
+        if names.iter().all(|name| name == &names[0]) && names[0] != "before" {
+            break names[0].clone();
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "members did not converge on one name; got {names:?}"
+        );
+        sleep(Duration::from_millis(100)).await;
+    };
+    assert!(
+        winner_name == "alice's name" || winner_name == "bob's name",
+        "{winner_name}"
+    );
+    drop(conflict);
+    runtime.shutdown().await;
 }

--- a/crates/marmot-c/include/marmot.h
+++ b/crates/marmot-c/include/marmot.h
@@ -3378,6 +3378,16 @@ typedef enum MarmotEvent_Tag {
    * between: the group cannot catch up; re-syncing is recommended.
    */
   MARMOT_EVENT_EPOCH_STALL_ESCALATED,
+  /**
+   * A group change this device committed lost a same-epoch race and was
+   * withdrawn by branch selection. `kind` names the change
+   * (`group_profile`, `app_components`, `remove_members`, `invite`),
+   * `outcome` what the runtime did about it (`reissued`, `conflict`,
+   * `already_satisfied`, `reinvite_required`, `abandoned`, `not_member`),
+   * and `reason` a stable explanation. Only `reissued` needs no user
+   * action; every other outcome means the change did not land.
+   */
+  MARMOT_EVENT_GROUP_CHANGE_SUPERSEDED,
 } MarmotEvent_Tag;
 
 typedef struct MarmotEvent_GroupJoined_Body {
@@ -3434,6 +3444,16 @@ typedef struct MarmotEvent_EpochStallEscalated_Body {
   uint32_t arms;
 } MarmotEvent_EpochStallEscalated_Body;
 
+typedef struct MarmotEvent_GroupChangeSuperseded_Body {
+  char *account_id_hex;
+  char *account_label;
+  char *group_id_hex;
+  char *commit_id_hex;
+  char *kind;
+  char *outcome;
+  char *reason;
+} MarmotEvent_GroupChangeSuperseded_Body;
+
 typedef struct MarmotEvent {
   MarmotEvent_Tag tag;
   union {
@@ -3446,6 +3466,7 @@ typedef struct MarmotEvent {
     MarmotEvent_AgentStreamActivity_Body AGENT_STREAM_ACTIVITY;
     MarmotEvent_WelcomeDeliveryPending_Body WELCOME_DELIVERY_PENDING;
     MarmotEvent_EpochStallEscalated_Body EPOCH_STALL_ESCALATED;
+    MarmotEvent_GroupChangeSuperseded_Body GROUP_CHANGE_SUPERSEDED;
   };
 } MarmotEvent;
 

--- a/crates/marmot-c/src/types/event.rs
+++ b/crates/marmot-c/src/types/event.rs
@@ -278,6 +278,22 @@ pub enum MarmotEvent {
         stalled_epoch: u64,
         arms: u32,
     },
+    /// A group change this device committed lost a same-epoch race and was
+    /// withdrawn by branch selection. `kind` names the change
+    /// (`group_profile`, `app_components`, `remove_members`, `invite`),
+    /// `outcome` what the runtime did about it (`reissued`, `conflict`,
+    /// `already_satisfied`, `reinvite_required`, `abandoned`, `not_member`),
+    /// and `reason` a stable explanation. Only `reissued` needs no user
+    /// action; every other outcome means the change did not land.
+    GroupChangeSuperseded {
+        account_id_hex: *mut c_char,
+        account_label: *mut c_char,
+        group_id_hex: *mut c_char,
+        commit_id_hex: *mut c_char,
+        kind: *mut c_char,
+        outcome: *mut c_char,
+        reason: *mut c_char,
+    },
 }
 
 impl From<MarmotEventFfi> for MarmotEvent {
@@ -361,6 +377,23 @@ impl From<MarmotEventFfi> for MarmotEvent {
                 stalled_epoch,
                 arms,
             },
+            F::GroupChangeSuperseded {
+                account_id_hex,
+                account_label,
+                group_id_hex,
+                commit_id_hex,
+                kind,
+                outcome,
+                reason,
+            } => Self::GroupChangeSuperseded {
+                account_id_hex: owned_c_string(account_id_hex),
+                account_label: owned_c_string(account_label),
+                group_id_hex: owned_c_string(group_id_hex),
+                commit_id_hex: owned_c_string(commit_id_hex),
+                kind: owned_c_string(kind),
+                outcome: owned_c_string(outcome),
+                reason: owned_c_string(reason),
+            },
         }
     }
 }
@@ -434,6 +467,23 @@ impl CFree for MarmotEvent {
                     free_c_string(*account_id_hex);
                     free_c_string(*account_label);
                     free_c_string(*group_id_hex);
+                }
+                Self::GroupChangeSuperseded {
+                    account_id_hex,
+                    account_label,
+                    group_id_hex,
+                    commit_id_hex,
+                    kind,
+                    outcome,
+                    reason,
+                } => {
+                    free_c_string(*account_id_hex);
+                    free_c_string(*account_label);
+                    free_c_string(*group_id_hex);
+                    free_c_string(*commit_id_hex);
+                    free_c_string(*kind);
+                    free_c_string(*outcome);
+                    free_c_string(*reason);
                 }
             }
         }

--- a/crates/marmot-uniffi/src/conversions/event.rs
+++ b/crates/marmot-uniffi/src/conversions/event.rs
@@ -93,6 +93,23 @@ pub enum MarmotEventFfi {
         stalled_epoch: u64,
         arms: u32,
     },
+    /// A group change this device committed lost a same-epoch race and was
+    /// withdrawn by branch selection. `kind` names the change
+    /// (`group_profile`, `app_components`, `remove_members`, `invite`),
+    /// `outcome` says what the runtime did about it (`reissued`, `conflict`,
+    /// `already_satisfied`, `reinvite_required`, `abandoned`, `not_member`),
+    /// and `reason` is a stable low-cardinality explanation. Only `reissued`
+    /// needs no user action; every other outcome means the change did not
+    /// land and the host should tell the user (mdk#1734).
+    GroupChangeSuperseded {
+        account_id_hex: String,
+        account_label: String,
+        group_id_hex: String,
+        commit_id_hex: String,
+        kind: String,
+        outcome: String,
+        reason: String,
+    },
 }
 
 /// FFI projection of [`cgka_traits::engine::GroupEvent`]. The previous FFI
@@ -388,6 +405,23 @@ impl From<MarmotAppEvent> for MarmotEventFfi {
                 stalled_epoch,
                 arms,
             },
+            MarmotAppEvent::GroupChangeSuperseded {
+                account_id_hex,
+                account_label,
+                group_id,
+                commit_id_hex,
+                kind,
+                outcome,
+                reason,
+            } => Self::GroupChangeSuperseded {
+                account_id_hex,
+                account_label,
+                group_id_hex: hex::encode(group_id.as_slice()),
+                commit_id_hex,
+                kind: kind.as_str().to_owned(),
+                outcome: outcome.as_str().to_owned(),
+                reason: reason.to_owned(),
+            },
         }
     }
 }
@@ -414,6 +448,39 @@ mod tests {
             } => {
                 assert_eq!(message_id_hex, "22".repeat(32));
                 assert_eq!(resource, "transport_deferred_residence_budget");
+            }
+            other => panic!("unexpected FFI event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn superseded_group_change_reaches_the_ffi_as_stable_strings() {
+        // A host that cannot see the runtime's typed enums still has to tell
+        // "your change was re-issued" from "your change was dropped", so the
+        // kind and outcome cross as the same stable strings the runtime logs.
+        let event = MarmotAppEvent::GroupChangeSuperseded {
+            account_id_hex: "aa".repeat(32),
+            account_label: "alice".to_owned(),
+            group_id: GroupId::new(vec![0x11; 16]),
+            commit_id_hex: "22".repeat(32),
+            kind: cgka_traits::engine::SupersededIntentKind::GroupProfile,
+            outcome: cgka_traits::engine::SupersededIntentOutcome::Conflict,
+            reason: "winner changed the same field",
+        };
+        match MarmotEventFfi::from(event) {
+            MarmotEventFfi::GroupChangeSuperseded {
+                group_id_hex,
+                commit_id_hex,
+                kind,
+                outcome,
+                reason,
+                ..
+            } => {
+                assert_eq!(group_id_hex, "11".repeat(16));
+                assert_eq!(commit_id_hex, "22".repeat(32));
+                assert_eq!(kind, "group_profile");
+                assert_eq!(outcome, "conflict");
+                assert_eq!(reason, "winner changed the same field");
             }
             other => panic!("unexpected FFI event: {other:?}"),
         }

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -122,6 +122,8 @@ mod migration_0060_released_transport_receipts;
 mod migration_0061_transport_reconciliation_replay_cursor;
 #[path = "migrations/0062_chat_list_preview_indexes.rs"]
 mod migration_0062_chat_list_preview_indexes;
+#[path = "migrations/0063_own_commit_intents.rs"]
+mod migration_0063_own_commit_intents;
 #[cfg(test)]
 #[path = "migrations/test_support.rs"]
 mod test_support;
@@ -446,6 +448,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 62,
         name: "0062_chat_list_preview_indexes",
         apply: migration_0062_chat_list_preview_indexes::apply,
+    },
+    Migration {
+        version: 63,
+        name: "0063_own_commit_intents",
+        apply: migration_0063_own_commit_intents::apply,
     },
 ];
 
@@ -1042,7 +1049,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 62,
+                found: 63,
                 latest_supported: 46,
             }
         ));
@@ -1098,7 +1105,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 62,
+                found: 63,
                 latest_supported: 46,
             }
         ));
@@ -1402,7 +1409,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 62,
+                found: 63,
                 latest_supported: 46,
             }
         ));

--- a/crates/storage-sqlite/src/migrations/0063_own_commit_intents.rs
+++ b/crates/storage-sqlite/src/migrations/0063_own_commit_intents.rs
@@ -1,0 +1,22 @@
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+/// The intent behind each own commit this device stages, retained until the
+/// commit is confirmed or rolled back so a supersession by convergence can
+/// re-issue it against the canonical state (mdk#1734).
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE TABLE cgka_own_commit_intents (
+    commit_id BLOB PRIMARY KEY,
+    group_id BLOB NOT NULL REFERENCES cgka_groups(id) ON DELETE CASCADE,
+    insert_order INTEGER NOT NULL UNIQUE,
+    record BLOB NOT NULL
+);
+CREATE INDEX cgka_own_commit_intents_group_idx
+    ON cgka_own_commit_intents (group_id, insert_order);
+"#,
+    )
+    .storage()
+}

--- a/crates/storage-sqlite/src/storage/outbound.rs
+++ b/crates/storage-sqlite/src/storage/outbound.rs
@@ -3,7 +3,8 @@ use crate::connection::retry_on_busy;
 use crate::{SqliteAccountStorage, SqliteResultExt, created_at_to_i64, deserialize, serialize};
 use cgka_traits::OutboundFanout;
 use cgka_traits::storage::{
-    OutboundFanoutStorage, OutboundIntentStorage, QueuedOutboundIntent, StorageError, StorageResult,
+    OutboundFanoutStorage, OutboundIntentStorage, OwnCommitIntent, QueuedOutboundIntent,
+    StorageError, StorageResult,
 };
 use cgka_traits::types::{GroupId, MessageId};
 use rusqlite::{OptionalExtension, params};
@@ -81,6 +82,104 @@ impl OutboundIntentStorage for SqliteAccountStorage {
         };
         if changed == 0 {
             return Err(StorageError::NotFound);
+        }
+        Ok(())
+    }
+
+    fn put_own_commit_intent(&self, record: &OwnCommitIntent) -> StorageResult<()> {
+        // Written inside the send path right after a commit is staged, and
+        // read only by supersession reconcilers, so a single autocommit upsert
+        // is safe to retry on transient lock contention.
+        let serialized = serialize(record)?;
+        let write = || {
+            let conn = self.lock()?;
+            conn.execute_cached(
+                "INSERT INTO cgka_own_commit_intents (commit_id, group_id, insert_order, record)
+                 VALUES (
+                    ?1,
+                    ?2,
+                    (SELECT COALESCE(MAX(insert_order), 0) + 1 FROM cgka_own_commit_intents),
+                    ?3
+                 )
+                 ON CONFLICT(commit_id) DO UPDATE SET
+                    group_id = excluded.group_id,
+                    record = excluded.record",
+                params![
+                    record.commit_id.as_slice(),
+                    record.group_id.as_slice(),
+                    serialized,
+                ],
+            )
+            .storage()?;
+            Ok(())
+        };
+        if self.connection.is_current_thread_transaction_owner() {
+            write()
+        } else {
+            retry_on_busy(write)
+        }
+    }
+
+    fn own_commit_intent(&self, commit_id: &MessageId) -> StorageResult<Option<OwnCommitIntent>> {
+        let conn = self.lock()?;
+        let record = conn
+            .query_row_cached(
+                "SELECT record FROM cgka_own_commit_intents WHERE commit_id = ?1",
+                params![commit_id.as_slice()],
+                |row| row.get::<_, Vec<u8>>(0),
+            )
+            .optional()
+            .storage()?;
+        record.map(|record| deserialize(&record)).transpose()
+    }
+
+    fn list_own_commit_intents(
+        &self,
+        group_id: Option<&GroupId>,
+    ) -> StorageResult<Vec<OwnCommitIntent>> {
+        let conn = self.lock()?;
+        let records = match group_id {
+            Some(group_id) => {
+                let mut stmt = conn
+                    .prepare_cached(
+                        "SELECT record FROM cgka_own_commit_intents
+                         WHERE group_id = ?1
+                         ORDER BY insert_order",
+                    )
+                    .storage()?;
+                stmt.query_map(params![group_id.as_slice()], |row| row.get::<_, Vec<u8>>(0))
+                    .storage()?
+                    .collect::<Result<Vec<_>, _>>()
+                    .storage()?
+            }
+            None => {
+                let mut stmt = conn
+                    .prepare_cached(
+                        "SELECT record FROM cgka_own_commit_intents ORDER BY insert_order",
+                    )
+                    .storage()?;
+                stmt.query_map([], |row| row.get::<_, Vec<u8>>(0))
+                    .storage()?
+                    .collect::<Result<Vec<_>, _>>()
+                    .storage()?
+            }
+        };
+        records.iter().map(|record| deserialize(record)).collect()
+    }
+
+    fn delete_own_commit_intent(&self, commit_id: &MessageId) -> StorageResult<()> {
+        let delete = || {
+            self.lock()?
+                .execute_cached(
+                    "DELETE FROM cgka_own_commit_intents WHERE commit_id = ?1",
+                    params![commit_id.as_slice()],
+                )
+                .storage()
+        };
+        if self.connection.is_current_thread_transaction_owner() {
+            delete()?;
+        } else {
+            retry_on_busy(delete)?;
         }
         Ok(())
     }
@@ -363,6 +462,69 @@ mod tests {
             .map(|queued| queued.id)
             .collect();
         assert_eq!(ids, vec![mid(1)]);
+    }
+
+    #[test]
+    fn own_commit_intents_round_trip_and_list_in_insert_order() {
+        use cgka_traits::storage::{OwnCommitBaseline, OwnCommitIntent};
+        use cgka_traits::types::{GroupId, MessageId};
+        use cgka_traits::{EpochId, SendIntent};
+
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store.put_group(&sample_group(gid(1), 0, 0)).unwrap();
+        store.put_group(&sample_group(gid(2), 0, 0)).unwrap();
+        let record = |commit_id: MessageId, group_id: GroupId| OwnCommitIntent {
+            commit_id,
+            group_id: group_id.clone(),
+            source_epoch: EpochId(3),
+            intent: SendIntent::UpdateGroupData {
+                group_id,
+                name: Some("renamed".to_owned()),
+                description: None,
+            },
+            baseline: OwnCommitBaseline::GroupProfile {
+                name: "before".to_owned(),
+                description: "described".to_owned(),
+            },
+            reissue_attempts: 1,
+            created_at_ms: 42,
+        };
+        store
+            .put_own_commit_intent(&record(mid(3), gid(1)))
+            .unwrap();
+        store
+            .put_own_commit_intent(&record(mid(1), gid(1)))
+            .unwrap();
+        store
+            .put_own_commit_intent(&record(mid(2), gid(2)))
+            .unwrap();
+
+        assert_eq!(
+            store.own_commit_intent(&mid(1)).unwrap(),
+            Some(record(mid(1), gid(1))),
+            "every field must survive the round trip"
+        );
+        let ids = |group_id: Option<&GroupId>| {
+            store
+                .list_own_commit_intents(group_id)
+                .unwrap()
+                .into_iter()
+                .map(|intent| intent.commit_id)
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(ids(Some(&gid(1))), vec![mid(3), mid(1)]);
+        assert_eq!(ids(None), vec![mid(3), mid(1), mid(2)]);
+
+        store.delete_own_commit_intent(&mid(3)).unwrap();
+        store
+            .delete_own_commit_intent(&mid(3))
+            .expect("deleting a consumed record is idempotent");
+        assert_eq!(store.own_commit_intent(&mid(3)).unwrap(), None);
+        assert_eq!(ids(Some(&gid(1))), vec![mid(1)]);
+
+        // A record dies with its group.
+        store.delete_group(&gid(2)).unwrap();
+        assert_eq!(ids(None), vec![mid(1)]);
     }
 
     #[test]

--- a/crates/storage-sqlite/src/storage/test_support.rs
+++ b/crates/storage-sqlite/src/storage/test_support.rs
@@ -66,5 +66,6 @@ pub(crate) fn sample_queued_intent(id: MessageId, group_id: GroupId) -> QueuedOu
             payload: b"queued".to_vec(),
         },
         created_at_ms: 42,
+        reissue_attempts: 0,
     }
 }

--- a/crates/traits/src/engine.rs
+++ b/crates/traits/src/engine.rs
@@ -175,6 +175,76 @@ pub enum SendIntent {
 ///
 /// `GroupEvolution` carries both the commit and any welcomes produced by
 /// member additions.
+/// Which kind of own commit convergence superseded (mdk#1734).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SupersededIntentKind {
+    GroupProfile,
+    AppComponents,
+    RemoveMembers,
+    Invite,
+}
+
+impl SupersededIntentKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::GroupProfile => "group_profile",
+            Self::AppComponents => "app_components",
+            Self::RemoveMembers => "remove_members",
+            Self::Invite => "invite",
+        }
+    }
+}
+
+/// What the engine did with a superseded own commit's intent (mdk#1734).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SupersededIntentOutcome {
+    /// The intent is still valid against the canonical state and has been
+    /// queued again; the next outbound drain re-issues it.
+    Reissued,
+    /// The winning branch changed the same field or component. The caller's
+    /// edit is dropped; the winner's value stands.
+    Conflict,
+    /// The winning branch already produced the requested state (for example
+    /// it removed the same members), so there is nothing to re-issue.
+    AlreadySatisfied,
+    /// A lost invite cannot be replayed: its KeyPackages were consumed by the
+    /// parked Welcome. The inviter must re-invite with fresh material.
+    ReinviteRequired,
+    /// The intent lost more races than the engine will retry, or the outbound
+    /// queue is full; the caller must repeat the change deliberately.
+    Abandoned,
+    /// This device is no longer a member of the group.
+    NotMember,
+}
+
+impl SupersededIntentOutcome {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Reissued => "reissued",
+            Self::Conflict => "conflict",
+            Self::AlreadySatisfied => "already_satisfied",
+            Self::ReinviteRequired => "reinvite_required",
+            Self::Abandoned => "abandoned",
+            Self::NotMember => "not_member",
+        }
+    }
+}
+
+/// One superseded own commit and what became of its intent. Carries no
+/// payloads or member identities beyond the group and commit ids so it can
+/// travel through effects and runtime events unchanged (mdk#1734).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SupersededIntentReport {
+    pub group_id: GroupId,
+    pub commit_id: MessageId,
+    pub kind: SupersededIntentKind,
+    pub outcome: SupersededIntentOutcome,
+    /// Fixed, privacy-safe explanation for logs and UI copy.
+    pub reason: &'static str,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SendResult {
     /// The requested idempotent mutation was already reflected by canonical

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -9,6 +9,7 @@
 //! future backend needs async I/O (e.g. a remote KV), it can wrap sync
 //! methods in `tokio::task::spawn_blocking`.
 
+use crate::app_components::AppComponentData;
 use crate::capabilities::{CapabilityRequirement, GroupCapabilities};
 use crate::convergence_pass::DurableConvergencePass;
 use crate::engine::{GroupEvent, SendIntent};
@@ -396,6 +397,48 @@ pub struct QueuedOutboundIntent {
     pub group_id: GroupId,
     pub intent: SendIntent,
     pub created_at_ms: u64,
+    /// How many times convergence has already superseded a commit carrying
+    /// this intent and re-queued it (mdk#1734). Bounded by the engine so a
+    /// perpetually losing edit cannot re-issue forever.
+    #[serde(default)]
+    pub reissue_attempts: u32,
+}
+
+/// The group state an own commit's intent was authored against, so a later
+/// supersession can tell "the winner left my field alone" from "the winner
+/// changed the same field" (mdk#1734).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum OwnCommitBaseline {
+    /// Membership intents carry no value to compare; validity is whether the
+    /// targets are still members.
+    None,
+    /// The profile as it stood before an `UpdateGroupData` commit.
+    GroupProfile { name: String, description: String },
+    /// The exact bytes of every component an `UpdateAppComponents` commit
+    /// replaced, as they stood before it.
+    AppComponents { components: Vec<AppComponentData> },
+}
+
+/// The intent behind a commit this device staged. A confirmed commit can still
+/// be parked by convergence for as long as it sits inside the group's rewind
+/// horizon, so the record outlives publication: it is removed when the publish
+/// is rolled back, when a supersession has been decided, or once the commit's
+/// source epoch falls below the horizon. When convergence parks the commit, the
+/// record is what lets the engine re-issue the intent against the canonical
+/// state or report why it cannot (mdk#1734).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OwnCommitIntent {
+    /// Transport `MessageId` of the staged commit.
+    pub commit_id: MessageId,
+    pub group_id: GroupId,
+    /// Epoch the commit was staged from.
+    pub source_epoch: EpochId,
+    pub intent: SendIntent,
+    pub baseline: OwnCommitBaseline,
+    #[serde(default)]
+    pub reissue_attempts: u32,
+    pub created_at_ms: u64,
 }
 
 pub trait OutboundIntentStorage {
@@ -405,6 +448,18 @@ pub trait OutboundIntentStorage {
         group_id: &GroupId,
     ) -> StorageResult<Vec<QueuedOutboundIntent>>;
     fn delete_queued_outbound_intent(&self, id: &MessageId) -> StorageResult<()>;
+
+    /// Record or replace the intent behind a staged own commit.
+    fn put_own_commit_intent(&self, record: &OwnCommitIntent) -> StorageResult<()>;
+    fn own_commit_intent(&self, commit_id: &MessageId) -> StorageResult<Option<OwnCommitIntent>>;
+    /// Every retained own-commit intent, or only one group's when `group_id`
+    /// is given, in staging order.
+    fn list_own_commit_intents(
+        &self,
+        group_id: Option<&GroupId>,
+    ) -> StorageResult<Vec<OwnCommitIntent>>;
+    /// Idempotent: a commit that never recorded an intent is not an error.
+    fn delete_own_commit_intent(&self, commit_id: &MessageId) -> StorageResult<()>;
 }
 
 // ── OutboundFanoutStorage ──────────────────────────────────────────────────

--- a/docs/marmot-architecture/cgka-engine-spec.md
+++ b/docs/marmot-architecture/cgka-engine-spec.md
@@ -210,6 +210,18 @@ group. Auto-publish and explicit `send` paths now share the same publish-before-
 If a group has unresolved convergence input, `send(intent)` MUST store the intent durably and return
 `SendResult::Queued`.
 
+### Superseded own commits
+
+A confirmed group evolution can still lose a same-epoch race inside the rewind horizon. The engine MUST retain the
+intent behind every own `Invite`, `RemoveMembers`, `UpdateGroupData`, and `UpdateAppComponents` commit, with the
+authoring baseline of the fields it changed, until the group has advanced more than `max_rewind_commits` epochs past
+the commit's source epoch. When branch selection withdraws such a commit, the engine MUST decide the intent's fate
+from that record rather than replay the losing bytes: a profile or component edit is re-queued as an ordinary outbound
+intent only when the canonical state still holds the baseline for every field the edit changed, and is otherwise
+reported as a conflict; a removal is re-queued for targets that are still members; an invite is reported as requiring
+a fresh invitation. Re-issue is bounded (two attempts), and every decision is reported to the host so a change the
+caller was told had saved is never silently lost.
+
 `PendingPublish` and `Merging` are the two steps of resolving a publication this client staged, and neither exit is
 something the sender controls — a transport outcome, then the local merge that outcome authorizes. An
 application-message intent offered in one of those states MUST also be stored durably and returned as


### PR DESCRIPTION
Fixes #1734.

## Problem

When two admins commit from the same epoch, the losing device's `update_group_profile`, `invite_members`, or `remove_members` call has already returned `Ok`, but branch selection parks its commit and nothing re-issues or reports the intent. Only `SelfUpdate` evolutions re-armed. The strict profile-edit journey showed both edits "saved" and one of them gone everywhere, with no error on any device.

## Fix

**Engine.** `do_send_ready` retains the intent behind every own group evolution (`Invite`, `RemoveMembers`, `UpdateGroupData`, `UpdateAppComponents`) as an `OwnCommitIntent`: kind, the pre-staging baseline of the fields it changed, source epoch, and attempt count, keyed by the commit's message id in a new `cgka_own_commit_intents` table (migration 63). `publish_failed` deletes the record; confirmation does not, because a confirmed commit can still be parked inside the rewind horizon. `reissue_superseded_own_commits_from_state` garbage-collects a `Processed` record once the group is more than `max_rewind_commits` epochs past its source epoch.

When branch selection withdraws the commit, `reissue_superseded_own_commit` decides from the record, never from the losing bytes:

| Kind | Rule |
| --- | --- |
| profile / component edit | re-queue only when the canonical value of every edited field still equals the baseline, otherwise `Conflict` |
| removal | re-queue for targets still on the roster, `AlreadySatisfied` when none remain |
| invite | `ReinviteRequired` (the invitee's side is #1735) |
| any | at most two re-issues, then `Abandoned`; `NotMember` when the group is gone |

**Account.** Both supersession reconcilers (the `GroupStateInvalidated` event path and the derived-state repair in `run_due_maintenance`) hand the decision back as `SupersededIntentReport`s in `AccountDeviceEffects::superseded_intents`.

**App.** Each report becomes one `MarmotAppEvent::GroupChangeSuperseded { kind, outcome, reason }` (UniFFI `MarmotEventFfi` and C ABI mirrors, stable lower-snake strings). The account worker now flushes the client's pending event buffer from every seam that can observe a pass, including the live relay-delivery arm, the scheduled-convergence arm, and the catch-up commands; without that, a report noted on the delivery arm sat until an unrelated command.

## Tests

- `cgka-engine/tests/distributed_convergence.rs`: `superseded_profile_edit_is_reissued_when_the_winner_left_the_field_alone` (re-issue, `reissue_attempts == 1`, both fields converge, horizon GC) and `superseded_profile_edit_on_the_same_field_is_reported_as_a_conflict`.
- `marmot-app/tests/relay_runtime.rs`: two admins race on a real relay behind a publish gate for the re-issued and the conflict announcement.
- `storage-sqlite`: own-commit intent round trip, group-scoped listing, idempotent delete, cascade on group delete.
- `marmot-uniffi`: FFI mapping of the new event.
- Journey 08 (`public_app_08_concurrent_admin_profile_edits_are_never_lost`) is strict by default now; the strict journey 09 stays ignored for the invite half (#1735).

Local: `just fast-ci` gates (fmt, check, clippy), full `storage-sqlite` suite, the engine, UniFFI, C ABI, relay-runtime, tracing-audit, and journey-08 runs above are green after rebasing onto `788eaf08`.

## Notes

- Storage trait change (`OutboundIntentStorage` gained four methods) per the agreed release-bump plan; no version bump here.
- Docs: `APP_PATH_COVERAGE.md`, `SCENARIOS.md`, engine `AGENTS.md`, `marmot-account/AGENTS.md`, `cgka-engine-spec.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
