### PR TITLE
Bound chat-list and media retention query work

### DIFF
--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -2316,20 +2316,25 @@ pub(crate) fn chat_list_rows_tx(
     tx: &Connection,
     query: ChatListQuery,
 ) -> StorageResult<Vec<ChatListRow>> {
-    let sql = if query.include_archived {
-        format!(
-            "{CHAT_LIST_ROW_SELECT_AND_JOINS}
-             ORDER BY pin.ordinal IS NULL, pin.ordinal ASC,
-                      row.activity_sort_at DESC, row.group_id_hex"
-        )
+    // Rank the pin table once, including pins whose projection is absent.
+    // Keyed reads retain their single ordinal-count lookup.
+    let archived_filter = if query.include_archived {
+        ""
     } else {
-        format!(
-            "{CHAT_LIST_ROW_SELECT_AND_JOINS}
-             WHERE row.archived = 0
-             ORDER BY pin.ordinal IS NULL, pin.ordinal ASC,
-                      row.activity_sort_at DESC, row.group_id_hex"
-        )
+        "WHERE row.archived = 0"
     };
+    let sql = format!(
+        "{CHAT_LIST_ROW_SELECT_LIST} pin.position
+         {CHAT_LIST_ROW_JOINS}
+         LEFT JOIN (
+             SELECT group_id_hex, ordinal,
+                    ROW_NUMBER() OVER (ORDER BY ordinal) - 1 AS position
+             FROM chat_pin_positions
+         ) AS pin ON pin.group_id_hex = row.group_id_hex
+         {archived_filter}
+         ORDER BY pin.ordinal IS NULL, pin.ordinal ASC,
+                  row.activity_sort_at DESC, row.group_id_hex"
+    );
     let now_ms = unix_now_ms();
     let mut stmt = tx.prepare_cached(&sql).storage()?;
     let mut rows = stmt
@@ -2358,7 +2363,7 @@ fn direct_conversation_candidate_sql() -> String {
     // Drive from the peer index, then join the matching chat-list row.
     // Durable activity order, not pin-first chat-list order.
     format!(
-        "{CHAT_LIST_ROW_SELECT_LIST}
+        "{CHAT_LIST_ROW_SELECT_LIST} {CHAT_PIN_POSITION_SQL}
          FROM direct_conversation_members AS dcm
          JOIN chat_list_rows AS row ON row.group_id_hex = dcm.group_id_hex
          LEFT JOIN account_groups AS ag ON ag.group_id_hex = row.group_id_hex
@@ -2412,7 +2417,8 @@ pub(crate) fn chat_list_row_tx(
 ) -> StorageResult<Option<ChatListRow>> {
     let now_ms = unix_now_ms();
     let sql = format!(
-        "{CHAT_LIST_ROW_SELECT_AND_JOINS}
+        "{CHAT_LIST_ROW_SELECT_LIST} {CHAT_PIN_POSITION_SQL}
+         {CHAT_LIST_ROW_JOINS} {CHAT_PIN_JOIN}
          WHERE row.group_id_hex = ?1"
     );
     tx.query_row_cached(&sql, params![group_id_hex], |row| {
@@ -2434,11 +2440,7 @@ pub(crate) fn chat_list_row_tx(
     .transpose()
 }
 
-// Keep this projection in one place: `chat_list_row_from_row` decodes it by
-// index, so list and single-row queries must never drift in column order.
-// `CHAT_LIST_ROW_SELECT_LIST` must stay column-identical to
-// `CHAT_LIST_ROW_SELECT_AND_JOINS` so the peer-driven candidate query
-// decodes the same way.
+// All chat reads share these columns; only pin-rank computation differs.
 const CHAT_LIST_ROW_SELECT_LIST: &str =
     "SELECT row.group_id_hex, row.archived, row.pending_confirmation,
             row.title, row.group_name, row.avatar_url,
@@ -2460,45 +2462,20 @@ const CHAT_LIST_ROW_SELECT_LIST: &str =
                 SELECT 1 FROM cgka_disband_tombstones AS tomb
                 WHERE lower(hex(tomb.group_id)) = lower(row.group_id_hex)
             ),
-            pin.group_id_hex IS NOT NULL,
-            CASE WHEN pin.ordinal IS NULL THEN NULL ELSE (
+            pin.group_id_hex IS NOT NULL,";
+
+const CHAT_PIN_POSITION_SQL: &str = "CASE WHEN pin.ordinal IS NULL THEN NULL ELSE (
                 SELECT COUNT(*)
                 FROM chat_pin_positions AS earlier_pin
                 WHERE earlier_pin.ordinal < pin.ordinal
             ) END";
 
-const CHAT_LIST_ROW_SELECT_AND_JOINS: &str =
-    "SELECT row.group_id_hex, row.archived, row.pending_confirmation,
-            row.title, row.group_name, row.avatar_url,
-            row.avatar_image_hash_hex, row.avatar_image_key_hex,
-            row.avatar_image_nonce_hex, row.avatar_image_upload_key_hex,
-            row.avatar_media_type, row.last_message_id_hex,
-            row.last_message_sender, row.last_message_preview,
-            row.last_message_kind, row.last_message_timeline_at,
-            row.last_message_deleted, row.last_message_media_json,
-            row.last_message_delivery_state, row.unread_count,
-            row.manually_marked_unread, row.unread_mention_count,
-            row.first_unread_message_id_hex, row.last_read_message_id_hex,
-            row.last_read_timeline_at, row.conversation_created_at,
-            row.activity_sort_at, row.updated_at, row.self_membership,
-            ag.member_count,
-            mute.group_id_hex IS NOT NULL,
-            mute.muted_until_ms,
-            EXISTS (
-                SELECT 1 FROM cgka_disband_tombstones AS tomb
-                WHERE lower(hex(tomb.group_id)) = lower(row.group_id_hex)
-            ),
-            pin.group_id_hex IS NOT NULL,
-            CASE WHEN pin.ordinal IS NULL THEN NULL ELSE (
-                SELECT COUNT(*)
-                FROM chat_pin_positions AS earlier_pin
-                WHERE earlier_pin.ordinal < pin.ordinal
-            ) END
-     FROM chat_list_rows AS row
+const CHAT_LIST_ROW_JOINS: &str = "FROM chat_list_rows AS row
      LEFT JOIN account_groups AS ag ON ag.group_id_hex = row.group_id_hex
      LEFT JOIN chat_notification_settings AS mute
-        ON mute.group_id_hex = row.group_id_hex
-     LEFT JOIN chat_pin_positions AS pin
+        ON mute.group_id_hex = row.group_id_hex";
+
+const CHAT_PIN_JOIN: &str = "LEFT JOIN chat_pin_positions AS pin
         ON pin.group_id_hex = row.group_id_hex";
 
 fn chat_list_row_from_row(row: &rusqlite::Row<'_>, now_ms: i64) -> rusqlite::Result<ChatListRow> {

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -158,6 +158,84 @@ fn setup_store() -> SqliteAccountStorage {
     setup_store_with_group(group())
 }
 
+// Compare the existing readiness API with migration 0066’s index on synthetic history.
+// Setup, index construction, and the connection/KDF are outside the timed region.
+// Run: cargo test -p storage-sqlite --release --lib chat_startup_benchmark -- --ignored --nocapture
+#[test]
+#[ignore = "file-backed chat startup performance investigation"]
+fn chat_startup_benchmark() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("synthetic chat benchmark").unwrap();
+    let store =
+        SqliteAccountStorage::open_encrypted(dir.path().join("account.sqlite3"), &key).unwrap();
+    store
+        .save_account_projection_state(
+            &StoredAccountState {
+                label: "benchmark".to_owned(),
+                groups: vec![group()],
+                ..StoredAccountState::default()
+            },
+            256,
+            MAX_FUTURE_SKEW_SECS,
+        )
+        .unwrap();
+    store
+        .lock()
+        .unwrap()
+        .execute_batch("DROP INDEX idx_message_timeline_group_received")
+        .unwrap();
+    let mut seeded = 0;
+    let body = "x".repeat(512);
+    for count in [10_000, 100_000] {
+        cgka_traits::StorageProvider::with_transaction(&store, |store| {
+            for index in seeded..count {
+                let mut event = chat(&format!("{index:064x}"), REMOTE, index, &body);
+                event.source_epoch = Some(1);
+                store.record_app_event(&event)?;
+            }
+            Ok::<_, cgka_traits::StorageError>(())
+        })
+        .unwrap();
+        seeded = count;
+        let id = format!("{:064x}", count - 1);
+        store
+            .mark_timeline_message_read(LOCAL, GROUP, &id, &no_mentions)
+            .unwrap();
+        store.ensure_chat_list_rows(LOCAL, &no_mentions).unwrap();
+        let expected = store.chat_list_rows(ChatListQuery::default()).unwrap();
+        assert_eq!(expected.len(), 1);
+        assert_eq!(
+            expected[0].last_message.as_ref().unwrap().message_id_hex,
+            id
+        );
+        assert_eq!(expected[0].unread_count, 0);
+        // Repeat A/B after dropping the index to expose cache/order effects.
+        for mode in ["baseline", "indexed", "baseline", "indexed"] {
+            if mode == "indexed" {
+                store.lock().unwrap().execute_batch("CREATE INDEX idx_message_timeline_group_received ON message_timeline(group_id_hex, received_at)").unwrap();
+            }
+            store.ensure_chat_list_rows(LOCAL, &no_mentions).unwrap();
+            let mut samples = Vec::new();
+            for _ in 0..7 {
+                let start = std::time::Instant::now();
+                store.ensure_chat_list_rows(LOCAL, &no_mentions).unwrap();
+                let rows = store.chat_list_rows(ChatListQuery::default()).unwrap();
+                samples.push(start.elapsed().as_micros());
+                assert_eq!(rows, expected);
+            }
+            samples.sort_unstable();
+            eprintln!("count={count} mode={mode} median_us={}", samples[3]);
+            if mode == "indexed" {
+                store
+                    .lock()
+                    .unwrap()
+                    .execute_batch("DROP INDEX idx_message_timeline_group_received")
+                    .unwrap();
+            }
+        }
+    }
+}
+
 /// Preview work stays bounded for accepted history and displaced pending sends.
 #[test]
 fn preview_query_work() {

--- a/crates/storage-sqlite/src/encrypted_media_secrets.rs
+++ b/crates/storage-sqlite/src/encrypted_media_secrets.rs
@@ -245,7 +245,8 @@ pub(crate) fn replace_encrypted_media_secret_references_for_parts_tx(
         && let Some(source_epoch) = source_epoch
     {
         let source_epoch = u64_to_i64(source_epoch)?;
-        for component_id in encrypted_media_component_ids(tags) {
+        let component_ids = encrypted_media_component_ids(tags);
+        for component_id in &component_ids {
             tx.execute_cached(
                 "INSERT INTO encrypted_media_epoch_secret_references (
                      group_id_hex, message_id_hex, component_id, source_epoch
@@ -253,16 +254,20 @@ pub(crate) fn replace_encrypted_media_secret_references_for_parts_tx(
                 params![
                     group_id_hex,
                     message_id_hex,
-                    i64::from(component_id),
+                    i64::from(*component_id),
                     source_epoch,
                 ],
             )
             .storage()?;
+        }
+        // All media formats share the exporter; mark its cached rows once.
+        if !component_ids.is_empty() {
             tx.execute_cached(
                 "UPDATE encrypted_media_epoch_secrets
                  SET retention_managed = 1
                  WHERE group_id_hex = ?1
-                   AND source_epoch = ?2",
+                   AND source_epoch = ?2
+                   AND retention_managed = 0",
                 params![group_id_hex, source_epoch],
             )
             .storage()?;

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -132,6 +132,8 @@ mod migration_0065_chat_presentation;
 mod migration_0066_chat_presentation_maintenance;
 #[path = "migrations/0067_invitation_recovery.rs"]
 mod migration_0067_invitation_recovery;
+#[path = "migrations/0068_media_epoch_index.rs"]
+mod migration_0068_media_epoch_index;
 #[cfg(test)]
 #[path = "migrations/query_work_tests.rs"]
 mod query_work_tests;
@@ -484,6 +486,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 67,
         name: "0067_invitation_recovery",
         apply: migration_0067_invitation_recovery::apply,
+    },
+    Migration {
+        version: 68,
+        name: "0068_media_epoch_index",
+        apply: migration_0068_media_epoch_index::apply,
     },
 ];
 
@@ -1255,7 +1262,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 67,
+                found: 68,
                 latest_supported: 46,
             }
         ));
@@ -1311,7 +1318,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 67,
+                found: 68,
                 latest_supported: 46,
             }
         ));
@@ -1615,7 +1622,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 67,
+                found: 68,
                 latest_supported: 46,
             }
         ));

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -134,6 +134,8 @@ mod migration_0066_chat_presentation_maintenance;
 mod migration_0067_invitation_recovery;
 #[path = "migrations/0068_media_epoch_index.rs"]
 mod migration_0068_media_epoch_index;
+#[path = "migrations/0069_chat_readiness_index.rs"]
+mod migration_0069_chat_readiness_index;
 #[cfg(test)]
 #[path = "migrations/query_work_tests.rs"]
 mod query_work_tests;
@@ -491,6 +493,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 68,
         name: "0068_media_epoch_index",
         apply: migration_0068_media_epoch_index::apply,
+    },
+    Migration {
+        version: 69,
+        name: "0069_chat_readiness_index",
+        apply: migration_0069_chat_readiness_index::apply,
     },
 ];
 
