### PR TITLE
chore(release): prepare 0.9.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-connector"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "agent-control",
  "agent-stream-compose",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "agent-control"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "serde",
  "serde_json",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "agent-stream-compose"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -864,7 +864,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgka-conformance-simulator"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-engine"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-session"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-traits"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "async-trait",
  "criterion",
@@ -1196,7 +1196,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convergence-campaign-runner"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "async-trait",
  "cgka-conformance-simulator",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "fs-private"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "libc",
  "tempfile",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "incident-replay"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "cgka-conformance-simulator",
  "fs-private",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-account"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-app"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3384,7 +3384,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-c"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "libc",
  "marmot-uniffi",
@@ -3395,7 +3395,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-forensics"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "fs-private",
  "serde",
@@ -3406,7 +3406,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-markdown"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "serde",
  "serde_json",
@@ -3414,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-terminal-harness"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "agent-control",
  "async-trait",
@@ -3434,7 +3434,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-uniffi"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "cgka-engine",
  "cgka-traits",
@@ -5676,7 +5676,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-sqlite"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "cgka-traits",
  "fs-private",
@@ -6294,7 +6294,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-adapter"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6314,7 +6314,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-peeler"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6332,7 +6332,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-broker"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "cgka-traits",
  "clap",
@@ -6351,7 +6351,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-stream"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
@@ -7282,7 +7282,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wn-cli"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "agent-stream-compose",
  "cgka-traits",
