### PR TITLE
Bound unknown profile metadata retained in directory caches

### DIFF
--- a/crates/marmot-app/src/directory/records.rs
+++ b/crates/marmot-app/src/directory/records.rs
@@ -316,6 +316,10 @@ pub(crate) fn upsert_newer_directory_entry(
     }
 }
 
+/// Parse incoming profile metadata and bound the fields retained on ingestion.
+/// The full event is parsed first; this is not a cap on transient parse memory.
+/// Previously cached rows are not rewritten here: their bounds take effect when
+/// a newer profile is ingested and replaces the cached metadata.
 pub(crate) fn profile_from_record(
     record: RelayEventRecord,
 ) -> Option<(String, UserProfileMetadata)> {
@@ -357,8 +361,10 @@ pub(crate) const MAX_EXTRA_PROFILE_VALUE_BYTES: usize = 4096;
 /// Counting `Write` sink that accepts compact JSON only while it fits `remaining`.
 ///
 /// The next write that would exceed the budget fails immediately without
-/// accepting a prefix or counting those bytes. Measurement never materializes a
-/// serialized attacker-sized copy.
+/// accepting a prefix or counting those bytes. This stops further serialization
+/// writes and avoids allocating another encoded copy. It does not bound the raw
+/// event or already-parsed JSON allocations, and the serializer may scan a whole
+/// string before emitting a write that exceeds the budget.
 struct BoundedJsonWriteBudget {
     remaining: usize,
 }
@@ -380,11 +386,13 @@ impl Write for BoundedJsonWriteBudget {
     }
 }
 
+/// Measure compact JSON against an inclusive encoded-byte budget without buffering it.
 fn compact_json_within_budget<T: Serialize + ?Sized>(value: &T, budget: usize) -> bool {
     let mut sink = BoundedJsonWriteBudget { remaining: budget };
     serde_json::to_writer(&mut sink, value).is_ok()
 }
 