@@ -1262,7 +1269,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 68,
+                found: 69,
                 latest_supported: 46,
             }
         ));
@@ -1318,7 +1325,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 68,
+                found: 69,
                 latest_supported: 46,
             }
         ));
@@ -1622,7 +1629,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 68,
+                found: 69,
                 latest_supported: 46,
             }
         ));

--- a/crates/storage-sqlite/src/migrations/0068_media_epoch_index.rs
+++ b/crates/storage-sqlite/src/migrations/0068_media_epoch_index.rs
@@ -1,0 +1,13 @@
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(super) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    // Both first-reference retention and retirement address an entire epoch.
+    tx.execute_batch(
+        "DROP INDEX IF EXISTS idx_media_secrets_retirement;
+         CREATE INDEX IF NOT EXISTS idx_media_secrets_epoch
+             ON encrypted_media_epoch_secrets(group_id_hex, source_epoch);",
+    )
+    .storage()
+}

--- a/crates/storage-sqlite/src/migrations/0069_chat_readiness_index.rs
+++ b/crates/storage-sqlite/src/migrations/0069_chat_readiness_index.rs
@@ -1,0 +1,12 @@
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(super) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    // Readiness probes need the latest receipt, regardless of preview eligibility.
+    tx.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_message_timeline_group_received
+             ON message_timeline(group_id_hex, received_at);",
+    )
+    .storage()
+}

