### PR TITLE
Measure message latency and gate recovery

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -53,6 +53,10 @@ test-default:
 test-otlp:
     cargo nextest run --workspace --features {{diagnostics-features}},{{test-features}}
 
+# Message latency boundaries, abrupt exits, caller cancellation, and replay recovery.
+test-message-journeys:
+    cargo nextest run -p marmot-app -p marmot-uniffi --features marmot-app/test-policy-overrides -E 'test(message_journey) | test(unavailable_send_retries_the_exact_event_after_transport_recovers) | test(connectivity_restored_wakes_a_retained_send_before_the_retry_timer) | test(connectivity_restored_during_reconnect_wakes_the_retained_send)'
+
 # Startup scaling benchmarks (mdk#1161, mdk#1413): builds stores with
 # 0/10/100/1000 groups, 8/64-member rosters, and a message-heavy case;
 # reports the SQLCipher database footprint, cold-reopens each, and prints

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -3,7 +3,7 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use cgka_session::{
     AccountDeviceSession, CreateGroupEffects, IngestEffects, PublishWork, QueuedIntentRef,
@@ -2064,8 +2064,14 @@ where
             SendIntent::AppMessage { group_id, .. } => Some(group_id.clone()),
             _ => None,
         };
+        let accept_started = Instant::now();
         let effects = self.session.send(intent).await?;
+        let local_accept_duration = accept_started.elapsed();
+        let publish_started = Instant::now();
         let mut output = self.publish_session_effects(effects).await?;
+        output.local_accept_duration =
+            Some(local_accept_duration + output.local_accept_duration.unwrap_or_default());
+        output.publish_duration = Some(publish_started.elapsed());
         if let Some(group_id) = disposition_group
             && self.post_join_rotation_pending(&group_id)?
         {
@@ -2084,13 +2090,19 @@ where
             SendIntent::AppMessage { group_id, .. } => Some(group_id.clone()),
             _ => None,
         };
+        let accept_started = Instant::now();
         let effects = self
             .session
             .send_with_audit_context(intent, context.clone())
             .await?;
+        let local_accept_duration = accept_started.elapsed();
+        let publish_started = Instant::now();
         let mut output = self
             .publish_session_effects_with_audit_context(effects, Some(context))
             .await?;
