### PR TITLE
Centralize app transport receipt synchronization

### DIFF
--- a/crates/marmot-app/AGENTS.md
+++ b/crates/marmot-app/AGENTS.md
@@ -21,8 +21,9 @@ App runtime bridge for the first real Marmot app surfaces.
   send commands, and the lifecycle helpers and encrypted-media helpers they share), `sync.rs` (transport sync: `sync`,
   `next_event`, `sync_sdk_relay`, `ingest_delivery`, `sync_runtime_groups`, the relay-echo/transport-cursor helpers, and
   the cursor unit tests), `projection.rs` (timeline/group projection accessors, the `*_for_group` component reads, the
-  kind-1210 group-system row synthesis, and the local-send projection helpers), `push.rs` (push-token registration and
-  notification-trigger publishing), `retention.rs` (the engine-owned retention sweep policy, bounded timeline scan,
+  kind-1210 group-system row synthesis, and the local-send projection helpers), `receipts.rs` (the synchronized
+  transport receipt view, release-journal consumption, and seen-index maintenance), `push.rs` (push-token registration
+  and notification-trigger publishing), `retention.rs` (the engine-owned retention sweep policy, bounded timeline scan,
   per-group outcome orchestration, and classifier tests), and `audit.rs` (audit-context construction, the local/observed
   `human_action` recorders, and the `ObservedHumanActionAudit` descriptor). Private items referenced across these files
   are widened to `pub(crate)`; `pub` items keep stable `marmot_app::...` paths via the crate-root re-export.

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -305,6 +305,8 @@ pub struct AppClient {
     /// `remember_seen_event` (which removes pruned ring entries from it).
     /// Receipt decisions use `transport_receipts`; the index exposes no raw
     /// production membership lookup.
+    /// The persisted `state.seen_events` ring remains accessible for checkpoint
+    /// bookkeeping; reading it for receipt decisions would bypass synchronization.
     /// Derived state: rebuilt from the ordered ring at construction and never
     /// persisted. Before this index existed, every inbound delivery and every
     /// publish-report batch rebuilt a `HashSet` from the full 16k-entry ring.

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -56,24 +56,21 @@ use crate::{
     AppTransportRouting, CanonicalCreatedGroup, GroupInviteDeclineResult, MarmotApp,
     MarmotRelayPlane, MarmotRelayPlaneAccountAdapter, MediaAttachmentReference,
     MediaDownloadResult, MediaUploadRequest, MediaUploadResult, PendingWelcomeDelivery,
-    SelfMembership, SendSummary, remember_seen_event, unix_now_seconds,
+    SelfMembership, SendSummary, unix_now_seconds,
 };
 
 mod audit;
 pub(crate) mod epoch_stall;
 mod projection;
 mod push;
+mod receipts;
 mod retention;
 mod sync;
 
 use epoch_stall::EpochStallDetector;
 use push::notification_trigger_for_intent;
-// Re-exported so the crate's `tests` module can keep calling
-// `client::is_own_relay_echo`; the function itself lives in `client::sync`.
 #[cfg(test)]
 pub(crate) use sync::epoch_stall_now_ms;
-#[cfg(test)]
-pub(crate) use sync::is_own_relay_echo;
 pub(crate) use sync::{
     ConvergenceScheduleState, DeliveryOverflowRecoveryOutcome, EpochBackfillRunOutcome,
 };
@@ -306,10 +303,12 @@ pub struct AppClient {
     pub(crate) state: AccountState,
     /// O(1) membership index over `state.seen_events`, kept in lockstep by
     /// `remember_seen_event` (which removes pruned ring entries from it).
+    /// Receipt decisions use `transport_receipts`; the index exposes no raw
+    /// production membership lookup.
     /// Derived state: rebuilt from the ordered ring at construction and never
     /// persisted. Before this index existed, every inbound delivery and every
     /// publish-report batch rebuilt a `HashSet` from the full 16k-entry ring.
-    pub(crate) seen_events_index: HashSet<String>,
+    pub(crate) seen_events_index: receipts::SeenEventIndex,
     /// Number of ids at the tail of `state.seen_events` observed since the last
     /// successful account-projection checkpoint. The count saturates at the
     /// bounded ring length, so even a catch-up batch larger than the window
@@ -405,9 +404,9 @@ pub struct AppClient {
     pub(crate) epoch_backfill_retry_not_before: Option<Instant>,
     /// Armed epoch-gap recovery intent awaiting its account-wide replay.
     pub(crate) pending_epoch_backfill: Option<epoch_stall::PendingEpochBackfill>,
-    /// Release consumption durably armed recovery, but loading its intents
-    /// failed. Retry on this client even though the journal is already empty;
-    /// account open independently restores these intents after a restart.
+    /// Initial account open or release consumption requires a backfill reload.
+    /// Keep this armed after a failed read even if the journal is already empty;
+    /// the next synchronized receipt access retries on this same client.
     pub(crate) released_backfill_reload_pending: bool,
     /// One-shot storage-read failure after durable release consumption.
     #[cfg(test)]
@@ -4534,15 +4533,6 @@ impl AppClient {
         for report in &effects.reports {
             let event_id = hex::encode(report.message_id.as_slice());
             self.remember_seen_event(event_id);
-        }
-    }
-
-    pub(crate) fn remember_seen_event(&mut self, event_id: String) {
-        if remember_seen_event(&mut self.seen_events_index, &mut self.state, event_id) {
-            self.pending_seen_event_count = self
-                .pending_seen_event_count
-                .saturating_add(1)
-                .min(self.state.seen_events.len());
         }
     }
 

--- a/crates/marmot-app/src/client/receipts.rs
+++ b/crates/marmot-app/src/client/receipts.rs
@@ -13,7 +13,7 @@ use crate::{AppError, remember_seen_event};
 pub(crate) struct SynchronizedTransportReceipts<'a> {
     client: &'a mut AppClient,
     storage: SqliteAccountStorage,
-    released: Vec<String>,
+    released: HashSet<String>,
 }
 
 /// Production membership reads are available only through the synchronized
@@ -53,11 +53,11 @@ impl AppClient {
     fn synchronize_released_transport_receipts(
         &mut self,
         storage: &SqliteAccountStorage,
-    ) -> Result<Vec<String>, AppError> {
+    ) -> Result<HashSet<String>, AppError> {
         let released = storage.consume_released_transport_receipts()?;
         self.released_backfill_reload_pending |= !released.is_empty();
         if !self.released_backfill_reload_pending {
-            return Ok(Vec::new());
+            return Ok(HashSet::new());
         }
         let released = released
             .into_iter()
@@ -94,14 +94,14 @@ impl AppClient {
         }
         self.restore_persisted_epoch_backfill_intents(storage.pending_epoch_backfill_intents()?);
         self.released_backfill_reload_pending = false;
-        Ok(released.into_iter().collect())
+        Ok(released)
     }
 
     #[cfg(test)]
     pub(crate) fn reconcile_released_transport_receipts(
         &mut self,
     ) -> Result<Vec<String>, AppError> {
-        Ok(self.transport_receipts()?.released)
+        Ok(self.transport_receipts()?.released.into_iter().collect())
     }
 
     /// Synchronize at the account's exclusive mutation boundary. Storage-only
@@ -129,7 +129,7 @@ impl<'a> SynchronizedTransportReceipts<'a> {
     }
 
     pub(crate) fn was_released(&self, event_id: &str) -> bool {
-        self.released.iter().any(|id| id == event_id)
+        self.released.contains(event_id)
     }
 
     pub(crate) fn contains(&self, event_id: &str) -> bool {
@@ -312,17 +312,12 @@ mod tests {
             client.fail_next_released_backfill_reload = true;
             let ring_ptr = client.state.seen_events.as_ptr();
             let index_capacity = client.seen_events_index.0.capacity();
-            let started = std::time::Instant::now();
             for _ in 0..1024 {
                 let receipts = client.transport_receipts().unwrap();
                 std::hint::black_box(receipts.contains("absent"));
                 assert!(receipts.pending_seen_events().is_empty());
                 assert!(!receipts.was_released("absent"));
             }
-            eprintln!(
-                "MDK_BENCH receipt_empty_journal ring_size={ring_size} accesses=1024 elapsed_us={}",
-                started.elapsed().as_micros()
-            );
             assert_eq!(client.state.seen_events.as_ptr(), ring_ptr);
             assert_eq!(client.seen_events_index.0.capacity(), index_capacity);
             assert_eq!(client.seen_events_index.len(), ring_size);

--- a/crates/marmot-app/src/client/receipts.rs
+++ b/crates/marmot-app/src/client/receipts.rs
@@ -1,0 +1,332 @@
+//! Account-owned transport receipt access. Views cannot outlive an exclusive
+//! client borrow or overlap an engine step on that client.
+
+use std::collections::HashSet;
+
+use storage_sqlite::{
+    SqliteAccountStorage, TransportReconciliationInventory, TransportReconciliationRoute,
+};
+
+use super::AppClient;
+use crate::{AppError, remember_seen_event};
+
+pub(crate) struct SynchronizedTransportReceipts<'a> {
+    client: &'a mut AppClient,
+    storage: SqliteAccountStorage,
+    released: Vec<String>,
+}
+
+/// Production membership reads are available only through the synchronized
+/// view. Test accessors inspect pre/post-error cache state without repairing it.
+pub(crate) struct SeenEventIndex(HashSet<String>);
+
+impl FromIterator<String> for SeenEventIndex {
+    fn from_iter<T: IntoIterator<Item = String>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+#[cfg(test)]
+impl SeenEventIndex {
+    pub(crate) fn contains(&self, id: &str) -> bool {
+        self.0.contains(id)
+    }
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
+    pub(crate) fn insert(&mut self, id: String) -> bool {
+        self.0.insert(id)
+    }
+}
+
+impl AppClient {
+    pub(crate) fn remember_seen_event(&mut self, event_id: String) {
+        if remember_seen_event(&mut self.seen_events_index.0, &mut self.state, event_id) {
+            self.pending_seen_event_count = self
+                .pending_seen_event_count
+                .saturating_add(1)
+                .min(self.state.seen_events.len());
+        }
+    }
+
+    /// Repair durable release evidence independently of lossy engine effects.
+    fn synchronize_released_transport_receipts(
+        &mut self,
+        storage: &SqliteAccountStorage,
+    ) -> Result<Vec<String>, AppError> {
+        let released = storage.consume_released_transport_receipts()?;
+        self.released_backfill_reload_pending |= !released.is_empty();
+        if !self.released_backfill_reload_pending {
+            return Ok(Vec::new());
+        }
+        let released = released
+            .into_iter()
+            .map(|id| hex::encode(id.as_slice()))
+            .collect::<HashSet<_>>();
+        if !released.is_empty() {
+            // No await or fallible operation between acknowledging the durable
+            // journal and removing its ids from memory. Never checkpoint stale ids
+            // back over the transactional deletion, including unsaved ring entries.
+            let unsaved_start = self
+                .state
+                .seen_events
+                .len()
+                .saturating_sub(self.pending_seen_event_count);
+            self.pending_seen_event_count = self.state.seen_events[unsaved_start..]
+                .iter()
+                .filter(|id| !released.contains(*id))
+                .count();
+            self.seen_events_index.0.retain(|id| !released.contains(id));
+            self.state.seen_events.retain(|id| !released.contains(id));
+            tracing::info!(
+                target: "marmot_app::relay_plane",
+                method = "synchronize_released_transport_receipts",
+                released_count = released.len(),
+                "retired released transport receipt claims and restored replay eligibility"
+            );
+        }
+        #[cfg(test)]
+        if std::mem::take(&mut self.fail_next_released_backfill_reload) {
+            return Err(cgka_traits::storage::StorageError::Busy(
+                "injected released backfill intent read failure".into(),
+            )
+            .into());
+        }
+        self.restore_persisted_epoch_backfill_intents(storage.pending_epoch_backfill_intents()?);
+        self.released_backfill_reload_pending = false;
+        Ok(released.into_iter().collect())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn reconcile_released_transport_receipts(
+        &mut self,
+    ) -> Result<Vec<String>, AppError> {
+        Ok(self.transport_receipts()?.released)
+    }
+
+    /// Synchronize at the account's exclusive mutation boundary. Storage-only
+    /// readers must not consume this client's journal behind its active cache.
+    /// A failed reload returns no view, but already-acknowledged IDs have been
+    /// invalidated synchronously and reload remains armed for this same client.
+    pub(crate) fn transport_receipts(
+        &mut self,
+    ) -> Result<SynchronizedTransportReceipts<'_>, AppError> {
+        let storage = self.app.account_storage(&self.state.label)?;
+        let released = self.synchronize_released_transport_receipts(&storage)?;
+        Ok(SynchronizedTransportReceipts {
+            client: self,
+            storage,
+            released,
+        })
+    }
+}
+
+impl<'a> SynchronizedTransportReceipts<'a> {
+    /// Consume the receipt decision before entering an engine step. The SDK
+    /// duplicate check and admission share this borrow without a second query.
+    pub(super) fn into_client(self) -> &'a mut AppClient {
+        self.client
+    }
+
+    pub(crate) fn was_released(&self, event_id: &str) -> bool {
+        self.released.iter().any(|id| id == event_id)
+    }
+
+    pub(crate) fn contains(&self, event_id: &str) -> bool {
+        self.client.seen_events_index.0.contains(event_id)
+    }
+
+    pub(crate) fn inventory(
+        &self,
+        route: &TransportReconciliationRoute,
+        until: u64,
+    ) -> Result<TransportReconciliationInventory, AppError> {
+        Ok(self
+            .storage
+            .transport_reconciliation_inventory(route, until)?)
+    }
+
+    pub(crate) fn pending_seen_events(&self) -> Vec<String> {
+        let start = self
+            .client
+            .state
+            .seen_events
+            .len()
+            .saturating_sub(self.client.pending_seen_event_count);
+        self.client.state.seen_events[start..].to_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{MarmotApp, tests::ScriptedPushRelayClient};
+    use cgka_traits::storage::MessageStorage;
+    use cgka_traits::{EpochId, MessageId, MessageRecord, MessageState};
+    use marmot_account::AccountHome;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn receipt_access_retires_lost_releases_without_caller_reconciliation() {
+        for (boundary, fail_reload) in [
+            ("duplicate", false),
+            ("inventory", false),
+            ("checkpoint", false),
+            ("duplicate", true),
+            ("inventory", true),
+            ("checkpoint", true),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            AccountHome::open(dir.path())
+                .create_account("alice")
+                .unwrap();
+            let app = MarmotApp::with_relay(dir.path(), "wss://receipts.example")
+                .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+            let mut client = app.client("alice").await.unwrap();
+            let group = client.create_group("receipt boundary", &[]).await.unwrap();
+            let storage = app.account_storage("alice").unwrap();
+            let route = TransportReconciliationRoute::Group(
+                hex::decode(
+                    app.group("alice", &hex::encode(group.as_slice()))
+                        .unwrap()
+                        .unwrap()
+                        .nostr_routing
+                        .nostr_group_id_hex,
+                )
+                .unwrap()
+                .try_into()
+                .unwrap(),
+            );
+            let item = storage_sqlite::TransportReconciliationItem {
+                event_id: [0xfd; 32],
+                created_at: crate::unix_now_seconds(),
+            };
+            let raw = MessageRecord {
+                id: MessageId::new(vec![0xfd; 32]),
+                group_id: group,
+                epoch: EpochId(0),
+                state: MessageState::PeelDeferred,
+                payload: Vec::new(),
+                deferred_peel: None,
+            };
+            let id = hex::encode(raw.id.as_slice());
+            client.remember_seen_event(id.clone());
+            client
+                .save_state_with_pending_local_group_deletion_frontier_clears()
+                .unwrap();
+            client.pending_seen_event_count = client.state.seen_events.len();
+            storage.put_message(&raw).unwrap();
+            storage.release_message_for_replay(&raw).unwrap();
+            // Simulate an intervening stale inventory checkpoint. Consuming the
+            // durable journal must revoke it together with the active cache.
+            storage
+                .record_transport_reconciliation_item(&route, &item)
+                .unwrap();
+            assert!(
+                storage
+                    .transport_reconciliation_inventory(&route, item.created_at)
+                    .unwrap()
+                    .items
+                    .contains(&item)
+            );
+            // No effect observation or explicit reconcile between release and
+            // accessing receipts, including an unsaved checkpoint tail.
+            if fail_reload {
+                client.fail_next_released_backfill_reload = true;
+                assert!(matches!(
+                    client.transport_receipts(),
+                    Err(AppError::Storage(cgka_traits::storage::StorageError::Busy(
+                        _
+                    )))
+                ));
+                assert!(!client.seen_events_index.contains(&id));
+                assert!(!client.state.seen_events.contains(&id));
+                assert!(client.released_backfill_reload_pending);
+                assert!(
+                    storage
+                        .consume_released_transport_receipts()
+                        .unwrap()
+                        .is_empty()
+                );
+            }
+            // After a reload error this retries on the same client with an
+            // already-acknowledged journal; it must still restore backfill.
+            let receipts = client.transport_receipts().unwrap();
+            match boundary {
+                "duplicate" => assert!(!receipts.contains(&id)),
+                "inventory" => {
+                    assert!(
+                        !receipts
+                            .inventory(&route, item.created_at)
+                            .unwrap()
+                            .items
+                            .contains(&item)
+                    );
+                    assert!(!receipts.contains(&id));
+                }
+                "checkpoint" => assert!(!receipts.pending_seen_events().contains(&id)),
+                _ => unreachable!(),
+            }
+            assert!(!client.state.seen_events.contains(&id));
+            assert!(client.has_pending_epoch_backfill());
+            assert!(!client.released_backfill_reload_pending);
+            client
+                .save_state_with_pending_local_group_deletion_frontier_clears()
+                .unwrap();
+            assert!(!app.load_state("alice").unwrap().seen_events.contains(&id));
+        }
+    }
+
+    #[tokio::test]
+    async fn receipt_access_propagates_closed_storage() {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let app = MarmotApp::with_relay(dir.path(), "wss://receipts.example")
+            .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+        let mut client = app.client("alice").await.unwrap();
+        app.account_storage("alice").unwrap().close().unwrap();
+        assert!(client.transport_receipts().is_err());
+        assert!(
+            client
+                .save_state_with_pending_local_group_deletion_frontier_clears()
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn receipt_empty_journal_access_keeps_cache_and_reload_idle() {
+        for ring_size in [0, crate::MAX_SEEN_EVENT_IDS] {
+            let dir = tempfile::tempdir().unwrap();
+            AccountHome::open(dir.path())
+                .create_account("alice")
+                .unwrap();
+            let app = MarmotApp::with_relay(dir.path(), "wss://receipts.example")
+                .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+            let mut client = app.client("alice").await.unwrap();
+            for id in 0..ring_size {
+                client.remember_seen_event(format!("{id:064x}"));
+            }
+            client.pending_seen_event_count = 0;
+            client.fail_next_released_backfill_reload = true;
+            let ring_ptr = client.state.seen_events.as_ptr();
+            let index_capacity = client.seen_events_index.0.capacity();
+            let started = std::time::Instant::now();
+            for _ in 0..1024 {
+                let receipts = client.transport_receipts().unwrap();
+                std::hint::black_box(receipts.contains("absent"));
+                assert!(receipts.pending_seen_events().is_empty());
+                assert!(!receipts.was_released("absent"));
+            }
+            eprintln!(
+                "MDK_BENCH receipt_empty_journal ring_size={ring_size} accesses=1024 elapsed_us={}",
+                started.elapsed().as_micros()
+            );
+            assert_eq!(client.state.seen_events.as_ptr(), ring_ptr);
+            assert_eq!(client.seen_events_index.0.capacity(), index_capacity);
+            assert_eq!(client.seen_events_index.len(), ring_size);
+            assert!(client.fail_next_released_backfill_reload);
+        }
+    }
+}

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -718,6 +718,7 @@ impl AppClient {
         &mut self,
         effects: &marmot_account::AccountDeviceEffects,
     ) -> Result<(), AppError> {
+        // Retire released receipts even when this effects batch makes no receipt read.
         self.transport_receipts()?;
         self.observe_recovery_evidence(effects);
         self.remember_pending_convergence_groups(effects);
@@ -782,6 +783,9 @@ impl AppClient {
     /// Each route reconciles against the exact event-id set retained in this
     /// account's SQLCipher database, so traffic in one busy group cannot move
     /// or evict another route's completeness state.
+    /// Synchronize before each inventory read, since routes await network I/O.
+    /// With no routes there is no receipt decision to synchronize; this is not
+    /// a standalone release-repair tick.
     async fn reconcile_transport_history(&mut self, reconcile_until: u64) -> Result<(), AppError> {
         let storage = self.app.account_storage(&self.state.label)?;
         let routing = self.routing.snapshot();
@@ -1182,6 +1186,7 @@ impl AppClient {
         &mut self,
         effects: &marmot_account::AccountDeviceEffects,
     ) -> Result<SyncSummary, AppError> {
+        // Retire released receipts even when the drain emitted no app events.
         self.transport_receipts()?;
         // Session open seeds this list from durable queued/convergence input.
         // Preserve that scheduling edge even when hydration emitted no app
@@ -2001,6 +2006,8 @@ impl AppClient {
             // Any delivery proves the stream is alive, including one this drain
             // goes on to skip as an echo or a duplicate.
             silence_started = std::time::Instant::now();
+            // Evaluate before the exclusive receipt borrow; counts.deliveries
+            // stays unchanged until admission (duplicates only bump skipped).
             let fail_before_delivery = cfg!(feature = "test-policy-overrides")
                 && self
                     .app

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -13,7 +13,6 @@ use tokio::time::timeout;
 use transport_nostr_adapter::{
     AccountSubscriptionEose, NostrReconciliationItem as AdapterReconciliationItem,
 };
-use transport_nostr_peeler::NostrTransportEvent;
 
 use crate::app_telemetry::{AppPerformanceOperation, SyncFailureStage};
 use crate::groups::{
@@ -694,54 +693,6 @@ impl AppClient {
         }
     }
 
-    /// Repair durable release evidence independently of lossy engine effects.
-    pub(crate) fn reconcile_released_transport_receipts(
-        &mut self,
-    ) -> Result<Vec<String>, AppError> {
-        let storage = self.app.account_storage(&self.state.label)?;
-        let released = storage.consume_released_transport_receipts()?;
-        self.released_backfill_reload_pending |= !released.is_empty();
-        if !self.released_backfill_reload_pending {
-            return Ok(Vec::new());
-        }
-        let released = released
-            .into_iter()
-            .map(|id| hex::encode(id.as_slice()))
-            .collect::<HashSet<_>>();
-        // No await or fallible operation between acknowledging the durable
-        // journal and removing its ids from memory. Never checkpoint stale ids
-        // back over the transactional deletion, including unsaved ring entries.
-        let unsaved_start = self
-            .state
-            .seen_events
-            .len()
-            .saturating_sub(self.pending_seen_event_count);
-        self.pending_seen_event_count = self.state.seen_events[unsaved_start..]
-            .iter()
-            .filter(|id| !released.contains(*id))
-            .count();
-        self.seen_events_index.retain(|id| !released.contains(id));
-        self.state.seen_events.retain(|id| !released.contains(id));
-        if !released.is_empty() {
-            tracing::info!(
-                target: "marmot_app::relay_plane",
-                method = "reconcile_released_transport_receipts",
-                released_count = released.len(),
-                "retired released transport receipt claims and restored replay eligibility"
-            );
-        }
-        #[cfg(test)]
-        if std::mem::take(&mut self.fail_next_released_backfill_reload) {
-            return Err(cgka_traits::storage::StorageError::Busy(
-                "injected released backfill intent read failure".into(),
-            )
-            .into());
-        }
-        self.restore_persisted_epoch_backfill_intents(storage.pending_epoch_backfill_intents()?);
-        self.released_backfill_reload_pending = false;
-        Ok(released.into_iter().collect())
-    }
-
     /// Apply the publish gate to `effects`, observing the same batch's
     /// epoch-gap recovery evidence first.
     ///
@@ -767,7 +718,7 @@ impl AppClient {
         &mut self,
         effects: &marmot_account::AccountDeviceEffects,
     ) -> Result<(), AppError> {
-        self.reconcile_released_transport_receipts()?;
+        self.transport_receipts()?;
         self.observe_recovery_evidence(effects);
         self.remember_pending_convergence_groups(effects);
         let failed_updates = self.invalidate_failed_app_message_projections(effects, None)?;
@@ -832,7 +783,6 @@ impl AppClient {
     /// account's SQLCipher database, so traffic in one busy group cannot move
     /// or evict another route's completeness state.
     async fn reconcile_transport_history(&mut self, reconcile_until: u64) -> Result<(), AppError> {
-        self.reconcile_released_transport_receipts()?;
         let storage = self.app.account_storage(&self.state.label)?;
         let routing = self.routing.snapshot();
         let mut work = Vec::with_capacity(routing.group_routes.len().saturating_add(1));
@@ -876,7 +826,9 @@ impl AppClient {
             // defer this route until the next rotation, but cannot pin every
             // subsequent route behind it on each restart.
             storage.advance_transport_reconciliation_route_cursor(&route)?;
-            let inventory = storage.transport_reconciliation_inventory(&route, reconcile_until)?;
+            let inventory = self
+                .transport_receipts()?
+                .inventory(&route, reconcile_until)?;
             if inventory.since > reconcile_until {
                 continue;
             }
@@ -1230,7 +1182,7 @@ impl AppClient {
         &mut self,
         effects: &marmot_account::AccountDeviceEffects,
     ) -> Result<SyncSummary, AppError> {
-        self.reconcile_released_transport_receipts()?;
+        self.transport_receipts()?;
         // Session open seeds this list from durable queued/convergence input.
         // Preserve that scheduling edge even when hydration emitted no app
         // events; the worker drains this set immediately after startup sync.
@@ -1552,12 +1504,6 @@ impl AppClient {
     pub(crate) async fn receive_next_delivery(
         &mut self,
     ) -> Result<crate::relay_plane::AccountDeliveryReceive, AppError> {
-        let local_account_id_hex = self
-            .app
-            .account_home()
-            .account(&self.state.label)?
-            .account_id_hex;
-
         loop {
             let received = self
                 .adapter
@@ -1573,13 +1519,8 @@ impl AppClient {
                     ));
                 }
             };
-            self.reconcile_released_transport_receipts()?;
             let event_id = hex::encode(delivery.message.id.as_slice());
-            if is_own_relay_echo(&delivery, &local_account_id_hex, &self.seen_events_index) {
-                self.record_durable_transport_reconciliation_delivery(&delivery);
-                continue;
-            }
-            if self.seen_events_index.contains(&event_id) {
+            if self.transport_receipts()?.contains(&event_id) {
                 self.record_durable_transport_reconciliation_delivery(&delivery);
                 continue;
             }
@@ -1597,9 +1538,13 @@ impl AppClient {
         let display_names = self.app.display_names_by_id()?;
         let mut summary = SyncSummary::default();
         let event_id = hex::encode(delivery.message.id.as_slice());
-        let ingested = self
-            .ingest_delivery(delivery, &display_names, &mut summary)
-            .await?;
+        let ingested = Self::ingest_delivery(
+            self.transport_receipts()?,
+            delivery,
+            &display_names,
+            &mut summary,
+        )
+        .await?;
         if self.adapter.pending_delivery_overflow().is_some() {
             // `record_drop` publishes this process-local fence at the exact
             // omission, before marker I/O or the reserved control record can
@@ -1947,18 +1892,6 @@ impl AppClient {
                 SyncFailureStage::Unknown,
             )
         })?;
-        let local_account_id_hex = self
-            .app
-            .account_home()
-            .account(&self.state.label)
-            .map_err(|source| {
-                ClassifiedSyncFailure::at_stage(
-                    SyncSummary::default(),
-                    AppError::from(source),
-                    SyncFailureStage::Unknown,
-                )
-            })?
-            .account_id_hex;
         let mut summary = SyncSummary::default();
         let mut first_wait = true;
         // Forensic drain accounting: wall-clock span, deliveries actually
@@ -2068,22 +2001,29 @@ impl AppClient {
             // Any delivery proves the stream is alive, including one this drain
             // goes on to skip as an echo or a duplicate.
             silence_started = std::time::Instant::now();
-            if let Err(error) = self.reconcile_released_transport_receipts() {
-                return Err(self
-                    .finish_failed_sync_drain(
-                        summary,
-                        routes_dirty,
-                        counts.clone(),
-                        StagedSyncError::new(error, SyncFailureStage::StatePersist),
-                        drain_started,
-                        cursor_before_secs,
-                    )
-                    .await);
-            }
+            let fail_before_delivery = cfg!(feature = "test-policy-overrides")
+                && self
+                    .app
+                    .config
+                    .dev_fail_sync_before_delivery
+                    .is_some_and(|limit| counts.deliveries >= limit);
+            let receipts = match self.transport_receipts() {
+                Ok(receipts) => receipts,
+                Err(error) => {
+                    return Err(self
+                        .finish_failed_sync_drain(
+                            summary,
+                            routes_dirty,
+                            counts.clone(),
+                            StagedSyncError::new(error, SyncFailureStage::StatePersist),
+                            drain_started,
+                            cursor_before_secs,
+                        )
+                        .await);
+                }
+            };
             let event_id = hex::encode(delivery.message.id.as_slice());
-            if is_own_relay_echo(&delivery, &local_account_id_hex, &self.seen_events_index)
-                || self.seen_events_index.contains(&event_id)
-            {
+            if receipts.contains(&event_id) {
                 self.record_durable_transport_reconciliation_delivery(&delivery);
                 counts.skipped = counts.skipped.saturating_add(1);
                 // Liveness, but not progress. It must not outlast the moment
@@ -2096,13 +2036,7 @@ impl AppClient {
                 }
                 continue;
             }
-            if cfg!(feature = "test-policy-overrides")
-                && self
-                    .app
-                    .config
-                    .dev_fail_sync_before_delivery
-                    .is_some_and(|limit| counts.deliveries >= limit)
-            {
+            if fail_before_delivery {
                 return Err(self
                     .finish_failed_sync_drain(
                         summary,
@@ -2118,9 +2052,13 @@ impl AppClient {
                     .await);
             }
             let mut delivery_summary = SyncSummary::default();
-            let ingested = match self
-                .ingest_delivery(*delivery, &display_names, &mut delivery_summary)
-                .await
+            let ingested = match Self::ingest_delivery(
+                receipts,
+                *delivery,
+                &display_names,
+                &mut delivery_summary,
+            )
+            .await
             {
                 Ok(ingested) => ingested,
                 Err(error) => {
@@ -2361,34 +2299,37 @@ impl AppClient {
         }
     }
 
+    /// Consume the exclusive receipt view used for admission. The SDK drain
+    /// shares it with its duplicate decision, while direct ingestion opens one.
     async fn ingest_delivery(
-        &mut self,
+        receipts: super::receipts::SynchronizedTransportReceipts<'_>,
         delivery: cgka_traits::TransportDelivery,
         display_names: &HashMap<String, String>,
         summary: &mut SyncSummary,
     ) -> Result<DeliveryIngest, AppError> {
+        let client = receipts.into_client();
         let source_message_id_hex = hex::encode(delivery.message.id.as_slice());
         let outer_transport_at = delivery.message.timestamp.0;
         let source_received_at = delivery.received_at.0;
         let group_id_hint = delivery.group_id_hint.clone();
         let reconciliation_record =
-            transport_reconciliation_record(self.adapter.account_id(), &delivery);
-        self.reconcile_released_transport_receipts()?;
-        let effects = self.runtime.ingest_delivery(delivery).await?;
-        let released = self.reconcile_released_transport_receipts()?;
+            transport_reconciliation_record(client.adapter.account_id(), &delivery);
+        let effects = client.runtime.ingest_delivery(delivery).await?;
+        let source_released = client
+            .transport_receipts()?
+            .was_released(&source_message_id_hex);
         let publish_error = fail_if_publish_failed(&effects.effects).err();
-        let must_stay_fetchable =
-            effects.left_object_unpersisted || released.contains(&source_message_id_hex);
+        let must_stay_fetchable = effects.left_object_unpersisted || source_released;
         if !must_stay_fetchable && let Some((route, item)) = &reconciliation_record {
-            self.record_transport_reconciliation_item(route, item);
+            client.record_transport_reconciliation_item(route, item);
         }
         let refused_group = match &effects.outcome {
             IngestOutcome::ResourceRefused { group_id, .. } => Some(group_id.clone()),
             _ => None,
         };
-        self.remember_buffered_convergence_outcome(&effects.outcome);
-        self.remember_pending_convergence_groups(&effects.effects);
-        self.observe_recovery_evidence(&effects.effects);
+        client.remember_buffered_convergence_outcome(&effects.outcome);
+        client.remember_pending_convergence_groups(&effects.effects);
+        client.observe_recovery_evidence(&effects.effects);
         // The cursor is held back only by a resource refusal, which is
         // narrower than `must_stay_fetchable` on purpose.
         //
@@ -2408,9 +2349,9 @@ impl AppClient {
         // should instead hold the floor back until it converges is the separate
         // since-floor design item, not this seam's call.
         if refused_group.is_none() {
-            self.remember_transport_cursor(outer_transport_at);
+            client.remember_transport_cursor(outer_transport_at);
         }
-        self.detect_epoch_stall(group_id_hint, &source_message_id_hex, &effects.outcome);
+        client.detect_epoch_stall(group_id_hint, &source_message_id_hex, &effects.outcome);
         // A delivery can contain several application events. If projection
         // fails after an earlier event staged its acknowledgement, keep that
         // event in the durable engine outbox so a retained or reopened client
@@ -2430,9 +2371,9 @@ impl AppClient {
                 }
                 _ => None,
             })
-            .filter(|event_id| !self.pending_application_event_acks.contains(event_id))
+            .filter(|event_id| !client.pending_application_event_acks.contains(event_id))
             .collect::<Vec<_>>();
-        let routes_dirty = match self
+        let routes_dirty = match client
             .observe_account_device_effects(
                 &effects.effects,
                 display_names,
@@ -2445,7 +2386,7 @@ impl AppClient {
             Ok(routes_dirty) => routes_dirty,
             Err(error) => {
                 for event_id in new_application_event_ack_candidates {
-                    self.pending_application_event_acks.remove(&event_id);
+                    client.pending_application_event_acks.remove(&event_id);
                 }
                 return Err(error);
             }
@@ -4046,7 +3987,7 @@ impl AppClient {
         &mut self,
         created_group_id_hex: Option<&str>,
     ) -> Result<Option<crate::ChatListRow>, AppError> {
-        self.reconcile_released_transport_receipts()?;
+        let seen_events = self.transport_receipts()?.pending_seen_events();
         let frontiers_to_clear = self
             .pending_local_group_deletion_frontier_clears
             .iter()
@@ -4057,14 +3998,9 @@ impl AppClient {
             .iter()
             .cloned()
             .collect::<Vec<_>>();
-        let seen_start = self
-            .state
-            .seen_events
-            .len()
-            .saturating_sub(self.pending_seen_event_count);
         let delta = AccountState {
             label: self.state.label.clone(),
-            seen_events: self.state.seen_events[seen_start..].to_vec(),
+            seen_events,
             last_transport_timestamp: self.checkpointed_transport_timestamp,
             groups: self
                 .state
@@ -4401,20 +4337,6 @@ impl AppClient {
             TRANSPORT_CURSOR_MAX_FUTURE_SKEW.as_secs(),
         );
     }
-}
-
-pub(crate) fn is_own_relay_echo(
-    delivery: &cgka_traits::TransportDelivery,
-    local_account_id_hex: &str,
-    known_event_ids: &HashSet<String>,
-) -> bool {
-    let event_id = hex::encode(delivery.message.id.as_slice());
-    if !known_event_ids.contains(&event_id) {
-        return false;
-    }
-    NostrTransportEvent::from_transport_message(&delivery.message)
-        .ok()
-        .is_some_and(|event| event.pubkey == local_account_id_hex)
 }
 
 /// Apply the runtime's [`CursorPersistence`] policy to a candidate inbound
@@ -5524,7 +5446,11 @@ mod tests {
             .queued_epoch_backfills
             .push_back(armed_backfill(&queued, 0));
         client.clear_epoch_backfill_intent(&completed).unwrap();
-        let remaining = app.pending_epoch_backfill_intents("alice").unwrap();
+        let remaining = app
+            .account_storage("alice")
+            .unwrap()
+            .pending_epoch_backfill_intents()
+            .unwrap();
         assert_eq!(remaining.len(), 2);
         assert!(
             !remaining

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -101,6 +101,8 @@ mod relay_telemetry_export;
 mod root_runtime_lease;
 mod runtime;
 mod sqlcipher;
+#[cfg(feature = "test-policy-overrides")]
+mod test_support;
 
 pub use cgka_traits::engine::{
     SupersededIntentKind, SupersededIntentOutcome, SupersededIntentReport,

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1687,12 +1687,7 @@ impl MarmotApp {
         if let Some(lifecycle) = &lifecycle {
             lifecycle.ensure_running()?;
         }
-        let seen_events_index = open
-            .state
-            .seen_events
-            .iter()
-            .cloned()
-            .collect::<std::collections::HashSet<_>>();
+        let seen_events_index = open.state.seen_events.iter().cloned().collect();
         let checkpointed_transport_timestamp = open.state.last_transport_timestamp;
         // The wedge clock is the one detector threshold a test has to be able
         // to shorten: its production value is an hour, and reading a clock
@@ -1745,7 +1740,7 @@ impl MarmotApp {
                 .with_wedge_rearm_interval_ms(wedge_rearm_interval_ms),
             epoch_backfill_retry_not_before: None,
             pending_epoch_backfill: None,
-            released_backfill_reload_pending: false,
+            released_backfill_reload_pending: true,
             #[cfg(test)]
             fail_next_released_backfill_reload: false,
             queued_epoch_backfills: std::collections::VecDeque::new(),
@@ -1753,9 +1748,9 @@ impl MarmotApp {
             encrypted_media_not_required_epochs: HashMap::new(),
             checkpoint_route_refresh_recomputes: 0,
         };
-        client.reconcile_released_transport_receipts()?;
-        let persisted_backfills = self.pending_epoch_backfill_intents(&client.state.label)?;
-        client.restore_persisted_epoch_backfill_intents(persisted_backfills);
+        // Initial access also restores durable backfill work, with or without
+        // new releases, so open does not read the intent table twice.
+        client.transport_receipts()?;
         let persisted_evidence = self.epoch_stall_evidence(&client.state.label)?;
         client.restore_persisted_epoch_stall_evidence(persisted_evidence);
         // Reads only the durable terminal guards, never live group state, so it
@@ -3277,16 +3272,6 @@ impl MarmotApp {
         self.account_storage(label)?
             .arm_epoch_backfill_intents(intents)?;
         Ok(())
-    }
-
-    pub(crate) fn pending_epoch_backfill_intents(
-        &self,
-        label: &str,
-    ) -> Result<Vec<storage_sqlite::StoredEpochBackfillIntent>, AppError> {
-        self.ensure_account_state(label)?;
-        Ok(self
-            .account_storage(label)?
-            .pending_epoch_backfill_intents()?)
     }
 
     pub(crate) fn clear_epoch_backfill_intents(

--- a/crates/marmot-app/src/test_support.rs
+++ b/crates/marmot-app/src/test_support.rs
@@ -1,0 +1,18 @@
+use cgka_traits::GroupId;
+use cgka_traits::convergence_pass::DurableConvergencePass;
+use cgka_traits::storage::ConvergencePassStorage;
+
+use crate::{AppError, MarmotApp};
+
+impl MarmotApp {
+    /// Inspect the durable pass without advancing the engine or its scheduler.
+    /// Relay tests use this to witness retained input before exercising a send.
+    #[doc(hidden)]
+    pub fn convergence_pass_for_test(
+        &self,
+        label: &str,
+        group_id: &GroupId,
+    ) -> Result<Option<DurableConvergencePass>, AppError> {
+        Ok(self.account_storage(label)?.convergence_pass(group_id)?)
+    }
+}

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -11269,36 +11269,28 @@ fn ingest_applies_owner_signed_transitive_448_and_drops_spoof() {
     assert_eq!(stored[0].owner_ts, 1000, "victim's original stamp survives");
 }
 
-#[test]
-fn own_relay_echo_requires_known_event_id_not_just_pubkey() {
-    let local_pubkey = "11".repeat(32);
-
+#[tokio::test]
+async fn own_relay_echo_requires_known_event_id_not_just_pubkey() {
+    let dir = tempfile::tempdir().unwrap();
+    let local_pubkey = AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap()
+        .account_id_hex;
+    let app = MarmotApp::with_relay(dir.path(), "wss://receipts.example")
+        .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+    let mut client = app.client("alice").await.unwrap();
     let known_local_delivery = relay_delivery("known", local_pubkey.clone());
-    let known_event_ids = HashSet::from([hex::encode(known_local_delivery.message.id.as_slice())]);
-    assert!(client::is_own_relay_echo(
-        &known_local_delivery,
-        &local_pubkey,
-        &known_event_ids
-    ));
+    let known_id = hex::encode(known_local_delivery.message.id.as_slice());
+    client.remember_seen_event(known_id.clone());
+    let receipts = client.transport_receipts().unwrap();
+    assert!(receipts.contains(&known_id));
 
-    let same_pubkey_new_event = relay_delivery("new-cross-device", local_pubkey.clone());
-    assert!(!client::is_own_relay_echo(
-        &same_pubkey_new_event,
-        &local_pubkey,
-        &known_event_ids
-    ));
-
-    // A delivery claiming a known id under another pubkey can no longer come
-    // out of the transport boundary (the id is verified against the event
-    // hash, #351); forge one directly to prove the echo check independently
-    // requires the local pubkey.
-    let mut known_other_pubkey_delivery = relay_delivery("known", "44".repeat(32));
-    known_other_pubkey_delivery.message.id = known_local_delivery.message.id.clone();
-    assert!(!client::is_own_relay_echo(
-        &known_other_pubkey_delivery,
-        &local_pubkey,
-        &known_event_ids
-    ));
+    // Same-account cross-device input is admitted unless this exact signed
+    // outer ID is known. Peer input uses the same synchronized membership rule.
+    let same_pubkey_new_event = relay_delivery("new-cross-device", local_pubkey);
+    assert!(!receipts.contains(&hex::encode(same_pubkey_new_event.message.id.as_slice())));
+    let peer_delivery = relay_delivery("peer", "44".repeat(32));
+    assert!(!receipts.contains(&hex::encode(peer_delivery.message.id.as_slice())));
 }
 
 #[test]
@@ -19077,7 +19069,15 @@ async fn reconcile_repairs_stale_two_member_count_on_three_member_group_body() {
 fn released_transport_is_replayed_after_lost_effect_and_reopen() {
     run_composed_app_runtime_test("released-transport-replay", || async {
         use cgka_traits::storage::MessageStorage;
-        for handling in ["checkpoint", "reopen", "failed effects", "unsaved receipts"] {
+        for handling in [
+            "checkpoint",
+            "reopen",
+            "failed effects",
+            "unsaved receipts",
+            "direct ingest",
+            "sdk drain",
+            "receive",
+        ] {
             let dir = tempfile::tempdir().unwrap();
             let relay = Arc::new(ScriptedPushRelayClient::default());
             let (app, mut client, route) =
@@ -19114,6 +19114,43 @@ fn released_transport_is_replayed_after_lost_effect_and_reopen() {
                 assert!(client.seen_events_index.contains(&probe.id));
             }
             storage.release_message_for_replay(&record).unwrap();
+            if matches!(handling, "direct ingest" | "sdk drain" | "receive") {
+                // Readmit immediately, with no effect observation, explicit
+                // reconcile or unrelated checkpoint to clean up the cache.
+                if handling == "direct ingest" {
+                    client
+                        .ingest_received_delivery(delivery.clone())
+                        .await
+                        .unwrap();
+                } else {
+                    inject_epoch_gap_probe(&app, probe.clone()).await;
+                    if handling == "sdk drain" {
+                        client.sync().await.unwrap();
+                    } else {
+                        let received = tokio::time::timeout(
+                            Duration::from_secs(5),
+                            client.receive_next_delivery(),
+                        )
+                        .await
+                        .unwrap()
+                        .unwrap();
+                        let crate::relay_plane::AccountDeliveryReceive::Delivery(delivery) =
+                            received
+                        else {
+                            panic!("unexpected overflow")
+                        };
+                        client.ingest_received_delivery(*delivery).await.unwrap();
+                    }
+                }
+                assert_eq!(
+                    recorded_ingest_outcomes(&app, &probe.id).len(),
+                    2,
+                    "{handling}: released ID never reached engine admission"
+                );
+                assert!(storage.get_message(&delivery.message.id).is_ok());
+                assert!(client.seen_events_index.contains(&probe.id));
+                continue;
+            }
             if handling == "reopen" {
                 drop(client);
                 client = client_on_app_relay_plane(&app, "alice").await;

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -6178,9 +6178,9 @@ async fn app_runtime_chat_and_group_state_subscriptions_stream_projection_update
 /// his own send — not a receive — applied it.
 ///
 /// This regression uses explicit test-policy overrides to create the precise
-/// post-cutoff/pre-scheduler state. `update_group_profile` completes its
-/// cross-account catch-up before returning, proving bob has ingested the
-/// rename. The test then lets the 100ms engine cutoff elapse while holding the
+/// post-cutoff/pre-scheduler state. Cross-account catch-up is best-effort, so
+/// the test witnesses the rename's commit edge in bob's durable active
+/// pass before allowing its engine cutoff to elapse while holding the
 /// scheduled worker for 60s. The send is therefore the only operation that can
 /// move bob's durable row from the old name to the new one, and the
 /// subscription must update within 5s, well before scheduled convergence can
@@ -6236,17 +6236,18 @@ async fn group_state_subscription_observes_rename_applied_during_interleaved_sen
         .await
         .unwrap();
 
+    let source_epoch = runtime
+        .group_mls_state(&bob_id, &group_id)
+        .await
+        .unwrap()
+        .epoch;
     let renamed = "renamed during retained send".to_owned();
-    runtime
+    let rename_summary = runtime
         .update_group_profile(&alice_id, &group_id, Some(renamed.clone()), None)
         .await
         .unwrap();
-    assert_ne!(
-        row_title(&app, &bob.account.label, &group_id_hex).as_deref(),
-        Some(renamed.as_str()),
-        "bob's completed catch-up must retain the rename without applying it"
-    );
-    sleep(Duration::from_millis(250)).await;
+    assert!(rename_summary.published > 0, "the rename must be published");
+    wait_for_retained_commit_cutoff(&app, &bob.account.label, &group_id, source_epoch).await;
     assert_ne!(
         row_title(&app, &bob.account.label, &group_id_hex).as_deref(),
         Some(renamed.as_str()),
@@ -6343,17 +6344,18 @@ async fn group_state_subscription_observes_rename_applied_during_failed_send() {
         .await
         .unwrap();
 
+    let source_epoch = runtime
+        .group_mls_state(&bob_id, &group_id)
+        .await
+        .unwrap()
+        .epoch;
     let renamed = "renamed during rejected send".to_owned();
-    runtime
+    let rename_summary = runtime
         .update_group_profile(&alice_id, &group_id, Some(renamed.clone()), None)
         .await
         .unwrap();
-    assert_ne!(
-        row_title(&app, &bob.account.label, &group_id_hex).as_deref(),
-        Some(renamed.as_str()),
-        "bob's completed catch-up must retain the rename without applying it"
-    );
-    sleep(Duration::from_millis(250)).await;
+    assert!(rename_summary.published > 0, "the rename must be published");
+    wait_for_retained_commit_cutoff(&app, &bob.account.label, &group_id, source_epoch).await;
     assert_ne!(
         row_title(&app, &bob.account.label, &group_id_hex).as_deref(),
         Some(renamed.as_str()),
@@ -6587,6 +6589,48 @@ where
     })
     .await
     .expect("runtime chat update")
+}
+
+/// Witness a rename admitted at the receiver's current epoch before waiting
+/// out its cutoff. A completed best-effort catch-up and an unchanged title do
+/// not prove delivery. Passive reads leave the send as the only settling seam.
+#[cfg(feature = "test-policy-overrides")]
+async fn wait_for_retained_commit_cutoff(
+    app: &MarmotApp,
+    label: &str,
+    group_id: &GroupId,
+    source_epoch: u64,
+) {
+    use cgka_traits::convergence_pass::{ConvergencePassMemberRole, ConvergencePassPhase};
+
+    let pass = timeout(Duration::from_secs(5), async {
+        loop {
+            if let Some(pass) = app.convergence_pass_for_test(label, group_id).unwrap()
+                && matches!(
+                    pass.phase,
+                    ConvergencePassPhase::Collecting | ConvergencePassPhase::Frozen
+                )
+                && pass.base_epoch.0 == source_epoch
+                && pass.members.iter().any(|member| {
+                    member.role == ConvergencePassMemberRole::CommitEdge
+                        && member.source_epoch == source_epoch
+                })
+            {
+                break pass;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("receiver must retain the rename in its active pass");
+    // Wait a full observed pass window using a monotonic timer, avoiding any
+    // assumption about how long publication/catch-up took or wall-clock phase.
+    sleep(Duration::from_millis(
+        pass.cutoff_monotonic_ms()
+            .saturating_sub(pass.opened_monotonic_ms)
+            .saturating_add(1),
+    ))
+    .await;
 }
 
 /// Current chat-list row title for one group, read fresh from the projection

--- a/docs/marmot-architecture/storage-format-v2.md
+++ b/docs/marmot-architecture/storage-format-v2.md
@@ -1,7 +1,7 @@
 ---
 title: "Storage Format v2"
 created: 2026-08-13
-updated: 2026-09-07
+updated: 2026-09-08
 tags: [marmot, storage, sqlite, migration, encoding]
 status: current
 ---
@@ -46,8 +46,22 @@ sweep, including retries of unrelated rows. Recovery resumes after the app
 consumes the journal; retaining the raw bytes and replay evidence takes priority
 over progress while the journal is full.
 
-The app consumes this evidence on account open and before receipt checkpoints,
-reconciliation, duplicate/echo shortcuts, and after engine ingest. Consumption
+`AppClient::transport_receipts` is the account-owned synchronization boundary.
+Its `SynchronizedTransportReceipts` view requires an exclusive client borrow and
+owns access to duplicate membership, reconciliation inventory, and pending seen
+checkpoint entries. The raw membership index exposes no production lookup API.
+The SDK drain passes the same view from its duplicate check into engine admission,
+so no intervening engine step or second pre-ingest journal query is needed.
+Direct ingestion creates its own view; post-ingest access synchronizes again
+because that engine step may have released more input. Account open restores
+pending backfill intents through this boundary, including when the journal is
+empty. Low-level storage reads and other read-only app APIs retain their existing
+behavior; this view is for the owning account client, not concurrent observers.
+
+The app consumes release evidence on account open, before receipt checkpoints,
+reconciliation and duplicate shortcuts, after engine ingest, and when observing
+engine effects. The empty-journal path remains a bounded existence query, without
+rebuilding the seen ring/index or loading all backfill intents. Consumption
 again removes both durable receipts (including an intervening stale checkpoint),
 arms the existing durable group backfill intent, and acknowledges the journal
 in one transaction. The caller then clears its in-memory seen ring/index


### PR DESCRIPTION
## Summary

Receipt decisions depended on callers remembering to reconcile the durable release journal. Introduce an account-owned `SynchronizedTransportReceipts` view for duplicate membership, reconciliation inventory, and pending seen-event checkpoints. The raw seen index no longer exposes production lookups, and a failed backfill reload returns no view after synchronously invalidating acknowledged releases.

The SDK drain carries the same exclusive client borrow from its duplicate check into engine admission, removing the repeated pre-ingest journal query. Post-ingest synchronization remains mandatory because ingest can release more input. Account open restores pending backfill intents through the same boundary once. Empty-journal accesses do not scan or rebuild the ring/index or reload backfill intents.

SQLCipher retirement/backfill/journal transactions, standalone engine behavior, retention policy, and production public APIs remain unchanged. Historical pre-journal repair remains #1724.

The relay subscription regressions now witness a commit edge at the receiver's current epoch in a durable active convergence pass before waiting out its cutoff. This replaces the assumption that best-effort catch-up plus a fixed sleep proves delivery; the send must still apply the rename and broadcast the group-state update. The passive inspection helper is compiled only with `test-policy-overrides`.

Fixes #1730.

## Test plan

- [x] New receipt-access regression failed on stale membership before synchronization was added to the access boundary, then passed. Covers lost effects, duplicate/inventory/checkpoint access, stale inventory checkpointing, and same-client reload errors.
- [x] `just fast-ci` on follow-up `e5662e3b`.
- [x] [Full GitHub CI](https://github.com/marmot-protocol/mdk/actions/runs/34197948815) passed on `e5662e3b`, including Simulator and vectors, all workspace test partitions, and Required CI. The serial relay suite passed 161 tests with zero failures and one ignored diagnostic.
- [x] [Platform binary workflow](https://github.com/marmot-protocol/mdk/actions/runs/34197948893) passed on the same commit.
- [x] All four `tracing_audit` checks; removed test benchmark direct output without weakening the audit.
- [x] Four receipt-boundary tests and eight release/replay regressions on the follow-up.
- [x] Both interleaved-send relay regressions pass five consecutive serial runs with the durable-input barrier.
- [x] `cargo nextest run -p marmot-app --features test-policy-overrides --test-threads 8 --no-fail-fast -E 'not binary(relay_runtime)'`: 1,071 passed, 10 skipped.
- [x] Four `relay_runtime` tests run serially: real message exchange, timeline reopen, unread preservation during backfill, and member reads before initial catch-up completes.
- [x] Five `storage-sqlite` released-transport tests: atomicity, reopen, capacity, app ownership, and standalone engine lifetime.
- [x] Expanded exact-ID replay regression covers direct ingestion, SDK drains, and receive/ingest without an intervening repair checkpoint; existing release/projection and interrupted/rearmed backfill tests pass.
- [x] Local unoptimized no-release measurement: 1,024 view accesses took 3.488 ms with an empty ring and 3.888 ms with 16,384 entries. Cache allocation and reload-idle assertions pass.

The default `cargo test -p marmot-app` run recorded 1,008 passing tests, two ignored, and four failures. Three backfill tests reproduced with the same assertions on unchanged base `5b89a7c0`: `drains_that_never_confirmed_stored_history_are_not_evidence`, `frozen_epoch_evidence_outlives_the_process_that_gathered_it`, and `three_fruitless_end_of_stored_events_replays_at_one_epoch_escalate`. They depend on the test-policy rearm override and all pass in the CI-configured run above. The fourth was the five-second readiness timeout in `account_reconcile_returns_local_readiness_before_relay_subscription_registration`; it passed on the base in isolation and on this branch in the CI-configured run.

