### PR TITLE
Maintain durable chat presentation in the background (P2)

### DIFF
--- a/crates/marmot-app/src/chat_presentation.rs
+++ b/crates/marmot-app/src/chat_presentation.rs
@@ -1,4 +1,6 @@
 //! Shared selected chat presentation policy; no network access or client-specific formatting.
+pub(crate) mod maintenance;
+pub(crate) mod signals;
 use crate::UserProfileMetadata;
 use sha2::{Digest, Sha256};
 use storage_sqlite::{
@@ -9,7 +11,6 @@ use storage_sqlite::{
 /// Resolve already-cached evidence. Profile subjects must match the current peer.
 /// Remote descriptors do not authorize a download; the media layer still owns dial safety,
 /// including `reject_unsafe_group_avatar_contact_url` and validated-address pinning.
-#[allow(dead_code)] // Internal P1 policy; the P2 account worker supplies the production caller.
 pub(crate) fn select_chat_presentation(
     input: &ChatPresentationInput,
     local_id: &str,
@@ -24,6 +25,7 @@ pub(crate) fn select_chat_presentation(
     let peer = match (&local_id, &members) {
         (Some(local), Some(members))
             if input.member_count == Some(2)
+                && input.self_membership == storage_sqlite::SelfMembership::Member
                 && members.len() == 2
                 && members[0] != members[1]
                 && members.contains(local) =>
@@ -103,66 +105,67 @@ pub(crate) fn select_chat_presentation(
         }
         hex::encode(digest.finalize())
     };
-    let (avatar, avatar_source) = if let Some(image) = input.avatar.as_ref().filter(|image| {
-        valid_hex(&image.image_hash_hex, 32)
-            && valid_hex(&image.image_key_hex, 32)
-            && valid_hex(&image.image_nonce_hex, 12)
-            && valid_hex(&image.image_upload_key_hex, 32)
-    }) {
-        (
-            SelectedAvatar::EncryptedGroupImage {
-                image: image.clone(),
-                cache_key: key(
-                    &input.group_id_hex,
-                    "group-image",
-                    &[
-                        &image.image_hash_hex,
-                        &image.image_key_hex,
-                        &image.image_nonce_hex,
-                        &image.image_upload_key_hex,
-                        image.media_type.as_deref().unwrap_or(""),
-                    ],
-                ),
-            },
-            PresentationSource::Group,
-        )
-    } else if let Some(url) = input.avatar_url.as_deref().and_then(safe_image_url) {
-        (
-            SelectedAvatar::RemoteImage {
-                cache_key: key(&input.group_id_hex, "group-url", &[&url]),
-                url,
-            },
-            PresentationSource::Group,
-        )
-    } else if let Some((peer, url)) = peer.as_deref().zip(
-        profile
-            .and_then(|p| p.picture.as_deref())
-            .and_then(safe_image_url),
-    ) {
-        (
-            SelectedAvatar::RemoteImage {
-                cache_key: key(peer, "peer-url", &[&url]),
-                url,
-            },
-            PresentationSource::PeerProfile,
-        )
-    } else {
-        (
-            SelectedAvatar::Placeholder {
-                stable_seed: key(
-                    peer.as_deref().unwrap_or(&input.group_id_hex),
-                    match fallback_source {
-                        PresentationSource::PeerFallback => "person",
-                        PresentationSource::GroupFallback => "group",
-                        _ => "unknown",
-                    },
-                    &[],
-                ),
-                source: fallback_source,
-            },
-            fallback_source,
-        )
-    };
+    let (avatar, avatar_source) =
+        if let Some(url) = input.avatar_url.as_deref().and_then(safe_image_url) {
+            (
+                SelectedAvatar::RemoteImage {
+                    cache_key: key(&input.group_id_hex, "group-url", &[&url]),
+                    url,
+                },
+                PresentationSource::Group,
+            )
+        } else if let Some(image) = input.avatar.as_ref().filter(|image| {
+            valid_hex(&image.image_hash_hex, 32)
+                && valid_hex(&image.image_key_hex, 32)
+                && valid_hex(&image.image_nonce_hex, 12)
+                && valid_hex(&image.image_upload_key_hex, 32)
+        }) {
+            (
+                SelectedAvatar::EncryptedGroupImage {
+                    image: image.clone(),
+                    cache_key: key(
+                        &input.group_id_hex,
+                        "group-image",
+                        &[
+                            &image.image_hash_hex,
+                            &image.image_key_hex,
+                            &image.image_nonce_hex,
+                            &image.image_upload_key_hex,
+                            image.media_type.as_deref().unwrap_or(""),
+                        ],
+                    ),
+                },
+                PresentationSource::Group,
+            )
+        } else if let Some((peer, url)) = peer.as_deref().zip(
+            profile
+                .and_then(|p| p.picture.as_deref())
+                .and_then(safe_image_url),
+        ) {
+            (
+                SelectedAvatar::RemoteImage {
+                    cache_key: key(peer, "peer-url", &[&url]),
+                    url,
+                },
+                PresentationSource::PeerProfile,
+            )
+        } else {
+            (
+                SelectedAvatar::Placeholder {
+                    stable_seed: key(
+                        peer.as_deref().unwrap_or(&input.group_id_hex),
+                        match fallback_source {
+                            PresentationSource::PeerFallback => "person",
+                            PresentationSource::GroupFallback => "group",
+                            _ => "unknown",
+                        },
+                        &[],
+                    ),
+                    source: fallback_source,
+                },
+                fallback_source,
+            )
+        };
     let resolution = if matches!(
         title_source,
         PresentationSource::Group | PresentationSource::PeerProfile
@@ -259,6 +262,7 @@ mod tests {
             },
             group_name: name.into(),
             member_count: Some(2),
+            self_membership: storage_sqlite::SelfMembership::Member,
             members: vec!["aa".repeat(32), "bb".repeat(32)],
             avatar_url: None,
             avatar: None,
@@ -342,6 +346,12 @@ mod tests {
             p.avatar,
             SelectedAvatar::EncryptedGroupImage { .. }
         ));
+        input.avatar_url = Some("https://example.com/group.png".into());
+        assert!(matches!(
+            select_chat_presentation(&input, &"aa".repeat(32), None).avatar,
+            SelectedAvatar::RemoteImage { .. }
+        ));
+        input.avatar_url = None;
         input.members = vec!["aa".repeat(32), "cc".repeat(32)];
         assert!(select_chat_presentation(&input, &"aa".repeat(32), None).avatar == p.avatar);
         input.members = vec!["aa".repeat(32), "bb".repeat(32)];

--- a/crates/marmot-app/src/chat_presentation.rs
+++ b/crates/marmot-app/src/chat_presentation.rs
@@ -116,67 +116,67 @@ pub(crate) fn select_chat_presentation(
         }
         hex::encode(digest.finalize())
     };
-    let (avatar, avatar_source) =
-        if let Some(url) = input.avatar_url.as_deref().and_then(safe_image_url) {
-            (
-                SelectedAvatar::RemoteImage {
-                    cache_key: key(&input.group_id_hex, "group-url", &[&url]),
-                    url,
-                },
-                PresentationSource::Group,
-            )
-        } else if let Some(image) = input.avatar.as_ref().filter(|image| {
-            valid_hex(&image.image_hash_hex, 32)
-                && valid_hex(&image.image_key_hex, 32)
-                && valid_hex(&image.image_nonce_hex, 12)
-                && valid_hex(&image.image_upload_key_hex, 32)
-        }) {
-            (
-                SelectedAvatar::EncryptedGroupImage {
-                    image: image.clone(),
-                    cache_key: key(
-                        &input.group_id_hex,
-                        "group-image",
-                        &[
-                            &image.image_hash_hex,
-                            &image.image_key_hex,
-                            &image.image_nonce_hex,
-                            &image.image_upload_key_hex,
-                            image.media_type.as_deref().unwrap_or(""),
-                        ],
-                    ),
-                },
-                PresentationSource::Group,
-            )
-        } else if let Some((peer, url)) = peer.as_deref().zip(
-            profile
-                .and_then(|p| p.picture.as_deref())
-                .and_then(safe_image_url),
-        ) {
-            (
-                SelectedAvatar::RemoteImage {
-                    cache_key: key(peer, "peer-url", &[&url]),
-                    url,
-                },
-                PresentationSource::PeerProfile,
-            )
-        } else {
-            (
-                SelectedAvatar::Placeholder {
-                    stable_seed: key(
-                        peer.as_deref().unwrap_or(&input.group_id_hex),
-                        match fallback_source {
-                            PresentationSource::PeerFallback => "person",
-                            PresentationSource::GroupFallback => "group",
-                            _ => "unknown",
-                        },
-                        &[],
-                    ),
-                    source: fallback_source,
-                },
-                fallback_source,
-            )
-        };
+    // Valid encrypted group material wins when both group sources are present.
+    let (avatar, avatar_source) = if let Some(image) = input.avatar.as_ref().filter(|image| {
+        valid_hex(&image.image_hash_hex, 32)
+            && valid_hex(&image.image_key_hex, 32)
+            && valid_hex(&image.image_nonce_hex, 12)
+            && valid_hex(&image.image_upload_key_hex, 32)
+    }) {
+        (
+            SelectedAvatar::EncryptedGroupImage {
+                image: image.clone(),
+                cache_key: key(
+                    &input.group_id_hex,
+                    "group-image",
+                    &[
+                        &image.image_hash_hex,
+                        &image.image_key_hex,
+                        &image.image_nonce_hex,
+                        &image.image_upload_key_hex,
+                        image.media_type.as_deref().unwrap_or(""),
+                    ],
+                ),
+            },
+            PresentationSource::Group,
+        )
+    } else if let Some(url) = input.avatar_url.as_deref().and_then(safe_image_url) {
+        (
+            SelectedAvatar::RemoteImage {
+                cache_key: key(&input.group_id_hex, "group-url", &[&url]),
+                url,
+            },
+            PresentationSource::Group,
+        )
+    } else if let Some((peer, url)) = peer.as_deref().zip(
+        profile
+            .and_then(|p| p.picture.as_deref())
+            .and_then(safe_image_url),
+    ) {
+        (
+            SelectedAvatar::RemoteImage {
+                cache_key: key(peer, "peer-url", &[&url]),
+                url,
+            },
+            PresentationSource::PeerProfile,
+        )
+    } else {
+        (
+            SelectedAvatar::Placeholder {
+                stable_seed: key(
+                    peer.as_deref().unwrap_or(&input.group_id_hex),
+                    match fallback_source {
+                        PresentationSource::PeerFallback => "person",
+                        PresentationSource::GroupFallback => "group",
+                        _ => "unknown",
+                    },
+                    &[],
+                ),
+                source: fallback_source,
+            },
+            fallback_source,
+        )
+    };
     let resolution = if matches!(
         title_source,
         PresentationSource::Group | PresentationSource::PeerProfile
@@ -360,8 +360,20 @@ mod tests {
         input.avatar_url = Some("https://example.com/group.png".into());
         assert!(matches!(
             select_chat_presentation(&input, &"aa".repeat(32), None).avatar,
+            SelectedAvatar::EncryptedGroupImage { .. }
+        ));
+        let valid_image = input.avatar.clone();
+        input.avatar.as_mut().unwrap().image_key_hex.clear();
+        assert!(matches!(
+            select_chat_presentation(&input, &"aa".repeat(32), None).avatar,
             SelectedAvatar::RemoteImage { .. }
         ));
+        input.avatar = None;
+        assert!(matches!(
+            select_chat_presentation(&input, &"aa".repeat(32), None).avatar,
+            SelectedAvatar::RemoteImage { .. }
+        ));
+        input.avatar = valid_image;
         input.avatar_url = None;
         input.members = vec!["aa".repeat(32), "cc".repeat(32)];
         assert!(select_chat_presentation(&input, &"aa".repeat(32), None).avatar == p.avatar);

--- a/crates/marmot-app/src/chat_presentation.rs
+++ b/crates/marmot-app/src/chat_presentation.rs
@@ -8,6 +8,28 @@ use storage_sqlite::{
     PresentationText, SelectedAvatar,
 };
 
+/// Determine the eligible peer without selecting text, avatars, or cache keys.
+fn presentation_peer(input: &ChatPresentationInput, local_id: &str) -> Option<String> {
+    let local_id = canonical_identity(local_id);
+    let members: Option<Vec<_>> = input
+        .members
+        .iter()
+        .map(|s| canonical_identity(s))
+        .collect();
+    match (&local_id, &members) {
+        (Some(local), Some(members))
+            if input.member_count == Some(2)
+                && input.self_membership == storage_sqlite::SelfMembership::Member
+                && members.len() == 2
+                && members[0] != members[1]
+                && members.contains(local) =>
+        {
+            members.iter().find(|id| *id != local).cloned()
+        }
+        _ => None,
+    }
+}
+
 /// Resolve already-cached evidence. Profile subjects must match the current peer.
 /// Remote descriptors do not authorize a download; the media layer still owns dial safety,
 /// including `reject_unsafe_group_avatar_contact_url` and validated-address pinning.
@@ -22,18 +44,7 @@ pub(crate) fn select_chat_presentation(
         .iter()
         .map(|s| canonical_identity(s))
         .collect();
-    let peer = match (&local_id, &members) {
-        (Some(local), Some(members))
-            if input.member_count == Some(2)
-                && input.self_membership == storage_sqlite::SelfMembership::Member
-                && members.len() == 2
-                && members[0] != members[1]
-                && members.contains(local) =>
-        {
-            members.iter().find(|id| *id != local).cloned()
-        }
-        _ => None,
-    };
+    let peer = presentation_peer(input, local_id.as_deref().unwrap_or(""));
     let profile = profile
         .filter(|(id, _)| {
             canonical_identity(id)

--- a/crates/marmot-app/src/chat_presentation/maintenance.rs
+++ b/crates/marmot-app/src/chat_presentation/maintenance.rs
@@ -1,5 +1,5 @@
 //! One bounded local maintenance step. Shared snapshots are released before account writes.
-use super::select_chat_presentation;
+use super::{presentation_peer, select_chat_presentation};
 use crate::{AppError, UserProfileMetadata};
 use storage_sqlite::{
     CHAT_PRESENTATION_BATCH_LIMIT, ChatPresentationActivePeer, ChatPresentationCatchUp,
@@ -16,7 +16,7 @@ fn prepare(
     inputs
         .into_iter()
         .map(|input| {
-            let peer = select_chat_presentation(&input, local, None).peer_id;
+            let peer = presentation_peer(&input, local);
             let (profile, version) = if let Some(peer) = &peer {
                 let evidence = shared.directory_presentation(peer)?;
                 if evidence.version.store_epoch != epoch {
@@ -75,8 +75,7 @@ pub(crate) fn maintain(
             revision: head.revision,
             ..Default::default()
         };
-        account.commit_chat_presentation_batch(&checkpoint, &next, &[])?;
-        return Ok(true);
+        return commit_progress(account, &checkpoint, &next, &[]);
     }
     if next.reconciling {
         let inputs = account.chat_presentation_inputs_after(next.reconcile_after.as_deref())?;
@@ -89,15 +88,13 @@ pub(crate) fn maintain(
             next.reconcile_after = None;
         }
         let values = prepare(shared, local, &next.shared_epoch, inputs)?;
-        account.commit_chat_presentation_batch(&checkpoint, &next, &values)?;
-        return Ok(true);
+        return commit_progress(account, &checkpoint, &next, &values);
     }
     // New dependencies hydrate directly even when their profile predates the watermark.
     let pending = account.pending_chat_presentation_inputs()?;
     if !pending.is_empty() {
         let values = prepare(shared, local, &next.shared_epoch, pending)?;
-        account.commit_chat_presentation_batch(&checkpoint, &next, &values)?;
-        return Ok(true);
+        return commit_progress(account, &checkpoint, &next, &values);
     }
     if let Some(mut active) = next.active.clone() {
         let current = shared.directory_presentation(&active.member_id_hex)?;
@@ -108,8 +105,7 @@ pub(crate) fn maintain(
             // Coalescing moved this identity past other unprocessed revisions. Abandon the old
             // cursor but keep the watermark; advancing it to the newer revision would skip them.
             next.active = None;
-            account.commit_chat_presentation_batch(&checkpoint, &next, &[])?;
-            return Ok(true);
+            return commit_progress(account, &checkpoint, &next, &[]);
         }
         let groups = account
             .chat_presentation_dependents(&active.member_id_hex, active.after_group.as_deref())?;
@@ -127,8 +123,7 @@ pub(crate) fn maintain(
             }
         }
         let values = prepare(shared, local, &next.shared_epoch, inputs)?;
-        account.commit_chat_presentation_batch(&checkpoint, &next, &values)?;
-        return Ok(true);
+        return commit_progress(account, &checkpoint, &next, &values);
     }
     if next.revision == head.revision {
         return Ok(false);
@@ -155,8 +150,21 @@ pub(crate) fn maintain(
     if changes.changes.is_empty() {
         next.revision = changes.head.revision;
     }
-    account.commit_chat_presentation_batch(&checkpoint, &next, &[])?;
-    Ok(true)
+    commit_progress(account, &checkpoint, &next, &[])
+}
+
+fn commit_progress(
+    account: &SqliteAccountStorage,
+    checkpoint: &storage_sqlite::ChatPresentationCheckpoint,
+    next: &ChatPresentationCatchUp,
+    values: &[(ChatPresentationInput, StoredChatPresentation)],
+) -> Result<bool, AppError> {
+    let advanced = account.commit_chat_presentation_batch(checkpoint, next, values)?;
+    if !advanced {
+        tracing::warn!(target: "marmot_app::runtime", method = "chat_presentation_maintenance",
+            "presentation batch made no progress; retrying on the next wakeup or maintenance tick");
+    }
+    Ok(advanced)
 }
 #[cfg(test)]
 mod tests;

--- a/crates/marmot-app/src/chat_presentation/maintenance.rs
+++ b/crates/marmot-app/src/chat_presentation/maintenance.rs
@@ -1,0 +1,162 @@
+//! One bounded local maintenance step. Shared snapshots are released before account writes.
+use super::select_chat_presentation;
+use crate::{AppError, UserProfileMetadata};
+use storage_sqlite::{
+    CHAT_PRESENTATION_BATCH_LIMIT, ChatPresentationActivePeer, ChatPresentationCatchUp,
+    ChatPresentationInput, ChatPresentationVersion, SqliteAccountStorage, SqliteSharedStorage,
+    StoredChatPresentation,
+};
+
+fn prepare(
+    shared: &SqliteSharedStorage,
+    local: &str,
+    epoch: &[u8],
+    inputs: Vec<ChatPresentationInput>,
+) -> Result<Vec<(ChatPresentationInput, StoredChatPresentation)>, AppError> {
+    inputs
+        .into_iter()
+        .map(|input| {
+            let peer = select_chat_presentation(&input, local, None).peer_id;
+            let (profile, version) = if let Some(peer) = &peer {
+                let evidence = shared.directory_presentation(peer)?;
+                if evidence.version.store_epoch != epoch {
+                    return Err(cgka_traits::storage::StorageError::Serialization(
+                        "directory incarnation changed during presentation preparation".into(),
+                    )
+                    .into());
+                }
+                let profile = evidence
+                    .profile_json
+                    .map(|json| {
+                        serde_json::from_str::<UserProfileMetadata>(&json).map_err(|_| {
+                            cgka_traits::storage::StorageError::Serialization(
+                                "invalid cached presentation profile".into(),
+                            )
+                        })
+                    })
+                    .transpose()?;
+                (profile, evidence.version)
+            } else {
+                (
+                    None,
+                    ChatPresentationVersion {
+                        store_epoch: epoch.to_vec(),
+                        revision: 0,
+                    },
+                )
+            };
+            let presentation =
+                select_chat_presentation(&input, local, peer.as_deref().zip(profile.as_ref()));
+            Ok((
+                input,
+                StoredChatPresentation {
+                    presentation,
+                    profile_version: Some(version),
+                },
+            ))
+        })
+        .collect()
+}
+
+/// Returns whether another bounded step should be scheduled after yielding.
+pub(crate) fn maintain(
+    account: &SqliteAccountStorage,
+    shared: &SqliteSharedStorage,
+    local: &str,
+) -> Result<bool, AppError> {
+    let checkpoint = account.chat_presentation_checkpoint()?;
+    let head = shared.directory_presentation_version()?;
+    let mut next = checkpoint.state.clone();
+    if next.shared_epoch != head.store_epoch {
+        next = ChatPresentationCatchUp {
+            shared_epoch: head.store_epoch,
+            // Reconciliation reads current profiles directly. Only changes after this
+            // captured head need replaying, including changes made while it runs.
+            revision: head.revision,
+            ..Default::default()
+        };
+        account.commit_chat_presentation_batch(&checkpoint, &next, &[])?;
+        return Ok(true);
+    }
+    if next.reconciling {
+        let inputs = account.chat_presentation_inputs_after(next.reconcile_after.as_deref())?;
+        next.reconcile_after = inputs
+            .last()
+            .map(|input| input.group_id_hex.clone())
+            .or(next.reconcile_after);
+        if inputs.len() < CHAT_PRESENTATION_BATCH_LIMIT {
+            next.reconciling = false;
+            next.reconcile_after = None;
+        }
+        let values = prepare(shared, local, &next.shared_epoch, inputs)?;
+        account.commit_chat_presentation_batch(&checkpoint, &next, &values)?;
+        return Ok(true);
+    }
+    // New dependencies hydrate directly even when their profile predates the watermark.
+    let pending = account.pending_chat_presentation_inputs()?;
+    if !pending.is_empty() {
+        let values = prepare(shared, local, &next.shared_epoch, pending)?;
+        account.commit_chat_presentation_batch(&checkpoint, &next, &values)?;
+        return Ok(true);
+    }
+    if let Some(mut active) = next.active.clone() {
+        let current = shared.directory_presentation(&active.member_id_hex)?;
+        if current.version.store_epoch != next.shared_epoch {
+            return Ok(true);
+        }
+        if current.version.revision != active.revision {
+            // Coalescing moved this identity past other unprocessed revisions. Abandon the old
+            // cursor but keep the watermark; advancing it to the newer revision would skip them.
+            next.active = None;
+            account.commit_chat_presentation_batch(&checkpoint, &next, &[])?;
+            return Ok(true);
+        }
+        let groups = account
+            .chat_presentation_dependents(&active.member_id_hex, active.after_group.as_deref())?;
+        active.after_group = groups.last().cloned().or(active.after_group);
+        if groups.len() < CHAT_PRESENTATION_BATCH_LIMIT {
+            next.revision = active.revision;
+            next.active = None;
+        } else {
+            next.active = Some(active);
+        }
+        let mut inputs = Vec::with_capacity(groups.len());
+        for group in groups {
+            if let Some(input) = account.chat_presentation_input(&group)? {
+                inputs.push(input);
+            }
+        }
+        let values = prepare(shared, local, &next.shared_epoch, inputs)?;
+        account.commit_chat_presentation_batch(&checkpoint, &next, &values)?;
+        return Ok(true);
+    }
+    if next.revision == head.revision {
+        return Ok(false);
+    }
+    let changes = shared.directory_presentation_changes(next.revision)?;
+    if changes.head.store_epoch != next.shared_epoch {
+        return Ok(true);
+    }
+    for change in &changes.changes {
+        if account
+            .chat_presentation_dependents(&change.member_id_hex, None)?
+            .is_empty()
+        {
+            next.revision = change.version.revision;
+            continue;
+        }
+        next.active = Some(ChatPresentationActivePeer {
+            member_id_hex: change.member_id_hex.clone(),
+            revision: change.version.revision,
+            after_group: None,
+        });
+        break;
+    }
+    if changes.changes.is_empty() {
+        next.revision = changes.head.revision;
+    }
+    account.commit_chat_presentation_batch(&checkpoint, &next, &[])?;
+    Ok(true)
+}
+#[cfg(test)]
+mod tests;

--- a/crates/marmot-app/src/chat_presentation/maintenance/tests.rs
+++ b/crates/marmot-app/src/chat_presentation/maintenance/tests.rs
@@ -321,3 +321,161 @@ fn unrelated_directory_history_is_skipped_and_new_unrelated_changes_are_batched(
     );
     assert_eq!(account.chat_presentation_version().unwrap(), version);
 }
+
+#[test]
+fn rejected_pending_presentation_yields_until_new_evidence_allows_progress() {
+    let account = SqliteAccountStorage::in_memory().unwrap();
+    let shared = SqliteSharedStorage::in_memory().unwrap();
+    profile(&shared, Some("First"));
+    seed(&account, "11", "");
+    drain(&account, &shared);
+    let input = account.chat_presentation_input("11").unwrap().unwrap();
+    let ChatPresentationRead::Ready(mut future) = account.chat_presentation("11").unwrap() else {
+        panic!("initial presentation");
+    };
+    future.profile_version.as_mut().unwrap().revision += 1;
+    account.store_chat_presentation(&input, &future).unwrap();
+    let mut state = account
+        .load_account_projection_state("fixture", 100)
+        .unwrap();
+    state.groups[0].image_media_type = Some("image/png".into());
+    account.save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events(
+        &state, 101, 121, &[], &[],
+    ).unwrap();
+    let generation = account.chat_presentation_checkpoint().unwrap().generation;
+    assert!(
+        !maintain(&account, &shared, &"aa".repeat(32)).unwrap(),
+        "an entirely rejected pending batch must wait instead of scheduling a hot loop"
+    );
+    assert_eq!(
+        account.chat_presentation_checkpoint().unwrap().generation,
+        generation
+    );
+    assert_eq!(account.pending_chat_presentation_inputs().unwrap().len(), 1);
+    profile(&shared, Some("Second"));
+    drain(&account, &shared);
+    assert!(title(&account, "11") == PresentationText::Literal("Second".into()));
+    assert!(
+        account
+            .pending_chat_presentation_inputs()
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
+fn account_catchup_and_replacement_cannot_restore_another_accounts_deleted_chat() {
+    let first = SqliteAccountStorage::in_memory().unwrap();
+    let second = SqliteAccountStorage::in_memory().unwrap();
+    let shared = SqliteSharedStorage::in_memory().unwrap();
+    profile(&shared, Some("Initial"));
+    seed(&first, "11", "");
+    seed(&second, "11", "");
+    second
+        .set_chat_presentation_members("11", &["cc".repeat(32), "bb".repeat(32)])
+        .unwrap();
+    drain(&first, &shared);
+    for _ in 0..100 {
+        if !maintain(&second, &shared, &"cc".repeat(32)).unwrap() {
+            break;
+        }
+    }
+    assert!(title(&second, "11") == PresentationText::Literal("Initial".into()));
+    let delayed_input = first.chat_presentation_input("11").unwrap().unwrap();
+    let ChatPresentationRead::Ready(delayed_value) = first.chat_presentation("11").unwrap() else {
+        panic!("first presentation");
+    };
+    assert_eq!(
+        second
+            .store_chat_presentation(&delayed_input, &delayed_value)
+            .unwrap(),
+        storage_sqlite::ChatPresentationWrite::Stale
+    );
+    second.delete_local_group_data("11").unwrap();
+    let second_checkpoint = second.chat_presentation_checkpoint().unwrap();
+    let second_version = second.chat_presentation_version().unwrap();
+    profile(&shared, Some("Updated"));
+    drain(&first, &shared);
+    assert!(title(&first, "11") == PresentationText::Literal("Updated".into()));
+    assert_eq!(
+        second.chat_presentation_checkpoint().unwrap().generation,
+        second_checkpoint.generation
+    );
+    assert_eq!(second.chat_presentation_version().unwrap(), second_version);
+    assert_eq!(
+        second.chat_presentation("11").unwrap(),
+        ChatPresentationRead::Missing
+    );
+    let replacement = SqliteSharedStorage::in_memory().unwrap();
+    drain(&first, &replacement);
+    for _ in 0..100 {
+        if !maintain(&second, &replacement, &"cc".repeat(32)).unwrap() {
+            break;
+        }
+    }
+    assert_eq!(
+        second.chat_presentation("11").unwrap(),
+        ChatPresentationRead::Missing
+    );
+    assert!(
+        second
+            .chat_presentation_dependents(&"bb".repeat(32), None)
+            .unwrap()
+            .is_empty()
+    );
+    let replacement_account = SqliteAccountStorage::in_memory().unwrap();
+    seed(&replacement_account, "11", "");
+    drain(&replacement_account, &replacement);
+    assert_eq!(
+        replacement_account
+            .store_chat_presentation(&delayed_input, &delayed_value)
+            .unwrap(),
+        storage_sqlite::ChatPresentationWrite::Stale
+    );
+}
+
+#[test]
+fn named_pair_roster_matches_durable_order_and_unchanged_hydration_stays_clean() {
+    let account = SqliteAccountStorage::in_memory().unwrap();
+    let shared = SqliteSharedStorage::in_memory().unwrap();
+    seed(&account, "11", "Named pair");
+    drain(&account, &shared);
+    let mut state = account
+        .load_account_projection_state("fixture", 100)
+        .unwrap();
+    let mut group =
+        crate::conversions::app_group_from_stored_group(state.groups[0].clone()).unwrap();
+    let before = group.presentation_member_ids_hex.clone();
+    let members = ["bb", "aa"].map(|id| cgka_traits::group::Member {
+        id: cgka_traits::MemberId::new(hex::decode(id.repeat(32)).unwrap()),
+        credential: vec![],
+    });
+    group.set_direct_member_ids_from_roster(&members);
+    assert_eq!(
+        group.presentation_member_ids_hex, before,
+        "MLS leaf order must not appear as a source change after a durable reload"
+    );
+    assert!(group.direct_member_ids_hex.is_none());
+    let version = account.chat_presentation_version().unwrap();
+    let input = account.chat_presentation_input("11").unwrap().unwrap();
+    state.groups[0] = crate::conversions::stored_group_from_app_group(&group);
+    account.save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events(
+        &state, 101, 121, &[], &[],
+    ).unwrap();
+    assert_eq!(
+        account
+            .chat_presentation_input("11")
+            .unwrap()
+            .unwrap()
+            .source_version,
+        input.source_version
+    );
+    assert!(!maintain(&account, &shared, &"aa".repeat(32)).unwrap());
+    assert_eq!(account.chat_presentation_version().unwrap(), version);
+    group.profile.name.clear();
+    group.set_direct_member_ids_from_roster(&members);
+    assert_eq!(group.direct_member_ids_hex, before);
+    group.set_direct_member_ids_from_roster(&[members[0].clone(), members[0].clone()]);
+    assert!(group.presentation_member_ids_hex.is_none());
+    assert!(group.direct_member_ids_hex.is_none());
+}

--- a/crates/marmot-app/src/chat_presentation/maintenance/tests.rs
+++ b/crates/marmot-app/src/chat_presentation/maintenance/tests.rs
@@ -1,0 +1,323 @@
+use super::*;
+use crate::*;
+use storage_sqlite::{
+    ChatPresentationRead, PresentationText, PublicDirectoryUserRecord, StoredAccountState,
+};
+fn seed(account: &SqliteAccountStorage, id: &str, name: &str) {
+    let routing = AppGroupNostrRoutingComponent::new(cgka_traits::app_components::NostrRoutingV1 {
+        nostr_group_id: [1; 32],
+        relays: vec!["wss://relay.example.com".into()],
+    })
+    .unwrap();
+    let mut group = AppGroupRecord::new(
+        id.into(),
+        routing,
+        name.into(),
+        String::new(),
+        AppGroupImageInput::default(),
+        AppGroupAdminPolicyComponent::new(Vec::new()),
+        AppGroupMessageRetentionComponent::disabled(),
+    );
+    group.member_count = Some(2);
+    group.presentation_member_ids_hex = Some(vec!["aa".repeat(32), "bb".repeat(32)]);
+    let state = StoredAccountState {
+        label: "fixture".into(),
+        groups: vec![crate::conversions::stored_group_from_app_group(&group)],
+        ..Default::default()
+    };
+    account.save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events(&state,100,120,&[],&[]).unwrap();
+    account
+        .refresh_chat_list_row(&"aa".repeat(32), id, &|_, _| false)
+        .unwrap();
+}
+fn profile(shared: &SqliteSharedStorage, name: Option<&str>) {
+    shared
+        .put_public_directory_user(&PublicDirectoryUserRecord {
+            account_id_hex: "bb".repeat(32),
+            npub: "fixture".into(),
+            profile_json: name.map(|name| {
+                serde_json::to_string(&UserProfileMetadata {
+                    display_name: Some(name.into()),
+                    picture: Some("https://example.com/avatar".into()),
+                    ..Default::default()
+                })
+                .unwrap()
+            }),
+            relay_lists_json: "{}".into(),
+            key_package_json: None,
+            event_id_hex: None,
+            event_kind: None,
+            event_created_at: None,
+            follows: vec![],
+        })
+        .unwrap();
+}
+fn drain(account: &SqliteAccountStorage, shared: &SqliteSharedStorage) {
+    for _ in 0..100 {
+        if !maintain(account, shared, &"aa".repeat(32)).unwrap() {
+            return;
+        }
+    }
+    panic!("presentation maintenance did not quiesce");
+}
+fn title(account: &SqliteAccountStorage, id: &str) -> PresentationText {
+    match account.chat_presentation(id).unwrap() {
+        ChatPresentationRead::Ready(value) => value.presentation.title,
+        _ => panic!("presentation was not prepared"),
+    }
+}
+#[test]
+fn cached_before_creation_and_later_profile_changes_apply_without_a_subscriber() {
+    let account = SqliteAccountStorage::in_memory().unwrap();
+    let shared = SqliteSharedStorage::in_memory().unwrap();
+    profile(&shared, Some("First"));
+    seed(&account, "11", "");
+    drain(&account, &shared);
+    assert!(title(&account, "11") == PresentationText::Literal("First".into()));
+    profile(&shared, Some("Second"));
+    drain(&account, &shared);
+    assert!(title(&account, "11") == PresentationText::Literal("Second".into()));
+}
+
+#[test]
+fn dirty_same_subject_display_survives_until_maintenance_and_new_titles_notify_once() {
+    let account = SqliteAccountStorage::in_memory().unwrap();
+    let shared = SqliteSharedStorage::in_memory().unwrap();
+    profile(&shared, Some("Peer"));
+    seed(&account, "11", "");
+    drain(&account, &shared);
+    let before = account.chat_presentation_version().unwrap();
+    let mut state = account
+        .load_account_projection_state("fixture", 100)
+        .unwrap();
+    state.groups[0].image_media_type = Some("image/jpeg".into());
+    account.save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events(
+        &state, 101, 121, &[], &[],
+    ).unwrap();
+    let ChatPresentationRead::Ready(value) = account.chat_presentation("11").unwrap() else {
+        panic!("same-subject display was erased");
+    };
+    assert_eq!(
+        value.presentation.resolution,
+        storage_sqlite::PresentationResolution::LastKnown
+    );
+    assert!(value.presentation.title == PresentationText::Literal("Peer".into()));
+    drain(&account, &shared);
+    assert_eq!(account.chat_presentation_version().unwrap(), before);
+    state.groups[0].profile_name = "Custom".into();
+    account.save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events(
+        &state, 102, 122, &[], &[],
+    ).unwrap();
+    drain(&account, &shared);
+    assert!(title(&account, "11") == PresentationText::Literal("Custom".into()));
+    assert_eq!(
+        account.chat_presentation_version().unwrap().revision,
+        before.revision + 1
+    );
+    state.groups[0].profile_name.clear();
+    account.save_account_projection_delta_clearing_local_group_deletion_frontiers_and_acking_application_events(
+        &state, 103, 123, &[], &[],
+    ).unwrap();
+    assert_eq!(
+        account.chat_presentation("11").unwrap(),
+        ChatPresentationRead::Pending
+    );
+    drain(&account, &shared);
+    assert!(title(&account, "11") == PresentationText::Literal("Peer".into()));
+    assert!(
+        account
+            .pending_chat_presentation_inputs()
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
+fn restart_mid_fanout_and_coalesced_newer_profiles_do_not_skip_other_identities() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("account.db");
+    let key = storage_sqlite::SqlCipherKey::new("presentation test key").unwrap();
+    let account = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+    let shared = SqliteSharedStorage::in_memory().unwrap();
+    profile(&shared, Some("Original"));
+    for i in 0..65 {
+        seed(&account, &format!("{i:04x}"), "");
+    }
+    seed(&account, "cc", "");
+    account
+        .set_chat_presentation_members("cc", &["aa".repeat(32), "cc".repeat(32)])
+        .unwrap();
+    drain(&account, &shared);
+    profile(&shared, Some("First update"));
+    // Select the changed identity, then commit one bounded group page.
+    assert!(maintain(&account, &shared, &"aa".repeat(32)).unwrap());
+    assert!(maintain(&account, &shared, &"aa".repeat(32)).unwrap());
+    let checkpoint = account.chat_presentation_checkpoint().unwrap();
+    assert!(
+        checkpoint
+            .state
+            .active
+            .as_ref()
+            .unwrap()
+            .after_group
+            .is_some()
+    );
+    drop(account);
+    // Another identity lands between this peer's old and new coalesced revisions.
+    shared
+        .put_public_directory_user(&PublicDirectoryUserRecord {
+            account_id_hex: "cc".repeat(32),
+            npub: "fixture".into(),
+            profile_json: Some(
+                serde_json::to_string(&UserProfileMetadata {
+                    name: Some("Other peer".into()),
+                    ..Default::default()
+                })
+                .unwrap(),
+            ),
+            relay_lists_json: "{}".into(),
+            key_package_json: None,
+            event_id_hex: None,
+            event_kind: None,
+            event_created_at: None,
+            follows: vec![],
+        })
+        .unwrap();
+    profile(&shared, Some("Latest update"));
+    let account = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+    drain(&account, &shared);
+    for i in 0..65 {
+        assert!(
+            title(&account, &format!("{i:04x}"))
+                == PresentationText::Literal("Latest update".into())
+        );
+    }
+    assert!(title(&account, "cc") == PresentationText::Literal("Other peer".into()));
+}
+
+#[test]
+fn removal_store_replacement_and_new_dependency_after_watermark_clear_stale_data() {
+    let account = SqliteAccountStorage::in_memory().unwrap();
+    let shared = SqliteSharedStorage::in_memory().unwrap();
+    profile(&shared, Some("Cached"));
+    seed(&account, "11", "");
+    drain(&account, &shared);
+    let before = account.chat_list_row("11").unwrap();
+    seed(&account, "22", "");
+    drain(&account, &shared);
+    assert!(title(&account, "22") == PresentationText::Literal("Cached".into()));
+    profile(&shared, None);
+    drain(&account, &shared);
+    assert!(
+        title(&account, "11")
+            == PresentationText::Literal(crate::default_profile_pseudonym(&"bb".repeat(32)))
+    );
+    assert_eq!(account.chat_list_row("11").unwrap(), before);
+    profile(&shared, Some("Cached again"));
+    drain(&account, &shared);
+    let replacement = SqliteSharedStorage::in_memory().unwrap();
+    drain(&account, &replacement);
+    assert!(
+        title(&account, "11")
+            == PresentationText::Literal(crate::default_profile_pseudonym(&"bb".repeat(32)))
+    );
+    let generation = account.chat_presentation_checkpoint().unwrap().generation;
+    let version = account.chat_presentation_version().unwrap();
+    assert!(!maintain(&account, &replacement, &"aa".repeat(32)).unwrap());
+    assert_eq!(
+        account.chat_presentation_checkpoint().unwrap().generation,
+        generation
+    );
+    assert_eq!(account.chat_presentation_version().unwrap(), version);
+}
+
+#[test]
+fn named_pair_depends_on_peer_avatar_and_membership_changes_clear_old_peer_immediately() {
+    let account = SqliteAccountStorage::in_memory().unwrap();
+    let shared = SqliteSharedStorage::in_memory().unwrap();
+    profile(&shared, Some("Peer"));
+    seed(&account, "11", "Custom");
+    drain(&account, &shared);
+    assert_eq!(
+        account
+            .chat_presentation_dependents(&"bb".repeat(32), None)
+            .unwrap(),
+        ["11"]
+    );
+    assert!(title(&account, "11") == PresentationText::Literal("Custom".into()));
+    account
+        .set_chat_presentation_members("11", &["aa".repeat(32), "cc".repeat(32)])
+        .unwrap();
+    assert!(matches!(
+        account.chat_presentation("11").unwrap(),
+        ChatPresentationRead::Pending
+    ));
+    assert!(
+        account
+            .chat_presentation_dependents(&"bb".repeat(32), None)
+            .unwrap()
+            .is_empty()
+    );
+    drain(&account, &shared);
+    let ChatPresentationRead::Ready(selected) = account.chat_presentation("11").unwrap() else {
+        panic!("not ready")
+    };
+    assert_eq!(selected.presentation.peer_id, Some("cc".repeat(32)));
+    assert!(matches!(
+        selected.presentation.avatar,
+        storage_sqlite::SelectedAvatar::Placeholder { .. }
+    ));
+    account
+        .set_group_self_membership("11", storage_sqlite::SelfMembership::Left)
+        .unwrap();
+    drain(&account, &shared);
+    let ChatPresentationRead::Ready(selected) = account.chat_presentation("11").unwrap() else {
+        panic!("not ready")
+    };
+    assert!(selected.presentation.peer_id.is_none());
+}
+
+#[test]
+fn unrelated_directory_history_is_skipped_and_new_unrelated_changes_are_batched() {
+    let account = SqliteAccountStorage::in_memory().unwrap();
+    let shared = SqliteSharedStorage::in_memory().unwrap();
+    for i in 0..250 {
+        shared
+            .put_public_directory_user(&PublicDirectoryUserRecord {
+                account_id_hex: format!("{i:064x}"),
+                npub: "fixture".into(),
+                profile_json: Some("{\"name\":\"Unrelated\"}".into()),
+                relay_lists_json: "{}".into(),
+                key_package_json: None,
+                event_id_hex: None,
+                event_kind: None,
+                event_created_at: None,
+                follows: vec![],
+            })
+            .unwrap();
+    }
+    profile(&shared, Some("Relevant"));
+    seed(&account, "11", "");
+    assert!(maintain(&account, &shared, &"aa".repeat(32)).unwrap());
+    assert!(maintain(&account, &shared, &"aa".repeat(32)).unwrap());
+    assert!(
+        !maintain(&account, &shared, &"aa".repeat(32)).unwrap(),
+        "initial reconciliation must not replay pre-existing unrelated changes"
+    );
+    let version = account.chat_presentation_version().unwrap();
+    for i in 0..100 {
+        let mut record = shared
+            .public_directory_user(&format!("{i:064x}"))
+            .unwrap()
+            .unwrap();
+        record.profile_json = Some("{\"name\":\"Changed unrelated\"}".into());
+        shared.put_public_directory_user(&record).unwrap();
+    }
+    assert!(maintain(&account, &shared, &"aa".repeat(32)).unwrap());
+    assert!(maintain(&account, &shared, &"aa".repeat(32)).unwrap());
+    assert!(
+        !maintain(&account, &shared, &"aa".repeat(32)).unwrap(),
+        "unrelated changes should advance 50 identities per batch"
+    );
+    assert_eq!(account.chat_presentation_version().unwrap(), version);
+}

--- a/crates/marmot-app/src/chat_presentation/signals.rs
+++ b/crates/marmot-app/src/chat_presentation/signals.rs
@@ -2,20 +2,12 @@
 use storage_sqlite::ChatPresentationVersion;
 use tokio::sync::{broadcast, watch};
 
+// P3 consumes the fields; P2 publishes and tests the handoff.
+#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Clone)]
 pub(crate) struct PresentationInvalidation {
     pub(crate) account_label: String,
     pub(crate) version: ChatPresentationVersion,
-}
-// P3 consumes these fields in the presented-snapshot subscription; P2 publishes and tests the handoff.
-#[allow(dead_code)]
-impl PresentationInvalidation {
-    pub(crate) fn account_label(&self) -> &str {
-        &self.account_label
-    }
-    pub(crate) fn version(&self) -> &ChatPresentationVersion {
-        &self.version
-    }
 }
 pub(crate) struct PresentationSignals {
     wakeups: watch::Sender<()>,

--- a/crates/marmot-app/src/chat_presentation/signals.rs
+++ b/crates/marmot-app/src/chat_presentation/signals.rs
@@ -1,0 +1,39 @@
+//! Coalesced process-local wakeups. Durable revisions remain the recovery authority.
+use storage_sqlite::ChatPresentationVersion;
+use tokio::sync::{broadcast, watch};
+
+#[derive(Clone)]
+pub(crate) struct PresentationInvalidation {
+    pub(crate) account_label: String,
+    pub(crate) version: ChatPresentationVersion,
+}
+// P3 consumes these fields in the presented-snapshot subscription; P2 publishes and tests the handoff.
+#[allow(dead_code)]
+impl PresentationInvalidation {
+    pub(crate) fn account_label(&self) -> &str {
+        &self.account_label
+    }
+    pub(crate) fn version(&self) -> &ChatPresentationVersion {
+        &self.version
+    }
+}
+pub(crate) struct PresentationSignals {
+    wakeups: watch::Sender<()>,
+    pub(crate) updates: broadcast::Sender<PresentationInvalidation>,
+}
+impl Default for PresentationSignals {
+    fn default() -> Self {
+        Self {
+            wakeups: watch::channel(()).0,
+            updates: broadcast::channel(64).0,
+        }
+    }
+}
+impl PresentationSignals {
+    pub(crate) fn wake(&self) {
+        self.wakeups.send_modify(|_| {});
+    }
+    pub(crate) fn subscribe_work(&self) -> watch::Receiver<()> {
+        self.wakeups.subscribe()
+    }
+}

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -467,7 +467,27 @@ impl AppClient {
             .map(|group| group.group_id_hex.clone())
             .collect::<std::collections::HashSet<_>>();
         let live_group_ids = self.runtime.live_group_ids()?;
-        let mut changed = false;
+        let quarantined: std::collections::HashSet<_> = self
+            .runtime
+            .quarantined_groups()
+            .into_iter()
+            .map(|(id, _)| hex::encode(id.as_slice()))
+            .collect();
+        let mut cleared = Vec::new();
+        for group in &mut self.state.groups {
+            if quarantined.contains(&group.group_id_hex)
+                && (group.member_count.is_some() || group.presentation_member_ids_hex.is_some())
+            {
+                group.member_count = None;
+                group.direct_member_ids_hex = None;
+                group.presentation_member_ids_hex = None;
+                cleared.push(group.group_id_hex.clone());
+            }
+        }
+        let mut changed = !cleared.is_empty();
+        for id in cleared {
+            self.mark_group_projection_dirty_hex(id);
+        }
         for group_id in live_group_ids {
             let group_id_hex = hex::encode(group_id.as_slice());
             if !projected.contains(group_id_hex.as_str()) {
@@ -500,8 +520,11 @@ impl AppClient {
                     dirty = true;
                 }
                 let previous_direct_members = projected_group.direct_member_ids_hex.clone();
+                let previous_presentation_members =
+                    projected_group.presentation_member_ids_hex.clone();
                 projected_group.set_direct_member_ids_from_roster(&group.members);
-                dirty |= projected_group.direct_member_ids_hex != previous_direct_members;
+                dirty |= projected_group.direct_member_ids_hex != previous_direct_members
+                    || projected_group.presentation_member_ids_hex != previous_presentation_members;
             }
             if dirty {
                 self.mark_group_projection_dirty_hex(group_id_hex);

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -476,10 +476,8 @@ impl AppClient {
         let mut cleared = Vec::new();
         for group in &mut self.state.groups {
             if quarantined.contains(&group.group_id_hex)
-                && (group.member_count.is_some() || group.presentation_member_ids_hex.is_some())
+                && group.presentation_member_ids_hex.is_some()
             {
-                group.member_count = None;
-                group.direct_member_ids_hex = None;
                 group.presentation_member_ids_hex = None;
                 cleared.push(group.group_id_hex.clone());
             }

--- a/crates/marmot-app/src/conversions.rs
+++ b/crates/marmot-app/src/conversions.rs
@@ -72,6 +72,7 @@ pub(crate) fn stored_group_from_app_group(group: &AppGroupRecord) -> StoredAccou
         pending_confirmation: group.pending_confirmation,
         member_count: group.member_count,
         direct_member_ids_hex: group.direct_member_ids_hex.clone(),
+        presentation_member_ids_hex: group.presentation_member_ids_hex.clone(),
         // Ignored by the projection save (owned by `set_group_self_membership`);
         // carried for struct completeness and round-trip symmetry.
         self_membership: group.self_membership,
@@ -242,6 +243,7 @@ pub(crate) fn app_group_from_stored_group(
     group.self_membership = stored.self_membership;
     group.member_count = stored.member_count;
     group.direct_member_ids_hex = stored.direct_member_ids_hex;
+    group.presentation_member_ids_hex = stored.presentation_member_ids_hex;
     group.welcomer_account_id_hex = stored.welcomer_account_id_hex;
     group.via_welcome_message_id_hex = stored.via_welcome_message_id_hex;
     group.nostr_routing_last_epoch = stored.nostr_routing_last_epoch;

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -1639,6 +1639,7 @@ impl MarmotApp {
         let shared_storage = self.shared_storage()?;
         for entry in &entries {
             shared_storage.put_public_directory_user(&public_directory_user_record(entry)?)?;
+            // Each row commits independently; a later import error must not hide this work.
             self.presentation_signals.wake();
         }
         for cache in caches {

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -1501,6 +1501,7 @@ impl MarmotApp {
             return Ok(());
         }
         shared_storage.put_public_directory_user(&public_entry)?;
+        self.presentation_signals.wake();
         for cache in caches {
             cache.put_with_reason(&entry, reason)?;
         }
@@ -1638,6 +1639,7 @@ impl MarmotApp {
         let shared_storage = self.shared_storage()?;
         for entry in &entries {
             shared_storage.put_public_directory_user(&public_directory_user_record(entry)?)?;
+            self.presentation_signals.wake();
         }
         for cache in caches {
             for entry in &entries {

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -133,7 +133,7 @@ pub struct PendingGroupInvite {
     pub welcomer: Option<MemberId>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AppGroupRecord {
     pub group_id_hex: String,
     /// Compatibility profile for all profile-gated behavior in this group.
@@ -180,6 +180,9 @@ pub struct AppGroupRecord {
     /// (empty name, roster size 2). Persisted as the peer-keyed reuse index.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub direct_member_ids_hex: Option<Vec<String>>,
+    /// Current authoritative two-member roster, including explicitly named groups.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub presentation_member_ids_hex: Option<Vec<String>>,
     /// Whether the local account is still a member of this group, and if not,
     /// whether it left voluntarily (`Left`) or was removed (`Removed`).
     #[serde(default)]
@@ -708,6 +711,17 @@ impl Default for AppGroupMessageRetentionComponent {
     }
 }
 
+impl std::fmt::Debug for AppGroupRecord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AppGroupRecord")
+            .field("member_count", &self.member_count)
+            .field("archived", &self.archived)
+            .field("pending_confirmation", &self.pending_confirmation)
+            .field("self_membership", &self.self_membership)
+            .finish_non_exhaustive()
+    }
+}
+
 impl AppGroupRecord {
     pub(crate) fn new(
         group_id_hex: String,
@@ -738,6 +752,7 @@ impl AppGroupRecord {
             pending_confirmation: false,
             member_count: None,
             direct_member_ids_hex: None,
+            presentation_member_ids_hex: None,
             self_membership: SelfMembership::Member,
             leave_requested_at_ms: None,
             disbanding: false,
@@ -831,6 +846,12 @@ impl AppGroupRecord {
         &mut self,
         members: &[cgka_traits::group::Member],
     ) {
+        self.presentation_member_ids_hex = (members.len() == 2).then(|| {
+            members
+                .iter()
+                .map(|member| hex::encode(member.id.as_slice()).to_ascii_lowercase())
+                .collect()
+        });
         self.direct_member_ids_hex = if self.profile.name.trim().is_empty() && members.len() == 2 {
             Some(
                 members

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -153,8 +153,8 @@ pub struct AppGroupRecord {
     pub prior_nostr_routes: Vec<AppPriorNostrRoute>,
     pub profile: AppGroupProfileComponent,
     pub image: AppGroupImageComponent,
-    /// URL-based group avatar. When `present`, it takes precedence over `image`
-    /// for rendering (spec: `marmot.group.avatar-url.v1`).
+    /// URL-based group avatar, used when no valid encrypted `image` is available.
+    /// When both sources are present, encrypted group image material wins.
     #[serde(default)]
     pub avatar_url: AppGroupAvatarUrlComponent,
     pub admin_policy: AppGroupAdminPolicyComponent,

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -846,19 +846,21 @@ impl AppGroupRecord {
         &mut self,
         members: &[cgka_traits::group::Member],
     ) {
-        self.presentation_member_ids_hex = (members.len() == 2).then(|| {
-            members
+        self.presentation_member_ids_hex = (members.len() == 2
+            && members
                 .iter()
-                .map(|member| hex::encode(member.id.as_slice()).to_ascii_lowercase())
-                .collect()
-        });
-        self.direct_member_ids_hex = if self.profile.name.trim().is_empty() && members.len() == 2 {
-            Some(
-                members
+                .all(|member| member.id.as_slice().len() == 32)
+            && members[0].id != members[1].id)
+            .then(|| {
+                let mut ids: Vec<_> = members
                     .iter()
-                    .map(|member| hex::encode(member.id.as_slice()).to_ascii_lowercase())
-                    .collect(),
-            )
+                    .map(|member| hex::encode(member.id.as_slice()))
+                    .collect();
+                ids.sort_unstable();
+                ids
+            });
+        self.direct_member_ids_hex = if self.profile.name.trim().is_empty() {
+            self.presentation_member_ids_hex.clone()
         } else {
             None
         };

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -622,6 +622,7 @@ pub struct MarmotApp {
     #[cfg(test)]
     test_relay_client: Option<Arc<dyn NostrRelayClient>>,
     shared_storage: Arc<Mutex<Option<SqliteSharedStorage>>>,
+    pub(crate) presentation_signals: Arc<chat_presentation::signals::PresentationSignals>,
     account_state_ready: Arc<Mutex<HashSet<String>>>,
     chat_list_projection_warmed: Arc<Mutex<HashSet<String>>>,
     chat_list_projection_stale: Arc<Mutex<HashSet<String>>>,
@@ -1490,6 +1491,7 @@ impl MarmotApp {
             #[cfg(test)]
             test_relay_client: None,
             shared_storage: Arc::new(Mutex::new(None)),
+            presentation_signals: Arc::new(Default::default()),
             account_state_ready: Arc::new(Mutex::new(HashSet::new())),
             chat_list_projection_warmed: Arc::new(Mutex::new(HashSet::new())),
             chat_list_projection_stale: Arc::new(Mutex::new(HashSet::new())),
@@ -1570,6 +1572,7 @@ impl MarmotApp {
             #[cfg(test)]
             test_relay_client: None,
             shared_storage: Arc::new(Mutex::new(None)),
+            presentation_signals: Arc::new(Default::default()),
             account_state_ready: Arc::new(Mutex::new(HashSet::new())),
             chat_list_projection_warmed: Arc::new(Mutex::new(HashSet::new())),
             chat_list_projection_stale: Arc::new(Mutex::new(HashSet::new())),
@@ -3273,6 +3276,7 @@ impl MarmotApp {
             return Ok(());
         }
         storage.set_group_self_membership(group_id_hex, membership)?;
+        self.presentation_signals.wake();
         Ok(())
     }
 
@@ -4841,6 +4845,7 @@ impl MarmotApp {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .insert(delta.label.clone());
+        self.presentation_signals.wake();
         Ok(())
     }
 
@@ -4870,6 +4875,7 @@ impl MarmotApp {
                 &classifier,
             )?
             .ok_or_else(|| AppError::UnknownGroup(group_id_hex.to_owned()))?;
+        self.presentation_signals.wake();
         self.hydrate_chat_list_row(Some(&mut row))?;
 
         // Only the created row belongs on the response tail. Preserve any
@@ -4901,6 +4907,7 @@ impl MarmotApp {
             return Err(AppError::GroupDisbanding(group_id_hex.to_owned()));
         }
         let deleted = storage.delete_local_group_data(group_id_hex)?.did_delete();
+        self.presentation_signals.wake();
         self.chat_list_projection_stale
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -997,6 +997,9 @@ async fn run_app_runtime_account_worker(
     let mut maintenance_tick = interval(Duration::from_secs(15));
     maintenance_tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
     let mut legacy_message_promotion = LegacyMessagePromotionSchedule::new();
+    let mut presentation_maintenance = super::presentation::PresentationMaintenance::default();
+    let mut presentation_wakeups = app.presentation_signals.subscribe_work();
+    let mut presentation_due = true;
     // Prepare exact Welcome attempts under the serialized owner, then let only
     // relay I/O run independently. The worker stays available for inbound
     // delivery, maintenance, media completions, timers, and commands while a
@@ -1563,7 +1566,22 @@ async fn run_app_runtime_account_worker(
                     }
                 }
             }
+            result = presentation_wakeups.changed() => {
+                if result.is_ok() { presentation_due = true; }
+            }
+            _ = tokio::task::yield_now(), if presentation_due => {
+                if lifecycle.is_stopping() { continue 'worker; }
+                presentation_due = match presentation_maintenance.run(&client, &account_id_hex) {
+                    Ok(more) => more,
+                    Err(_) => {
+                        tracing::warn!(target: "marmot_app::runtime", method = "chat_presentation_maintenance",
+                            "local chat presentation maintenance failed; retrying on the next wakeup or maintenance tick");
+                        false
+                    }
+                };
+            }
             _ = maintenance_tick.tick() => {
+                presentation_due = true;
                 // Periodic maintenance is never urgent, and its longest legs
                 // run well past the whole shutdown budget: the key-package
                 // catch-up below is capped at 15s, and an armed epoch-gap

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -63,6 +63,7 @@ mod audit_tracker;
 mod commands;
 mod event_routing;
 mod onboarding;
+mod presentation;
 pub use onboarding::*;
 mod subscriptions;
 

--- a/crates/marmot-app/src/runtime/presentation.rs
+++ b/crates/marmot-app/src/runtime/presentation.rs
@@ -12,16 +12,18 @@ impl PresentationMaintenance {
         let storage = app.account_storage(&client.state.label)?;
         let shared = app.shared_storage()?;
         let result = (|| {
-            // Build a missing legacy chat row through its existing owner. This is first-row
-            // construction only; profile updates and idle maintenance never revisit history.
+            // Initialize queued legacy rows through their existing owner. Only
+            // durable completion counts as progress; a row may already exist.
             let missing = storage.pending_chat_presentation_rows()?;
             let classifier = crate::MarmotApp::chat_list_mention_classifier(account_id);
+            let mut initialized = false;
             for group in &missing {
-                storage.refresh_chat_list_row(account_id, group, &classifier)?;
+                initialized |=
+                    storage.initialize_chat_presentation_row(account_id, group, &classifier)?;
             }
             let more =
                 crate::chat_presentation::maintenance::maintain(&storage, &shared, account_id)?;
-            Ok(more || !missing.is_empty())
+            Ok(more || initialized)
         })();
         // Inspect committed state even after a failed later step. A fresh worker always compares,
         // so interruption between a row commit and this send recovers without another message.
@@ -36,5 +38,88 @@ impl PresentationMaintenance {
             self.last_notified = Some(version);
         }
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{MarmotApp, tests::ScriptedPushRelayClient};
+    use marmot_account::AccountHome;
+    use std::sync::Arc;
+    use storage_sqlite::{ChatPresentationRead, StoredAccountState};
+
+    #[tokio::test]
+    async fn composed_maintenance_drains_reinserted_groups_and_defers_rejected_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let account = AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+        let mut client = app.client("alice").await.unwrap();
+        let group = client.create_group("Original", &[]).await.unwrap();
+        let id = hex::encode(group.as_slice());
+        let storage = app.account_storage("alice").unwrap();
+        app.chat_list_row("alice", &id).unwrap().unwrap();
+        let mut snapshot = storage.load_account_projection_state("alice", 100).unwrap();
+        storage
+            .save_account_projection_state(
+                &StoredAccountState {
+                    label: "alice".into(),
+                    ..Default::default()
+                },
+                100,
+                120,
+            )
+            .unwrap();
+        assert!(
+            storage.chat_list_row(&id).unwrap().is_none(),
+            "normal snapshot pruning cascades the chat row"
+        );
+        storage
+            .save_account_projection_state(&snapshot, 100, 120)
+            .unwrap();
+        assert_eq!(
+            storage.pending_chat_presentation_rows().unwrap(),
+            std::slice::from_ref(&id)
+        );
+        let mut worker = PresentationMaintenance::default();
+        let mut stopped = false;
+        for _ in 0..4 {
+            if !worker.run(&client, &account.account_id_hex).unwrap() {
+                stopped = true;
+                break;
+            }
+        }
+        assert!(
+            stopped,
+            "the entire worker step must quiesce after initialization"
+        );
+        assert!(storage.pending_chat_presentation_rows().unwrap().is_empty());
+        let before = storage.chat_list_row(&id).unwrap();
+        let version = storage.chat_presentation_version().unwrap();
+        assert!(!worker.run(&client, &account.account_id_hex).unwrap());
+        assert_eq!(storage.chat_list_row(&id).unwrap(), before);
+        assert_eq!(storage.chat_presentation_version().unwrap(), version);
+
+        // A retained profile version newer than available evidence rejects every
+        // attempt. The outer worker must honor the inner no-progress result too.
+        let input = storage.chat_presentation_input(&id).unwrap().unwrap();
+        let ChatPresentationRead::Ready(mut retained) = storage.chat_presentation(&id).unwrap()
+        else {
+            panic!("initialized presentation");
+        };
+        retained.profile_version.as_mut().unwrap().revision += 1;
+        storage.store_chat_presentation(&input, &retained).unwrap();
+        snapshot.groups[0].profile_name = "Changed".into();
+        storage
+            .save_account_projection_state(&snapshot, 100, 120)
+            .unwrap();
+        assert!(
+            !worker.run(&client, &account.account_id_hex).unwrap(),
+            "rejected work must defer instead of immediately rebuilding"
+        );
+        assert_eq!(storage.pending_chat_presentation_inputs().unwrap().len(), 1);
     }
 }

--- a/crates/marmot-app/src/runtime/presentation.rs
+++ b/crates/marmot-app/src/runtime/presentation.rs
@@ -1,0 +1,40 @@
+//! Account-owner maintenance and commit-before-notification recovery for selected presentation.
+use crate::{AppClient, AppError};
+use storage_sqlite::ChatPresentationVersion;
+
+#[derive(Default)]
+pub(super) struct PresentationMaintenance {
+    last_notified: Option<ChatPresentationVersion>,
+}
+impl PresentationMaintenance {
+    pub(super) fn run(&mut self, client: &AppClient, account_id: &str) -> Result<bool, AppError> {
+        let app = &client.app;
+        let storage = app.account_storage(&client.state.label)?;
+        let shared = app.shared_storage()?;
+        let result = (|| {
+            // Build a missing legacy chat row through its existing owner. This is first-row
+            // construction only; profile updates and idle maintenance never revisit history.
+            let missing = storage.pending_chat_presentation_rows()?;
+            let classifier = crate::MarmotApp::chat_list_mention_classifier(account_id);
+            for group in &missing {
+                storage.refresh_chat_list_row(account_id, group, &classifier)?;
+            }
+            let more =
+                crate::chat_presentation::maintenance::maintain(&storage, &shared, account_id)?;
+            Ok(more || !missing.is_empty())
+        })();
+        // Inspect committed state even after a failed later step. A fresh worker always compares,
+        // so interruption between a row commit and this send recovers without another message.
+        let version = storage.chat_presentation_version()?;
+        if self.last_notified.as_ref() != Some(&version) {
+            let _ = app.presentation_signals.updates.send(
+                crate::chat_presentation::signals::PresentationInvalidation {
+                    account_label: client.state.label.clone(),
+                    version: version.clone(),
+                },
+            );
+            self.last_notified = Some(version);
+        }
+        result
+    }
+}

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -19831,13 +19831,13 @@ fn presentation_worker_refreshes_without_screen_subscribers_and_recovers_notific
         tokio::time::timeout(Duration::from_secs(10), async {
             loop {
                 let update = updates.recv().await.unwrap();
-                if update.account_label() == "alice"
+                if update.account_label == "alice"
                     && let storage_sqlite::ChatPresentationRead::Ready(value) =
                         storage.chat_presentation(&group).unwrap()
                     && value.presentation.title
                         == storage_sqlite::PresentationText::Literal("Restarted peer".into())
                     // Earlier valid invalidations can remain queued after a newer commit.
-                    && update.version() == &storage.chat_presentation_version().unwrap()
+                    && update.version == storage.chat_presentation_version().unwrap()
                 {
                     break;
                 }
@@ -19872,7 +19872,7 @@ fn presentation_worker_refreshes_without_screen_subscribers_and_recovers_notific
         tokio::time::timeout(Duration::from_secs(10), async {
             loop {
                 let update = recovered.recv().await.unwrap();
-                if update.account_label() == "alice" && update.version() == &committed {
+                if update.account_label == "alice" && update.version == committed {
                     break;
                 }
             }
@@ -19880,5 +19880,84 @@ fn presentation_worker_refreshes_without_screen_subscribers_and_recovers_notific
         .await
         .expect("fresh worker must publish a commit whose original notification was lost");
         third.shutdown().await;
+    });
+}
+
+#[test]
+fn presentation_quarantine_preserves_existing_chat_kind_and_direct_reuse() {
+    run_composed_app_runtime_test("presentation-quarantine", || async {
+        use cgka_traits::storage::GroupStorage;
+        let dir = tempfile::tempdir().unwrap();
+        let home = AccountHome::open(dir.path());
+        let alice_account = home.create_account("alice").unwrap();
+        let bob_account = home.create_account("bob").unwrap();
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+        remember_test_member_inbox(&app, &bob_account.account_id_hex, "wss://relay.example");
+        let group_id;
+        {
+            let mut bob = app.client("bob").await.unwrap();
+            bob.publish_key_package().await.unwrap();
+            let mut alice = app.client("alice").await.unwrap();
+            group_id = alice
+                .create_group("", &[&bob_account.account_id_hex])
+                .await
+                .unwrap();
+        }
+        let id = hex::encode(group_id.as_slice());
+        let storage = app.account_storage("alice").unwrap();
+        let before = app.chat_list_row("alice", &id).unwrap().unwrap();
+        let original = storage.get_group(&group_id).unwrap();
+        let mut damaged = original.clone();
+        damaged.protocol_profile = cgka_traits::group::ProtocolProfile::Legacy;
+        assert_ne!(damaged.protocol_profile, original.protocol_profile);
+        storage.put_group(&damaged).unwrap();
+        let mut alice = app.client("alice").await.unwrap();
+        assert_eq!(
+            alice.quarantined_groups().len(),
+            1,
+            "fixture must enter real hydration quarantine"
+        );
+        let quarantined = app.chat_list_row("alice", &id).unwrap().unwrap();
+        assert_eq!(quarantined.conversation_kind, before.conversation_kind);
+        assert_eq!(
+            storage
+                .direct_conversation_candidate_rows(&bob_account.account_id_hex)
+                .unwrap()
+                .len(),
+            1
+        );
+        let input = storage.chat_presentation_input(&id).unwrap().unwrap();
+        assert_eq!(input.member_count, Some(2));
+        assert!(
+            input.members.is_empty(),
+            "quarantined presentation roster must be withdrawn"
+        );
+        let selected = crate::chat_presentation::select_chat_presentation(
+            &input,
+            &alice_account.account_id_hex,
+            None,
+        );
+        assert!(selected.title == storage_sqlite::PresentationText::UnavailableConversation);
+        assert!(selected.peer_id.is_none());
+        storage.put_group(&original).unwrap();
+        assert!(alice.retry_hydrate_quarantined_group(&group_id).unwrap());
+        alice.reconcile_hydrated_account_state().unwrap();
+        assert_eq!(
+            storage
+                .chat_presentation_input(&id)
+                .unwrap()
+                .unwrap()
+                .members
+                .len(),
+            2
+        );
+        assert_eq!(
+            storage
+                .direct_conversation_candidate_rows(&bob_account.account_id_hex)
+                .unwrap()
+                .len(),
+            1
+        );
     });
 }

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -18852,6 +18852,7 @@ fn pending_group_invites_skips_malformed_rows() {
             pending_confirmation: true,
             member_count: None,
             direct_member_ids_hex: None,
+            presentation_member_ids_hex: None,
             welcomer_account_id_hex: welcomer.map(str::to_owned),
             via_welcome_message_id_hex: None,
             nostr_routing_last_epoch: 0,
@@ -18927,6 +18928,7 @@ fn account_unread_summary_includes_badge_attention_without_session_load() {
             pending_confirmation: pending,
             member_count: None,
             direct_member_ids_hex: None,
+            presentation_member_ids_hex: None,
             welcomer_account_id_hex: None,
             via_welcome_message_id_hex: None,
             nostr_routing_last_epoch: 0,
@@ -19757,4 +19759,126 @@ async fn diagnostics_maintenance_reuses_failed_obligation_levels_across_ticks() 
             client.quarantined_groups().len()
         );
     }
+}
+
+#[test]
+fn presentation_worker_refreshes_without_screen_subscribers_and_recovers_notification_after_restart()
+ {
+    run_composed_app_runtime_test("presentation-worker-recovery", || async {
+        let dir = tempfile::tempdir().unwrap();
+        let home = AccountHome::open(dir.path());
+        home.create_account("alice").unwrap();
+        let bob = home.create_account("bob").unwrap();
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(relay.clone());
+        remember_test_member_inbox(&app, &bob.account_id_hex, "wss://relay.example");
+        let _eose = scripted_eose_pump(app.relay_plane.clone(), relay.clone(), every_subscription);
+        let runtime = MarmotAppRuntime::new(app.clone());
+        runtime.reconcile_accounts().await.unwrap();
+        runtime.catch_up_accounts().await.unwrap();
+        let created = runtime
+            .create_group_detailed("alice", "", std::slice::from_ref(&bob.account_id_hex), None)
+            .await
+            .unwrap();
+        let group = created.chat_list_row.group_id_hex;
+        let storage = app.account_storage("alice").unwrap();
+        // No UI or presentation subscriber is attached for initial hydration or this update.
+        let mut entry = app
+            .directory_entry_for_account_id(&bob.account_id_hex)
+            .unwrap()
+            .unwrap();
+        entry.profile = Some(UserProfileMetadata {
+            display_name: Some("Updated peer".into()),
+            created_at: unix_now_seconds() + 1,
+            ..Default::default()
+        });
+        app.save_directory_entry(&entry).unwrap();
+        tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                if let storage_sqlite::ChatPresentationRead::Ready(value) =
+                    storage.chat_presentation(&group).unwrap()
+                    && value.presentation.title
+                        == storage_sqlite::PresentationText::Literal("Updated peer".into())
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("worker should hydrate and refresh without a subscriber");
+        runtime.shutdown().await;
+        // Commit a shared change with no wakeup (like interruption after shared commit).
+        let shared = app.shared_storage().unwrap();
+        let mut record = shared
+            .public_directory_user(&bob.account_id_hex)
+            .unwrap()
+            .unwrap();
+        record.profile_json = Some(
+            serde_json::to_string(&UserProfileMetadata {
+                display_name: Some("Restarted peer".into()),
+                created_at: unix_now_seconds() + 2,
+                ..Default::default()
+            })
+            .unwrap(),
+        );
+        shared.put_public_directory_user(&record).unwrap();
+        let mut updates = app.presentation_signals.updates.subscribe();
+        let restarted = MarmotAppRuntime::new(app.clone());
+        restarted.reconcile_accounts().await.unwrap();
+        restarted.catch_up_accounts().await.unwrap();
+        tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                let update = updates.recv().await.unwrap();
+                if update.account_label() == "alice"
+                    && let storage_sqlite::ChatPresentationRead::Ready(value) =
+                        storage.chat_presentation(&group).unwrap()
+                    && value.presentation.title
+                        == storage_sqlite::PresentationText::Literal("Restarted peer".into())
+                    // Earlier valid invalidations can remain queued after a newer commit.
+                    && update.version() == &storage.chat_presentation_version().unwrap()
+                {
+                    break;
+                }
+            }
+        })
+        .await
+        .expect("restart should recover the missed shared wakeup and notify after commit");
+        restarted.shutdown().await;
+
+        // Simulate account commit followed by process interruption before its notification.
+        record.profile_json = Some(
+            serde_json::to_string(&UserProfileMetadata {
+                display_name: Some("Already committed".into()),
+                created_at: unix_now_seconds() + 3,
+                ..Default::default()
+            })
+            .unwrap(),
+        );
+        shared.put_public_directory_user(&record).unwrap();
+        while crate::chat_presentation::maintenance::maintain(
+            &storage,
+            &shared,
+            &home.account("alice").unwrap().account_id_hex,
+        )
+        .unwrap()
+        {}
+        let committed = storage.chat_presentation_version().unwrap();
+        let mut recovered = app.presentation_signals.updates.subscribe();
+        let third = MarmotAppRuntime::new(app.clone());
+        third.reconcile_accounts().await.unwrap();
+        third.catch_up_accounts().await.unwrap();
+        tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                let update = recovered.recv().await.unwrap();
+                if update.account_label() == "alice" && update.version() == &committed {
+                    break;
+                }
+            }
+        })
+        .await
+        .expect("fresh worker must publish a commit whose original notification was lost");
+        third.shutdown().await;
+    });
 }

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -4333,6 +4333,14 @@ async fn removed_member_triggers_local_push_token_cleanup() {
     let alice = create_network_ready_identity(&runtime, setup.relay_options_only()).await;
     let bob = create_network_ready_identity(&runtime, setup.relay_options_only()).await;
     let carol = create_network_ready_identity(&runtime, setup).await;
+    let mut bob_chats = runtime
+        .subscribe_chats(&bob.account.account_id_hex, false)
+        .await
+        .unwrap();
+    let mut carol_chats = runtime
+        .subscribe_chats(&carol.account.account_id_hex, false)
+        .await
+        .unwrap();
     let group_id = runtime
         .create_group(
             &alice.account.account_id_hex,
@@ -4345,6 +4353,12 @@ async fn removed_member_triggers_local_push_token_cleanup() {
         )
         .await
         .unwrap();
+    // Group creation schedules recipient catch-up in the background. Wait for
+    // both recipients to join before registering tokens, otherwise a share can
+    // succeed with no joined groups and leave this cleanup test racing setup.
+    let group_id_hex = hex::encode(group_id.as_slice());
+    wait_for_chat_update(&mut bob_chats, |chat| chat.group_id_hex == group_id_hex).await;
+    wait_for_chat_update(&mut carol_chats, |chat| chat.group_id_hex == group_id_hex).await;
     let server_pubkey = nostr::Keys::generate().public_key().to_hex();
 
     for member in [&bob, &carol] {
@@ -4358,10 +4372,12 @@ async fn removed_member_triggers_local_push_token_cleanup() {
             Some(url.clone()),
         )
         .unwrap();
-        runtime
+        let share = runtime
             .share_push_registration(&member.account.account_id_hex)
             .await
             .unwrap();
+        assert_eq!(share.failed_groups, 0);
+        assert_eq!(share.pending_groups, 0);
     }
     runtime.catch_up_accounts().await.unwrap();
 

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -186,6 +186,8 @@ pub struct StoredAccountGroup {
     /// peer without scanning every unnamed two-member chat. `None` when the
     /// group is not currently classified as Direct.
     pub direct_member_ids_hex: Option<Vec<String>>,
+    /// Current authoritative two-member roster, including explicitly named groups.
+    pub presentation_member_ids_hex: Option<Vec<String>>,
     pub welcomer_account_id_hex: Option<String>,
     pub via_welcome_message_id_hex: Option<String>,
     pub nostr_routing_last_epoch: u64,
@@ -848,6 +850,7 @@ impl SqliteAccountStorage {
 
         let mut components_by_group = all_account_group_components(&conn)?;
         let mut members_by_group = load_direct_conversation_members(&conn)?;
+        let mut presentation_members = load_presentation_members(&conn)?;
         let mut groups = Vec::with_capacity(raw_groups.len());
         for raw in raw_groups {
             let prior_nostr_routes = serde_json::from_str(&raw.prior_nostr_routes_json)
@@ -856,6 +859,7 @@ impl SqliteAccountStorage {
                 .remove(&raw.group_id_hex)
                 .unwrap_or_default();
             let direct_member_ids_hex = members_by_group.remove(&raw.group_id_hex);
+            let presentation_member_ids_hex = presentation_members.remove(&raw.group_id_hex);
             groups.push(StoredAccountGroup {
                 group_id_hex: raw.group_id_hex,
                 endpoint: raw.endpoint,
@@ -871,6 +875,7 @@ impl SqliteAccountStorage {
                 pending_confirmation: raw.pending_confirmation,
                 member_count: raw.member_count.and_then(|value| value.try_into().ok()),
                 direct_member_ids_hex,
+                presentation_member_ids_hex,
                 welcomer_account_id_hex: raw.welcomer_account_id_hex,
                 via_welcome_message_id_hex: raw.via_welcome_message_id_hex,
                 nostr_routing_last_epoch: raw
@@ -1263,6 +1268,8 @@ impl SqliteAccountStorage {
                     group.direct_member_ids_hex.as_deref(),
                     persist_direct_conversation_members(group),
                 )?;
+                crate::chat_presentation::replace_members_tx(&conn, &group.group_id_hex,
+                    group.presentation_member_ids_hex.as_deref().unwrap_or(&[]))?;
             }
             for message_id in application_event_ids_to_ack {
                 conn.execute_cached(
@@ -3779,6 +3786,29 @@ fn load_direct_conversation_members(
         .prepare_cached(
             "SELECT group_id_hex, member_id_hex
              FROM direct_conversation_members
+             ORDER BY group_id_hex, member_id_hex",
+        )
+        .storage()?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .storage()?;
+    let mut members_by_group = HashMap::new();
+    for row in rows {
+        let (group_id_hex, member_id_hex) = row.storage()?;
+        members_by_group
+            .entry(group_id_hex)
+            .or_insert_with(Vec::new)
+            .push(member_id_hex);
+    }
+    Ok(members_by_group)
+}
+fn load_presentation_members(conn: &Connection) -> StorageResult<HashMap<String, Vec<String>>> {
+    let mut statement = conn
+        .prepare_cached(
+            "SELECT group_id_hex, member_id_hex
+             FROM chat_presentation_members
              ORDER BY group_id_hex, member_id_hex",
         )
         .storage()?;

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -229,7 +229,7 @@ impl fmt::Debug for StoredAccountGroup {
             .field("prior_nostr_routes", &self.prior_nostr_routes)
             .field("self_membership", &self.self_membership)
             .field("components", &self.components)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/storage-sqlite/src/account_projection/tests.rs
+++ b/crates/storage-sqlite/src/account_projection/tests.rs
@@ -314,6 +314,7 @@ fn group(id: &str, name: &str) -> StoredAccountGroup {
         pending_confirmation: false,
         member_count: None,
         direct_member_ids_hex: None,
+        presentation_member_ids_hex: None,
         welcomer_account_id_hex: None,
         via_welcome_message_id_hex: None,
         nostr_routing_last_epoch: 0,

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -38,6 +38,7 @@ fn group() -> StoredAccountGroup {
         pending_confirmation: false,
         member_count: None,
         direct_member_ids_hex: None,
+        presentation_member_ids_hex: None,
         welcomer_account_id_hex: None,
         via_welcome_message_id_hex: None,
         nostr_routing_last_epoch: 0,

--- a/crates/storage-sqlite/src/chat_presentation.rs
+++ b/crates/storage-sqlite/src/chat_presentation.rs
@@ -4,10 +4,14 @@
 //! named and unnamed groups via `set_chat_presentation_members`. Missing evidence deliberately
 //! produces a typed fallback, not a retry loop; later roster hydration must call that same
 //! setter, which requeues the row. P2 wires both lifecycle paths before enabling its worker.
+mod maintenance;
 use crate::connection::CachedSql;
 use crate::{ChatListAvatar, SqliteAccountStorage, SqliteResultExt, serialize, u64_to_i64};
 use cgka_traits::app_components::GROUP_AVATAR_URL_COMPONENT_ID;
 use cgka_traits::storage::{StorageError, StorageResult};
+pub use maintenance::{
+    ChatPresentationActivePeer, ChatPresentationCatchUp, ChatPresentationCheckpoint,
+};
 use rusqlite::{OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 
@@ -99,6 +103,7 @@ pub struct ChatPresentationInput {
     pub row_epoch: Vec<u8>,
     pub group_name: String,
     pub member_count: Option<u64>,
+    pub self_membership: crate::SelfMembership,
     pub members: Vec<String>,
     pub avatar_url: Option<String>,
     pub avatar: Option<ChatListAvatar>,
@@ -229,7 +234,7 @@ impl SqliteAccountStorage {
                         a.image_media_type,
                         (SELECT component_data_hex FROM account_group_app_components c
                          WHERE c.group_id_hex = a.group_id_hex AND c.component_id = ?2),
-                        r.presentation_row_epoch
+                        r.presentation_row_epoch, a.self_membership
                  FROM chat_list_rows r JOIN account_groups a ON a.group_id_hex = r.group_id_hex
                  CROSS JOIN chat_presentation_meta m WHERE r.group_id_hex = ?1 AND m.id = 1",
                 params![group, GROUP_AVATAR_URL_COMPONENT_ID],
@@ -250,6 +255,7 @@ impl SqliteAccountStorage {
                     Ok(ChatPresentationInput {
                         group_id_hex: group.to_owned(),
                         row_epoch: row.get(10)?,
+                        self_membership: crate::SelfMembership::from_storage(&row.get::<_, String>(11)?),
                         source_version: ChatPresentationVersion {
                             store_epoch: row.get(0)?,
                             revision: nonnegative(row, 1)?,
@@ -282,49 +288,9 @@ impl SqliteAccountStorage {
         group: &str,
         members: &[String],
     ) -> StorageResult<()> {
-        let mut normalized: Vec<_> = if members.len() == 2 {
-            members
-                .iter()
-                .map(|s| s.trim().to_ascii_lowercase())
-                .collect()
-        } else {
-            Vec::new()
-        };
-        normalized.sort();
-        normalized.dedup();
-        if normalized.len() != 2 || normalized.iter().any(|s| !valid_member_identity(s)) {
-            normalized.clear();
-        }
         self.connection.with_transaction(|| {
             let conn = self.lock()?;
-            let mut query = conn.prepare_cached(
-                "SELECT member_id_hex FROM chat_presentation_members
-                 WHERE group_id_hex = ?1 ORDER BY member_id_hex LIMIT 3",
-            ).storage()?;
-            let previous = query.query_map([group], |row| row.get::<_, String>(0))
-                .storage()?.collect::<rusqlite::Result<Vec<_>>>().storage()?;
-            drop(query);
-            if previous == normalized {
-                return Ok(());
-            }
-            conn.execute_cached(
-                "DELETE FROM chat_presentation_members WHERE group_id_hex = ?1", [group],
-            ).storage()?;
-            for member in normalized {
-                conn.execute_cached(
-                    "INSERT INTO chat_presentation_members(group_id_hex, member_id_hex) VALUES (?1, ?2)",
-                    params![group, member],
-                ).storage()?;
-            }
-            conn.execute_cached(
-                "UPDATE chat_list_rows SET presentation_json = NULL,
-                    presentation_source_revision = presentation_source_revision + 1
-                 WHERE group_id_hex = ?1", [group],
-            ).storage()?;
-            conn.execute_cached(
-                "DELETE FROM chat_presentation_dependencies WHERE group_id_hex = ?1", [group],
-            ).storage()?;
-            Ok(())
+            replace_members_tx(&conn, group, members)
         })
     }
     /// Compare-and-store also makes batched backfill restart-safe. A failed write rolls back its dependencies.
@@ -349,6 +315,15 @@ impl SqliteAccountStorage {
             return Err(invalid("presentation peer is not in captured roster"));
         }
         self.connection.with_transaction(|| {
+            let checkpoint = self.chat_presentation_checkpoint()?;
+            if !checkpoint.state.shared_epoch.is_empty()
+                && value
+                    .profile_version
+                    .as_ref()
+                    .is_none_or(|v| v.store_epoch != checkpoint.state.shared_epoch)
+            {
+                return Ok(ChatPresentationWrite::Stale);
+            }
             let conn = self.lock()?;
             let existing: Option<(Option<Vec<u8>>, i64)> = conn
                 .query_row(
@@ -468,6 +443,66 @@ impl SqliteAccountStorage {
             .collect::<rusqlite::Result<Vec<_>>>()
             .storage()
     }
+}
+
+pub(crate) fn replace_members_tx(
+    conn: &rusqlite::Connection,
+    group: &str,
+    members: &[String],
+) -> StorageResult<()> {
+    let mut normalized: Vec<_> = if members.len() == 2 {
+        members
+            .iter()
+            .map(|s| s.trim().to_ascii_lowercase())
+            .collect()
+    } else {
+        Vec::new()
+    };
+    normalized.sort();
+    normalized.dedup();
+    if normalized.len() != 2 || normalized.iter().any(|s| !valid_member_identity(s)) {
+        normalized.clear();
+    }
+    let mut query = conn
+        .prepare_cached(
+            "SELECT member_id_hex FROM chat_presentation_members
+                 WHERE group_id_hex = ?1 ORDER BY member_id_hex LIMIT 3",
+        )
+        .storage()?;
+    let previous = query
+        .query_map([group], |row| row.get::<_, String>(0))
+        .storage()?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .storage()?;
+    drop(query);
+    if previous == normalized {
+        return Ok(());
+    }
+    conn.execute_cached(
+        "DELETE FROM chat_presentation_members WHERE group_id_hex = ?1",
+        [group],
+    )
+    .storage()?;
+    for member in normalized {
+        conn.execute_cached(
+            "INSERT INTO chat_presentation_members(group_id_hex, member_id_hex) VALUES (?1, ?2)",
+            params![group, member],
+        )
+        .storage()?;
+    }
+    conn.execute_cached(
+        "UPDATE chat_list_rows SET presentation_json = NULL,
+                    presentation_source_revision = presentation_source_revision + 1
+                 WHERE group_id_hex = ?1",
+        [group],
+    )
+    .storage()?;
+    conn.execute_cached(
+        "DELETE FROM chat_presentation_dependencies WHERE group_id_hex = ?1",
+        [group],
+    )
+    .storage()?;
+    Ok(())
 }
 
 fn valid_member_identity(raw: &str) -> bool {

--- a/crates/storage-sqlite/src/chat_presentation/maintenance.rs
+++ b/crates/storage-sqlite/src/chat_presentation/maintenance.rs
@@ -1,0 +1,135 @@
+//! Bounded account-side application and durable restart positions. No shared-store locks here.
+use super::*;
+
+#[derive(Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChatPresentationActivePeer {
+    pub member_id_hex: String,
+    pub revision: u64,
+    pub after_group: Option<String>,
+}
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChatPresentationCatchUp {
+    pub shared_epoch: Vec<u8>,
+    pub revision: u64,
+    pub active: Option<ChatPresentationActivePeer>,
+    pub reconciling: bool,
+    pub reconcile_after: Option<String>,
+}
+impl Default for ChatPresentationCatchUp {
+    fn default() -> Self {
+        Self {
+            shared_epoch: Vec::new(),
+            revision: 0,
+            active: None,
+            reconciling: true,
+            reconcile_after: None,
+        }
+    }
+}
+#[derive(Clone)]
+pub struct ChatPresentationCheckpoint {
+    pub generation: u64,
+    pub state: ChatPresentationCatchUp,
+}
+impl SqliteAccountStorage {
+    pub fn chat_presentation_checkpoint(&self) -> StorageResult<ChatPresentationCheckpoint> {
+        let conn = self.lock()?;
+        let (generation, bytes): (i64, Option<Vec<u8>>) = conn
+            .query_row(
+                "SELECT generation,state FROM chat_presentation_checkpoint WHERE id=1",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .storage()?;
+        let state = bytes
+            .map(|bytes| {
+                serde_json::from_slice(&bytes)
+                    .map_err(|_| invalid("invalid presentation checkpoint"))
+            })
+            .transpose()?
+            .unwrap_or_default();
+        Ok(ChatPresentationCheckpoint {
+            generation: generation as u64,
+            state,
+        })
+    }
+    /// The checkpoint and up to 50 selected rows commit together. Racing preparation retries its whole batch.
+    pub fn commit_chat_presentation_batch(
+        &self,
+        expected: &ChatPresentationCheckpoint,
+        next: &ChatPresentationCatchUp,
+        values: &[(ChatPresentationInput, StoredChatPresentation)],
+    ) -> StorageResult<bool> {
+        if values.len() > CHAT_PRESENTATION_BATCH_LIMIT {
+            return Err(invalid("oversized presentation batch"));
+        }
+        self.connection.with_transaction(|| {
+            let current = self.chat_presentation_checkpoint()?;
+            if current.generation != expected.generation || current.state != expected.state {
+                return Ok(false);
+            }
+            // Prevent pre-reset work from moving a checkpoint back to a previous directory incarnation.
+            for (_, value) in values {
+                if value.profile_version.as_ref().is_some_and(|v| v.store_epoch != next.shared_epoch) {
+                    return Err(invalid("presentation batch directory epoch mismatch"));
+                }
+            }
+            {
+                let conn = self.lock()?;
+                conn.execute(
+                    "UPDATE chat_presentation_checkpoint SET generation=generation+1,state=?1 WHERE id=1",
+                    [serialize(next)?],
+                ).storage()?;
+            }
+            // Stale source rows remain on the pending worklist; they must not hold up unrelated fanout.
+            for (input, value) in values {
+                self.store_chat_presentation(input, value)?;
+            }
+            Ok(true)
+        })
+    }
+    pub fn chat_presentation_inputs_after(
+        &self,
+        after: Option<&str>,
+    ) -> StorageResult<Vec<ChatPresentationInput>> {
+        self.connection.with_transaction(|| {
+            let groups = {
+                let conn = self.lock()?;
+                let mut query = conn
+                    .prepare_cached(
+                        "SELECT group_id_hex FROM chat_list_rows WHERE group_id_hex>?1
+                     ORDER BY group_id_hex LIMIT ?2",
+                    )
+                    .storage()?;
+                query
+                    .query_map(
+                        params![after.unwrap_or(""), CHAT_PRESENTATION_BATCH_LIMIT as i64],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .storage()?
+                    .collect::<rusqlite::Result<Vec<_>>>()
+                    .storage()?
+            };
+            groups
+                .iter()
+                .map(|group| {
+                    self.chat_presentation_input(group)?
+                        .ok_or_else(|| invalid("presentation row disappeared"))
+                })
+                .collect()
+        })
+    }
+    /// Existing legacy row construction is queued only for groups without a chat row.
+    pub fn pending_chat_presentation_rows(&self) -> StorageResult<Vec<String>> {
+        let conn = self.lock()?;
+        let mut q = conn.prepare_cached(
+            "SELECT group_id_hex FROM chat_presentation_row_work ORDER BY group_id_hex LIMIT ?1",
+        ).storage()?;
+        q.query_map([CHAT_PRESENTATION_BATCH_LIMIT as i64], |r| {
+            r.get::<_, String>(0)
+        })
+        .storage()?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .storage()
+    }
+}

--- a/crates/storage-sqlite/src/chat_presentation/maintenance.rs
+++ b/crates/storage-sqlite/src/chat_presentation/maintenance.rs
@@ -53,7 +53,10 @@ impl SqliteAccountStorage {
             state,
         })
     }
-    /// The checkpoint and up to 50 selected rows commit together. Racing preparation retries its whole batch.
+    /// The checkpoint and up to 50 selected rows commit together.
+    /// Returns true only if the checkpoint state or a row advanced. A rejected
+    /// checkpoint CAS or an entirely stale/unchanged batch returns false so the
+    /// caller can wait for a later wakeup instead of spinning without progress.
     pub fn commit_chat_presentation_batch(
         &self,
         expected: &ChatPresentationCheckpoint,
@@ -74,7 +77,8 @@ impl SqliteAccountStorage {
                     return Err(invalid("presentation batch directory epoch mismatch"));
                 }
             }
-            {
+            let state_changed = current.state != *next;
+            if state_changed {
                 let conn = self.lock()?;
                 conn.execute(
                     "UPDATE chat_presentation_checkpoint SET generation=generation+1,state=?1 WHERE id=1",
@@ -82,10 +86,16 @@ impl SqliteAccountStorage {
                 ).storage()?;
             }
             // Stale source rows remain on the pending worklist; they must not hold up unrelated fanout.
+            let mut applied = false;
             for (input, value) in values {
-                self.store_chat_presentation(input, value)?;
+                applied |= self.store_chat_presentation(input, value)? == ChatPresentationWrite::Applied;
             }
-            Ok(true)
+            if applied && !state_changed {
+                self.lock()?.execute(
+                    "UPDATE chat_presentation_checkpoint SET generation=generation+1 WHERE id=1", [],
+                ).storage()?;
+            }
+            Ok(state_changed || applied)
         })
     }
     pub fn chat_presentation_inputs_after(

--- a/crates/storage-sqlite/src/chat_presentation/maintenance.rs
+++ b/crates/storage-sqlite/src/chat_presentation/maintenance.rs
@@ -129,7 +129,43 @@ impl SqliteAccountStorage {
                 .collect()
         })
     }
-    /// Existing legacy row construction is queued only for groups without a chat row.
+
+    /// Refresh and complete one queued initialization in the same transaction.
+    /// Returns false if another operation already completed or removed the work.
+    /// Tolerates queued work overlapping an existing row without depending on
+    /// the INSERT-only completion trigger, including unexpected recovery state.
+    pub fn initialize_chat_presentation_row(
+        &self,
+        local_account_id_hex: &str,
+        group_id_hex: &str,
+        mention_classifier: &crate::chat_list::MentionClassifier<'_>,
+    ) -> StorageResult<bool> {
+        self.connection.with_transaction(|| {
+            let queued = || -> StorageResult<bool> {
+                self.lock()?.query_row(
+                    "SELECT EXISTS(SELECT 1 FROM chat_presentation_row_work WHERE group_id_hex=?1)",
+                    [group_id_hex], |row| row.get(0),
+                ).storage()
+            };
+            if !queued()? {
+                return Ok(false);
+            }
+            self.refresh_chat_list_row(local_account_id_hex, group_id_hex, mention_classifier)?;
+            self.lock()?
+                .execute_cached(
+                    "DELETE FROM chat_presentation_row_work WHERE group_id_hex=?1",
+                    [group_id_hex],
+                )
+                .storage()?;
+            if queued()? {
+                return Err(invalid("presentation initialization did not complete"));
+            }
+            Ok(true)
+        })
+    }
+
+    /// Read at most one bounded page of groups needing legacy row initialization.
+    /// A queued group may already have a chat row; initialization also handles upserts.
     pub fn pending_chat_presentation_rows(&self) -> StorageResult<Vec<String>> {
         let conn = self.lock()?;
         let mut q = conn.prepare_cached(

--- a/crates/storage-sqlite/src/chat_presentation/tests.rs
+++ b/crates/storage-sqlite/src/chat_presentation/tests.rs
@@ -574,3 +574,125 @@ fn catchup_checkpoint_and_batch_roll_back_together_and_fence_old_workers() {
         ChatPresentationRead::Ready(Box::new(value("bb", "Current", 2)))
     );
 }
+
+#[test]
+fn initialization_completes_an_upsert_over_an_existing_chat_row() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    seed(&store, "11");
+    // Inject overlapping queued/existing state defensively. Normal snapshot
+    // pruning cascades the chat row; it does not create this overlap.
+    store
+        .lock()
+        .unwrap()
+        .execute("INSERT INTO chat_presentation_row_work VALUES ('11')", [])
+        .unwrap();
+    store
+        .refresh_chat_list_row(&"aa".repeat(32), "11", &|_, _| false)
+        .unwrap();
+    assert_eq!(
+        store.pending_chat_presentation_rows().unwrap(),
+        ["11"],
+        "an upsert alone does not run the INSERT-only completion trigger"
+    );
+    let row_epoch = store
+        .chat_presentation_input("11")
+        .unwrap()
+        .unwrap()
+        .row_epoch;
+    assert!(
+        store
+            .initialize_chat_presentation_row(&"aa".repeat(32), "11", &|_, _| false)
+            .unwrap()
+    );
+    assert!(store.pending_chat_presentation_rows().unwrap().is_empty());
+    assert_eq!(
+        store
+            .chat_presentation_input("11")
+            .unwrap()
+            .unwrap()
+            .row_epoch,
+        row_epoch
+    );
+    let row = store.chat_list_row("11").unwrap();
+    assert!(
+        !store
+            .initialize_chat_presentation_row(&"aa".repeat(32), "11", &|_, _| false)
+            .unwrap()
+    );
+    assert_eq!(store.chat_list_row("11").unwrap(), row);
+}
+
+#[test]
+fn initialization_completion_failure_rolls_back_refresh_and_retries_after_reopen() {
+    for fail_with in ["ABORT, 'injected completion failure'", "IGNORE"] {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("initialization.db");
+        let key = SqlCipherKey::new("initialization fixture").unwrap();
+        let store = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+        seed(&store, "11");
+        store
+            .lock()
+            .unwrap()
+            .execute_batch(&format!(
+                "INSERT INTO chat_presentation_row_work VALUES ('11');
+             UPDATE account_groups SET profile_name='Changed' WHERE group_id_hex='11';
+             CREATE TRIGGER prevent_completion BEFORE DELETE ON chat_presentation_row_work
+             BEGIN SELECT RAISE({fail_with}); END;"
+            ))
+            .unwrap();
+        let before = store.chat_list_row("11").unwrap();
+        assert!(
+            store
+                .initialize_chat_presentation_row(&"aa".repeat(32), "11", &|_, _| false)
+                .is_err()
+        );
+        assert_eq!(
+            store.chat_list_row("11").unwrap(),
+            before,
+            "refresh and completion must roll back together"
+        );
+        assert_eq!(store.pending_chat_presentation_rows().unwrap(), ["11"]);
+        drop(store);
+        let store = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+        assert_eq!(store.pending_chat_presentation_rows().unwrap(), ["11"]);
+        assert_eq!(store.chat_list_row("11").unwrap(), before);
+        store
+            .lock()
+            .unwrap()
+            .execute_batch("DROP TRIGGER prevent_completion")
+            .unwrap();
+        assert!(
+            store
+                .initialize_chat_presentation_row(&"aa".repeat(32), "11", &|_, _| false)
+                .unwrap()
+        );
+        assert!(store.pending_chat_presentation_rows().unwrap().is_empty());
+        assert_ne!(store.chat_list_row("11").unwrap(), before);
+    }
+}
+
+#[test]
+fn initialization_completes_a_new_row_and_ignores_deleted_work() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    store.lock().unwrap().execute("INSERT INTO account_groups(group_id_hex,endpoint,profile_name,updated_at) VALUES ('11','fixture','New',7)", []).unwrap();
+    assert_eq!(store.pending_chat_presentation_rows().unwrap(), ["11"]);
+    assert!(
+        store
+            .initialize_chat_presentation_row(&"aa".repeat(32), "11", &|_, _| false)
+            .unwrap()
+    );
+    assert!(store.chat_list_row("11").unwrap().is_some());
+    assert!(store.pending_chat_presentation_rows().unwrap().is_empty());
+    store.lock().unwrap().execute("INSERT INTO account_groups(group_id_hex,endpoint,profile_name,updated_at) VALUES ('22','fixture','Removed',7)", []).unwrap();
+    store
+        .lock()
+        .unwrap()
+        .execute("DELETE FROM account_groups WHERE group_id_hex='22'", [])
+        .unwrap();
+    assert!(
+        !store
+            .initialize_chat_presentation_row(&"aa".repeat(32), "22", &|_, _| false)
+            .unwrap()
+    );
+    assert!(store.chat_list_row("22").unwrap().is_none());
+}

--- a/crates/storage-sqlite/src/chat_presentation/tests.rs
+++ b/crates/storage-sqlite/src/chat_presentation/tests.rs
@@ -524,3 +524,53 @@ fn removing_group_name_or_required_image_material_never_returns_removed_display(
         assert_eq!(store.pending_chat_presentation_inputs().unwrap().len(), 1);
     }
 }
+
+#[test]
+fn catchup_checkpoint_and_batch_roll_back_together_and_fence_old_workers() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    seed(&store, "11");
+    seed(&store, "22");
+    let initial = store.chat_presentation_checkpoint().unwrap();
+    let mut next = initial.state.clone();
+    next.shared_epoch = vec![3; 16];
+    let first = store.chat_presentation_input("11").unwrap().unwrap();
+    let second = store.chat_presentation_input("22").unwrap().unwrap();
+    assert!(
+        store
+            .commit_chat_presentation_batch(
+                &initial,
+                &next,
+                &[
+                    (first.clone(), value("bb", "First", 1)),
+                    (second, value("cc", "Invalid peer", 1))
+                ]
+            )
+            .is_err()
+    );
+    assert!(matches!(
+        store.chat_presentation("11").unwrap(),
+        ChatPresentationRead::Pending
+    ));
+    assert_eq!(
+        store.chat_presentation_checkpoint().unwrap().generation,
+        initial.generation
+    );
+    assert!(
+        store
+            .commit_chat_presentation_batch(
+                &initial,
+                &next,
+                &[(first.clone(), value("bb", "Current", 2))]
+            )
+            .unwrap()
+    );
+    assert!(
+        !store
+            .commit_chat_presentation_batch(&initial, &next, &[(first, value("bb", "Old", 1))])
+            .unwrap()
+    );
+    assert_eq!(
+        store.chat_presentation("11").unwrap(),
+        ChatPresentationRead::Ready(Box::new(value("bb", "Current", 2)))
+    );
+}

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -36,7 +36,8 @@ pub use chat_list::{
     ChatPinState, ExistingDirectConversation, select_reusable_direct_conversation,
 };
 pub use chat_presentation::{
-    CHAT_PRESENTATION_BATCH_LIMIT, ChatPresentationInput, ChatPresentationRead,
+    CHAT_PRESENTATION_BATCH_LIMIT, ChatPresentationActivePeer, ChatPresentationCatchUp,
+    ChatPresentationCheckpoint, ChatPresentationInput, ChatPresentationRead,
     ChatPresentationVersion, ChatPresentationWrite, ConversationPresentation,
     PresentationResolution, PresentationSource, PresentationText, SelectedAvatar,
     StoredChatPresentation,
@@ -60,8 +61,9 @@ pub use prepared_group_image_upload::{
     PreparedGroupImageUploadState,
 };
 pub use shared::{
-    PublicDirectoryUserRecord, SqliteSharedStorage, StoredAuditLogSettings,
-    StoredRelayTelemetrySettings, StoredUsageDiagnosticsSettings,
+    DirectoryPresentation, DirectoryPresentationChanges, PublicDirectoryUserRecord,
+    SqliteSharedStorage, StoredAuditLogSettings, StoredRelayTelemetrySettings,
+    StoredUsageDiagnosticsSettings,
 };
 pub use storage::messages::MessageFormatPromotionProgress;
 #[cfg(feature = "storage-format-benchmarks")]

--- a/crates/storage-sqlite/src/message_drafts.rs
+++ b/crates/storage-sqlite/src/message_drafts.rs
@@ -541,6 +541,7 @@ mod tests {
             pending_confirmation: false,
             member_count: None,
             direct_member_ids_hex: None,
+            presentation_member_ids_hex: None,
             welcomer_account_id_hex: None,
             via_welcome_message_id_hex: None,
             nostr_routing_last_epoch: 0,

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -128,6 +128,8 @@ mod migration_0063_query_indexes;
 mod migration_0064_own_commit_intents;
 #[path = "migrations/0065_chat_presentation.rs"]
 mod migration_0065_chat_presentation;
+#[path = "migrations/0066_chat_presentation_maintenance.rs"]
+mod migration_0066_chat_presentation_maintenance;
 #[cfg(test)]
 #[path = "migrations/query_work_tests.rs"]
 mod query_work_tests;
@@ -470,6 +472,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 65,
         name: "0065_chat_presentation",
         apply: migration_0065_chat_presentation::apply,
+    },
+    Migration {
+        version: 66,
+        name: "0066_chat_presentation_maintenance",
+        apply: migration_0066_chat_presentation_maintenance::apply,
     },
 ];
 
@@ -1193,7 +1200,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 65,
+                found: 66,
                 latest_supported: 46,
             }
         ));
@@ -1249,7 +1256,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 65,
+                found: 66,
                 latest_supported: 46,
             }
         ));
@@ -1553,7 +1560,7 @@ mod tests {
         assert!(matches!(
             error,
             StorageError::UnsupportedSchemaVersion {
-                found: 65,
+                found: 66,
                 latest_supported: 46,
             }
         ));

--- a/crates/storage-sqlite/src/migrations/0066_chat_presentation_maintenance.rs
+++ b/crates/storage-sqlite/src/migrations/0066_chat_presentation_maintenance.rs
@@ -1,0 +1,21 @@
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch("CREATE TABLE chat_presentation_checkpoint (
+        id INTEGER PRIMARY KEY CHECK(id=1), generation INTEGER NOT NULL DEFAULT 0
+            CHECK(typeof(generation)='integer' AND generation>=0), state BLOB);
+        INSERT INTO chat_presentation_checkpoint(id) VALUES(1);
+        CREATE TABLE chat_presentation_row_work (
+            group_id_hex TEXT PRIMARY KEY REFERENCES account_groups(group_id_hex) ON DELETE CASCADE);
+        INSERT INTO chat_presentation_row_work SELECT a.group_id_hex FROM account_groups a
+            WHERE NOT EXISTS(SELECT 1 FROM chat_list_rows r WHERE r.group_id_hex=a.group_id_hex);
+        CREATE TRIGGER chat_presentation_group_created AFTER INSERT ON account_groups BEGIN
+            INSERT OR IGNORE INTO chat_presentation_row_work VALUES(NEW.group_id_hex);
+        END;
+        CREATE TRIGGER chat_presentation_row_prepared AFTER INSERT ON chat_list_rows BEGIN
+            DELETE FROM chat_presentation_row_work WHERE group_id_hex=NEW.group_id_hex;
+        END;")
+        .storage()
+}

--- a/crates/storage-sqlite/src/migrations/0066_chat_presentation_maintenance.rs
+++ b/crates/storage-sqlite/src/migrations/0066_chat_presentation_maintenance.rs
@@ -3,6 +3,9 @@ use cgka_traits::storage::StorageResult;
 use rusqlite::Transaction;
 
 pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    // The INSERT trigger opportunistically clears work created with a new row.
+    // Initialization also explicitly completes UPDATE/upsert work in its refresh
+    // transaction; a queued account group may have a surviving legacy chat row.
     tx.execute_batch("CREATE TABLE chat_presentation_checkpoint (
         id INTEGER PRIMARY KEY CHECK(id=1), generation INTEGER NOT NULL DEFAULT 0
             CHECK(typeof(generation)='integer' AND generation>=0), state BLOB);

--- a/crates/storage-sqlite/src/shared.rs
+++ b/crates/storage-sqlite/src/shared.rs
@@ -884,7 +884,7 @@ mod migration_contract_tests {
                 |r| Ok((r.get(0)?, r.get(1)?)),
             )
             .unwrap();
-        assert_eq!(row, (2, "0002_usage_diagnostics".into()));
+        assert_eq!(row, (3, "0003_directory_presentation".into()));
     }
 
     #[test]

--- a/crates/storage-sqlite/src/shared.rs
+++ b/crates/storage-sqlite/src/shared.rs
@@ -1,5 +1,7 @@
 mod error;
 mod migrations;
+mod presentation;
+pub use presentation::{DirectoryPresentation, DirectoryPresentationChanges};
 
 use error::SharedSqliteResultExt;
 

--- a/crates/storage-sqlite/src/shared/migration_tests.rs
+++ b/crates/storage-sqlite/src/shared/migration_tests.rs
@@ -458,3 +458,42 @@ fn ledger_integer_primary_key_rejects_text_and_bad_name_is_invalid_history() {
         "backend failure: invalid shared store migration history"
     );
 }
+
+#[test]
+fn presentation_migration_preserves_existing_usage_settings_and_cached_profiles() {
+    let mut conn = Connection::open_in_memory().unwrap();
+    run(&mut conn, &MIGRATIONS[..2]).unwrap();
+    conn.execute_batch("UPDATE usage_diagnostics_settings SET decision=1, policy_revision='accepted', updated_at_ms=123;
+        INSERT INTO directory_users(account_id_hex, npub, profile_json, relay_lists_json)
+        VALUES ('peer', 'fixture', '{\"name\":\"Cached before P2\"}', '{}');").unwrap();
+    run_all(&mut conn).unwrap();
+    run_all(&mut conn).unwrap();
+    assert_eq!(count(&conn), 3);
+    let settings: (i64, String, i64) = conn
+        .query_row(
+            "SELECT decision, policy_revision, updated_at_ms FROM usage_diagnostics_settings",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(settings, (1, "accepted".into(), 123));
+    let profile: String = conn
+        .query_row(
+            "SELECT profile_json FROM directory_users WHERE account_id_hex='peer'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(profile, "{\"name\":\"Cached before P2\"}");
+    let revision: i64 = conn
+        .query_row(
+            "SELECT revision FROM directory_presentation_meta",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        revision, 0,
+        "existing profiles are read directly without replaying history"
+    );
+}

--- a/crates/storage-sqlite/src/shared/migration_tests.rs
+++ b/crates/storage-sqlite/src/shared/migration_tests.rs
@@ -16,7 +16,7 @@ fn fresh_file_preserves_pragmas_permissions_and_close() {
     let storage = SqliteSharedStorage::open(&path).unwrap();
     {
         let conn = storage.lock().unwrap();
-        assert_eq!(count(&conn), 2);
+        assert_eq!(count(&conn), 3);
         for (pragma, expected) in [
             ("busy_timeout", 5000),
             ("synchronous", 1),
@@ -79,7 +79,7 @@ fn current_open_is_read_only_and_idempotent_while_writer_holds_lock() {
         .unwrap();
     let second = SqliteSharedStorage::open(&path).unwrap();
     let conn = second.lock().unwrap();
-    assert_eq!(count(&conn), 2);
+    assert_eq!(count(&conn), 3);
     assert_eq!(
         conn.query_row(
             "SELECT applied_at_unix_seconds FROM shared_schema_migrations",
@@ -110,7 +110,7 @@ fn concurrent_openers_record_once() {
                 scope.spawn(|| {
                     barrier.wait();
                     let storage = SqliteSharedStorage::open(&path).unwrap();
-                    assert_eq!(count(&storage.lock().unwrap()), 2);
+                    assert_eq!(count(&storage.lock().unwrap()), 3);
                 })
             })
             .collect();
@@ -118,7 +118,7 @@ fn concurrent_openers_record_once() {
             handle.join().unwrap();
         }
     });
-    assert_eq!(count(&conn), 2);
+    assert_eq!(count(&conn), 3);
 }
 
 #[test]
@@ -182,7 +182,7 @@ fn invalid_history_and_future_versions_fail_before_body() {
         "(1, 'private name', 0)",
         "(0, '0001_shared_store', 0)",
         "(-1, '0001_shared_store', 0), (1, '0001_shared_store', 0)",
-        "(3, 'future private name', 0)",
+        "(4, 'future private name', 0)",
     ] {
         let mut conn = Connection::open_in_memory().unwrap();
         conn.execute_batch(LEDGER_SQL).unwrap();
@@ -191,12 +191,12 @@ fn invalid_history_and_future_versions_fail_before_body() {
         ))
         .unwrap();
         let error = run_all(&mut conn).unwrap_err();
-        if rows.starts_with("(3") {
+        if rows.starts_with("(4") {
             assert!(matches!(
                 error,
                 StorageError::UnsupportedSchemaVersion {
-                    found: 3,
-                    latest_supported: 2
+                    found: 4,
+                    latest_supported: 3
                 }
             ));
         } else {
@@ -269,7 +269,7 @@ fn body_and_ledger_failures_roll_back_and_redact_sqlite_messages() {
     assert!(!table_exists(&conn, "directory_users").unwrap());
     conn.execute_batch("DROP TRIGGER reject").unwrap();
     run_all(&mut conn).unwrap();
-    assert_eq!(count(&conn), 2);
+    assert_eq!(count(&conn), 3);
 }
 
 #[test]

--- a/crates/storage-sqlite/src/shared/migrations.rs
+++ b/crates/storage-sqlite/src/shared/migrations.rs
@@ -21,6 +21,14 @@ const MIGRATIONS: &[Migration] = &[
         name: "0002_usage_diagnostics",
         apply: version_2,
     },
+    Migration {
+        version: 3,
+        name: "0003_directory_presentation",
+        apply: |tx| {
+            tx.execute_batch(include_str!("v3.sql"))
+                .map_err(sqlite_error)
+        },
+    },
 ];
 
 fn version_2(tx: &Transaction<'_>) -> StorageResult<()> {

--- a/crates/storage-sqlite/src/shared/presentation.rs
+++ b/crates/storage-sqlite/src/shared/presentation.rs
@@ -1,0 +1,204 @@
+//! Snapshot accepted profile bytes and their local revision under one shared-store transaction.
+use super::{SharedSqliteResultExt, SqliteSharedStorage};
+use crate::{CHAT_PRESENTATION_BATCH_LIMIT, ChatPresentationVersion, u64_to_i64};
+use cgka_traits::storage::StorageResult;
+use rusqlite::{OptionalExtension, params};
+
+#[derive(Clone)]
+pub struct DirectoryPresentation {
+    pub member_id_hex: String,
+    pub profile_json: Option<String>,
+    pub version: ChatPresentationVersion,
+}
+#[derive(Clone)]
+pub struct DirectoryPresentationChanges {
+    pub head: ChatPresentationVersion,
+    pub changes: Vec<DirectoryPresentation>,
+}
+fn version(conn: &rusqlite::Connection) -> StorageResult<ChatPresentationVersion> {
+    conn.query_row(
+        "SELECT store_epoch, revision FROM directory_presentation_meta WHERE id=1",
+        [],
+        |r| {
+            Ok(ChatPresentationVersion {
+                store_epoch: r.get(0)?,
+                revision: r.get::<_, i64>(1)? as u64,
+            })
+        },
+    )
+    .storage()
+}
+impl SqliteSharedStorage {
+    pub fn directory_presentation_version(&self) -> StorageResult<ChatPresentationVersion> {
+        let conn = self.lock()?;
+        version(&conn)
+    }
+    pub fn directory_presentation(&self, member: &str) -> StorageResult<DirectoryPresentation> {
+        let mut conn = self.lock()?;
+        let tx = conn.transaction().storage()?;
+        let mut source = version(&tx)?;
+        source.revision = tx
+            .query_row(
+                "SELECT revision FROM directory_presentation_changes WHERE member_id_hex=?1",
+                [member],
+                |r| r.get::<_, i64>(0),
+            )
+            .optional()
+            .storage()?
+            .unwrap_or(0) as u64;
+        let profile_json = tx
+            .query_row(
+                "SELECT profile_json FROM directory_users WHERE account_id_hex=?1",
+                [member],
+                |r| r.get::<_, Option<String>>(0),
+            )
+            .optional()
+            .storage()?
+            .flatten();
+        tx.commit().storage()?;
+        Ok(DirectoryPresentation {
+            member_id_hex: member.to_owned(),
+            profile_json,
+            version: source,
+        })
+    }
+    pub fn directory_presentation_changes(
+        &self,
+        after: u64,
+    ) -> StorageResult<DirectoryPresentationChanges> {
+        let mut conn = self.lock()?;
+        let tx = conn.transaction().storage()?;
+        let head = version(&tx)?;
+        let changes = {
+            let mut stmt = tx.prepare_cached("SELECT c.member_id_hex, c.revision, u.profile_json
+                FROM directory_presentation_changes c LEFT JOIN directory_users u ON u.account_id_hex=c.member_id_hex
+                WHERE c.revision>?1 AND c.revision<=?2 ORDER BY c.revision LIMIT ?3").storage()?;
+            stmt.query_map(
+                params![
+                    u64_to_i64(after)?,
+                    u64_to_i64(head.revision)?,
+                    CHAT_PRESENTATION_BATCH_LIMIT as i64
+                ],
+                |r| {
+                    Ok(DirectoryPresentation {
+                        member_id_hex: r.get(0)?,
+                        profile_json: r.get(2)?,
+                        version: ChatPresentationVersion {
+                            store_epoch: head.store_epoch.clone(),
+                            revision: r.get::<_, i64>(1)? as u64,
+                        },
+                    })
+                },
+            )
+            .storage()?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .storage()?
+        };
+        tx.commit().storage()?;
+        Ok(DirectoryPresentationChanges { head, changes })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::SqliteSharedStorage;
+    #[test]
+    fn accepted_profile_changes_have_a_durable_revision_domain() {
+        let store = SqliteSharedStorage::in_memory().unwrap();
+        let exists: bool = store.lock().unwrap().query_row("SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE name = 'directory_presentation_changes')", [], |r| r.get(0)).unwrap();
+        assert!(
+            exists,
+            "accepted profiles need a durable coalesced change index"
+        );
+    }
+    fn record(member: &str, name: &str) -> crate::PublicDirectoryUserRecord {
+        crate::PublicDirectoryUserRecord {
+            account_id_hex: member.into(),
+            npub: "fixture".into(),
+            profile_json: Some(format!("{{\"name\":\"{name}\"}}")),
+            relay_lists_json: "{}".into(),
+            key_package_json: None,
+            event_id_hex: None,
+            event_kind: None,
+            event_created_at: None,
+            follows: vec![],
+        }
+    }
+    #[test]
+    fn writes_coalesce_and_raw_import_removal_and_rollback_share_the_revision() {
+        let store = SqliteSharedStorage::in_memory().unwrap();
+        let first = record("aa", "First");
+        store.put_public_directory_user(&first).unwrap();
+        let v = store.directory_presentation_version().unwrap();
+        store.put_public_directory_user(&first).unwrap();
+        let mut metadata_only = first.clone();
+        metadata_only.profile_json=Some(r#"{"name":"First","about":"changed","source_relays":["wss://relay.example"],"created_at":99}"#.into());
+        store.put_public_directory_user(&metadata_only).unwrap();
+        assert_eq!(store.directory_presentation_version().unwrap(), v);
+        store
+            .put_public_directory_user(&record("aa", "Second"))
+            .unwrap();
+        let changes = store.directory_presentation_changes(0).unwrap();
+        assert_eq!(changes.changes.len(), 1);
+        assert_eq!(
+            changes.changes[0].profile_json,
+            record("aa", "Second").profile_json
+        );
+        assert!(changes.changes[0].version.revision > v.revision);
+        let v = store.directory_presentation_version().unwrap();
+        store
+            .lock()
+            .unwrap()
+            .execute_batch("BEGIN; UPDATE directory_users SET profile_json=NULL; ROLLBACK;")
+            .unwrap();
+        assert_eq!(store.directory_presentation_version().unwrap(), v);
+        store
+            .lock()
+            .unwrap()
+            .execute("DELETE FROM directory_users WHERE account_id_hex='aa'", [])
+            .unwrap();
+        let deletion = store.directory_presentation_changes(v.revision).unwrap();
+        assert_eq!(deletion.changes.len(), 1);
+        assert!(deletion.changes[0].profile_json.is_none());
+        assert!(
+            store
+                .directory_presentation("aa")
+                .unwrap()
+                .profile_json
+                .is_none()
+        );
+    }
+    #[test]
+    fn bounded_changes_and_epoch_survive_reopen() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("shared.db");
+        let store = SqliteSharedStorage::open(&path).unwrap();
+        for i in 0..65 {
+            store
+                .put_public_directory_user(&record(&format!("{i:04x}"), "Profile"))
+                .unwrap();
+        }
+        let version = store.directory_presentation_version().unwrap();
+        let batch = store.directory_presentation_changes(0).unwrap();
+        assert_eq!(batch.changes.len(), 50);
+        drop(store);
+        let store = SqliteSharedStorage::open(&path).unwrap();
+        assert_eq!(store.directory_presentation_version().unwrap(), version);
+        assert_eq!(
+            store
+                .directory_presentation_changes(batch.changes.last().unwrap().version.revision)
+                .unwrap()
+                .changes
+                .len(),
+            15
+        );
+        assert_ne!(
+            SqliteSharedStorage::in_memory()
+                .unwrap()
+                .directory_presentation_version()
+                .unwrap()
+                .store_epoch,
+            version.store_epoch
+        );
+    }
+}

--- a/crates/storage-sqlite/src/shared/v3.sql
+++ b/crates/storage-sqlite/src/shared/v3.sql
@@ -1,0 +1,31 @@
+-- Coalesced accepted-profile changes. Old directory rows are read directly at revision zero.
+CREATE TABLE directory_presentation_meta (
+ id INTEGER PRIMARY KEY CHECK(id=1),
+ store_epoch BLOB NOT NULL CHECK(length(store_epoch)=16),
+ revision INTEGER NOT NULL CHECK(typeof(revision)='integer' AND revision>=0)
+);
+INSERT INTO directory_presentation_meta VALUES(1, randomblob(16), 0);
+CREATE TABLE directory_presentation_changes (
+ member_id_hex TEXT PRIMARY KEY NOT NULL,
+ revision INTEGER NOT NULL CHECK(typeof(revision)='integer' AND revision>=0)
+);
+CREATE UNIQUE INDEX directory_presentation_by_revision ON directory_presentation_changes(revision);
+CREATE TRIGGER directory_presentation_insert AFTER INSERT ON directory_users
+WHEN json_extract(CASE WHEN json_valid(NEW.profile_json) THEN NEW.profile_json ELSE '{}' END, '$.display_name', '$.name', '$.picture') IS NOT '[null,null,null]' BEGIN
+ UPDATE directory_presentation_meta SET revision=revision+1 WHERE id=1;
+ INSERT INTO directory_presentation_changes VALUES(NEW.account_id_hex,(SELECT revision FROM directory_presentation_meta WHERE id=1))
+ ON CONFLICT(member_id_hex) DO UPDATE SET revision=excluded.revision;
+END;
+CREATE TRIGGER directory_presentation_update AFTER UPDATE OF profile_json ON directory_users
+WHEN json_extract(CASE WHEN json_valid(OLD.profile_json) THEN OLD.profile_json ELSE '{}' END, '$.display_name', '$.name', '$.picture') IS NOT json_extract(CASE WHEN json_valid(NEW.profile_json) THEN NEW.profile_json ELSE '{}' END, '$.display_name', '$.name', '$.picture') BEGIN
+ UPDATE directory_presentation_meta SET revision=revision+1 WHERE id=1;
+ INSERT INTO directory_presentation_changes VALUES(NEW.account_id_hex,(SELECT revision FROM directory_presentation_meta WHERE id=1))
+ ON CONFLICT(member_id_hex) DO UPDATE SET revision=excluded.revision;
+END;
+-- Retain a tombstone so offline accounts can clear previously selected data.
+CREATE TRIGGER directory_presentation_delete AFTER DELETE ON directory_users
+WHEN json_extract(CASE WHEN json_valid(OLD.profile_json) THEN OLD.profile_json ELSE '{}' END, '$.display_name', '$.name', '$.picture') IS NOT '[null,null,null]' BEGIN
+ UPDATE directory_presentation_meta SET revision=revision+1 WHERE id=1;
+ INSERT INTO directory_presentation_changes VALUES(OLD.account_id_hex,(SELECT revision FROM directory_presentation_meta WHERE id=1))
+ ON CONFLICT(member_id_hex) DO UPDATE SET revision=excluded.revision;
+END;

--- a/docs/marmot-architecture/further-context/chat-presentation-first-slice.md
+++ b/docs/marmot-architecture/further-context/chat-presentation-first-slice.md
@@ -100,7 +100,9 @@ PresentedChatListUpdate {
 | Same peer, newer profile awaiting apply | Last usable same-peer selection | Last usable same-peer selection |
 | Peer replaced or roster no longer qualifies | Recompute against new evidence; never carry old peer as current | Recompute or placeholder; never reuse old peer cache key |
 
-An explicit group image wins in every row independently. Terminal lifecycle flags and command restrictions remain
+An explicit group image wins in every row independently. When both group sources are present, valid encrypted
+group image material takes precedence over the group avatar URL; the URL is the fallback when encrypted material is
+absent or invalid. Terminal lifecycle flags and command restrictions remain
 unchanged; a screen record does not authorize a mutation. Current projected membership determines peer eligibility.
 
 ### Names and historical data
@@ -265,7 +267,9 @@ tick recovers missed wakeups. A batch with no checkpoint or row progress stops i
 commit-before-broadcast interruption. These internal invalidations are the P3 subscription input.
 
 Groups missing a legacy chat row use a durable, bounded initialization queue and the existing row projector. This
-first-row construction retains the legacy projector's query cost; profile refresh and steady-state repair do not
+initialization retains the legacy projector's query cost; refresh and queue completion commit atomically even if a
+chat row already exists. Only durable completion counts as initialization progress. Profile refresh and steady-state
+repair do not
 rebuild history. Quarantined rosters lose current peer evidence until live reconciliation supplies it again; existing member counts and direct-conversation reuse indexes remain intact. Two-person roster identities use the same canonical order in memory and storage.
 
 ### Consumer accounting

--- a/docs/marmot-architecture/further-context/chat-presentation-first-slice.md
+++ b/docs/marmot-architecture/further-context/chat-presentation-first-slice.md
@@ -261,12 +261,12 @@ pending-work and revision reads; they do not scan groups, directory history, or 
 
 The existing account worker runs these bounded steps after readiness, yields between batches, and stops with its
 normal lifecycle. Coalesced process-local wakeups cover directory/source writes; the existing 15-second maintenance
-tick recovers missed wakeups. A fresh worker compares committed presentation revisions before notifying, recovering
+tick recovers missed wakeups. A batch with no checkpoint or row progress stops immediate rescheduling and retries on a later wakeup/tick. A fresh worker compares committed presentation revisions before notifying, recovering
 commit-before-broadcast interruption. These internal invalidations are the P3 subscription input.
 
 Groups missing a legacy chat row use a durable, bounded initialization queue and the existing row projector. This
 first-row construction retains the legacy projector's query cost; profile refresh and steady-state repair do not
-rebuild history. Quarantined rosters lose current peer evidence until live reconciliation supplies it again.
+rebuild history. Quarantined rosters lose current peer evidence until live reconciliation supplies it again; existing member counts and direct-conversation reuse indexes remain intact. Two-person roster identities use the same canonical order in memory and storage.
 
 ### Consumer accounting
 

--- a/docs/marmot-architecture/further-context/chat-presentation-first-slice.md
+++ b/docs/marmot-architecture/further-context/chat-presentation-first-slice.md
@@ -9,8 +9,8 @@ tags: [marmot, architecture, projections, implementation-plan]
 
 Implementation plan for [#1517](https://github.com/marmot-protocol/mdk/issues/1517), under
 [#1742](https://github.com/marmot-protocol/mdk/issues/1742). This is the first C2/C3 slice; the C1 design needed for this
-slice is ready. P1 now has an internal selection/storage implementation; runtime maintenance and native adoption
-remain P2–P4. No client performance success is claimed. Later screen contracts retain their own design
+slice is ready. P1 supplies selection/storage; P2 adds background maintenance and recovery. Native APIs and
+client adoption remain P3–P4. No client performance success is claimed. Later screen contracts retain their own design
 and acceptance work. The [broader contract draft](chat-screen-contract-draft.md) maps those boundaries.
 
 ## Outcome and scope
@@ -238,13 +238,35 @@ compatibility gate prevents an older binary from opening those newer-format rows
 `ChatPresentationWrite::Applied` reports committed row/dependency/progress work, including an identical refresh;
 notifications use the committed presentation revision rather than this write result.
 
-P1 seeds only roster evidence already available in the direct-member index. P2 must supply authoritative two-person
-rosters for named groups too before draining backfill, wire every source mutation, and run bounded hydration/catch-up
-after account readiness. Missing roster evidence yields a typed fallback; later hydration must call the roster setter
-to requeue it. It must not create a permanent busy retry loop for legitimately unavailable/quarantined groups.
+P1 seeds only roster evidence already available in the direct-member index. P2 carries authoritative two-person
+rosters for named groups through source projection transactions and live reconciliation before draining backfill.
+Missing roster evidence yields a typed fallback; later hydration uses the roster setter to requeue it, without
+creating a permanent busy retry loop for legitimately unavailable/quarantined groups.
 The P1 methods and resolver are internal Rust building blocks; existing app, UniFFI and C chat-list behavior is unchanged.
-P2 must also authorize shared-store epoch transitions at its catch-up boundary; revisions in different shared-store
-incarnations are not ordered by the P1 account writer. P3 supplies atomic whole-row reads and subscription handoff.
+P2 authorizes shared-store epoch transitions at its checkpoint boundary; delayed work from an older checkpoint
+or directory incarnation cannot overwrite a newer application. P3 supplies atomic whole-row reads and subscription handoff.
+
+### P2 maintenance boundary
+
+Shared schema 3 records one latest change per identity, comparing accepted `display_name`, `name`, and `picture`.
+Timestamps, relay observations and unrelated metadata do not advance this revision. Triggers cover normal saves,
+legacy import, and profile removal; tombstones remain until a future cleanup can prove no account needs them.
+
+Account schema 66 persists the directory incarnation, processed revision, active identity/group cursor and reset
+reconciliation cursor. Selected rows and checkpoint progress commit together. A newer coalesced change abandons the
+old identity cursor without skipping intervening identities. New dependencies always hydrate from the current shared
+cache, even behind the watermark. Store replacement captures the shared head and reconciles at most 50 rows per step,
+then processes changes since that head. Unrelated changes advance in batches of at most 50 identities. Idle steps use only indexed
+pending-work and revision reads; they do not scan groups, directory history, or messages.
+
+The existing account worker runs these bounded steps after readiness, yields between batches, and stops with its
+normal lifecycle. Coalesced process-local wakeups cover directory/source writes; the existing 15-second maintenance
+tick recovers missed wakeups. A fresh worker compares committed presentation revisions before notifying, recovering
+commit-before-broadcast interruption. These internal invalidations are the P3 subscription input.
+
+Groups missing a legacy chat row use a durable, bounded initialization queue and the existing row projector. This
+first-row construction retains the legacy projector's query cost; profile refresh and steady-state repair do not
+rebuild history. Quarantined rosters lose current peer evidence until live reconciliation supplies it again.
 
 ### Consumer accounting
 
@@ -277,8 +299,7 @@ incarnations are not ordered by the P1 account writer. P3 supplies atomic whole-
 
 Use meaningful existing regression foundations and add targeted storage, app-runtime and binding tests for new seams.
 Run `just fast-ci` before pushing, touched-crate tests, and C parity/header/smoke/alloc-audit gates when P3 changes them.
-Native adoption follows each client's own screenshot/device-test requirements. The plan itself changes documentation
-only; no new runtime tests have been executed for it.
+Native adoption follows each client's own screenshot/device-test requirements. P1/P2 tests cover storage and local maintenance; native binding and client validation remain P3/P4 work.
 
 For performance, preserve the recorded Pixel 9a / 20×40 fixture and artifact provenance. Measure native presented-list
 read, profile commit-to-update, first upgrade and ready offline reopen separately from whole-app startup. Report p50/p95


### PR DESCRIPTION
Chat titles and avatar descriptors must stay current in account storage even when no chat screen is subscribed. This adds durable profile-change tracking and bounded background maintenance on the existing account worker, with restartable progress and notification recovery.

P1 (#1753) is merged; this PR targets `master`. Refs #1517 and parent #1742. P3 owns the public whole-row Rust/UniFFI/C reads and snapshot subscription.

## Changes

- Shared schema 3 tracks coalesced changes to accepted name/avatar fields and removal tombstones. It preserves schema 2's usage/diagnostics settings. Duplicate observations and unrelated metadata create no presentation work.
- Account schema 66 persists catch-up progress and missing-row initialization work. Selected values and progress commit together; epoch/source checks reject stale work.
- Valid encrypted group avatar material wins over the group avatar URL when both are present; the URL is the fallback for absent/invalid encrypted material. The app-type documentation now agrees with this rule.
- Canonical two-person rosters support both named and unnamed groups. Quarantine withdraws current peer-presentation evidence while preserving existing chat classification and DM reuse.
- The worker processes at most 50 rows or changed identities per step, recovers missed wakeups and commit-before-notification interruption, and defers batches that make no progress to a later wakeup/tick. Idle steps do not scan group or message history.

Queued row initialization uses the existing row projector and atomically completes work on both insert and update paths. The worker reschedules for completed initialization, not merely for a nonempty input queue. Media downloads, native APIs, and client adoption remain later work.

## Validation

- `just fast-ci` on the rebased branch.
- Full `storage-sqlite` tests, including upgrade from existing shared schema 2 with cached profiles and usage settings preserved.
- 19 app presentation tests: selection, bounded/coalesced catch-up, account isolation, replacement/deletion fencing, roster ordering, quarantine/recovery, composed initialization/maintenance quiescence, no-progress backoff, and real-worker no-subscriber/restart recovery.
- Targeted push-token integration tests. The original relay-runtime CI failure was fixed before self-review; all CI checks passed on the reviewed commit `589c52a0`.
- Roster-ordering, quarantine, and rejected-batch regressions each failed against the pre-fix implementation and pass with the fixes.

Claude Opus and Cursor Grok reviewed that commit; this branch includes one follow-up pass addressing their substantive findings. The follow-up also covers injected queued/existing-row overlap, completion rollback and reopen, and normal snapshot-delete cascading. The review claim that migration 0006 omitted the chat-row FK was incorrect; the overlap check is defensive hardening, not proof of that proposed production path. Fresh CI will validate the follow-up commit. No new native/device benchmark result is claimed.