+/// Retain bounded unknown entries whole; known and rejected fields use no quota.
 fn extra_profile_fields(content: &serde_json::Value) -> BTreeMap<String, serde_json::Value> {
     let Some(object) = content.as_object() else {
         return BTreeMap::new();
@@ -855,12 +863,6 @@ mod tests {
         "x".repeat(count)
     }
 
-    /// Braces, encoded keys, colons, values, and commas at maximum occupancy.
-    const MAX_RETAINED_EXTRA_PROFILE_JSON_BYTES: usize = 2
-        + MAX_EXTRA_PROFILE_FIELDS
-            * (MAX_EXTRA_PROFILE_KEY_BYTES + 1 + MAX_EXTRA_PROFILE_VALUE_BYTES)
-        + MAX_EXTRA_PROFILE_FIELDS.saturating_sub(1);
-
     #[test]
     fn bounded_json_write_budget_rejects_the_write_that_would_exceed() {
         let mut sink = BoundedJsonWriteBudget { remaining: 4 };
@@ -1068,6 +1070,67 @@ mod tests {
     }
 
     #[test]
+    fn extra_profile_key_limits_include_escaping_and_multibyte_utf8() {
+        for key in [
+            ascii_xs(254),
+            "\"".repeat(127),
+            "\\".repeat(127),
+            "\n".repeat(127),
+            format!("{}aa", "\u{0001}".repeat(42)),
+            "é".repeat(127),
+            format!("{}aa", "🦦".repeat(63)),
+        ] {
+            let over = format!("{key}x");
+            assert_eq!(
+                serde_json::to_vec(&key).unwrap().len(),
+                MAX_EXTRA_PROFILE_KEY_BYTES
+            );
+            assert_eq!(
+                serde_json::to_vec(&over).unwrap().len(),
+                MAX_EXTRA_PROFILE_KEY_BYTES + 1
+            );
+            let profile = profile_from_content(serde_json::json!({
+                key.clone(): "kept", over.clone(): "dropped"
+            }));
+            assert_eq!(profile.extra.len(), 1);
+            assert_eq!(profile.extra.get(&key), Some(&serde_json::json!("kept")));
+            assert!(!profile.extra.contains_key(&over));
+        }
+    }
+
+    /// Saturate every budget, including JSON punctuation, rather than checking
+    /// a large ceiling against a map whose entries are all tiny.
+    #[test]
+    fn extra_profile_fields_saturate_the_exact_retained_json_ceiling() {
+        let mut content = serde_json::Map::new();
+        for index in 0..MAX_EXTRA_PROFILE_FIELDS {
+            let key = format!("{index:02}{}", ascii_xs(MAX_EXTRA_PROFILE_KEY_BYTES - 4));
+            let value = serde_json::json!(ascii_xs(MAX_EXTRA_PROFILE_VALUE_BYTES - 2));
+            assert_eq!(
+                serde_json::to_vec(&key).unwrap().len(),
+                MAX_EXTRA_PROFILE_KEY_BYTES
+            );
+            assert_eq!(
+                serde_json::to_vec(&value).unwrap().len(),
+                MAX_EXTRA_PROFILE_VALUE_BYTES
+            );
+            content.insert(key, value);
+        }
+        let profile = profile_from_content(serde_json::Value::Object(content.clone()));
+        assert_eq!(profile.extra.len(), MAX_EXTRA_PROFILE_FIELDS);
+        // Two braces, a colon per entry, and one fewer comma than entries.
+        let ceiling = 2
+            + MAX_EXTRA_PROFILE_FIELDS
+                * (MAX_EXTRA_PROFILE_KEY_BYTES + 1 + MAX_EXTRA_PROFILE_VALUE_BYTES)
+            + (MAX_EXTRA_PROFILE_FIELDS - 1);
+        assert_eq!(ceiling, 139_329);
+        assert_eq!(serde_json::to_vec(&profile.extra).unwrap().len(), ceiling);
+        content.insert("zz_overflow".into(), serde_json::json!("dropped"));
+        let overflow = profile_from_content(serde_json::Value::Object(content));
+        assert_eq!(overflow.extra, profile.extra);
+    }
+
+    #[test]
     fn extra_profile_fields_quota_skips_known_and_oversized_without_consuming_slots() {
         assert!(extra_profile_fields(&serde_json::json!({})).is_empty());
 
@@ -1077,8 +1140,6 @@ mod tests {
         }
         let at_limit_profile = profile_from_content(serde_json::Value::Object(at_limit.clone()));
         assert_eq!(at_limit_profile.extra.len(), MAX_EXTRA_PROFILE_FIELDS);
-        let encoded = serde_json::to_vec(&at_limit_profile.extra).unwrap();
-        assert!(encoded.len() <= MAX_RETAINED_EXTRA_PROFILE_JSON_BYTES);
         let repeated = profile_from_content(serde_json::Value::Object(at_limit.clone()));
         assert_eq!(repeated.extra, at_limit_profile.extra);
 
@@ -1104,16 +1165,16 @@ mod tests {
                 Some(&serde_json::json!(index))
             );
         }
-        let encoded = serde_json::to_vec(&over_profile.extra).unwrap();
-        assert!(encoded.len() <= MAX_RETAINED_EXTRA_PROFILE_JSON_BYTES);
         assert_eq!(
             profile_content_json(&over_profile)["name"],
             serde_json::json!("typed")
         );
     }
 
+    /// Tripwire against disabling serde_json's default parse recursion limit.
+    /// This fails before extra-field retention, independently of its budgets.
     #[test]
-    fn extra_profile_fields_do_not_enable_unbounded_json_recursion() {
+    fn profile_parse_preserves_the_json_recursion_limit() {
         let mut deep = String::from("null");
         for _ in 0..200 {
             deep = format!("[{deep}]");

--- a/crates/marmot-app/src/directory/records.rs
+++ b/crates/marmot-app/src/directory/records.rs
@@ -8,6 +8,7 @@
 //! operate purely on records.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::io::{self, Write};
 
 use serde::{Deserialize, Serialize};
 use storage_sqlite::PublicDirectoryUserRecord;
@@ -338,15 +339,73 @@ pub(crate) fn profile_from_record(
     ))
 }
 
+/// Inclusive maximum number of unknown kind:0 fields retained on ingest.
+/// Known and rejected entries do not consume a slot.
+pub(crate) const MAX_EXTRA_PROFILE_FIELDS: usize = 32;
+
+/// Inclusive maximum compact `serde_json` encoding of one unknown field key,
+/// including the surrounding quotes and any escape expansion. Raw character
+/// count is not the unit: a short key with quotes or backslashes can exceed
+/// this after encoding.
+pub(crate) const MAX_EXTRA_PROFILE_KEY_BYTES: usize = 256;
+
+/// Inclusive maximum compact `serde_json` encoding of one unknown field value,
+/// including string quotes/escapes and all nested containers and member keys.
+/// Oversized values are dropped whole, never truncated.
+pub(crate) const MAX_EXTRA_PROFILE_VALUE_BYTES: usize = 4096;
+
+/// Counting `Write` sink that accepts compact JSON only while it fits `remaining`.
+///
+/// The next write that would exceed the budget fails immediately without
+/// accepting a prefix or counting those bytes. Measurement never materializes a
+/// serialized attacker-sized copy.
+struct BoundedJsonWriteBudget {
+    remaining: usize,
+}
+
+impl Write for BoundedJsonWriteBudget {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if buf.len() > self.remaining {
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "compact json encoding exceeds budget",
+            ));
+        }
+        self.remaining -= buf.len();
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn compact_json_within_budget<T: Serialize + ?Sized>(value: &T, budget: usize) -> bool {
+    let mut sink = BoundedJsonWriteBudget { remaining: budget };
+    serde_json::to_writer(&mut sink, value).is_ok()
+}
+
 fn extra_profile_fields(content: &serde_json::Value) -> BTreeMap<String, serde_json::Value> {
     let Some(object) = content.as_object() else {
         return BTreeMap::new();
     };
-    object
-        .iter()
-        .filter(|(key, _)| !is_known_profile_field(key))
-        .map(|(key, value)| (key.clone(), value.clone()))
-        .collect()
+    let mut extra = BTreeMap::new();
+    for (key, value) in object {
+        if extra.len() >= MAX_EXTRA_PROFILE_FIELDS {
+            break;
+        }
+        if is_known_profile_field(key) {
+            continue;
+        }
+        if !compact_json_within_budget(key, MAX_EXTRA_PROFILE_KEY_BYTES) {
+            continue;
+        }
+        if !compact_json_within_budget(value, MAX_EXTRA_PROFILE_VALUE_BYTES) {
+            continue;
+        }
+        extra.insert(key.clone(), value.clone());
+    }
+    extra
 }
 
 fn is_known_profile_field(field: &str) -> bool {
@@ -621,6 +680,8 @@ pub(crate) fn latest_fresh_profiles_from_records(
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
+
     use cgka_traits::TransportEndpoint;
     use transport_nostr_peeler::NostrTransportEvent;
 
@@ -771,5 +832,359 @@ mod tests {
         );
         assert_eq!(local_only.resolved_name.as_deref(), Some("local-label"));
         assert_eq!(local_only.profile, None);
+    }
+
+    fn profile_from_content(content: serde_json::Value) -> UserProfileMetadata {
+        let account_id = "11".repeat(32);
+        let mut event = NostrTransportEvent::new_unsigned(
+            account_id,
+            KIND_NOSTR_METADATA,
+            Vec::new(),
+            content.to_string(),
+        );
+        event.created_at = 1_700_000_000;
+        profile_from_record(RelayEventRecord {
+            endpoints: vec![TransportEndpoint("wss://relay.example".to_owned())],
+            event,
+        })
+        .expect("object kind:0 content parses")
+        .1
+    }
+
+    fn ascii_xs(count: usize) -> String {
+        "x".repeat(count)
+    }
+
+    /// Braces, encoded keys, colons, values, and commas at maximum occupancy.
+    const MAX_RETAINED_EXTRA_PROFILE_JSON_BYTES: usize = 2
+        + MAX_EXTRA_PROFILE_FIELDS
+            * (MAX_EXTRA_PROFILE_KEY_BYTES + 1 + MAX_EXTRA_PROFILE_VALUE_BYTES)
+        + MAX_EXTRA_PROFILE_FIELDS.saturating_sub(1);
+
+    #[test]
+    fn bounded_json_write_budget_rejects_the_write_that_would_exceed() {
+        let mut sink = BoundedJsonWriteBudget { remaining: 4 };
+        assert_eq!(sink.write(b"abcd").unwrap(), 4);
+        assert_eq!(sink.remaining, 0);
+        assert!(sink.write(b"x").is_err());
+        assert_eq!(sink.remaining, 0, "a rejected write must not be counted");
+
+        let mut sink = BoundedJsonWriteBudget { remaining: 3 };
+        assert!(sink.write(b"abcd").is_err());
+        assert_eq!(
+            sink.remaining, 3,
+            "an oversized write must not consume any budget"
+        );
+
+        let mut sink = BoundedJsonWriteBudget { remaining: 5 };
+        assert_eq!(sink.write(b"ab").unwrap(), 2);
+        assert_eq!(sink.write(b"cd").unwrap(), 2);
+        assert_eq!(sink.remaining, 1);
+        assert!(sink.write(b"ef").is_err());
+        assert_eq!(sink.remaining, 1);
+        assert_eq!(sink.write(b"e").unwrap(), 1);
+        assert_eq!(sink.remaining, 0);
+    }
+
+    #[test]
+    fn compact_json_budget_uses_encoded_bytes_not_raw_character_count() {
+        assert!(compact_json_within_budget(
+            &ascii_xs(254),
+            MAX_EXTRA_PROFILE_KEY_BYTES
+        ));
+        assert!(!compact_json_within_budget(
+            &ascii_xs(255),
+            MAX_EXTRA_PROFILE_KEY_BYTES
+        ));
+
+        let quotes_at_limit = "\"".repeat(2047);
+        let quotes_over = "\"".repeat(2048);
+        assert!(compact_json_within_budget(
+            &quotes_at_limit,
+            MAX_EXTRA_PROFILE_VALUE_BYTES
+        ));
+        assert!(!compact_json_within_budget(
+            &quotes_over,
+            MAX_EXTRA_PROFILE_VALUE_BYTES
+        ));
+
+        let backslashes_at_limit = "\\".repeat(2047);
+        assert!(compact_json_within_budget(
+            &backslashes_at_limit,
+            MAX_EXTRA_PROFILE_VALUE_BYTES
+        ));
+        assert!(!compact_json_within_budget(
+            &format!("{backslashes_at_limit}\\"),
+            MAX_EXTRA_PROFILE_VALUE_BYTES
+        ));
+
+        let newlines_at_limit = "\n".repeat(2047);
+        assert_eq!(
+            serde_json::to_vec(&newlines_at_limit).unwrap().len(),
+            MAX_EXTRA_PROFILE_VALUE_BYTES
+        );
+        assert!(compact_json_within_budget(
+            &newlines_at_limit,
+            MAX_EXTRA_PROFILE_VALUE_BYTES
+        ));
+        assert!(!compact_json_within_budget(
+            &format!("{newlines_at_limit}\n"),
+            MAX_EXTRA_PROFILE_VALUE_BYTES
+        ));
+        // SOH encodes as `\u0001` (6 bytes). 683 raw chars are far below a
+        // 4096-character cap but still miss the encoded-byte budget.
+        let soh_over = "\u{0001}".repeat(683);
+        assert!(soh_over.chars().count() < MAX_EXTRA_PROFILE_VALUE_BYTES);
+        assert!(!compact_json_within_budget(
+            &soh_over,
+            MAX_EXTRA_PROFILE_VALUE_BYTES
+        ));
+
+        let utf8_at_limit = "é".repeat(2047);
+        assert_eq!(
+            serde_json::to_vec(&utf8_at_limit).unwrap().len(),
+            MAX_EXTRA_PROFILE_VALUE_BYTES
+        );
+        assert!(compact_json_within_budget(
+            &utf8_at_limit,
+            MAX_EXTRA_PROFILE_VALUE_BYTES
+        ));
+        assert!(!compact_json_within_budget(
+            &format!("{utf8_at_limit}é"),
+            MAX_EXTRA_PROFILE_VALUE_BYTES
+        ));
+    }
+
+    #[test]
+    fn extra_profile_fields_preserve_accepted_json_types_and_drop_oversized_entries() {
+        let huge = ascii_xs(2 * 1024 * 1024);
+        let nested_over = serde_json::json!({
+            "leaf": ascii_xs(MAX_EXTRA_PROFILE_VALUE_BYTES)
+        });
+        let array_over = serde_json::json!([ascii_xs(MAX_EXTRA_PROFILE_VALUE_BYTES)]);
+        let oversized_key = ascii_xs(255);
+        let profile = profile_from_content(serde_json::json!({
+            "name": "alice",
+            "displayName": "Alice",
+            "banner": "https://example.test/banner.png",
+            "website": "https://example.test",
+            "bot": false,
+            "count": 7,
+            "missing": null,
+            "tags": ["a", "b"],
+            "nested": {"ok": true, "n": 1},
+            "unicode": "café ☕",
+            "custom_blob": huge,
+            "nested_blob": nested_over,
+            "array_blob": array_over,
+            oversized_key.clone(): "tiny",
+            "later": "kept",
+            "created_at": 42,
+            "source_relays": ["wss://spoof.example"]
+        }));
+
+        assert_eq!(profile.name.as_deref(), Some("alice"));
+        assert_eq!(profile.display_name.as_deref(), Some("Alice"));
+        assert_eq!(
+            profile.banner.as_deref(),
+            Some("https://example.test/banner.png")
+        );
+        assert_eq!(profile.created_at, 1_700_000_000);
+        assert_eq!(
+            profile.source_relays,
+            vec!["wss://relay.example".to_owned()]
+        );
+        assert_eq!(
+            profile.extra.get("website"),
+            Some(&serde_json::json!("https://example.test"))
+        );
+        assert_eq!(profile.extra.get("bot"), Some(&serde_json::json!(false)));
+        assert_eq!(profile.extra.get("count"), Some(&serde_json::json!(7)));
+        assert_eq!(profile.extra.get("missing"), Some(&serde_json::json!(null)));
+        assert_eq!(
+            profile.extra.get("tags"),
+            Some(&serde_json::json!(["a", "b"]))
+        );
+        assert_eq!(
+            profile.extra.get("nested"),
+            Some(&serde_json::json!({"ok": true, "n": 1}))
+        );
+        assert_eq!(
+            profile.extra.get("unicode"),
+            Some(&serde_json::json!("café ☕"))
+        );
+        assert_eq!(profile.extra.get("later"), Some(&serde_json::json!("kept")));
+        assert!(!profile.extra.contains_key("custom_blob"));
+        assert!(!profile.extra.contains_key("nested_blob"));
+        assert!(!profile.extra.contains_key("array_blob"));
+        assert!(!profile.extra.contains_key(&oversized_key));
+        assert!(!profile.extra.contains_key("created_at"));
+        assert!(!profile.extra.contains_key("source_relays"));
+        assert!(!profile.extra.contains_key("name"));
+        assert!(!profile.extra.contains_key("banner"));
+        assert!(!profile.extra.contains_key("displayName"));
+    }
+
+    #[test]
+    fn extra_profile_fields_keep_exactly_at_limit_and_drop_one_byte_over() {
+        let key_at_limit = ascii_xs(254);
+        let key_over = ascii_xs(255);
+        let value_at_limit = ascii_xs(MAX_EXTRA_PROFILE_VALUE_BYTES - 2);
+        let value_over = ascii_xs(MAX_EXTRA_PROFILE_VALUE_BYTES - 1);
+        assert_eq!(
+            serde_json::to_vec(&key_at_limit).unwrap().len(),
+            MAX_EXTRA_PROFILE_KEY_BYTES
+        );
+        assert_eq!(
+            serde_json::to_vec(&key_over).unwrap().len(),
+            MAX_EXTRA_PROFILE_KEY_BYTES + 1
+        );
+        assert_eq!(
+            serde_json::to_vec(&value_at_limit).unwrap().len(),
+            MAX_EXTRA_PROFILE_VALUE_BYTES
+        );
+        assert_eq!(
+            serde_json::to_vec(&value_over).unwrap().len(),
+            MAX_EXTRA_PROFILE_VALUE_BYTES + 1
+        );
+
+        let profile = profile_from_content(serde_json::json!({
+            key_at_limit.clone(): "ok",
+            key_over.clone(): "tiny",
+            "value_ok": value_at_limit.clone(),
+            "value_over": value_over
+        }));
+
+        assert_eq!(
+            profile.extra.get(&key_at_limit),
+            Some(&serde_json::json!("ok"))
+        );
+        assert!(!profile.extra.contains_key(&key_over));
+        assert_eq!(
+            profile.extra.get("value_ok"),
+            Some(&serde_json::Value::String(value_at_limit))
+        );
+        assert!(!profile.extra.contains_key("value_over"));
+    }
+
+    #[test]
+    fn extra_profile_fields_quota_skips_known_and_oversized_without_consuming_slots() {
+        assert!(extra_profile_fields(&serde_json::json!({})).is_empty());
+
+        let mut at_limit = serde_json::Map::new();
+        for index in 0..MAX_EXTRA_PROFILE_FIELDS {
+            at_limit.insert(format!("k{index:02}"), serde_json::json!(index));
+        }
+        let at_limit_profile = profile_from_content(serde_json::Value::Object(at_limit.clone()));
+        assert_eq!(at_limit_profile.extra.len(), MAX_EXTRA_PROFILE_FIELDS);
+        let encoded = serde_json::to_vec(&at_limit_profile.extra).unwrap();
+        assert!(encoded.len() <= MAX_RETAINED_EXTRA_PROFILE_JSON_BYTES);
+        let repeated = profile_from_content(serde_json::Value::Object(at_limit.clone()));
+        assert_eq!(repeated.extra, at_limit_profile.extra);
+
+        let mut over = at_limit;
+        over.insert(
+            format!("k{MAX_EXTRA_PROFILE_FIELDS:02}"),
+            serde_json::json!("overflow"),
+        );
+        over.insert("name".to_owned(), serde_json::json!("typed"));
+        over.insert("custom_blob".to_owned(), serde_json::json!(ascii_xs(8000)));
+        let over_profile = profile_from_content(serde_json::Value::Object(over));
+        assert_eq!(over_profile.extra.len(), MAX_EXTRA_PROFILE_FIELDS);
+        assert_eq!(over_profile.name.as_deref(), Some("typed"));
+        assert!(!over_profile.extra.contains_key("custom_blob"));
+        assert!(
+            !over_profile
+                .extra
+                .contains_key(&format!("k{MAX_EXTRA_PROFILE_FIELDS:02}"))
+        );
+        for index in 0..MAX_EXTRA_PROFILE_FIELDS {
+            assert_eq!(
+                over_profile.extra.get(&format!("k{index:02}")),
+                Some(&serde_json::json!(index))
+            );
+        }
+        let encoded = serde_json::to_vec(&over_profile.extra).unwrap();
+        assert!(encoded.len() <= MAX_RETAINED_EXTRA_PROFILE_JSON_BYTES);
+        assert_eq!(
+            profile_content_json(&over_profile)["name"],
+            serde_json::json!("typed")
+        );
+    }
+
+    #[test]
+    fn extra_profile_fields_do_not_enable_unbounded_json_recursion() {
+        let mut deep = String::from("null");
+        for _ in 0..200 {
+            deep = format!("[{deep}]");
+        }
+        let content =
+            format!(r#"{{"name":"alice","deep":{deep},"website":"https://example.test"}}"#);
+        assert!(
+            serde_json::from_str::<serde_json::Value>(&content).is_err(),
+            "ingest must keep serde_json's default recursion rejection"
+        );
+        let account_id = "11".repeat(32);
+        let mut event = NostrTransportEvent::new_unsigned(
+            account_id.clone(),
+            KIND_NOSTR_METADATA,
+            Vec::new(),
+            content,
+        );
+        event.created_at = 1_700_000_000;
+        assert!(
+            profile_from_record(RelayEventRecord {
+                endpoints: vec![TransportEndpoint("wss://relay.example".to_owned())],
+                event,
+            })
+            .is_none(),
+            "excessively nested kind:0 content must not become a profile"
+        );
+    }
+
+    #[test]
+    fn known_profile_fields_remain_character_capped_including_banner_alias() {
+        let oversized = format!("{}!", ascii_xs(MAX_PROFILE_FIELD_CHARS));
+        let profile = profile_from_content(serde_json::json!({
+            "name": oversized,
+            "displayName": oversized,
+            "banner": oversized,
+            "about": oversized
+        }));
+        assert_eq!(
+            profile.name.as_deref().map(|value| value.chars().count()),
+            Some(MAX_PROFILE_FIELD_CHARS)
+        );
+        assert_eq!(
+            profile
+                .display_name
+                .as_deref()
+                .map(|value| value.chars().count()),
+            Some(MAX_PROFILE_FIELD_CHARS)
+        );
+        assert_eq!(
+            profile.banner.as_deref().map(|value| value.chars().count()),
+            Some(MAX_PROFILE_FIELD_CHARS)
+        );
+        assert_eq!(
+            profile.about.as_deref().map(|value| value.chars().count()),
+            Some(MAX_PROFILE_FIELD_CHARS)
+        );
+    }
+
+    #[test]
+    fn flattened_profile_round_trip_preserves_retained_extensions() {
+        let profile = profile_from_content(serde_json::json!({
+            "name": "alice",
+            "website": "https://example.test",
+            "bot": false
+        }));
+        let json = serde_json::to_value(&profile).unwrap();
+        let round_trip: UserProfileMetadata = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, profile);
+        let content = profile_content_json(&profile);
+        assert_eq!(content["name"], "alice");
+        assert_eq!(content["website"], "https://example.test");
+        assert_eq!(content["bot"], false);
     }
 }

--- a/crates/marmot-app/src/directory/search.rs
+++ b/crates/marmot-app/src/directory/search.rs
@@ -1190,6 +1190,8 @@ pub fn sort_user_search_results(results: &mut [UserDirectorySearchResult]) {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
     use crate::AccountRelayListStatus;
     use crate::ids::npub_for_account_id_lossy;
@@ -1495,6 +1497,123 @@ mod tests {
         assert!(
             cache.entry(&stranger.account_id_hex).unwrap().is_none(),
             "caching a search result must not promote them into directory_users"
+        );
+    }
+
+    /// Hostile kind:0 extensions on a relay-resolved stranger must inherit the
+    /// shared ingest bounds in both the streamed result and the un-promoted
+    /// search-graph cache. The stranger is still not promoted.
+    #[tokio::test]
+    async fn a_relay_resolved_search_profile_inherits_extra_field_bounds() {
+        use crate::directory::records::{
+            MAX_EXTRA_PROFILE_FIELDS, MAX_EXTRA_PROFILE_KEY_BYTES, MAX_EXTRA_PROFILE_VALUE_BYTES,
+        };
+
+        const MAX_RETAINED_EXTRA_PROFILE_JSON_BYTES: usize = 2
+            + MAX_EXTRA_PROFILE_FIELDS
+                * (MAX_EXTRA_PROFILE_KEY_BYTES + 1 + MAX_EXTRA_PROFILE_VALUE_BYTES)
+            + MAX_EXTRA_PROFILE_FIELDS.saturating_sub(1);
+
+        let relay = nostr_relay_builder::MockRelay::run().await.unwrap();
+        let relay_url = relay.url().await.to_string();
+        let endpoint = cgka_traits::TransportEndpoint(relay_url.clone());
+        let stranger_dir = tempfile::tempdir().unwrap();
+        let stranger_app = MarmotApp::with_relay(stranger_dir.path(), relay_url.clone());
+        let stranger_runtime = stranger_app.runtime();
+        let stranger = stranger_runtime
+            .create_identity(crate::AccountSetupRequest {
+                default_relays: vec![endpoint.clone()],
+                bootstrap_relays: vec![endpoint.clone()],
+                publish_missing_relay_lists: true,
+                ..crate::AccountSetupRequest::default()
+            })
+            .await
+            .expect("create the stranger's identity")
+            .account;
+        wait_for_network_ready(&stranger_runtime, &stranger.account_id_hex).await;
+        stranger_app
+            .publish_user_profile(
+                &stranger.account_id_hex,
+                UserProfileMetadata {
+                    name: Some("needle".to_owned()),
+                    extra: BTreeMap::from([
+                        (
+                            "website".to_owned(),
+                            serde_json::json!("https://example.test"),
+                        ),
+                        ("bot".to_owned(), serde_json::json!(false)),
+                        (
+                            "custom_blob".to_owned(),
+                            serde_json::json!("x".repeat(8000)),
+                        ),
+                    ]),
+                    ..UserProfileMetadata::default()
+                },
+                crate::AccountRelayListBootstrap::new(vec![endpoint.clone()], Vec::new()),
+            )
+            .await
+            .expect("publish the stranger's hostile profile");
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = AccountHome::open(dir.path());
+        let account = home.create_account("alice").unwrap();
+        let app = MarmotApp::with_relay(dir.path(), relay_url);
+        let cache = app.directory_cache_for_account(&account).unwrap();
+        cache
+            .put(&UserDirectoryRecord {
+                follows: vec![stranger.account_id_hex.clone()],
+                ..record_named(&account.account_id_hex, "alice")
+            })
+            .unwrap();
+
+        let subscription = app
+            .search_users(params(&account.account_id_hex, "needle", (1, 1)))
+            .await
+            .unwrap();
+        let updates = drain(subscription).await;
+        let matched = updates
+            .iter()
+            .flat_map(|update| &update.new_results)
+            .find(|result| result.account_id_hex == stranger.account_id_hex)
+            .expect("the search must resolve the stranger from the relay");
+        let result_profile = matched.profile.as_ref().expect("search result profile");
+        assert_eq!(result_profile.name.as_deref(), Some("needle"));
+        assert_eq!(
+            result_profile.extra.get("website"),
+            Some(&serde_json::json!("https://example.test"))
+        );
+        assert_eq!(
+            result_profile.extra.get("bot"),
+            Some(&serde_json::json!(false))
+        );
+        assert!(!result_profile.extra.contains_key("custom_blob"));
+        assert!(result_profile.extra.len() <= MAX_EXTRA_PROFILE_FIELDS);
+        assert!(
+            serde_json::to_vec(&result_profile.extra).unwrap().len()
+                <= MAX_RETAINED_EXTRA_PROFILE_JSON_BYTES
+        );
+
+        let now = crate::unix_now_seconds() as i64;
+        let cached = cache
+            .search_record(&stranger.account_id_hex, now)
+            .unwrap()
+            .expect("the resolved profile must be cached for the next search");
+        let cached_profile = cached.profile.expect("un-promoted cached profile");
+        assert_eq!(cached_profile.extra, result_profile.extra);
+        assert!(!cached_profile.extra.contains_key("custom_blob"));
+        assert!(
+            cache.entry(&stranger.account_id_hex).unwrap().is_none(),
+            "caching a search result must not promote them into directory_users"
+        );
+        let plan = app.directory_sync_plan().unwrap();
+        let watched = plan
+            .batches
+            .iter()
+            .flat_map(|batch| batch.authors.clone())
+            .collect::<std::collections::HashSet<_>>();
+        assert!(
+            !watched.contains(&stranger.account_id_hex),
+            "a search-resolved stranger must not enter live directory sync"
         );
     }
 

--- a/crates/marmot-app/src/directory/search.rs
+++ b/crates/marmot-app/src/directory/search.rs
@@ -1419,101 +1419,12 @@ mod tests {
         assert_eq!(matched.matched_field, MatchedField::Name);
     }
 
-    /// A profile resolved from a relay to answer a search is kept, so the next
-    /// search for the same person is warm -- and it is kept in the un-promoted
-    /// tier only. Caching a stranger must never turn them into a directory
-    /// entry, because that is what feeds live per-author subscriptions
-    /// (mdk#418). The `entry` assertion is the guard on that.
-    #[tokio::test]
-    async fn a_profile_resolved_from_a_relay_is_cached_without_promoting_the_stranger() {
-        let relay = nostr_relay_builder::MockRelay::run().await.unwrap();
-        let relay_url = relay.url().await.to_string();
-
-        // The stranger publishes a profile from their own device. This needs a
-        // real signing identity, not a bare account row -- the profile is a
-        // signed kind:0 the searcher will fetch back off the relay.
-        let endpoint = cgka_traits::TransportEndpoint(relay_url.clone());
-        let stranger_dir = tempfile::tempdir().unwrap();
-        let stranger_app = MarmotApp::with_relay(stranger_dir.path(), relay_url.clone());
-        let stranger_runtime = stranger_app.runtime();
-        let stranger = stranger_runtime
-            .create_identity(crate::AccountSetupRequest {
-                default_relays: vec![endpoint.clone()],
-                bootstrap_relays: vec![endpoint.clone()],
-                publish_missing_relay_lists: true,
-                ..crate::AccountSetupRequest::default()
-            })
-            .await
-            .expect("create the stranger's identity")
-            .account;
-        wait_for_network_ready(&stranger_runtime, &stranger.account_id_hex).await;
-        stranger_app
-            .publish_user_profile(
-                &stranger.account_id_hex,
-                UserProfileMetadata {
-                    name: Some("needle".to_owned()),
-                    ..UserProfileMetadata::default()
-                },
-                crate::AccountRelayListBootstrap::new(vec![endpoint.clone()], Vec::new()),
-            )
-            .await
-            .expect("publish the stranger's profile");
-
-        // The searcher follows them but has never cached their profile.
-        let dir = tempfile::tempdir().unwrap();
-        let home = AccountHome::open(dir.path());
-        let account = home.create_account("alice").unwrap();
-        let app = MarmotApp::with_relay(dir.path(), relay_url);
-        let cache = app.directory_cache_for_account(&account).unwrap();
-        cache
-            .put(&UserDirectoryRecord {
-                follows: vec![stranger.account_id_hex.clone()],
-                ..record_named(&account.account_id_hex, "alice")
-            })
-            .unwrap();
-
-        let subscription = app
-            .search_users(params(&account.account_id_hex, "needle", (1, 1)))
-            .await
-            .unwrap();
-        let updates = drain(subscription).await;
-        assert!(
-            updates
-                .iter()
-                .flat_map(|update| &update.new_results)
-                .any(|result| result.account_id_hex == stranger.account_id_hex),
-            "the search must resolve the stranger from the relay: {updates:?}"
-        );
-
-        let now = crate::unix_now_seconds() as i64;
-        let cached = cache
-            .search_record(&stranger.account_id_hex, now)
-            .unwrap()
-            .expect("the resolved profile must be cached for the next search");
-        assert_eq!(
-            cached.profile.and_then(|profile| profile.name),
-            Some("needle".to_owned())
-        );
-        assert!(
-            cache.entry(&stranger.account_id_hex).unwrap().is_none(),
-            "caching a search result must not promote them into directory_users"
-        );
-    }
-
     /// Hostile kind:0 extensions on a relay-resolved stranger must inherit the
     /// shared ingest bounds in both the streamed result and the un-promoted
-    /// search-graph cache. The stranger is still not promoted.
+    /// search-graph cache. The stranger must not be promoted into directory_users
+    /// or its per-author subscriptions (mdk#418).
     #[tokio::test]
-    async fn a_relay_resolved_search_profile_inherits_extra_field_bounds() {
-        use crate::directory::records::{
-            MAX_EXTRA_PROFILE_FIELDS, MAX_EXTRA_PROFILE_KEY_BYTES, MAX_EXTRA_PROFILE_VALUE_BYTES,
-        };
-
-        const MAX_RETAINED_EXTRA_PROFILE_JSON_BYTES: usize = 2
-            + MAX_EXTRA_PROFILE_FIELDS
-                * (MAX_EXTRA_PROFILE_KEY_BYTES + 1 + MAX_EXTRA_PROFILE_VALUE_BYTES)
-            + MAX_EXTRA_PROFILE_FIELDS.saturating_sub(1);
-
+    async fn a_profile_resolved_from_a_relay_is_cached_without_promoting_the_stranger() {
         let relay = nostr_relay_builder::MockRelay::run().await.unwrap();
         let relay_url = relay.url().await.to_string();
         let endpoint = cgka_traits::TransportEndpoint(relay_url.clone());
@@ -1587,11 +1498,7 @@ mod tests {
             Some(&serde_json::json!(false))
         );
         assert!(!result_profile.extra.contains_key("custom_blob"));
-        assert!(result_profile.extra.len() <= MAX_EXTRA_PROFILE_FIELDS);
-        assert!(
-            serde_json::to_vec(&result_profile.extra).unwrap().len()
-                <= MAX_RETAINED_EXTRA_PROFILE_JSON_BYTES
-        );
+        assert_eq!(result_profile.extra.len(), 2);
 
         let now = crate::unix_now_seconds() as i64;
         let cached = cache
@@ -1604,16 +1511,6 @@ mod tests {
         assert!(
             cache.entry(&stranger.account_id_hex).unwrap().is_none(),
             "caching a search result must not promote them into directory_users"
-        );
-        let plan = app.directory_sync_plan().unwrap();
-        let watched = plan
-            .batches
-            .iter()
-            .flat_map(|batch| batch.authors.clone())
-            .collect::<std::collections::HashSet<_>>();
-        assert!(
-            !watched.contains(&stranger.account_id_hex),
-            "a search-resolved stranger must not enter live directory sync"
         );
     }
 

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -10339,6 +10339,116 @@ fn ingesting_remote_contact_list_does_not_promote_follows_and_caps_stored_follow
 }
 
 #[test]
+fn ingesting_kind0_profile_persists_only_bounded_unknown_fields() {
+    use crate::directory::records::{
+        MAX_EXTRA_PROFILE_FIELDS, MAX_EXTRA_PROFILE_KEY_BYTES, MAX_EXTRA_PROFILE_VALUE_BYTES,
+    };
+
+    const MAX_RETAINED_EXTRA_PROFILE_JSON_BYTES: usize = 2
+        + MAX_EXTRA_PROFILE_FIELDS
+            * (MAX_EXTRA_PROFILE_KEY_BYTES + 1 + MAX_EXTRA_PROFILE_VALUE_BYTES)
+        + MAX_EXTRA_PROFILE_FIELDS.saturating_sub(1);
+
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    home.create_account("alice").unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    let author = format!("{:064x}", 867);
+    let mut event = NostrTransportEvent::new_unsigned(
+        author.clone(),
+        KIND_NOSTR_METADATA,
+        Vec::new(),
+        serde_json::json!({
+            "name": "alice",
+            "banner": "https://example.test/banner.png",
+            "website": "https://example.test",
+            "bot": false,
+            "nested": {"ok": true, "tags": ["a"]},
+            "custom_blob": "x".repeat(8000),
+            "created_at": 42,
+            "source_relays": ["wss://spoof.example"]
+        })
+        .to_string(),
+    );
+    event.created_at = 1_700_000_867;
+    app.ingest_directory_relay_event(crate::relay_plane::DirectoryRelayEventRecord {
+        endpoints: vec![TransportEndpoint("wss://profiles.example".to_owned())],
+        event,
+    })
+    .unwrap();
+
+    let assert_bounded_extra = |profile: &UserProfileMetadata| {
+        assert_eq!(profile.name.as_deref(), Some("alice"));
+        assert_eq!(
+            profile.banner.as_deref(),
+            Some("https://example.test/banner.png")
+        );
+        assert_eq!(profile.created_at, 1_700_000_867);
+        assert_eq!(
+            profile.extra.get("website"),
+            Some(&serde_json::json!("https://example.test"))
+        );
+        assert_eq!(profile.extra.get("bot"), Some(&serde_json::json!(false)));
+        assert_eq!(
+            profile.extra.get("nested"),
+            Some(&serde_json::json!({"ok": true, "tags": ["a"]}))
+        );
+        assert!(!profile.extra.contains_key("custom_blob"));
+        assert!(!profile.extra.contains_key("created_at"));
+        assert!(!profile.extra.contains_key("source_relays"));
+        assert!(profile.extra.len() <= MAX_EXTRA_PROFILE_FIELDS);
+        let encoded = serde_json::to_vec(&profile.extra).unwrap();
+        assert!(encoded.len() <= MAX_RETAINED_EXTRA_PROFILE_JSON_BYTES);
+    };
+
+    let cached = app
+        .directory_entry_for_account_id(&author)
+        .unwrap()
+        .expect("ingested profile is cached");
+    let cached_profile = cached.profile.expect("cached profile");
+    assert_bounded_extra(&cached_profile);
+    assert_eq!(
+        cached_profile.source_relays,
+        vec!["wss://profiles.example".to_owned()]
+    );
+
+    let shared = app
+        .shared_storage()
+        .unwrap()
+        .public_directory_user(&author)
+        .unwrap()
+        .expect("shared directory row");
+    let shared_profile: UserProfileMetadata =
+        serde_json::from_str(shared.profile_json.as_ref().expect("profile_json")).unwrap();
+    assert_bounded_extra(&shared_profile);
+    assert_eq!(shared_profile.extra, cached_profile.extra);
+    assert!(
+        !shared
+            .profile_json
+            .as_ref()
+            .unwrap()
+            .contains("custom_blob")
+    );
+
+    drop(app);
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    let reopened = app
+        .directory_entries()
+        .unwrap()
+        .into_iter()
+        .find(|entry| entry.account_id_hex == author)
+        .expect("reopened directory_entries still lists the author")
+        .profile
+        .expect("reopened profile");
+    assert_bounded_extra(&reopened);
+    assert_eq!(reopened.extra, cached_profile.extra);
+    assert_eq!(
+        reopened.source_relays,
+        vec!["wss://profiles.example".to_owned()]
+    );
+}
+
+#[test]
 fn local_account_directory_refresh_still_promotes_follows() {
     let dir = tempfile::tempdir().unwrap();
     let home = AccountHome::open(dir.path());

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -10340,15 +10340,6 @@ fn ingesting_remote_contact_list_does_not_promote_follows_and_caps_stored_follow
 
 #[test]
 fn ingesting_kind0_profile_persists_only_bounded_unknown_fields() {
-    use crate::directory::records::{
-        MAX_EXTRA_PROFILE_FIELDS, MAX_EXTRA_PROFILE_KEY_BYTES, MAX_EXTRA_PROFILE_VALUE_BYTES,
-    };
-
-    const MAX_RETAINED_EXTRA_PROFILE_JSON_BYTES: usize = 2
-        + MAX_EXTRA_PROFILE_FIELDS
-            * (MAX_EXTRA_PROFILE_KEY_BYTES + 1 + MAX_EXTRA_PROFILE_VALUE_BYTES)
-        + MAX_EXTRA_PROFILE_FIELDS.saturating_sub(1);
-
     let dir = tempfile::tempdir().unwrap();
     let home = AccountHome::open(dir.path());
     home.create_account("alice").unwrap();
@@ -10396,9 +10387,7 @@ fn ingesting_kind0_profile_persists_only_bounded_unknown_fields() {
         assert!(!profile.extra.contains_key("custom_blob"));
         assert!(!profile.extra.contains_key("created_at"));
         assert!(!profile.extra.contains_key("source_relays"));
-        assert!(profile.extra.len() <= MAX_EXTRA_PROFILE_FIELDS);
-        let encoded = serde_json::to_vec(&profile.extra).unwrap();
-        assert!(encoded.len() <= MAX_RETAINED_EXTRA_PROFILE_JSON_BYTES);
+        assert_eq!(profile.extra.len(), 3);
     };
 
     let cached = app

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -2116,6 +2116,93 @@ async fn runtime_profile_publish_preserves_unknown_kind0_fields() {
 }
 
 #[tokio::test]
+async fn fetch_and_refresh_profile_inherit_extra_field_bounds_from_shared_parser() {
+    let dir_fetch = tempfile::tempdir().unwrap();
+    let (_relay, fetch_app, url) = mock_app(&dir_fetch).await;
+    let fetch_runtime = MarmotAppRuntime::new(fetch_app.clone());
+    let _fetch_account = create_network_ready_identity(
+        &fetch_runtime,
+        AccountSetupRequest {
+            default_relays: vec![endpoint(&url)],
+            bootstrap_relays: vec![endpoint(&url)],
+            ..AccountSetupRequest::default()
+        },
+    )
+    .await;
+
+    let publisher = Keys::generate();
+    let content = serde_json::json!({
+        "name": "hostile",
+        "website": "https://example.test",
+        "bot": false,
+        "custom_blob": "x".repeat(8000),
+        "created_at": 42,
+        "source_relays": ["wss://spoof.example"]
+    })
+    .to_string();
+    let signed = EventBuilder::new(Kind::Metadata, content)
+        .custom_created_at(NostrTimestamp::from_secs(1_700_000_867))
+        .sign_with_keys(&publisher)
+        .expect("sign hostile kind:0");
+    let transport_event =
+        NostrTransportEvent::from_nostr_event(&signed).expect("dto from signed kind:0");
+    let relay_client = NostrSdkRelayClient::new(NostrSdkClient::builder().build());
+    relay_client
+        .publish_event(&[endpoint(&url)], &transport_event, 1)
+        .await
+        .expect("publish hostile kind:0 from a separate publisher");
+
+    let publisher_hex = publisher.public_key().to_hex();
+    let fetched = fetch_app
+        .fetch_current_user_profile_for_account_id(&publisher_hex, vec![endpoint(&url)])
+        .await
+        .unwrap()
+        .expect("profile on relay");
+    assert_eq!(fetched.name.as_deref(), Some("hostile"));
+    assert_eq!(
+        fetched.extra.get("website"),
+        Some(&serde_json::json!("https://example.test"))
+    );
+    assert_eq!(fetched.extra.get("bot"), Some(&serde_json::json!(false)));
+    assert!(!fetched.extra.contains_key("custom_blob"));
+    assert!(!fetched.extra.contains_key("created_at"));
+    assert!(!fetched.extra.contains_key("source_relays"));
+    assert_eq!(fetched.created_at, 1_700_000_867);
+    assert!(
+        fetched
+            .source_relays
+            .iter()
+            .all(|relay| !relay.contains("spoof")),
+        "provenance must stay endpoint-derived"
+    );
+
+    let dir_refresh = tempfile::tempdir().unwrap();
+    AccountHome::open(dir_refresh.path())
+        .create_account("bob")
+        .unwrap();
+    let refresh_app = MarmotApp::with_relay_and_config(
+        dir_refresh.path(),
+        url.clone(),
+        MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true),
+    );
+    refresh_app
+        .refresh_profile_for_account_id(&publisher_hex, vec![endpoint(&url)])
+        .await
+        .unwrap();
+    let refreshed = refresh_app
+        .directory_entry_for_account_id(&publisher_hex)
+        .unwrap()
+        .expect("refresh cached the inbound profile")
+        .profile
+        .expect("refreshed profile");
+    assert_eq!(refreshed.name.as_deref(), Some("hostile"));
+    assert_eq!(refreshed.extra, fetched.extra);
+    assert!(!refreshed.extra.contains_key("custom_blob"));
+
+    fetch_runtime.shutdown().await;
+}
+
+#[tokio::test]
 async fn app_runtime_republish_key_package_resends_exact_current_event() {
     let dir = tempfile::tempdir().unwrap();
     let (_relay, app, url) = mock_app(&dir).await;

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -2131,16 +2131,15 @@ async fn fetch_and_refresh_profile_inherit_extra_field_bounds_from_shared_parser
     .await;
 
     let publisher = Keys::generate();
-    let content = serde_json::json!({
+    let mut content = serde_json::json!({
         "name": "hostile",
         "website": "https://example.test",
         "bot": false,
         "custom_blob": "x".repeat(8000),
         "created_at": 42,
         "source_relays": ["wss://spoof.example"]
-    })
-    .to_string();
-    let signed = EventBuilder::new(Kind::Metadata, content)
+    });
+    let signed = EventBuilder::new(Kind::Metadata, content.to_string())
         .custom_created_at(NostrTimestamp::from_secs(1_700_000_867))
         .sign_with_keys(&publisher)
         .expect("sign hostile kind:0");
@@ -2176,28 +2175,37 @@ async fn fetch_and_refresh_profile_inherit_extra_field_bounds_from_shared_parser
         "provenance must stay endpoint-derived"
     );
 
-    let dir_refresh = tempfile::tempdir().unwrap();
-    AccountHome::open(dir_refresh.path())
-        .create_account("bob")
+    // A newer event makes refresh prove it fetched and filtered new content,
+    // rather than passing against the profile already cached by fetch.
+    content["name"] = serde_json::json!("refreshed");
+    content["bot"] = serde_json::json!(true);
+    let newer = EventBuilder::new(Kind::Metadata, content.to_string())
+        .custom_created_at(NostrTimestamp::from_secs(1_700_000_868))
+        .sign_with_keys(&publisher)
         .unwrap();
-    let refresh_app = MarmotApp::with_relay_and_config(
-        dir_refresh.path(),
-        url.clone(),
-        MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true),
-    );
-    refresh_app
+    relay_client
+        .publish_event(
+            &[endpoint(&url)],
+            &NostrTransportEvent::from_nostr_event(&newer).unwrap(),
+            1,
+        )
+        .await
+        .unwrap();
+    fetch_app
         .refresh_profile_for_account_id(&publisher_hex, vec![endpoint(&url)])
         .await
         .unwrap();
-    let refreshed = refresh_app
+    let refreshed = fetch_app
         .directory_entry_for_account_id(&publisher_hex)
         .unwrap()
         .expect("refresh cached the inbound profile")
         .profile
         .expect("refreshed profile");
-    assert_eq!(refreshed.name.as_deref(), Some("hostile"));
-    assert_eq!(refreshed.extra, fetched.extra);
-    assert!(!refreshed.extra.contains_key("custom_blob"));
+    assert_eq!(refreshed.name.as_deref(), Some("refreshed"));
+    let mut expected_extra = fetched.extra;
+    expected_extra.insert("bot".into(), serde_json::json!(true));
+    assert_eq!(refreshed.extra, expected_extra);
+    assert_eq!(refreshed.created_at, 1_700_000_868);
 
     fetch_runtime.shutdown().await;
 }


### PR DESCRIPTION
<!-- pip-control:v1 effect=repo:1055628515#867@3:draft-pr sha256=8ed390ff90a85fdd2799d8be6bb1e8f2294e9f4da1790036ec8b1a7407fb40af -->
## Problem

Known profile fields already have retention limits, but unknown kind:0 fields were copied into directory caches without size or count bounds. Oversized remote metadata could therefore bloat stored profiles and downstream reads.

## Solution

Bound unknown fields in the shared profile-ingestion parser:

- Retain at most 32 fields, with compact-JSON limits of 256 bytes per key and 4,096 bytes per value.
- Drop oversized entries whole; measure encoded size without allocating another attacker-sized serialized copy.
- Preserve supported profile fields and normal custom-field round trips.
- Cover parser boundaries, cache persistence, search, fetch, and refresh paths with regression tests.

[Implementation plan](https://github.com/marmot-protocol/mdk/issues/867#issuecomment-5574608033)

Fixes #867

## Scope and limitations

These limits apply when profiles are ingested again; this change does not shrink existing cached rows immediately. Bounding the initial raw event JSON parse is a separate hardening task and is not included here.

<details>
<summary>Builder-reported checks and known baseline failures</summary>

- cargo fmt -p marmot-app: passed
- git diff --check: passed
- cargo clippy --locked -p marmot-app --all-targets -- -D warnings: passed
- cargo test --locked -p marmot-app --lib directory::records::tests: 14 passed
- cargo test --locked -p marmot-app --lib directory::search::tests: 26 passed
- cargo test --locked -p marmot-app --lib ingesting_kind0_profile_persists_only_bounded_unknown_fields: passed
- cargo test --locked -p marmot-app --lib unknown_kind0_fields: 2 passed
- cargo test --locked -p marmot-app --lib remember_directory_profile_if_newer_keeps_local_edit_on_equal_timestamp: passed
- cargo test --locked -p marmot-app --test relay_runtime fetch_and_refresh_profile_inherit_extra_field_bounds_from_shared_parser: passed
- cargo test --locked -p marmot-app --test relay_runtime runtime_profile_publish_preserves_unknown_kind0_fields: passed
- cargo test --locked -p marmot-app --lib: 1004 passed, 4 failed, 2 ignored; three epoch-stall tests also fail on planned base a65c1fa72a984d1893edbb6be575384ae8725008 without this change; account_reconcile_returns_local_readiness_before_relay_subscription_registration passed on serial retry
- cargo test --locked -p marmot-app --test relay_runtime: 148 passed, 5 failed, 1 ignored; sampled encrypted-media and retention failures also fail on planned base a65c1fa72a984d1893edbb6be575384ae8725008 without this change
- just fast-ci: passed

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Limited retention of unknown profile fields to prevent oversized or excessive metadata from being stored.
  - Oversized, deeply nested, or invalid extra fields are now omitted while supported profile information remains available.
  - Applied consistent profile-field limits across ingestion, search results, caching, fetching, refreshing, and reopened sessions.
  - Preserved recognized profile fields and endpoint-derived information while excluding conflicting or untrusted duplicates.
  - Ensured refreshed profiles consistently reflect newer metadata while retaining valid extra fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->