@@ -7315,7 +7315,7 @@ dependencies = [
 
 [[package]]
 name = "wn-codex"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "async-trait",
  "clap",
@@ -7329,7 +7329,7 @@ dependencies = [
 
 [[package]]
 name = "wn-opencode"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "async-trait",
  "clap",
@@ -7344,7 +7344,7 @@ dependencies = [
 
 [[package]]
 name = "wn-pi"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.9.18"
+version = "0.9.19"
 license = "MIT"
 publish = false
 

--- a/crates/cgka-conformance-simulator/tests/app_runtime_interaction_journeys.rs
+++ b/crates/cgka-conformance-simulator/tests/app_runtime_interaction_journeys.rs
@@ -933,7 +933,7 @@ async fn check(journey: Journey) {
             "relay_order": "native local Nostr relay", "debug_assertions": cfg!(debug_assertions),
             "settlement_policy": match journey {
                 Journey::ManualSelfUpdate => "protocol-pinned 1000 ms settlement; maintenance windows zeroed when built with test-policy-overrides",
-                _ => "default production policy; no test override requested",
+                _ => "protocol-pinned 1000 ms settlement; production maintenance windows",
             },
             "immediate_maintenance_honored": matches!(journey, Journey::ManualSelfUpdate)
                 && AppRuntimeHarness::honors_maintenance_timing_override(),
@@ -946,7 +946,10 @@ async fn check(journey: Journey) {
         Journey::ManualSelfUpdate => {
             AppRuntimeHarness::new_with_immediate_maintenance(&clients).await
         }
-        _ => AppRuntimeHarness::new(&clients).await,
+        // Workspace feature unification can enable marmot-app's instant
+        // test settlement default through another crate. These journeys claim
+        // production behavior, so pin that policy in every build.
+        _ => AppRuntimeHarness::new_with_pinned_settlement(&clients).await,
     }
     .expect("public runtime setup");
     let exercise = async {

--- a/crates/cgka-conformance-simulator/vectors/admin-handover.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-handover.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-handover/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "admin-handover/v1",

--- a/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-policy-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "admin-policy-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "concurrent-invite-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "concurrent-invite-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-committer-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "convergence-committer-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-witness-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "convergence-witness-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/conversation.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/conversation.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "conversation/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "conversation/v1",

--- a/crates/cgka-conformance-simulator/vectors/cross-route-own-commit-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/cross-route-own-commit-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "cross-route-own-commit-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "cross-route-own-commit-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "current-profile-required-set/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "application_profile": {
     "name": "current",

--- a/crates/cgka-conformance-simulator/vectors/deferred-tick-catchup.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/deferred-tick-catchup.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "deferred-tick-catchup/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "deferred-tick-catchup/v1",

--- a/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "delayed-past-epoch-app-message/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "delayed-past-epoch-app-message/v1",

--- a/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "drop-queued/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "drop-queued/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "group-data-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "group-data-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-profile-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-profile-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-profile-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "group-profile-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "convergence-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "membership-fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "membership-fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incremental-growth.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incremental-growth.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "incremental-growth/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "incremental-growth/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-member/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "invite-member/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "invite-publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/late-welcome-backfill.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/late-welcome-backfill.v1.json
@@ -1,7 +1,7 @@
 {
  "scenario_name": "late-welcome-backfill/v1",
  "vector_version": "1",
- "conformance_version": "0.9.18",
+ "conformance_version": "0.9.19",
  "seed": null,
  "scenario": {
   "name": "late-welcome-backfill/v1",

--- a/crates/cgka-conformance-simulator/vectors/latecomer-forward-secrecy.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/latecomer-forward-secrecy.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "latecomer-forward-secrecy/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "latecomer-forward-secrecy/v1",

--- a/crates/cgka-conformance-simulator/vectors/leaver-removal-secrecy.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/leaver-removal-secrecy.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "leaver-removal-secrecy/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "leaver-removal-secrecy/v1",

--- a/crates/cgka-conformance-simulator/vectors/multigroup-isolation.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/multigroup-isolation.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "multigroup-isolation/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "multigroup-isolation/v1",

--- a/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "partition-clear-leave/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "partition-clear-leave/v1",

--- a/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "queue-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "queue-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/readd-after-eviction.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/readd-after-eviction.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "readd-after-eviction/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "readd-after-eviction/v1",

--- a/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "restart-delivery-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "restart-delivery-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/route-equivalence.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/route-equivalence.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "route-equivalence/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "route-equivalence/v1",

--- a/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "three-client-message-exchange/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.18",
+  "conformance_version": "0.9.19",
   "seed": null,
   "scenario": {
     "name": "three-client-message-exchange/v1",

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,8 +9,44 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+## [0.9.19] - 2026-09-07
+
+### Added
+
+- Durable interactive account onboarding across the app runtime, CLI, Swift,
+  Kotlin, and C bindings supports resumable setup and explicit cancellation.
+- The core traits, engine, and Nostr peeler now compile for browser WASM.
+  This is compile-only coverage; it does not provide browser app-runtime,
+  SQLCipher, CLI, or binding support.
+
+### Changed
+
+- Account databases advance through migrations 60–64 for released transport
+  receipts, durable reconciliation replay cursors, query indexes, and own-commit
+  recovery intents. Shared account storage and the directory cache now have
+  versioned schemas. Back up before upgrading; downgrade is unsupported.
+  Re-upgrade or restore a pre-upgrade database/export instead of removing
+  migration rows. See the
+  [storage-format contract](../../docs/marmot-architecture/storage-format-v2.md).
+  Upgrades from before `0.9.15` also cross migration 47: keep at least 3.25
+  times the account database size free for its history-table rebuild and
+  gradual post-readiness promotion. The 2,048-row release check measured a
+  4.01-times peak footprint (3.01 times additional space), a 13,410 ms migration,
+  7,371 ms promotion, and 255 ms slowest 32-row batch.
+- Message sending, chat previews, and replay queries avoid full-history scans
+  and unnecessary sorts. Timeline bindings reuse matching conversions.
+- Automatic audit uploads batch sealed segments, back off failed passes,
+  and recover failed segment rotation.
+
 ### Fixed
 
+- Offline catch-up, background recovery, and group-change replay preserve
+  durable progress and recovery intents across account restarts. Replayed
+  proposals refresh their epoch anchor.
+- Removed devices stop routing and re-seeding groups they no longer belong to.
+- Login and invitation discovery preserve inbox/outbox metadata; default MLS
+  capabilities remain implicit in KeyPackages.
+- Relay telemetry connections pin validated collector addresses.
 - Non-JSON CLI and daemon human output now sanitizes untrusted remote text
   with the existing TUI terminal-safety policy, so message bodies, group
   profile fields, display names, stream previews, and related error text
@@ -2038,7 +2074,8 @@ Initial release of the `dm` command-line app, the `dmd` background daemon, and t
 - Local installation docs for `cargo install --path crates/cli --locked --bins`.
 - Homebrew release checklist and namespaced tap packaging path for `marmot-protocol/tap/darkmatter`.
 
-[Unreleased]: https://github.com/marmot-protocol/mdk/compare/v0.9.18...HEAD
+[Unreleased]: https://github.com/marmot-protocol/mdk/compare/v0.9.19...HEAD
+[0.9.19]: https://github.com/marmot-protocol/mdk/compare/v0.9.18...v0.9.19
 [0.9.18]: https://github.com/marmot-protocol/mdk/compare/v0.9.17...v0.9.18
 [0.9.17]: https://github.com/marmot-protocol/mdk/compare/v0.9.16...v0.9.17
 [0.9.16]: https://github.com/marmot-protocol/mdk/compare/v0.9.15...v0.9.16

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -23,7 +23,7 @@ Choose the runtime you already use:
 | Pi | Terminal harness | Repository and coding tasks through Pi |
 
 The guided installers prompt on the terminal for the White Noise account that
-may invite and message the agent. They install release `wn-agent-v0.9.18`, create
+may invite and message the agent. They install release `wn-agent-v0.9.19`, create
 an isolated White Noise identity for the selected connector, and start same-user
 services where supported. Download each installer with its adjacent checksum,
 verify it, and only then execute the local file:
@@ -50,7 +50,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.18"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
 ```
 
 ### Hermes
@@ -110,7 +110,7 @@ install_verified "$base_url/install-pi-marmot.sh" \
 
 ### Finish In White Noise
 
-Release 0.9.18 records the new agent's `npub` and `nprofile` in the
+Release 0.9.19 records the new agent's `npub` and `nprofile` in the
 `bootstrap.json` path printed at completion. Display them with:
 
 ```sh

--- a/integrations/codex/marmot/README.md
+++ b/integrations/codex/marmot/README.md
@@ -54,7 +54,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.18"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
 install_verified "$base_url/install-codex-marmot.sh" \
   "$base_url/install-codex-marmot.sh.sha256" \
   --yes --allow-welcomer npub1...

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -75,7 +75,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.18"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256"
 ```
@@ -92,7 +92,7 @@ repeated or given a comma-separated list to authorize multiple senders:
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.18"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256" \
   --yes \
@@ -108,7 +108,7 @@ with `--generate-identity`). To preserve an existing Nostr identity, place its
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.18"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256" \
   --yes \
@@ -138,7 +138,7 @@ To accept Marmot messages from any sender (explicit opt-in):
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.18"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256" \
   --yes --allow-all-users

--- a/integrations/openclaw/marmot/README.md
+++ b/integrations/openclaw/marmot/README.md
@@ -82,7 +82,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.18"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
 install_verified "$base_url/install-openclaw-marmot.sh" \
   "$base_url/install-openclaw-marmot.sh.sha256"
 ```
@@ -102,7 +102,7 @@ an `npub` or raw hex public key:
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.18"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
 install_verified "$base_url/install-openclaw-marmot.sh" \
   "$base_url/install-openclaw-marmot.sh.sha256" \
   --yes --allow-welcomer npub1...
@@ -116,7 +116,7 @@ with `--generate-identity`). To preserve an existing Nostr identity, place its
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.18"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
 install_verified "$base_url/install-openclaw-marmot.sh" \
   "$base_url/install-openclaw-marmot.sh.sha256" \
   --yes \

--- a/integrations/opencode/marmot/README.md
+++ b/integrations/opencode/marmot/README.md
@@ -56,7 +56,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.18"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
 install_verified "$base_url/install-opencode-marmot.sh" \
   "$base_url/install-opencode-marmot.sh.sha256"
 ```
@@ -67,7 +67,7 @@ as either an `npub` or raw hex public key:
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.18"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
 install_verified "$base_url/install-opencode-marmot.sh" \
   "$base_url/install-opencode-marmot.sh.sha256" \
   --yes --allow-welcomer npub1...

--- a/integrations/pi/marmot/README.md
+++ b/integrations/pi/marmot/README.md
@@ -48,7 +48,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.18"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
 install_verified "$base_url/install-pi-marmot.sh" \
   "$base_url/install-pi-marmot.sh.sha256"
 ```
@@ -58,7 +58,7 @@ For noninteractive setup, provide the allowed inviter and prompt sender:
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.18"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
 install_verified "$base_url/install-pi-marmot.sh" \
   "$base_url/install-pi-marmot.sh.sha256" \
   --yes --allow-welcomer npub1...

--- a/release.md
+++ b/release.md
@@ -354,7 +354,7 @@ workspace release looks like:
 ```sh
 (
 set -eu
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.18"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
 
 install_verified() (
   set -eu

--- a/scripts/install-hermes-marmot.sh
+++ b/scripts/install-hermes-marmot.sh
@@ -118,7 +118,7 @@ Hermes accepts after gateway restart via $HERMES_HOME/.env.
 
 Verified download (then choose one invocation below):
   set -eu
-  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.18
+  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19
   tmpdir="$(mktemp -d)"
   trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
   installer_script=install-hermes-marmot.sh

--- a/scripts/install-openclaw-marmot.sh
+++ b/scripts/install-openclaw-marmot.sh
@@ -110,7 +110,7 @@ Environment:
 
 Verified download (then choose one invocation below):
   set -eu
-  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.18
+  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19
   tmpdir="$(mktemp -d)"
   trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
   installer_script=install-openclaw-marmot.sh


### PR DESCRIPTION
Prepare compatibility cohort 0.9.19 for MDK, wn-agent, MarmotKit, and Marmot C. Synchronize all 26 workspace packages, 31 conformance fixtures, installer documentation pins, and the cohort changelog.

The release notes cover durable onboarding, offline and group-change recovery, audit upload fixes, query performance, and the compile-only WASM boundary. They document migrations 60–64, unsupported downgrade, pre-upgrade backups, and refreshed migration-47 disk/timing measurements.

Validation completed:
- `just fast-ci` and all five installer dry runs passed.
- `just tamarin`: all 78 lemmas verified.
- `MDK_STORAGE_OPS_ROWS=2048 just bench-storage-upgrade`: passed; 4.01x peak footprint, 13,410 ms migration, 7,371 ms promotion, 255 ms slowest batch.
- A helper linked against exact v0.9.18 storage source and its pinned dependencies upgraded the legacy fixture to schema 59. The candidate upgraded it to 64, preserved its group/message contents, and reopened without rewriting the database. The v0.9.18 helper refused schema 64 with `UnsupportedSchemaVersion` without changing database bytes; restoring the backup reopened successfully with v0.9.18.

Release validation also found that app interaction journeys inherited instant settlement through workspace feature unification while claiming production policy. Pin their existing 1,000 ms production harness constructor explicitly and label the evidence accordingly. No production behavior changes in this release-preparation PR.

Additional validation:
- All six active public interaction journeys passed serially in the workspace feature configuration after the policy pin (two intentionally ignored journeys remain ignored).
- The complete default workspace pass executed 5,246 tests across an initial run and its continuation. Six initial failures were observed: three journey cases covered by the policy correction and three database/subprocess cases that passed isolated reruns. This is not a clean first-pass result.
- iOS, macOS, and all four Android ABI binding builds passed. Apple deployment-target and SwiftPM source/link validators passed; iOS and macOS generated identical Swift.
- The final `just fast-ci` and workspace doc tests passed.
- The full OTLP workspace pass completed: 5,265 passed, 47 skipped, one flaky subprocess idle-deadline test passed its configured retry.
- Final-head CI passed at `5e2a19d65e2809fc38666d018feaa5e9883bfb9f`, including Tamarin and the wn-agent platform matrix.