--- a/crates/storage-sqlite/src/migrations/query_work_tests.rs
+++ b/crates/storage-sqlite/src/migrations/query_work_tests.rs
@@ -449,3 +449,105 @@ fn branch_origin_hex_matching() {
         [hex::encode(format!("{:032x}", 3)), "abcd".to_owned()]
     );
 }
+
+#[test]
+fn media_reference_query_work() {
+    use crate::encrypted_media_secrets::replace_encrypted_media_secret_references_for_parts_tx;
+    use cgka_traits::app_event::MARMOT_APP_EVENT_KIND_CHAT;
+
+    let _measurement = QUERY_MEASUREMENT.lock().unwrap();
+    for count in [256, 4_096] {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        seed_query_history(&store.lock().unwrap(), count);
+        store
+            .lock()
+            .unwrap()
+            .execute_batch(
+                "UPDATE encrypted_media_epoch_secrets SET retention_managed = 0;
+                 INSERT INTO encrypted_media_epoch_secrets
+                 SELECT group_id_hex, 2, source_epoch, secret, 0, 0
+                 FROM encrypted_media_epoch_secrets;
+                 INSERT INTO encrypted_media_epoch_secrets
+                 SELECT 'bb', component_id, source_epoch, secret, 0, 0
+                 FROM encrypted_media_epoch_secrets;",
+            )
+            .unwrap();
+        let tags = vec![
+            vec!["imeta".to_owned(), "v encrypted-media-v1".to_owned()],
+            vec!["imeta".to_owned(), "v encrypted-media-v2".to_owned()],
+        ];
+        let message = format!("{count:064x}");
+        for label in ["first reference", "replayed reference"] {
+            measured(&store, &format!("{label} rows={count}"), 400, || {
+                let mut conn = store.lock().unwrap();
+                let before = conn.total_changes();
+                let tx = conn.transaction().unwrap();
+                replace_encrypted_media_secret_references_for_parts_tx(
+                    &tx,
+                    "aa",
+                    &message,
+                    MARMOT_APP_EVENT_KIND_CHAT,
+                    Some(count as u64),
+                    &tags,
+                )
+                .unwrap();
+                tx.commit().unwrap();
+                // Two references plus first retention, or reference replacement only.
+                assert_eq!(conn.total_changes() - before, 4);
+            });
+            let conn = store.lock().unwrap();
+            let retained: i64 = conn.query_row(
+                    "SELECT count(*) FROM encrypted_media_epoch_secrets WHERE retention_managed = 1",
+                    [], |row| row.get(0),
+                ).unwrap();
+            assert_eq!(retained, 2);
+            let references: i64 = conn
+                .query_row(
+                    "SELECT count(*) FROM encrypted_media_epoch_secret_references",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(references, 2);
+        }
+    }
+}
+
+#[test]
+fn media_epoch_index_upgrade() {
+    let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+    super::run(&mut conn, &super::MIGRATIONS[..63]).unwrap();
+    seed_query_history(&conn, 256);
+    conn.execute_batch(
+        "UPDATE encrypted_media_epoch_secrets SET retention_managed = 0
+                        WHERE source_epoch % 2 = 0;",
+    )
+    .unwrap();
+    let contents = |conn: &rusqlite::Connection| {
+        conn.prepare(
+            "SELECT group_id_hex, component_id, source_epoch, secret,
+                             created_at_unix_seconds, retention_managed
+                      FROM encrypted_media_epoch_secrets ORDER BY rowid",
+        )
+        .unwrap()
+        .query_map([], |row| {
+            (0..6)
+                .map(|i| row.get::<_, rusqlite::types::Value>(i))
+                .collect::<rusqlite::Result<Vec<_>>>()
+        })
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap()
+    };
+    let before = contents(&conn);
+    super::run_all(&mut conn).unwrap();
+    super::run_all(&mut conn).unwrap();
+    let tx = conn.transaction().unwrap();
+    super::migration_0068_media_epoch_index::apply(&tx).unwrap();
+    tx.commit().unwrap();
+    assert_eq!(contents(&conn), before);
+    let integrity: String = conn
+        .query_row("PRAGMA integrity_check", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(integrity, "ok");
+}

--- a/crates/storage-sqlite/src/migrations/query_work_tests.rs
+++ b/crates/storage-sqlite/src/migrations/query_work_tests.rs
@@ -514,7 +514,7 @@ fn media_reference_query_work() {
 }
 
 #[test]
-fn media_epoch_index_upgrade() {
+fn retention_indexes_upgrade() {
     let mut conn = rusqlite::Connection::open_in_memory().unwrap();
     super::run(&mut conn, &super::MIGRATIONS[..63]).unwrap();
     seed_query_history(&conn, 256);
@@ -523,31 +523,201 @@ fn media_epoch_index_upgrade() {
                         WHERE source_epoch % 2 = 0;",
     )
     .unwrap();
+    conn.execute_batch(
+        "INSERT INTO message_timeline(group_id_hex, message_id_hex, direction, sender,
+             plaintext, kind, tags_json, timeline_at, received_at, reactions_json)
+         SELECT group_id_hex, message_id_hex, direction, sender, plaintext, kind,
+             tags_json, recorded_at, received_at, '{}' FROM app_events;",
+    )
+    .unwrap();
     let contents = |conn: &rusqlite::Connection| {
-        conn.prepare(
-            "SELECT group_id_hex, component_id, source_epoch, secret,
-                             created_at_unix_seconds, retention_managed
-                      FROM encrypted_media_epoch_secrets ORDER BY rowid",
-        )
-        .unwrap()
-        .query_map([], |row| {
-            (0..6)
-                .map(|i| row.get::<_, rusqlite::types::Value>(i))
+        let mut rows = Vec::new();
+        for table in ["encrypted_media_epoch_secrets", "message_timeline"] {
+            let mut stmt = conn
+                .prepare(&format!("SELECT * FROM {table} ORDER BY rowid"))
+                .unwrap();
+            let columns = stmt.column_count();
+            rows.extend(
+                stmt.query_map([], |row| {
+                    (0..columns)
+                        .map(|i| row.get::<_, rusqlite::types::Value>(i))
+                        .collect::<rusqlite::Result<Vec<_>>>()
+                })
+                .unwrap()
                 .collect::<rusqlite::Result<Vec<_>>>()
-        })
-        .unwrap()
-        .collect::<rusqlite::Result<Vec<_>>>()
-        .unwrap()
+                .unwrap(),
+            );
+        }
+        rows
     };
     let before = contents(&conn);
     super::run_all(&mut conn).unwrap();
     super::run_all(&mut conn).unwrap();
     let tx = conn.transaction().unwrap();
     super::migration_0068_media_epoch_index::apply(&tx).unwrap();
+    super::migration_0069_chat_readiness_index::apply(&tx).unwrap();
     tx.commit().unwrap();
     assert_eq!(contents(&conn), before);
     let integrity: String = conn
         .query_row("PRAGMA integrity_check", [], |row| row.get(0))
         .unwrap();
     assert_eq!(integrity, "ok");
+}
+
+#[test]
+fn chat_readiness_query_work() {
+    let _measurement = QUERY_MEASUREMENT.lock().unwrap();
+    for count in [256, 16_384] {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        {
+            let conn = store.lock().unwrap();
+            conn.execute_batch(
+                "INSERT INTO account_groups(group_id_hex, endpoint, updated_at)
+                                VALUES ('aa', 'fixture', 0);",
+            )
+            .unwrap();
+            conn.execute(
+                "WITH RECURSIVE n(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM n WHERE x < ?1)
+                 INSERT INTO app_events(group_id_hex, message_id_hex, source_message_id_hex,
+                     direction, sender, plaintext, kind, tags_json, recorded_at, received_at)
+                 SELECT 'aa', printf('%064x', x), printf('%064x', x),
+                     'received', 'sender', 'text', 9, '[]', x, x FROM n",
+                [count],
+            )
+            .unwrap();
+            conn.execute_batch(
+                "INSERT INTO message_timeline(group_id_hex, message_id_hex, source_message_id_hex,
+                     direction, sender, plaintext, kind, tags_json, timeline_at, received_at, reactions_json)
+                 SELECT group_id_hex, message_id_hex, source_message_id_hex, direction, sender,
+                     plaintext, kind, tags_json, recorded_at, received_at,
+                     '{\"by_emoji\":{},\"user_reactions\":[]}' FROM app_events;",
+            ).unwrap();
+        }
+        store
+            .refresh_chat_list_rows("local", &|_, _| false)
+            .unwrap();
+        let changes = store.lock().unwrap().total_changes();
+        {
+            measured(&store, &format!("chat readiness rows={count}"), 700, || {
+                store
+                    .ensure_chat_list_rows("local", &|_, _| panic!("unexpected rebuild"))
+                    .unwrap();
+            });
+        }
+        assert_eq!(store.lock().unwrap().total_changes(), changes);
+        store
+            .lock()
+            .unwrap()
+            .execute_batch(
+                "UPDATE chat_list_rows SET updated_at = 100000;
+             UPDATE message_timeline SET received_at = 100001, deleted = 1
+             WHERE rowid = 1;
+             DELETE FROM chat_list_unread_dirty_messages;",
+            )
+            .unwrap();
+        store.ensure_chat_list_rows("local", &|_, _| false).unwrap();
+        let updated: i64 = store
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT updated_at FROM chat_list_rows WHERE group_id_hex = 'aa'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(updated > 100000);
+        store
+            .ensure_chat_list_rows("local", &|_, _| panic!("unexpected rebuild"))
+            .unwrap();
+    }
+}
+
+#[test]
+fn pinned_chat_query_work() {
+    let _measurement = QUERY_MEASUREMENT.lock().unwrap();
+    for count in [64, 4_096] {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        {
+            let conn = store.lock().unwrap();
+            conn.execute(
+                "WITH RECURSIVE n(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM n WHERE x < ?1)
+                 INSERT INTO account_groups(group_id_hex, endpoint, updated_at)
+                 SELECT printf('%064x', x), 'fixture', 0 FROM n",
+                [count],
+            )
+            .unwrap();
+            conn.execute_batch(
+                "INSERT INTO chat_list_rows(group_id_hex, updated_at)
+                 SELECT group_id_hex, 0 FROM account_groups;
+                 INSERT INTO chat_pin_positions(group_id_hex, ordinal)
+                 SELECT group_id_hex, rowid * 3 FROM account_groups;",
+            )
+            .unwrap();
+        }
+        {
+            let rows = measured(
+                &store,
+                &format!("pinned chats rows={count}"),
+                count * 170,
+                || {
+                    store
+                        .chat_list_rows(crate::ChatListQuery::default())
+                        .unwrap()
+                },
+            );
+            assert_eq!(rows.len(), count as usize);
+            for (position, row) in rows.iter().enumerate() {
+                assert!(row.pinned);
+                assert_eq!(row.pinned_position, Some(position as u32));
+                assert_eq!(row.group_id_hex, format!("{:064x}", position + 1));
+            }
+        }
+        let first = format!("{:064x}", 1);
+        let last = format!("{count:064x}");
+        store
+            .lock()
+            .unwrap()
+            .execute(
+                "DELETE FROM chat_list_rows WHERE group_id_hex = ?1",
+                [&first],
+            )
+            .unwrap();
+        let rows = store
+            .chat_list_rows(crate::ChatListQuery::default())
+            .unwrap();
+        assert_eq!(rows[0].pinned_position, Some(1));
+        assert_eq!(
+            store.chat_list_row(&last).unwrap().unwrap(),
+            *rows.last().unwrap()
+        );
+        {
+            let conn = store.lock().unwrap();
+            conn.execute(
+                "UPDATE account_groups SET archived = 1 WHERE group_id_hex = ?1",
+                [&last],
+            )
+            .unwrap();
+            conn.execute(
+                "UPDATE chat_list_rows SET archived = 1 WHERE group_id_hex = ?1",
+                [&last],
+            )
+            .unwrap();
+        }
+        assert_eq!(
+            store
+                .chat_list_rows(crate::ChatListQuery::default())
+                .unwrap()
+                .len(),
+            count as usize - 2
+        );
+        let rows = store
+            .chat_list_rows(crate::ChatListQuery {
+                include_archived: true,
+            })
+            .unwrap();
+        let archived = rows.last().unwrap();
+        assert_eq!(archived.group_id_hex, last);
+        assert!(!archived.pinned);
+        assert_eq!(archived.pinned_position, None);
+    }
 }


### PR DESCRIPTION
Chat-list readiness scanned retained message history, and listing pinned chats counted preceding pins separately for every row. Media-reference updates also scanned cached exporter history, repeated work per format, and rewrote retained secrets on replay.

Index the latest receipt by group, rank pins once for full-list reads, and seek media secrets by group and epoch with one retention update per message. Single-chat and peer-keyed reads retain their existing pin lookup. Follow-up to merged #1739.

| Operation | Synthetic workload | VM steps before → after | Mean time before → after |
| --- | --- | ---: | ---: |
| Chat-list readiness | 16,384 messages in one chat | 98,845 → 545 | 16.647 → 5.039 ms |
| Pinned chat list | 4,096 pinned chats with sparse ordinals | 25,712,687 → 643,145 | 680.644 → 55.240 ms |
| First media retention | 4,096 epochs per component/group | 123,233 → 209 | 3.025 → 0.516 ms |
| Media-reference replay | Same fixture after first retention | 123,325 → 263 | 2.691 → 0.383 ms |

Measurements use the in-memory SQLCipher backend in a local debug build, arithmetic means of 20 samples per version, and prepared-statement caches flushed before every sample. Setup is excluded. Chat measurements cover the full storage API calls, reusing one unchanged fixture per size. Readiness starts with a complete projection; pin-list timing includes decoding all returned chat rows. At 256 messages readiness also takes 545 VM steps. At 64 pins, list work falls from 14,735 to 10,121 VM steps (1.541 → 1.236 ms).

Media measurements use 20 independently seeded fixtures per version, two components with 4,096 cached epochs each in each of two groups (16,384 secret rows), and one message carrying both media formats. Each fixture measures first retention followed by replay. Timing includes the reference-replacement transaction, statement preparation, and commit; the surrounding app-event projection is excluded. Post-change VM counts are also 209 and 263 with 256 epochs per component/group.

These are synthetic storage measurements, not end-to-end messaging or disk-durability claims. Listing still decodes and sorts returned chats; pin ranking grows with the pin table. Readiness still inspects each chat, and media work grows with references and cached components for the selected epoch. Migration 0065 replaces the managed-only secret index with an index covering all cached secrets; retirement remains bounded at 105 VM steps versus 99 previously. Migration 0066 adds a receipt-time index, adding storage and write maintenance per timeline row.

Regression coverage includes bounded query work, no-write readiness checks, stale receipts on deleted non-preview messages, sparse pin ordinals, missing projections, archive filtering, agreement with keyed reads, replay write counts, and populated migration upgrades.


A release-mode, file-backed SQLCipher benchmark now measures readiness plus fetching the chat-list rows on one chat with 512-byte message bodies. With 100,000 retained messages, baseline medians were 150.326 / 151.057 ms and indexed medians were 0.142 / 0.197 ms (about 767–1,059×). With 10,000 messages the corresponding medians were 15.625 / 15.770 ms and 0.200 / 0.128 ms. Each pair uses seven warm-cache samples; the benchmark repeats index-off/index-on on the same database and asserts identical returned rows. Setup, index construction, connection/KDF, profile hydration, and write overhead are excluded. Run `cargo test -p storage-sqlite --release --lib chat_startup_benchmark -- --ignored --nocapture`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved chat-list query performance, especially for larger message histories.
  * Added database optimizations for encrypted media and chat readiness data.

* **Bug Fixes**
  * Improved encrypted-media retention tracking when references are added or replaced.
  * Preserved chat data and ordering more reliably during database upgrades.

* **Reliability**
  * Strengthened database migration handling, including persistence, repeatability, and integrity checks.
  * Improved behavior for pinned chats, archived chats, dirty messages, and chat readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->