+        output.local_accept_duration =
+            Some(local_accept_duration + output.local_accept_duration.unwrap_or_default());
+        output.publish_duration = Some(publish_started.elapsed());
         if let Some(group_id) = disposition_group
             && self.post_join_rotation_pending(&group_id)?
         {
@@ -2275,13 +2287,19 @@ where
         payload: Vec<u8>,
         context: AuditEventContext,
     ) -> AccountResult<AccountDeviceEffects> {
+        let accept_started = Instant::now();
         let effects = self
             .session
             .queue_app_message_with_audit_context(group_id.clone(), payload, context.clone())
             .await?;
+        let local_accept_duration = accept_started.elapsed();
+        let publish_started = Instant::now();
         let mut output = self
             .publish_session_effects_with_audit_context(effects, Some(context))
             .await?;
+        output.local_accept_duration =
+            Some(local_accept_duration + output.local_accept_duration.unwrap_or_default());
+        output.publish_duration = Some(publish_started.elapsed());
         if self.post_join_rotation_pending(&group_id)? {
             output.maintenance_disposition =
                 SendMaintenanceDisposition::PostJoinRotationPendingRetryable;
@@ -3595,6 +3613,7 @@ where
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
     ) -> AccountResult<PublishStatus> {
+        let stage_started = application_message.as_ref().map(|_| Instant::now());
         let (pending, pending_kind, post_confirmation_welcomes) = match continuation {
             Some(continuation) => (
                 Some(continuation.pending),
@@ -3676,6 +3695,11 @@ where
                 self.rollback_unstaged_pending(pending, output, queue)
                     .await?;
                 return Err(error.into());
+            }
+            if let Some(started) = stage_started {
+                // Sum only local application-message preparation, before relay I/O.
+                output.local_accept_duration =
+                    Some(output.local_accept_duration.unwrap_or_default() + started.elapsed());
             }
             Box::pin(self.drive_outbound_fanout(fanout, output, queue, context)).await
         } else {
@@ -4738,6 +4762,13 @@ fn publish_wire_metadata(message: &TransportMessage) -> AuditTransportWire {
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AccountDeviceEffects {
+    /// Sum of local engine acceptance and application fanout journal preparation.
+    /// Excludes relay I/O; a batch can stage sibling application messages.
+    /// Present only when effects return; not propagated from absorbed batches.
+    pub local_accept_duration: Option<Duration>,
+    /// Publication and reconciliation duration for this send's effects batch.
+    /// This is not a raw relay acknowledgement or recipient-delivery timestamp.
+    pub publish_duration: Option<Duration>,
     pub events: Vec<GroupEvent>,
     pub queued: Vec<QueuedIntentRef>,
     pub pending_convergence: Vec<GroupId>,

--- a/crates/marmot-app/src/app_telemetry.rs
+++ b/crates/marmot-app/src/app_telemetry.rs
@@ -47,7 +47,16 @@ pub(crate) enum AppPerformanceOperation {
     AccountSetupKeyPackageLocal,
     AccountSetupLocalReadyHandoff,
     AccountSetupNetworkReady,
+    InboundDeliveryProjection,
     OutboundMessageSend,
+    OutboundMessageQueueWait,
+    OutboundMessageLocalProjection,
+    OutboundMessageLocalAccept,
+    OutboundMessagePublish,
+    OutboundMessageResponse,
+    HostOutboundMessageVisible,
+    HostInboundMessageVisible,
+
     GroupCreateQueueWait,
     GroupCreateKeyPackageLookup,
     GroupMemberKeyPackagePrewarm,
@@ -105,6 +114,10 @@ pub(crate) enum AppPerformanceOperation {
 pub enum HostPerformanceOperation {
     SplashReady,
     ForegroundLocalReady,
+    /// From the user send action until the first local bubble is rendered.
+    OutboundMessageVisible,
+    /// From the host receiving a message update until it is rendered.
+    InboundMessageVisible,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -280,7 +293,24 @@ pub struct AppPerformanceSnapshot {
     /// passphrase KDF derivation (mdk#1439).
     #[serde(default)]
     pub sqlcipher_migration_probe_skips: u64,
+    #[serde(default)]
+    pub inbound_delivery_projection: AppPerformanceOperationSnapshot,
     pub outbound_message_send: AppPerformanceOperationSnapshot,
+    #[serde(default)]
+    pub outbound_message_queue_wait: AppPerformanceOperationSnapshot,
+    #[serde(default)]
+    pub outbound_message_local_projection: AppPerformanceOperationSnapshot,
+    #[serde(default)]
+    pub outbound_message_local_accept: AppPerformanceOperationSnapshot,
+    #[serde(default)]
+    pub outbound_message_publish: AppPerformanceOperationSnapshot,
+    #[serde(default)]
+    pub outbound_message_response: AppPerformanceOperationSnapshot,
+    #[serde(default)]
+    pub host_outbound_message_visible: AppPerformanceOperationSnapshot,
+    #[serde(default)]
+    pub host_inbound_message_visible: AppPerformanceOperationSnapshot,
+
     #[serde(default)]
     pub group_create_queue_wait: AppPerformanceOperationSnapshot,
     #[serde(default)]
@@ -405,7 +435,16 @@ struct AppPerformanceTelemetryInner {
     account_setup_key_package_local: AppPerformanceOperationTelemetry,
     account_setup_local_ready_handoff: AppPerformanceOperationTelemetry,
     account_setup_network_ready: AppPerformanceOperationTelemetry,
+    inbound_delivery_projection: AppPerformanceOperationTelemetry,
     outbound_message_send: AppPerformanceOperationTelemetry,
+    outbound_message_queue_wait: AppPerformanceOperationTelemetry,
+    outbound_message_local_projection: AppPerformanceOperationTelemetry,
+    outbound_message_local_accept: AppPerformanceOperationTelemetry,
+    outbound_message_publish: AppPerformanceOperationTelemetry,
+    outbound_message_response: AppPerformanceOperationTelemetry,
+    host_outbound_message_visible: AppPerformanceOperationTelemetry,
+    host_inbound_message_visible: AppPerformanceOperationTelemetry,
+
     group_create_queue_wait: AppPerformanceOperationTelemetry,
     group_create_key_package_lookup: AppPerformanceOperationTelemetry,
     group_member_key_package_prewarm: AppPerformanceOperationTelemetry,
@@ -728,6 +767,36 @@ impl AppPerformanceTelemetry {
             AppPerformanceOperation::AccountSetupNetworkReady => {
                 inner.account_setup_network_ready.record(duration, success)
             }
+            AppPerformanceOperation::OutboundMessageQueueWait => {
+                inner.outbound_message_queue_wait.record(duration, success);
+            }
+            AppPerformanceOperation::OutboundMessageLocalProjection => {
+                inner
+                    .outbound_message_local_projection
+                    .record(duration, success);
+            }
+            AppPerformanceOperation::OutboundMessageLocalAccept => {
+                inner
+                    .outbound_message_local_accept
+                    .record(duration, success);
+            }
+            AppPerformanceOperation::OutboundMessagePublish => {
+                inner.outbound_message_publish.record(duration, success);
+            }
+            AppPerformanceOperation::OutboundMessageResponse => {
+                inner.outbound_message_response.record(duration, success);
+            }
+            AppPerformanceOperation::HostOutboundMessageVisible => {
+                inner
+                    .host_outbound_message_visible
+                    .record(duration, success);
+            }
+            AppPerformanceOperation::HostInboundMessageVisible => {
+                inner.host_inbound_message_visible.record(duration, success);
+            }
+            AppPerformanceOperation::InboundDeliveryProjection => {
+                inner.inbound_delivery_projection.record(duration, success);
+            }
             AppPerformanceOperation::OutboundMessageSend => {
                 inner.outbound_message_send.record(duration, success);
             }
@@ -956,6 +1025,12 @@ impl AppPerformanceTelemetry {
         outcome: HostPerformanceOutcome,
     ) {
         let operation = match operation {
+            HostPerformanceOperation::OutboundMessageVisible => {
+                AppPerformanceOperation::HostOutboundMessageVisible
+            }
+            HostPerformanceOperation::InboundMessageVisible => {
+                AppPerformanceOperation::HostInboundMessageVisible
+            }
             HostPerformanceOperation::SplashReady => AppPerformanceOperation::HostSplashReady,
             HostPerformanceOperation::ForegroundLocalReady => {
                 AppPerformanceOperation::HostForegroundLocalReady
@@ -1008,7 +1083,16 @@ impl AppPerformanceTelemetry {
             account_setup_network_ready: inner.account_setup_network_ready.snapshot(),
             sqlcipher_migration_probe_runs,
             sqlcipher_migration_probe_skips,
+            inbound_delivery_projection: inner.inbound_delivery_projection.snapshot(),
             outbound_message_send: inner.outbound_message_send.snapshot(),
+            outbound_message_queue_wait: inner.outbound_message_queue_wait.snapshot(),
+            outbound_message_local_projection: inner.outbound_message_local_projection.snapshot(),
+            outbound_message_local_accept: inner.outbound_message_local_accept.snapshot(),
+            outbound_message_publish: inner.outbound_message_publish.snapshot(),
+            outbound_message_response: inner.outbound_message_response.snapshot(),
+            host_outbound_message_visible: inner.host_outbound_message_visible.snapshot(),
+            host_inbound_message_visible: inner.host_inbound_message_visible.snapshot(),
+
             group_create_queue_wait: inner.group_create_queue_wait.snapshot(),
             group_create_key_package_lookup: inner.group_create_key_package_lookup.snapshot(),
             group_member_key_package_prewarm: inner.group_member_key_package_prewarm.snapshot(),

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -293,6 +293,7 @@ pub(crate) struct GroupRouteRefresh {
 }
 
 pub struct AppClient {
+    pub(crate) send_telemetry: Option<AppPerformanceTelemetry>,
     pub(crate) app: MarmotApp,
     pub(crate) runtime: AppRuntime,
     pub(crate) maintenance_observation_generation: Option<crate::DiagnosticsPermit>,
@@ -3519,6 +3520,27 @@ impl AppClient {
                 return Err(err);
             }
         };
+        if should_project_locally {
+            if let Some(duration) = effects.local_accept_duration {
+                record_app_performance(
+                    self.send_telemetry.as_ref(),
+                    AppPerformanceOperation::OutboundMessageLocalAccept,
+                    duration,
+                    true,
+                );
+            }
+            if let Some(duration) = effects.publish_duration {
+                let published = effects.published_app_messages.iter().any(|message| {
+                    message.group_id == *group_id && message.app_event_id == app_event_id
+                });
+                record_app_performance(
+                    self.send_telemetry.as_ref(),
+                    AppPerformanceOperation::OutboundMessagePublish,
+                    duration,
+                    published,
+                );
+            }
+        }
         if let Err(publish_err) = self
             .observe_recovery_evidence_then_gate_send_publish(&effects, group_id, &app_event_id)
             .await

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1735,6 +1735,7 @@ impl MarmotApp {
         };
         let _ = open.runtime.take_maintenance_activity();
         let mut client = AppClient {
+            send_telemetry: None,
             app: self.clone(),
             maintenance_observation_generation: self.product_analytics.permit(),
             runtime: open.runtime,

--- a/crates/marmot-app/src/product_analytics/tests.rs
+++ b/crates/marmot-app/src/product_analytics/tests.rs
@@ -116,6 +116,85 @@ fn generation_never_revives() {
     assert!(!p.valid());
     assert!(c.permit().unwrap().valid());
 }
+
+#[tokio::test]
+#[cfg(feature = "product-analytics-export")]
+async fn custom_host_timing_events() {
+    use crate::HostPerformanceOutcome::{Failure, Success};
+
+    let (collector, _) = configured();
+    let mut config = collector.lock().config.clone();
+    config.registry.push(ProductEventSchema {
+        name: "app_inbox_layout".into(),
+        mode: ProductEventMode::Aggregate,
+        properties: vec![
+            ProductPropertySchema {
+                name: "elapsed".into(),
+                rule: ProductPropertyRule::DurationBucket,
+            },
+            ProductPropertySchema {
+                name: "outcome".into(),
+                rule: ProductPropertyRule::Enum(vec!["success".into(), "failure".into()]),
+            },
+        ],
+    });
+    collector
+        .configure(config, "http://127.0.0.1:9876".into())
+        .unwrap();
+    let root = tempfile::tempdir().unwrap();
+    let mut app = MarmotApp::with_relay(root.path(), "wss://relay.example");
+    app.product_analytics = collector.clone();
+    let runtime = app.runtime();
+    let elapsed = Duration::from_millis(250);
+    assert_eq!(
+        runtime
+            .record_host_timing("app_inbox_layout".into(), elapsed, Success)
+            .unwrap(),
+        ProductRecordResult::IgnoredDisabled
+    );
+    grant(&collector);
+    for name in ["app_unregistered", "app_test_view"] {
+        assert!(
+            runtime
+                .record_host_timing(name.into(), elapsed, Success)
+                .is_err()
+        );
+    }
+    for (duration, outcome) in [
+        (elapsed, Success),
+        (elapsed + Duration::from_nanos(1), Failure),
+    ] {
+        assert_eq!(
+            runtime
+                .record_host_timing("app_inbox_layout".into(), duration, outcome)
+                .unwrap(),
+            ProductRecordResult::Recorded
+        );
+    }
+    let rows = collector.test_payloads();
+    let timings: Vec<_> = rows
+        .iter()
+        .filter(|row| row["eventName"] == "app_inbox_layout")
+        .collect();
+    assert_eq!(timings.len(), 2);
+    for (outcome, bucket) in [("success", "le_250ms"), ("failure", "le_500ms")] {
+        let row = timings
+            .iter()
+            .find(|row| row["props"]["outcome"] == outcome)
+            .unwrap();
+        assert_eq!(row["props"]["elapsed"], bucket);
+        assert_eq!(row["props"]["count_bucket"], "1");
+        assert!(collector.valid_payload(&collector.lock().config, row));
+    }
+    collector.set_receipt(UsageDiagnosticsSettings::default(), String::new());
+    assert_eq!(
+        runtime
+            .record_host_timing("app_inbox_layout".into(), elapsed, Success)
+            .unwrap(),
+        ProductRecordResult::IgnoredDisabled
+    );
+    assert!(collector.test_payloads().is_empty());
+}
 #[test]
 fn keys_are_redacted_and_reserved_properties_rejected() {
     let (c, _) = configured();

--- a/crates/marmot-app/src/relay_telemetry_export.rs
+++ b/crates/marmot-app/src/relay_telemetry_export.rs
@@ -286,6 +286,69 @@ pub mod metric_names {
     /// Existing-database opens that skipped the recovery probe via a cached
     /// v2-open verdict (each avoided one passphrase KDF derivation, mdk#1439).
     pub const APP_SQLCIPHER_MIGRATION_PROBE_SKIPS: &str = "app_sqlcipher_migration_probe_skips";
+    /// Send command admission and worker queue wait.
+    pub const APP_OUTBOUND_MESSAGE_QUEUE_WAIT_DURATION: &str =
+        "app_outbound_message_queue_wait_duration_ms";
+    pub const APP_OUTBOUND_MESSAGE_QUEUE_WAIT_ATTEMPTS: &str =
+        "app_outbound_message_queue_wait_attempts";
+    pub const APP_OUTBOUND_MESSAGE_QUEUE_WAIT_SUCCESSES: &str =
+        "app_outbound_message_queue_wait_successes";
+    pub const APP_OUTBOUND_MESSAGE_QUEUE_WAIT_FAILURES: &str =
+        "app_outbound_message_queue_wait_failures";
+    pub const APP_OUTBOUND_MESSAGE_LOCAL_PROJECTION_DURATION: &str =
+        "app_outbound_message_local_projection_duration_ms";
+    pub const APP_OUTBOUND_MESSAGE_LOCAL_PROJECTION_ATTEMPTS: &str =
+        "app_outbound_message_local_projection_attempts";
+    pub const APP_OUTBOUND_MESSAGE_LOCAL_PROJECTION_SUCCESSES: &str =
+        "app_outbound_message_local_projection_successes";
+    pub const APP_OUTBOUND_MESSAGE_LOCAL_PROJECTION_FAILURES: &str =
+        "app_outbound_message_local_projection_failures";
+    pub const APP_OUTBOUND_MESSAGE_LOCAL_ACCEPT_DURATION: &str =
+        "app_outbound_message_local_accept_duration_ms";
+    pub const APP_OUTBOUND_MESSAGE_LOCAL_ACCEPT_ATTEMPTS: &str =
+        "app_outbound_message_local_accept_attempts";
+    pub const APP_OUTBOUND_MESSAGE_LOCAL_ACCEPT_SUCCESSES: &str =
+        "app_outbound_message_local_accept_successes";
+    pub const APP_OUTBOUND_MESSAGE_LOCAL_ACCEPT_FAILURES: &str =
+        "app_outbound_message_local_accept_failures";
+    pub const APP_OUTBOUND_MESSAGE_PUBLISH_DURATION: &str =
+        "app_outbound_message_publish_duration_ms";
+    pub const APP_OUTBOUND_MESSAGE_PUBLISH_ATTEMPTS: &str = "app_outbound_message_publish_attempts";
+    pub const APP_OUTBOUND_MESSAGE_PUBLISH_SUCCESSES: &str =
+        "app_outbound_message_publish_successes";
+    pub const APP_OUTBOUND_MESSAGE_PUBLISH_FAILURES: &str = "app_outbound_message_publish_failures";
+    pub const APP_OUTBOUND_MESSAGE_RESPONSE_DURATION: &str =
+        "app_outbound_message_response_duration_ms";
+    pub const APP_OUTBOUND_MESSAGE_RESPONSE_ATTEMPTS: &str =
+        "app_outbound_message_response_attempts";
+    pub const APP_OUTBOUND_MESSAGE_RESPONSE_SUCCESSES: &str =
+        "app_outbound_message_response_successes";
+    pub const APP_OUTBOUND_MESSAGE_RESPONSE_FAILURES: &str =
+        "app_outbound_message_response_failures";
+    pub const APP_HOST_OUTBOUND_MESSAGE_VISIBLE_DURATION: &str =
+        "app_host_outbound_message_visible_duration_ms";
+    pub const APP_HOST_OUTBOUND_MESSAGE_VISIBLE_ATTEMPTS: &str =
+        "app_host_outbound_message_visible_attempts";
+    pub const APP_HOST_OUTBOUND_MESSAGE_VISIBLE_SUCCESSES: &str =
+        "app_host_outbound_message_visible_successes";
+    pub const APP_HOST_OUTBOUND_MESSAGE_VISIBLE_FAILURES: &str =
+        "app_host_outbound_message_visible_failures";
+    pub const APP_HOST_INBOUND_MESSAGE_VISIBLE_DURATION: &str =
+        "app_host_inbound_message_visible_duration_ms";
+    pub const APP_HOST_INBOUND_MESSAGE_VISIBLE_ATTEMPTS: &str =
+        "app_host_inbound_message_visible_attempts";
+    pub const APP_HOST_INBOUND_MESSAGE_VISIBLE_SUCCESSES: &str =
+        "app_host_inbound_message_visible_successes";
+    pub const APP_HOST_INBOUND_MESSAGE_VISIBLE_FAILURES: &str =
+        "app_host_inbound_message_visible_failures";
+    pub const APP_INBOUND_DELIVERY_PROJECTION_DURATION: &str =
+        "app_inbound_delivery_projection_duration_ms";
+    pub const APP_INBOUND_DELIVERY_PROJECTION_ATTEMPTS: &str =
+        "app_inbound_delivery_projection_attempts";
+    pub const APP_INBOUND_DELIVERY_PROJECTION_SUCCESSES: &str =
+        "app_inbound_delivery_projection_successes";
+    pub const APP_INBOUND_DELIVERY_PROJECTION_FAILURES: &str =
+        "app_inbound_delivery_projection_failures";
     /// One-sided outbound message send duration histogram.
     pub const APP_OUTBOUND_MESSAGE_SEND_DURATION: &str = "app_outbound_message_send_duration_ms";
     /// One-sided outbound message send attempts.
@@ -1175,6 +1238,70 @@ fn append_app_performance_points(
         metric_names::APP_ACCOUNT_SETUP_NETWORK_READY_ATTEMPTS,
         metric_names::APP_ACCOUNT_SETUP_NETWORK_READY_SUCCESSES,
         metric_names::APP_ACCOUNT_SETUP_NETWORK_READY_FAILURES,
+    );
+    append_app_operation_points(
+        points,
+        &app_performance.outbound_message_queue_wait,
+        metric_names::APP_OUTBOUND_MESSAGE_QUEUE_WAIT_DURATION,
+        metric_names::APP_OUTBOUND_MESSAGE_QUEUE_WAIT_ATTEMPTS,
+        metric_names::APP_OUTBOUND_MESSAGE_QUEUE_WAIT_SUCCESSES,
+        metric_names::APP_OUTBOUND_MESSAGE_QUEUE_WAIT_FAILURES,
+    );
+    append_app_operation_points(
+        points,
+        &app_performance.outbound_message_local_projection,
+        metric_names::APP_OUTBOUND_MESSAGE_LOCAL_PROJECTION_DURATION,
+        metric_names::APP_OUTBOUND_MESSAGE_LOCAL_PROJECTION_ATTEMPTS,
+        metric_names::APP_OUTBOUND_MESSAGE_LOCAL_PROJECTION_SUCCESSES,
+        metric_names::APP_OUTBOUND_MESSAGE_LOCAL_PROJECTION_FAILURES,
+    );
+    append_app_operation_points(
+        points,
+        &app_performance.outbound_message_local_accept,
+        metric_names::APP_OUTBOUND_MESSAGE_LOCAL_ACCEPT_DURATION,
+        metric_names::APP_OUTBOUND_MESSAGE_LOCAL_ACCEPT_ATTEMPTS,
+        metric_names::APP_OUTBOUND_MESSAGE_LOCAL_ACCEPT_SUCCESSES,
+        metric_names::APP_OUTBOUND_MESSAGE_LOCAL_ACCEPT_FAILURES,
+    );
+    append_app_operation_points(
+        points,
+        &app_performance.outbound_message_publish,
+        metric_names::APP_OUTBOUND_MESSAGE_PUBLISH_DURATION,
+        metric_names::APP_OUTBOUND_MESSAGE_PUBLISH_ATTEMPTS,
+        metric_names::APP_OUTBOUND_MESSAGE_PUBLISH_SUCCESSES,
+        metric_names::APP_OUTBOUND_MESSAGE_PUBLISH_FAILURES,
+    );
+    append_app_operation_points(
+        points,
+        &app_performance.outbound_message_response,
+        metric_names::APP_OUTBOUND_MESSAGE_RESPONSE_DURATION,
+        metric_names::APP_OUTBOUND_MESSAGE_RESPONSE_ATTEMPTS,
+        metric_names::APP_OUTBOUND_MESSAGE_RESPONSE_SUCCESSES,
+        metric_names::APP_OUTBOUND_MESSAGE_RESPONSE_FAILURES,
+    );
+    append_app_operation_points(
+        points,
+        &app_performance.host_outbound_message_visible,
+        metric_names::APP_HOST_OUTBOUND_MESSAGE_VISIBLE_DURATION,
+        metric_names::APP_HOST_OUTBOUND_MESSAGE_VISIBLE_ATTEMPTS,
+        metric_names::APP_HOST_OUTBOUND_MESSAGE_VISIBLE_SUCCESSES,
+        metric_names::APP_HOST_OUTBOUND_MESSAGE_VISIBLE_FAILURES,
+    );
+    append_app_operation_points(
+        points,
+        &app_performance.host_inbound_message_visible,
+        metric_names::APP_HOST_INBOUND_MESSAGE_VISIBLE_DURATION,
+        metric_names::APP_HOST_INBOUND_MESSAGE_VISIBLE_ATTEMPTS,
+        metric_names::APP_HOST_INBOUND_MESSAGE_VISIBLE_SUCCESSES,
+        metric_names::APP_HOST_INBOUND_MESSAGE_VISIBLE_FAILURES,
+    );
+    append_app_operation_points(
+        points,
+        &app_performance.inbound_delivery_projection,
+        metric_names::APP_INBOUND_DELIVERY_PROJECTION_DURATION,
+        metric_names::APP_INBOUND_DELIVERY_PROJECTION_ATTEMPTS,
+        metric_names::APP_INBOUND_DELIVERY_PROJECTION_SUCCESSES,
+        metric_names::APP_INBOUND_DELIVERY_PROJECTION_FAILURES,
     );
     append_app_operation_points(
         points,

--- a/crates/marmot-app/src/relay_telemetry_export/tests.rs
+++ b/crates/marmot-app/src/relay_telemetry_export/tests.rs
@@ -701,3 +701,98 @@ fn late_cumulative_sources_start_at_zero_and_retain_their_baseline_when_absent()
     assert_eq!(reset.points[0].value, ExportMetricValue::Counter(0));
     assert_eq!(reset.points[1].value, batch(0).points[1].value);
 }
+
+#[test]
+fn message_journey_metric_export() {
+    use crate::app_telemetry::{
+        AppPerformanceOperation, AppPerformanceTelemetry, HostPerformanceOperation,
+        HostPerformanceOutcome,
+    };
+    let telemetry = AppPerformanceTelemetry::default();
+    for operation in [
+        AppPerformanceOperation::OutboundMessageQueueWait,
+        AppPerformanceOperation::OutboundMessageLocalProjection,
+        AppPerformanceOperation::OutboundMessageLocalAccept,
+        AppPerformanceOperation::OutboundMessagePublish,
+        AppPerformanceOperation::OutboundMessageResponse,
+        AppPerformanceOperation::InboundDeliveryProjection,
+    ] {
+        telemetry.record(operation, std::time::Duration::from_millis(60), true);
+        telemetry.record(operation, std::time::Duration::from_millis(120), false);
+    }
+    for operation in [
+        HostPerformanceOperation::OutboundMessageVisible,
+        HostPerformanceOperation::InboundMessageVisible,
+    ] {
+        telemetry.record_host_performance(
+            operation,
+            std::time::Duration::from_millis(60),
+            HostPerformanceOutcome::Success,
+        );
+        telemetry.record_host_performance(
+            operation,
+            std::time::Duration::from_millis(120),
+            HostPerformanceOutcome::Failure,
+        );
+    }
+    let snapshot = telemetry.snapshot();
+    let batch = build_export_batch_with_app_performance(
+        &RelayTelemetryRollup::default(),
+        &RelayLabelResolution::default(),
+        Some(&snapshot),
+    );
+    let mut legacy = serde_json::to_value(&snapshot).unwrap();
+    for (name, operation) in [
+        (
+            "outbound_message_queue_wait",
+            &snapshot.outbound_message_queue_wait,
+        ),
+        (
+            "outbound_message_local_projection",
+            &snapshot.outbound_message_local_projection,
+        ),
+        (
+            "outbound_message_local_accept",
+            &snapshot.outbound_message_local_accept,
+        ),
+        (
+            "outbound_message_publish",
+            &snapshot.outbound_message_publish,
+        ),
+        (
+            "outbound_message_response",
+            &snapshot.outbound_message_response,
+        ),
+        (
+            "inbound_delivery_projection",
+            &snapshot.inbound_delivery_projection,
+        ),
+        (
+            "host_outbound_message_visible",
+            &snapshot.host_outbound_message_visible,
+        ),
+        (
+            "host_inbound_message_visible",
+            &snapshot.host_inbound_message_visible,
+        ),
+    ] {
+        assert_eq!(operation.attempts, 2);
+        assert_eq!(operation.successes, 1);
+        assert_eq!(operation.failures, 1);
+        assert_eq!(operation.duration_ms.sum_ms, 180);
+        for suffix in ["duration_ms", "attempts", "successes", "failures"] {
+            let name = format!("app_{name}_{suffix}");
+            let points = batch
+                .points
+                .iter()
+                .filter(|point| point.name == name)
+                .collect::<Vec<_>>();
+            assert_eq!(points.len(), 1, "{name} must be exported exactly once");
+            assert!(points[0].relay.is_none());
+        }
+        legacy.as_object_mut().unwrap().remove(name);
+    }
+    let legacy: AppPerformanceSnapshot = serde_json::from_value(legacy).unwrap();
+    assert_eq!(legacy.outbound_message_queue_wait.attempts, 0);
+    assert_eq!(legacy.host_inbound_message_visible.attempts, 0);
+}

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -277,11 +277,13 @@ pub(crate) enum AccountWorkerCommand {
         respond: oneshot::Sender<Result<SendSummary, AppError>>,
     },
     SendMessage {
+        enqueued_at: Instant,
         group_id: GroupId,
         payload: Vec<u8>,
         respond: oneshot::Sender<Result<SendSummary, AppError>>,
     },
     SendAppEvent {
+        enqueued_at: Instant,
         group_id: GroupId,
         intent: AppMessageIntent,
         respond: oneshot::Sender<Result<SendSummary, AppError>>,
@@ -1288,6 +1290,8 @@ async fn run_app_runtime_account_worker(
                 // delivery has been claimed, finish ingest + incidental
                 // publish + projection as one uncancelled worker operation;
                 // commands remain queued until that durable sequence lands.
+                let delivery_started = matches!(&received, Ok(crate::relay_plane::AccountDeliveryReceive::Delivery(_)))
+                    .then(Instant::now);
                 let (result, overflow_recovery_incomplete) = match received {
                     Ok(crate::relay_plane::AccountDeliveryReceive::Delivery(delivery)) => {
                         (client.ingest_received_delivery(*delivery).await, false)
@@ -1322,6 +1326,13 @@ async fn run_app_runtime_account_worker(
                     }
                     Err(err) => (Err(err), false),
                 };
+                if result.is_err() && let Some(started) = delivery_started {
+                    shared.app_performance_telemetry().record(
+                        AppPerformanceOperation::InboundDeliveryProjection,
+                        started.elapsed(),
+                        false,
+                    );
+                }
                 match result {
                     Ok(summary) => {
                         reconnect_backoff.reset();
@@ -1336,6 +1347,13 @@ async fn run_app_runtime_account_worker(
                             &account_id_hex,
                             &account_label,
                         );
+                        if let Some(started) = delivery_started {
+                            shared.app_performance_telemetry().record(
+                                AppPerformanceOperation::InboundDeliveryProjection,
+                                started.elapsed(),
+                                true,
+                            );
+                        }
                         start_post_join_history_after_visibility(
                             &mut client,
                             &summary,
@@ -3633,13 +3651,29 @@ fn account_worker_command_future<'a>(
             true
         }),
         AccountWorkerCommand::SendMessage {
+            enqueued_at,
             group_id,
             payload,
             respond,
         } => Box::pin(async move {
             let send_started_at = Instant::now();
+            shared.app_performance_telemetry().record(
+                AppPerformanceOperation::OutboundMessageQueueWait,
+                enqueued_at.elapsed(),
+                true,
+            );
+            let mut first_projection = true;
+            client.send_telemetry = Some(shared.app_performance_telemetry());
             let result = client
                 .send_with_local_projection(&group_id, &payload, |update| {
+                    if first_projection {
+                        shared.app_performance_telemetry().record(
+                            AppPerformanceOperation::OutboundMessageLocalProjection,
+                            enqueued_at.elapsed(),
+                            true,
+                        );
+                        first_projection = false;
+                    }
                     publish_app_runtime_projection_update(
                         events,
                         account_id_hex,
@@ -3648,6 +3682,7 @@ fn account_worker_command_future<'a>(
                     );
                 })
                 .await;
+            client.send_telemetry = None;
             shared.app_performance_telemetry().record(
                 AppPerformanceOperation::OutboundMessageSend,
                 send_started_at.elapsed(),
@@ -3657,11 +3692,19 @@ fn account_worker_command_future<'a>(
             true
         }),
         AccountWorkerCommand::SendAppEvent {
+            enqueued_at,
             group_id,
             intent,
             respond,
         } => Box::pin(async move {
             let send_started_at = Instant::now();
+            shared.app_performance_telemetry().record(
+                AppPerformanceOperation::OutboundMessageQueueWait,
+                enqueued_at.elapsed(),
+                true,
+            );
+            let mut first_projection = true;
+            client.send_telemetry = Some(shared.app_performance_telemetry());
             let result = match intent {
                 AppMessageIntent::Reaction {
                     target_message_id,
@@ -3673,6 +3716,14 @@ fn account_worker_command_future<'a>(
                             &target_message_id,
                             &emoji,
                             |update| {
+                                if first_projection {
+                                    shared.app_performance_telemetry().record(
+                                        AppPerformanceOperation::OutboundMessageLocalProjection,
+                                        enqueued_at.elapsed(),
+                                        true,
+                                    );
+                                    first_projection = false;
+                                }
                                 publish_app_runtime_projection_update(
                                     events,
                                     account_id_hex,
@@ -3685,6 +3736,14 @@ fn account_worker_command_future<'a>(
                 }
                 intent => client
                     .send_app_event_with_local_projection(&group_id, intent, |update| {
+                        if first_projection {
+                            shared.app_performance_telemetry().record(
+                                AppPerformanceOperation::OutboundMessageLocalProjection,
+                                enqueued_at.elapsed(),
+                                true,
+                            );
+                            first_projection = false;
+                        }
                         publish_app_runtime_projection_update(
                             events,
                             account_id_hex,
@@ -3695,6 +3754,7 @@ fn account_worker_command_future<'a>(
                     .await
                     .map(|(_event, summary)| summary),
             };
+            client.send_telemetry = None;
             shared.app_performance_telemetry().record(
                 AppPerformanceOperation::OutboundMessageSend,
                 send_started_at.elapsed(),

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -1235,18 +1235,21 @@ impl AccountManager {
         payload: Vec<u8>,
     ) -> Result<SendSummary, AppError> {
         let enqueued_at = Instant::now();
-        let command = self.worker_commands(account_ref).await?;
-        let (respond, response) = oneshot::channel();
-        command
-            .send(AccountWorkerCommand::SendMessage {
-                enqueued_at,
-                group_id: group_id.clone(),
-                payload,
-                respond,
-            })
-            .await
-            .map_err(|_| AppError::TransportClosed)?;
-        let result = account_worker_response(response).await;
+        let result = async {
+            let command = self.worker_commands(account_ref).await?;
+            let (respond, response) = oneshot::channel();
+            command
+                .send(AccountWorkerCommand::SendMessage {
+                    enqueued_at,
+                    group_id: group_id.clone(),
+                    payload,
+                    respond,
+                })
+                .await
+                .map_err(|_| AppError::TransportClosed)?;
+            account_worker_response(response).await
+        }
+        .await;
         self.shared.app_performance_telemetry().record(
             AppPerformanceOperation::OutboundMessageResponse,
             enqueued_at.elapsed(),
@@ -1385,18 +1388,21 @@ impl AccountManager {
         intent: AppMessageIntent,
     ) -> Result<SendSummary, AppError> {
         let enqueued_at = Instant::now();
-        let command = self.worker_commands(account_ref).await?;
-        let (respond, response) = oneshot::channel();
-        command
-            .send(AccountWorkerCommand::SendAppEvent {
-                enqueued_at,
-                group_id: group_id.clone(),
-                intent,
-                respond,
-            })
-            .await
-            .map_err(|_| AppError::TransportClosed)?;
-        let result = account_worker_response(response).await;
+        let result = async {
+            let command = self.worker_commands(account_ref).await?;
+            let (respond, response) = oneshot::channel();
+            command
+                .send(AccountWorkerCommand::SendAppEvent {
+                    enqueued_at,
+                    group_id: group_id.clone(),
+                    intent,
+                    respond,
+                })
+                .await
+                .map_err(|_| AppError::TransportClosed)?;
+            account_worker_response(response).await
+        }
+        .await;
         self.shared.app_performance_telemetry().record(
             AppPerformanceOperation::OutboundMessageResponse,
             enqueued_at.elapsed(),

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -1234,17 +1234,25 @@ impl AccountManager {
         group_id: &GroupId,
         payload: Vec<u8>,
     ) -> Result<SendSummary, AppError> {
+        let enqueued_at = Instant::now();
         let command = self.worker_commands(account_ref).await?;
         let (respond, response) = oneshot::channel();
         command
             .send(AccountWorkerCommand::SendMessage {
+                enqueued_at,
                 group_id: group_id.clone(),
                 payload,
                 respond,
             })
             .await
             .map_err(|_| AppError::TransportClosed)?;
-        let summary = account_worker_response(response).await?;
+        let result = account_worker_response(response).await;
+        self.shared.app_performance_telemetry().record(
+            AppPerformanceOperation::OutboundMessageResponse,
+            enqueued_at.elapsed(),
+            result.is_ok(),
+        );
+        let summary = result?;
         self.schedule_audit_log_tracker_update("send_message");
         Ok(summary)
     }
@@ -1376,17 +1384,25 @@ impl AccountManager {
         group_id: &GroupId,
         intent: AppMessageIntent,
     ) -> Result<SendSummary, AppError> {
+        let enqueued_at = Instant::now();
         let command = self.worker_commands(account_ref).await?;
         let (respond, response) = oneshot::channel();
         command
             .send(AccountWorkerCommand::SendAppEvent {
+                enqueued_at,
                 group_id: group_id.clone(),
                 intent,
                 respond,
             })
             .await
             .map_err(|_| AppError::TransportClosed)?;
-        let summary = account_worker_response(response).await?;
+        let result = account_worker_response(response).await;
+        self.shared.app_performance_telemetry().record(
+            AppPerformanceOperation::OutboundMessageResponse,
+            enqueued_at.elapsed(),
+            result.is_ok(),
+        );
+        let summary = result?;
         self.schedule_audit_log_tracker_update("send_app_event");
         Ok(summary)
     }

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -2462,6 +2462,33 @@ impl MarmotAppRuntime {
         }
         Ok(self.shared.product_analytics.record(event)?)
     }
+
+    /// Record an app-defined timing through the consent-gated product exporter.
+    /// Register `name` with `elapsed: DurationBucket` and an `outcome` enum
+    /// containing `success` and `failure`. Durations are bucketed before admission;
+    /// these events do not enter the OTLP app-performance snapshot.
+    pub fn record_host_timing(
+        &self,
+        name: String,
+        duration: Duration,
+        outcome: crate::HostPerformanceOutcome,
+    ) -> Result<crate::ProductRecordResult, AppError> {
+        let outcome = match outcome {
+            crate::HostPerformanceOutcome::Success => "success",
+            crate::HostPerformanceOutcome::Failure => "failure",
+        };
+        self.record_product_event(crate::ProductEvent {
+            name,
+            properties: std::collections::BTreeMap::from([
+                (
+                    "elapsed".into(),
+                    crate::product_duration_bucket(duration).into(),
+                ),
+                ("outcome".into(), outcome.into()),
+            ]),
+        })
+    }
+
     pub async fn set_product_analytics_activity(&self, activity: crate::ProductAnalyticsActivity) {
         if self.is_stopping() {
             return;

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -10,6 +10,49 @@ use crate::publish_endpoints_from_bootstrap;
 use crate::tests::ScriptedPushRelayClient;
 
 #[tokio::test]
+async fn message_journey_early_errors() {
+    let root = tempfile::tempdir().unwrap();
+    let runtime = MarmotApp::with_relays(root.path(), vec![]).runtime();
+    let group = GroupId::new(vec![1; 16]);
+
+    for expected_failures in [2, 4] {
+        assert!(
+            runtime
+                .send_message("missing", &group, vec![])
+                .await
+                .is_err()
+        );
+        assert!(
+            runtime
+                .accounts
+                .send_app_event(
+                    "missing",
+                    &group,
+                    AppMessageIntent::Chat {
+                        content: String::new()
+                    },
+                )
+                .await
+                .is_err()
+        );
+        let snapshot = runtime.app_performance_snapshot();
+        assert_eq!(
+            snapshot.outbound_message_response.attempts,
+            expected_failures
+        );
+        assert_eq!(
+            snapshot.outbound_message_response.failures,
+            expected_failures
+        );
+        assert_eq!(snapshot.outbound_message_response.successes, 0);
+        assert_eq!(snapshot.outbound_message_queue_wait.attempts, 0);
+
+        // Repeat after shutdown to cover lifecycle rejection before account lookup.
+        runtime.shutdown().await;
+    }
+}
+
+#[tokio::test]
 async fn missing_diagnostics_executor_keeps_exporters_stopped() {
     let root = tempfile::tempdir().unwrap();
     let app = MarmotApp::with_relays(root.path(), vec![]);

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -2649,3 +2649,65 @@ fn key_package_deletion_relay_failures_dedupe_privacy_safe_publish_endpoint_cate
     assert!(!failures[0].reason.contains("leak.example"));
     assert!(!failures[0].reason.contains("attacker-controlled"));
 }
+
+#[tokio::test]
+async fn message_journey_overflow() {
+    let root = tempfile::tempdir().unwrap();
+    let account = marmot_account::AccountHome::open(root.path())
+        .create_account("sender")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app =
+        MarmotApp::with_relay(root.path(), "wss://journey.example").with_test_relay_client(relay);
+    let mut client = app.client("sender").await.unwrap();
+    let group = client.create_group("journey", &[]).await.unwrap();
+    let runtime = app.runtime();
+    let mut timeline = runtime
+        .subscribe_timeline_messages(
+            "sender",
+            TimelineMessageQuery {
+                group_id_hex: Some(hex::encode(group.as_slice())),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert!(timeline.take_snapshot().messages.is_empty());
+    let sent = client
+        .send(&group, b"recover missed projection")
+        .await
+        .unwrap();
+    for _ in 0..2 {
+        let mut observer = runtime.subscribe();
+        // No await: the single-thread executor cannot drain the 1024-event ring.
+        for _ in 0..2048 {
+            runtime
+                .events
+                .send(MarmotAppEvent::GroupStateUpdated {
+                    account_id_hex: account.account_id_hex.clone(),
+                    account_label: account.label.clone(),
+                    group_id: group.clone(),
+                })
+                .unwrap();
+        }
+        assert!(matches!(
+            observer.try_recv(),
+            Err(broadcast::error::TryRecvError::Lagged(_))
+        ));
+        let update = tokio::time::timeout(Duration::from_secs(5), timeline.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(update, RuntimeTimelineMessageUpdate::Page { .. }));
+        let page = timeline.take_snapshot();
+        assert_eq!(
+            page.messages.len(),
+            1,
+            "each gap refreshes authoritative state without duplicates"
+        );
+        assert_eq!(page.messages[0].message_id_hex, sent.message_ids[0]);
+        assert!(page.messages[0].source_message_id_hex.is_some());
+    }
+    drop(client);
+    runtime.shutdown_and_close().await.unwrap();
+}

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -1,3 +1,5 @@
+mod message_journeys;
+
 use super::*;
 use async_trait::async_trait;
 use cgka_traits::Timestamp;
@@ -18167,6 +18169,14 @@ async fn unavailable_send_retries_the_exact_event_after_transport_recovers() {
     assert_eq!(
         summary.accept_disposition,
         cgka_traits::SendAcceptDisposition::CompletionUnknown
+    );
+    let snapshot = runtime.app_performance_snapshot();
+    assert_eq!(snapshot.outbound_message_local_accept.successes, 1);
+    assert_eq!(snapshot.outbound_message_publish.successes, 0);
+    assert_eq!(snapshot.outbound_message_publish.failures, 1);
+    assert_eq!(
+        snapshot.outbound_message_response.successes, 1,
+        "accepted unknown is a truthful response, not a published message"
     );
     let failed_event_id = relay
         .attempted_event_ids()

--- a/crates/marmot-app/src/tests/message_journeys.rs
+++ b/crates/marmot-app/src/tests/message_journeys.rs
@@ -1,0 +1,332 @@
+//! Send boundaries exercised against file-backed SQLCipher and the real account runtime.
+use super::*;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+const CHILD_ROOT: &str = "MDK_MESSAGE_JOURNEY_ROOT";
+const CHILD_PHASE: &str = "MDK_MESSAGE_JOURNEY_PHASE";
+const CRASH_EXIT: i32 = 73;
+
+struct CrashRelay {
+    inner: ScriptedPushRelayClient,
+    root: PathBuf,
+    phase: String,
+    armed: AtomicBool,
+}
+
+#[async_trait]
+impl NostrRelayClient for CrashRelay {
+    async fn subscribe(
+        &self,
+        subscription: NostrSubscription,
+    ) -> Result<(), cgka_traits::TransportAdapterError> {
+        self.inner.subscribe(subscription).await
+    }
+
+    async fn unsubscribe(
+        &self,
+        subscription: NostrSubscription,
+    ) -> Result<(), cgka_traits::TransportAdapterError> {
+        self.inner.unsubscribe(subscription).await
+    }
+
+    async fn unsubscribe_account(
+        &self,
+        account: &MemberId,
+    ) -> Result<(), cgka_traits::TransportAdapterError> {
+        self.inner.unsubscribe_account(account).await
+    }
+
+    async fn publish_event(
+        &self,
+        endpoints: &[TransportEndpoint],
+        event: &NostrTransportEvent,
+        required_acks: usize,
+    ) -> Result<NostrPublishOutcome, cgka_traits::TransportAdapterError> {
+        if !self.armed.load(Ordering::SeqCst) {
+            return self
+                .inner
+                .publish_event(endpoints, event, required_acks)
+                .await;
+        }
+        fs_private::write_private(
+            &self.root.join("attempt.json"),
+            &serde_json::to_vec(event).unwrap(),
+        )
+        .unwrap();
+        if self.phase == "durable" {
+            // The account has persisted the exact fanout, but no relay accepted it.
+            std::process::exit(CRASH_EXIT);
+        }
+        let result = self
+            .inner
+            .publish_event(endpoints, event, required_acks)
+            .await;
+        if self.phase == "relay" {
+            assert!(result.is_ok());
+            fs_private::write_private(
+                &self.root.join("accepted.json"),
+                &serde_json::to_vec(event).unwrap(),
+            )
+            .unwrap();
+            // Relay acceptance survives independently of the sender's missing OK.
+            std::process::exit(CRASH_EXIT);
+        }
+        result
+    }
+}
+
+#[tokio::test]
+async fn message_journey_crash_child() {
+    let Some(root) = std::env::var_os(CHILD_ROOT) else {
+        return;
+    };
+    let root = PathBuf::from(root);
+    let phase = std::env::var(CHILD_PHASE).unwrap();
+    AccountHome::open(&root).create_account("sender").unwrap();
+    let relay = Arc::new(CrashRelay {
+        inner: ScriptedPushRelayClient::default(),
+        root: root.clone(),
+        phase: phase.clone(),
+        armed: AtomicBool::new(false),
+    });
+    let app =
+        MarmotApp::with_relay(&root, "wss://journey.example").with_test_relay_client(relay.clone());
+    let mut client = app.client("sender").await.unwrap();
+    let group = client.create_group("journey", &[]).await.unwrap();
+    fs_private::write_private(&root.join("group"), group.as_slice()).unwrap();
+    relay.armed.store(true, Ordering::SeqCst);
+    let mut updates = 0;
+    client
+        .send_with_local_projection(&group, b"one interrupted send", |_| {
+            updates += 1;
+            if (phase == "projection" && updates == 1) || (phase == "response" && updates == 2) {
+                // Exit without destructors or graceful shutdown, before the send returns.
+                std::process::exit(CRASH_EXIT);
+            }
+        })
+        .await
+        .unwrap();
+    panic!("crash boundary was not reached");
+}
+
+#[tokio::test]
+async fn message_journey_crash_reopen() {
+    for phase in ["projection", "durable", "relay", "response"] {
+        let root = tempfile::tempdir().unwrap();
+        let mut child = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "tests::message_journeys::message_journey_crash_child",
+                "--nocapture",
+            ])
+            .env(CHILD_ROOT, root.path())
+            .env(CHILD_PHASE, phase)
+            .spawn()
+            .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(60);
+        let status = loop {
+            if let Some(status) = child.try_wait().unwrap() {
+                break status;
+            }
+            if Instant::now() >= deadline {
+                child.kill().unwrap();
+                child.wait().unwrap();
+                panic!("{phase}: crash child stalled");
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        };
+        assert_eq!(
+            status.code(),
+            Some(CRASH_EXIT),
+            "{phase}: child must reach the selected boundary"
+        );
+        let group = GroupId::new(std::fs::read(root.path().join("group")).unwrap());
+        let relay = Arc::new(ScriptedPushRelayClient::default());
+        let app = MarmotApp::with_relay(root.path(), "wss://journey.example")
+            .with_test_relay_client(relay.clone());
+        let mut client = app.client("sender").await.unwrap();
+        client.note_connectivity_restored().unwrap();
+        client.retry_group_convergence(&group).await.unwrap();
+        client.retry_group_convergence(&group).await.unwrap();
+        let timeline = app
+            .timeline_messages_with_query(
+                "sender",
+                TimelineMessageQuery {
+                    group_id_hex: Some(hex::encode(group.as_slice())),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            timeline.messages.len(),
+            1,
+            "{phase}: reopening must not duplicate the bubble"
+        );
+        let message = &timeline.messages[0];
+        if phase == "projection" {
+            assert!(
+                message.source_message_id_hex.is_none(),
+                "optimistic projection is not publication evidence"
+            );
+            assert!(
+                relay.published_event_ids().is_empty(),
+                "no durable send was accepted"
+            );
+        } else {
+            let attempted: NostrTransportEvent =
+                serde_json::from_slice(&std::fs::read(root.path().join("attempt.json")).unwrap())
+                    .unwrap();
+            assert_eq!(
+                message.source_message_id_hex.as_deref(),
+                Some(attempted.id.as_str()),
+                "{phase}: recover the original exact event"
+            );
+            assert!(message.invalidation_status.is_none());
+            let publishes = relay.published_event_ids();
+            assert!(publishes.iter().all(|id| id == &attempted.id));
+            assert!(
+                publishes.len() <= 1,
+                "repeated recovery must not create new publications"
+            );
+            if phase == "relay" {
+                let accepted: NostrTransportEvent = serde_json::from_slice(
+                    &std::fs::read(root.path().join("accepted.json")).unwrap(),
+                )
+                .unwrap();
+                assert_eq!(
+                    accepted.id, attempted.id,
+                    "retry after an unknown outcome must preserve relay identity"
+                );
+            }
+        }
+        drop(client);
+        app.close_storage().unwrap();
+    }
+}
+
+#[tokio::test]
+async fn message_journey_queue_cancel() {
+    let root = tempfile::tempdir().unwrap();
+    AccountHome::open(root.path())
+        .create_account("sender")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(root.path(), "wss://journey.example")
+        .with_test_relay_client(relay.clone());
+    let mut client = app.client("sender").await.unwrap();
+    let group = client.create_group("journey", &[]).await.unwrap();
+    drop(client);
+    let runtime = app.runtime();
+    runtime.reconcile_accounts().await.unwrap();
+    relay.block_next_publish();
+    let sender = runtime.clone();
+    let first_group = group.clone();
+    let first = tokio::spawn(async move {
+        sender
+            .send_message("sender", &first_group, b"first".to_vec())
+            .await
+    });
+    tokio::time::timeout(Duration::from_secs(5), relay.wait_for_blocked_publish())
+        .await
+        .unwrap();
+    let snapshot = runtime.app_performance_snapshot();
+    assert_eq!(snapshot.outbound_message_local_projection.successes, 1);
+    assert_eq!(snapshot.outbound_message_response.attempts, 0);
+    assert_eq!(
+        snapshot.host_outbound_message_visible.attempts, 0,
+        "SDK projection must not invent host rendering"
+    );
+    let second = runtime.send_message("sender", &group, b"second".to_vec());
+    let mut second = std::pin::pin!(second);
+    assert!(
+        tokio::time::timeout(Duration::from_millis(60), &mut second)
+            .await
+            .is_err()
+    );
+    assert_eq!(
+        runtime
+            .app_performance_snapshot()
+            .outbound_message_queue_wait
+            .attempts,
+        1
+    );
+    first.abort();
+    assert!(first.await.unwrap_err().is_cancelled());
+    relay.release_publish();
+    tokio::time::timeout(Duration::from_secs(5), &mut second)
+        .await
+        .unwrap()
+        .unwrap();
+    let snapshot = runtime.app_performance_snapshot();
+    assert_eq!(snapshot.outbound_message_queue_wait.attempts, 2);
+    assert!(snapshot.outbound_message_queue_wait.duration_ms.sum_ms >= 50);
+    assert_eq!(snapshot.outbound_message_local_projection.successes, 2);
+    assert_eq!(snapshot.outbound_message_local_accept.successes, 2);
+    assert_eq!(snapshot.outbound_message_publish.successes, 2);
+    assert_eq!(
+        snapshot.outbound_message_response.successes, 1,
+        "cancelled host received no response"
+    );
+    let timeline = app
+        .timeline_messages_with_query(
+            "sender",
+            TimelineMessageQuery {
+                group_id_hex: Some(hex::encode(group.as_slice())),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(timeline.messages.len(), 2);
+    assert!(
+        timeline
+            .messages
+            .iter()
+            .all(|m| m.source_message_id_hex.is_some())
+    );
+    let echo = relay
+        .published_events
+        .lock()
+        .unwrap()
+        .last()
+        .unwrap()
+        .clone();
+    let route = &echo
+        .tags
+        .iter()
+        .find(|tag| tag.first().is_some_and(|name| name == "h"))
+        .unwrap()[1];
+    // Own relay echoes are suppressed before ingestion. A fresh signed probe
+    // exercises the live-delivery measurement without inventing a peer message.
+    let inbound = epoch_gap_probe(route, crate::unix_now_seconds(), "journey-metric");
+    let received = runtime
+        .shared_services()
+        .relay_plane()
+        .handle_relay_event_for_test(NostrRelayEvent {
+            endpoint: TransportEndpoint("wss://journey.example".into()),
+            subscription_id: None,
+            event: inbound,
+        })
+        .await
+        .unwrap();
+    assert_eq!(received, 1);
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while runtime
+            .app_performance_snapshot()
+            .inbound_delivery_projection
+            .successes
+            == 0
+        {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("live ingestion must record its projection handoff");
+    assert_eq!(
+        runtime
+            .app_performance_snapshot()
+            .host_inbound_message_visible
+            .attempts,
+        0
+    );
+    runtime.shutdown_and_close().await.unwrap();
+}

--- a/crates/marmot-app/src/tests/message_journeys.rs
+++ b/crates/marmot-app/src/tests/message_journeys.rs
@@ -184,9 +184,15 @@ async fn message_journey_crash_reopen() {
             assert!(message.invalidation_status.is_none());
             let publishes = relay.published_event_ids();
             assert!(publishes.iter().all(|id| id == &attempted.id));
-            assert!(
-                publishes.len() <= 1,
-                "repeated recovery must not create new publications"
+            let expected_publishes = match phase {
+                "response" => 0,
+                "durable" | "relay" => 1,
+                _ => unreachable!(),
+            };
+            assert_eq!(
+                publishes.len(),
+                expected_publishes,
+                "{phase}: retry only unconfirmed publications, exactly once"
             );
             if phase == "relay" {
                 let accepted: NostrTransportEvent = serde_json::from_slice(

--- a/crates/marmot-c/include/marmot.h
+++ b/crates/marmot-c/include/marmot.h
@@ -703,6 +703,8 @@ typedef enum MarmotSecretStoreStatus {
 typedef enum MarmotHostPerformanceOperation {
   MARMOT_HOST_PERFORMANCE_OPERATION_SPLASH_READY,
   MARMOT_HOST_PERFORMANCE_OPERATION_FOREGROUND_LOCAL_READY,
+  MARMOT_HOST_PERFORMANCE_OPERATION_OUTBOUND_MESSAGE_VISIBLE,
+  MARMOT_HOST_PERFORMANCE_OPERATION_INBOUND_MESSAGE_VISIBLE,
 } MarmotHostPerformanceOperation;
 
 /**
@@ -3095,7 +3097,15 @@ typedef struct MarmotAppPerformanceSnapshot {
    * verdict since process start.
    */
   uint64_t sqlcipher_migration_probe_skips;
+  struct MarmotAppPerformanceOperationSnapshot inbound_delivery_projection;
   struct MarmotAppPerformanceOperationSnapshot outbound_message_send;
+  struct MarmotAppPerformanceOperationSnapshot outbound_message_queue_wait;
+  struct MarmotAppPerformanceOperationSnapshot outbound_message_local_projection;
+  struct MarmotAppPerformanceOperationSnapshot outbound_message_local_accept;
+  struct MarmotAppPerformanceOperationSnapshot outbound_message_publish;
+  struct MarmotAppPerformanceOperationSnapshot outbound_message_response;
+  struct MarmotAppPerformanceOperationSnapshot host_outbound_message_visible;
+  struct MarmotAppPerformanceOperationSnapshot host_inbound_message_visible;
   struct MarmotAppPerformanceOperationSnapshot group_create_queue_wait;
   struct MarmotAppPerformanceOperationSnapshot group_create_key_package_lookup;
   struct MarmotAppPerformanceOperationSnapshot group_member_key_package_prewarm;

--- a/crates/marmot-c/include/marmot.h
+++ b/crates/marmot-c/include/marmot.h
@@ -6710,6 +6710,19 @@ MarmotStatus marmot_record_product_event(const struct MarmotClient *client,
                                          enum MarmotProductRecordResult *out);
 
 /**
+ * Record an app-defined timing through the consent-gated product exporter.
+ * Register `name` with `elapsed: DurationBucket` and `outcome: Enum` choices
+ * `success`/`failure`. Milliseconds are bucketed before recording.
+ * # Safety
+ * Client and borrowed name must be valid; out must be writable.
+ */
+MarmotStatus marmot_record_host_timing(const struct MarmotClient *client,
+                                       const char *name,
+                                       uint64_t duration_ms,
+                                       uint32_t outcome,
+                                       enum MarmotProductRecordResult *out);
+
+/**
  * Signal host activity. Discriminants are validated before conversion.
  * # Safety
  * Client must be a live handle.

--- a/crates/marmot-c/src/commands.rs
+++ b/crates/marmot-c/src/commands.rs
@@ -2591,6 +2591,38 @@ pub unsafe extern "C" fn marmot_record_product_event(
     })
 }
 
+/// Record an app-defined timing through the consent-gated product exporter.
+/// Register `name` with `elapsed: DurationBucket` and `outcome: Enum` choices
+/// `success`/`failure`. Milliseconds are bucketed before recording.
+/// # Safety
+/// Client and borrowed name must be valid; out must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn marmot_record_host_timing(
+    client: *const MarmotClient,
+    name: *const c_char,
+    duration_ms: u64,
+    outcome: u32,
+    out: *mut MarmotProductRecordResult,
+) -> MarmotStatus {
+    ffi_guard(|| {
+        try_arg!(unsafe { crate::check_out(out) });
+        unsafe {
+            *out = MarmotProductRecordResult::IgnoredDisabled;
+        }
+        let client = try_arg!(unsafe { client_ref(client) });
+        let name = try_arg!(unsafe { required_str(name) });
+        let outcome = try_arg!(MarmotHostPerformanceOutcome::from_c(outcome));
+        unsafe {
+            deliver_enum(
+                client
+                    .marmot
+                    .record_host_timing(name, duration_ms, outcome.into()),
+                out,
+            )
+        }
+    })
+}
+
 /// Signal host activity. Discriminants are validated before conversion.
 /// # Safety
 /// Client must be a live handle.

--- a/crates/marmot-c/src/types/telemetry.rs
+++ b/crates/marmot-c/src/types/telemetry.rs
@@ -15,12 +15,16 @@ c_enum! {
     MarmotHostPerformanceOperation from HostPerformanceOperationFfi {
         SplashReady,
         ForegroundLocalReady,
+        OutboundMessageVisible,
+        InboundMessageVisible,
     }
 }
 
 impl From<MarmotHostPerformanceOperation> for HostPerformanceOperationFfi {
     fn from(value: MarmotHostPerformanceOperation) -> Self {
         match value {
+            MarmotHostPerformanceOperation::OutboundMessageVisible => Self::OutboundMessageVisible,
+            MarmotHostPerformanceOperation::InboundMessageVisible => Self::InboundMessageVisible,
             MarmotHostPerformanceOperation::SplashReady => Self::SplashReady,
             MarmotHostPerformanceOperation::ForegroundLocalReady => Self::ForegroundLocalReady,
         }
@@ -109,7 +113,16 @@ c_mirror! {
         /// Existing-database opens that skipped the probe via a cached
         /// verdict since process start.
         copy sqlcipher_migration_probe_skips: u64,
+        rec inbound_delivery_projection: MarmotAppPerformanceOperationSnapshot,
         rec outbound_message_send: MarmotAppPerformanceOperationSnapshot,
+        rec outbound_message_queue_wait: MarmotAppPerformanceOperationSnapshot,
+        rec outbound_message_local_projection: MarmotAppPerformanceOperationSnapshot,
+        rec outbound_message_local_accept: MarmotAppPerformanceOperationSnapshot,
+        rec outbound_message_publish: MarmotAppPerformanceOperationSnapshot,
+        rec outbound_message_response: MarmotAppPerformanceOperationSnapshot,
+        rec host_outbound_message_visible: MarmotAppPerformanceOperationSnapshot,
+        rec host_inbound_message_visible: MarmotAppPerformanceOperationSnapshot,
+
         rec group_create_queue_wait: MarmotAppPerformanceOperationSnapshot,
         rec group_create_key_package_lookup: MarmotAppPerformanceOperationSnapshot,
         rec group_member_key_package_prewarm: MarmotAppPerformanceOperationSnapshot,

--- a/crates/marmot-uniffi/src/commands/telemetry.rs
+++ b/crates/marmot-uniffi/src/commands/telemetry.rs
@@ -2,13 +2,30 @@
 
 use std::time::Duration;
 
-use crate::Marmot;
 use crate::conversions::{
     AppPerformanceSnapshotFfi, HostPerformanceOperationFfi, HostPerformanceOutcomeFfi,
+    ProductRecordResultFfi,
 };
+use crate::{Marmot, MarmotKitError};
 
 #[uniffi::export]
 impl Marmot {
+    /// Record an app-defined timing in the consent-gated product event pipeline.
+    /// Register `name` with `elapsed: DurationBucket` and `outcome: Enum` choices
+    /// `success`/`failure` in the product analytics config. Milliseconds are
+    /// bucketed before recording; this does not add an OTLP performance metric.
+    pub fn record_host_timing(
+        &self,
+        name: String,
+        duration_ms: u64,
+        outcome: HostPerformanceOutcomeFfi,
+    ) -> Result<ProductRecordResultFfi, MarmotKitError> {
+        Ok(self
+            .runtime
+            .record_host_timing(name, Duration::from_millis(duration_ms), outcome.into())?
+            .into())
+    }
+
     /// Record one approved host-app milestone.
     ///
     /// The operation is a closed enum and the exported metrics carry no
@@ -62,6 +79,16 @@ mod tests {
                     );
                     let runtime = app.runtime();
                     let kit = Marmot { app, runtime };
+
+                    assert_eq!(
+                        kit.record_host_timing(
+                            "app_inbox_layout".into(),
+                            250,
+                            HostPerformanceOutcomeFfi::Success,
+                        )
+                        .unwrap(),
+                        ProductRecordResultFfi::IgnoredDisabled,
+                    );
 
                     kit.record_host_performance(
                         HostPerformanceOperationFfi::SplashReady,

--- a/crates/marmot-uniffi/src/conversions/telemetry.rs
+++ b/crates/marmot-uniffi/src/conversions/telemetry.rs
@@ -4,6 +4,8 @@
 pub enum HostPerformanceOperationFfi {
     SplashReady,
     ForegroundLocalReady,
+    OutboundMessageVisible,
+    InboundMessageVisible,
 }
 
 /// One fixed-bucket duration histogram bucket.
@@ -107,7 +109,16 @@ pub struct AppPerformanceSnapshotFfi {
     /// Existing-database opens that skipped the recovery probe via a cached
     /// verdict since process start.
     pub sqlcipher_migration_probe_skips: u64,
+    pub inbound_delivery_projection: AppPerformanceOperationSnapshotFfi,
     pub outbound_message_send: AppPerformanceOperationSnapshotFfi,
+    pub outbound_message_queue_wait: AppPerformanceOperationSnapshotFfi,
+    pub outbound_message_local_projection: AppPerformanceOperationSnapshotFfi,
+    pub outbound_message_local_accept: AppPerformanceOperationSnapshotFfi,
+    pub outbound_message_publish: AppPerformanceOperationSnapshotFfi,
+    pub outbound_message_response: AppPerformanceOperationSnapshotFfi,
+    pub host_outbound_message_visible: AppPerformanceOperationSnapshotFfi,
+    pub host_inbound_message_visible: AppPerformanceOperationSnapshotFfi,
+
     pub group_create_queue_wait: AppPerformanceOperationSnapshotFfi,
     pub group_create_key_package_lookup: AppPerformanceOperationSnapshotFfi,
     pub group_member_key_package_prewarm: AppPerformanceOperationSnapshotFfi,
@@ -189,7 +200,16 @@ impl From<marmot_app::AppPerformanceSnapshot> for AppPerformanceSnapshotFfi {
             account_setup_network_ready,
             sqlcipher_migration_probe_runs,
             sqlcipher_migration_probe_skips,
+            inbound_delivery_projection,
             outbound_message_send,
+            outbound_message_queue_wait,
+            outbound_message_local_projection,
+            outbound_message_local_accept,
+            outbound_message_publish,
+            outbound_message_response,
+            host_outbound_message_visible,
+            host_inbound_message_visible,
+
             group_create_queue_wait,
             group_create_key_package_lookup,
             group_member_key_package_prewarm,
@@ -265,7 +285,16 @@ impl From<marmot_app::AppPerformanceSnapshot> for AppPerformanceSnapshotFfi {
             account_setup_network_ready: account_setup_network_ready.into(),
             sqlcipher_migration_probe_runs,
             sqlcipher_migration_probe_skips,
+            inbound_delivery_projection: inbound_delivery_projection.into(),
             outbound_message_send: outbound_message_send.into(),
+            outbound_message_queue_wait: outbound_message_queue_wait.into(),
+            outbound_message_local_projection: outbound_message_local_projection.into(),
+            outbound_message_local_accept: outbound_message_local_accept.into(),
+            outbound_message_publish: outbound_message_publish.into(),
+            outbound_message_response: outbound_message_response.into(),
+            host_outbound_message_visible: host_outbound_message_visible.into(),
+            host_inbound_message_visible: host_inbound_message_visible.into(),
+
             group_create_queue_wait: group_create_queue_wait.into(),
             group_create_key_package_lookup: group_create_key_package_lookup.into(),
             group_member_key_package_prewarm: group_member_key_package_prewarm.into(),
@@ -320,6 +349,8 @@ impl From<marmot_app::AppPerformanceSnapshot> for AppPerformanceSnapshotFfi {
 impl From<HostPerformanceOperationFfi> for marmot_app::HostPerformanceOperation {
     fn from(value: HostPerformanceOperationFfi) -> Self {
         match value {
+            HostPerformanceOperationFfi::OutboundMessageVisible => Self::OutboundMessageVisible,
+            HostPerformanceOperationFfi::InboundMessageVisible => Self::InboundMessageVisible,
             HostPerformanceOperationFfi::SplashReady => Self::SplashReady,
             HostPerformanceOperationFfi::ForegroundLocalReady => Self::ForegroundLocalReady,
         }
@@ -346,6 +377,27 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
+
+    #[test]
+    fn message_journey_host_metrics() {
+        let telemetry = marmot_app::AppPerformanceTelemetry::default();
+        for operation in [
+            HostPerformanceOperationFfi::OutboundMessageVisible,
+            HostPerformanceOperationFfi::InboundMessageVisible,
+        ] {
+            telemetry.record_host_performance(
+                operation.into(),
+                Duration::from_millis(75),
+                marmot_app::HostPerformanceOutcome::Success,
+            );
+        }
+        let snapshot: AppPerformanceSnapshotFfi = telemetry.snapshot().into();
+        assert_eq!(
+            snapshot.host_outbound_message_visible.duration_ms.sum_ms,
+            75
+        );
+        assert_eq!(snapshot.host_inbound_message_visible.successes, 1);
+    }
 
     #[test]
     fn app_performance_snapshot_ffi_mirrors_counts_and_histogram_buckets() {

--- a/docs/marmot-architecture/telemetry.md
+++ b/docs/marmot-architecture/telemetry.md
@@ -296,8 +296,10 @@ These are correctness gates, not device benchmarks. Compare histogram distributi
 sum phase percentiles or treat SDK projection and host render timings as a single end-to-end sample. Counters and
 histograms are process-local, with no per-message correlation identifiers or persisted timing journal.
 
-Host applications can only select the closed `HostPerformanceOperation` enum; callers cannot supply metric names,
-label names, or label values. Adding a new cross-platform operation requires an MDK API change and review.
+OTLP host milestones use the closed `HostPerformanceOperation` enum without caller-supplied metric names or labels.
+For app-specific measurements such as inbox layout, image decoding, or navigation, use `record_host_timing` with a
+registered product event name. This consent-gated path sends duration buckets and outcomes to Aptabase; it does not
+add OTLP series or local app-performance snapshot fields. See the [registration example](usage-diagnostics.md#custom-host-timings).
 
 The `app_account_sync_failures` and `app_account_catch_up_failures` counters are the only app-performance metrics with
 metric attributes. Every failed attempt emits exactly one point in a bounded classification bucket:

--- a/docs/marmot-architecture/telemetry.md
+++ b/docs/marmot-architecture/telemetry.md
@@ -1,7 +1,7 @@
 ---
 title: "Telemetry, Logging, and Tracing Inventory"
 created: 2026-06-10
-updated: 2026-09-07
+updated: 2026-09-08
 tags: [marmot, architecture, telemetry, logging, tracing, privacy]
 status: current
 ---
@@ -232,6 +232,14 @@ Collected operations:
 | `account_setup_local_ready_handoff` | Complete generated-account caller latency through local worker readiness. | The host may render local state but must not claim invite readiness. |
 | `account_setup_network_ready` | Background work from local-ready scheduling through bootstrap and KeyPackage confirmation plus journal completion. | Success is the invite-receivable boundary. |
 | `outbound_message_send` | Worker `SendMessage` and `SendAppEvent` commands until their send call returns a `SendSummary` or error. | One-sided local send/publish confirmation only. It is not end-to-end remote delivery or read latency. |
+| `outbound_message_queue_wait` | Send API entry until the worker starts `SendMessage` / `SendAppEvent`. | Includes worker lookup, channel admission, and FIFO wait. Only commands actually started contribute samples. |
+| `outbound_message_local_projection` | Same API origin until the first persisted local projection is about to be broadcast. | One sample per command with a local projection. This is optimistic state, not durable outbox acceptance or host rendering. |
+| `outbound_message_local_accept` | Sum of session send/queue preparation and application fanout journal preparation, ending at durable fanout writes before relay I/O. | Local work only, including sibling app-message preparation in the same effects batch; not elapsed time from the UI action. Journal preparation also belongs to the wider `outbound_message_publish` envelope. Recorded when the account returns effects, including unknown publication outcomes; no sample if that call errors or the process exits first. |
+| `outbound_message_publish` | Account publication and reconciliation of the send's effects batch. | Includes transport journal preparation, possible sibling publications, retries and acknowledgement processing. Success requires publication evidence for this exact app event; accepted-pending and completion-unknown count as unsuccessful publication, even when the command succeeds. Not a raw relay-OK timestamp or recipient delivery. |
+| `outbound_message_response` | Send API entry until the caller consumes the worker result. | Includes queue wait and post-publication work. A cancelled caller contributes no completed-response sample; accepted work may still finish. Admission errors before enqueue are excluded. |
+| `inbound_delivery_projection` | Worker claims a live relay delivery through ingestion, incidental publication, and projection broadcast. | Includes non-chat deliveries that reach ingestion and failures. Excludes known receipts skipped before ingestion, transport queue residence, startup/catch-up batches, and host rendering. |
+| `host_outbound_message_visible` | Host measures user send action through first rendered local bubble. | Report `OutboundMessageVisible` through the existing host-performance API; never infer it from SDK completion. |
+| `host_inbound_message_visible` | Host receives a message update through its first rendered frame. | Report `InboundMessageVisible`. This measures host rendering delay, not sender-to-recipient latency. |
 | `group_create_key_package_lookup` | Total create-time member KeyPackage lookup from canonicalization through validated result collection. | Preserved aggregate dimension; includes either cache-only reuse or create-time relay resolution below. |
 | `group_member_key_package_prewarm` | Host/runtime composition prewarm for the current member set. | Aggregate duration only. No member count label, account/relay identity, reservation, or package consumption. |
 | `group_create_key_package_cache_reuse` | Successful create-time lookup when every canonical member was satisfied by revalidated local/directory state. | Closed operation name, not a caller-supplied label. A prewarm should shift the later Create wait into this bucket. |
@@ -276,6 +284,18 @@ latencies do not immediately fall into overflow:
 
 These app-performance samples deliberately do not include account labels, account ids, group ids, member refs, message
 ids, relay URLs, media URLs, payload sizes, content types, upload endpoints, download endpoints, or error strings.
+Message journey checks run with `just test-message-journeys` and also participate in the ordinary workspace test matrix.
+The subprocess checks exit without destructors after optimistic projection, durable fanout preparation, relay acceptance
+before its acknowledgement returns, and final projection before the send response. Reopening must preserve one timeline
+row and retry the exact transport event where acceptance was durable. A projection-only interruption has no accepted
+outbox entry: its row remains unconfirmed and is not automatically published. This gate prevents false success; it does
+not claim that orphaned optimistic rows already have automatic recovery. Additional checks cover caller cancellation,
+queue wait behind a stalled relay, unknown-outcome reconnect retries, and authoritative timeline refresh after overflow.
+
+These are correctness gates, not device benchmarks. Compare histogram distributions on representative devices; do not
+sum phase percentiles or treat SDK projection and host render timings as a single end-to-end sample. Counters and
+histograms are process-local, with no per-message correlation identifiers or persisted timing journal.
+
 Host applications can only select the closed `HostPerformanceOperation` enum; callers cannot supply metric names,
 label names, or label values. Adding a new cross-platform operation requires an MDK API change and review.
 

--- a/docs/marmot-architecture/usage-diagnostics.md
+++ b/docs/marmot-architecture/usage-diagnostics.md
@@ -122,8 +122,9 @@ UTC quarter-hour windows get fresh UUIDs. First/background/shutdown windows may 
 partial. Counts use `1`, `2`, `3_5`, `6_10`, `11_20`, `21_50`, `51_100`, `101_250`,
 `251_1000`, and `1001_plus`. Zero is reserved for backlog/coverage, not empty
 activity. Product duration upper bounds are inclusive: 10/25/50/100/250/500 ms;
-1/2/5/10/30 seconds; 1/5/15/60 minutes; overflow. Product and OTLP receive separate
-histograms from the same durations. Product sends neither raw durations nor sums.
+1/2/5/10/30 seconds; 1/5/15/60 minutes; overflow. Built-in operations feed product
+and OTLP separately from the same durations. Custom host events feed product only.
+Product sends neither raw durations nor sums.
 
 OTLP lifetime counters stay local. Each export collection period subtracts a
 counter/histogram baseline, retains cumulative temporality with the period's
@@ -137,6 +138,50 @@ nonacceptance permits bounded retries; ambiguous post-send failures are dropped.
 Authentication/configuration rejection suspends the affected exporter. Both
 exporters validate every resolved address, pin it, preserve configured-host TLS
 trust, disable redirects/proxies, and bound DNS/connect/request time.
+
+## Custom host timings
+
+Register app-specific stages before requesting consent, then call
+`record_host_timing(name, duration, outcome)` with a monotonic elapsed duration.
+For example, add this schema to `ProductAnalyticsRuntimeConfig.registry`:
+
+```rust
+ProductEventSchema {
+    name: "app_inbox_layout".into(),
+    mode: ProductEventMode::Aggregate,
+    properties: vec![
+        ProductPropertySchema {
+            name: "elapsed".into(),
+            rule: ProductPropertyRule::DurationBucket,
+        },
+        ProductPropertySchema {
+            name: "outcome".into(),
+            rule: ProductPropertyRule::Enum(vec!["success".into(), "failure".into()]),
+        },
+    ],
+}
+```
+
+Measure each stage with the host's monotonic clock. Rust accepts `Duration`;
+Swift/Kotlin and `marmot_record_host_timing` accept unsigned milliseconds plus
+`HostPerformanceOutcome` (`Success`/`Failure`). For example, Swift calls
+`try marmot.recordHostTiming(name: "app_inbox_layout", durationMs: 250, outcome: .success)`.
+Use static stage names such as `app_inbox_layout` or `app_attachment_decode`,
+never names derived from messages, accounts, files, or user input. Existing app
+metadata and separate operator app keys distinguish app versions and surfaces.
+
+The helper records exactly `elapsed` and `outcome`, validating the registered
+schema through `record_product_event`. Aggregate mode counts matching stage,
+duration bucket, and outcome combinations per window; Journey mode records each
+foreground observation. Disabled/unconfigured collection returns the existing
+ignored result; unregistered names or incompatible schemas return an error while
+collection is enabled. Consent revocation clears pending events. Extra registered
+dimensions can use `record_product_event` directly with a duration bucket value.
+
+These events reach Aptabase under their registered names and do not enter OTLP
+or `app_performance_snapshot`. Compare `elapsed` buckets by stage, outcome, app
+version, and OS; a 250 ms sample is `le_250ms`, and 251 ms is `le_500ms`. They do not
+provide exact percentiles, raw durations, or per-message trace correlation.
 
 ## Operator reports
 


### PR DESCRIPTION
Send timing currently starts after dequeue, hiding time spent behind account work. Add aggregate timings for queue wait, local projection, local acceptance and durable fanout preparation, publication, response, and live inbound processing. Host applications can report actual render milestones through Rust, UniFFI, and C; the same metrics reach the existing opt-in OTLP export.

Apps can also report their own stages with `record_host_timing(name, duration, outcome)` through Rust, Swift/Kotlin, and C. Reuse the existing product event registry and consent controls to send registered stage names, duration buckets, and success/failure outcomes to Aptabase. These custom events do not add OTLP series or raw-duration traces. Include a registration example for app-specific layout and decoding measurements.

Add `just test-message-journeys` to check abrupt process exits at four send boundaries, caller cancellation, exact-event retry after unknown outcomes and reconnects, and timeline recovery after subscription overflow. The checks assert recovery without duplicate visible messages or false publication success.

A crash between optimistic projection and durable acceptance still leaves an unconfirmed row without automatic retry. The test and telemetry documentation explicitly preserve that distinction; recovery behavior is unchanged.
