### PR TITLE
Expose complete presented chat-list APIs (P3)

### DIFF
--- a/crates/cgka-conformance-simulator/src/app_runtime.rs
+++ b/crates/cgka-conformance-simulator/src/app_runtime.rs
@@ -1900,6 +1900,7 @@ fn app_error_kind(error: &AppError) -> &'static str {
         AppError::AccountSessionBusy => "account_session_busy",
         AppError::AccountWorkerBusy => "account_worker_busy",
         AppError::AccountWorkerResponseTimedOut => "account_worker_response_timed_out",
+        AppError::ChatPresentationNotReady => "chat_presentation_not_ready",
         AppError::DirectConversationIndexNotReady => "direct_conversation_index_not_ready",
         AppError::RuntimeBusy => "runtime_busy",
         AppError::RuntimeStopping => "runtime_stopping",
@@ -1927,6 +1928,7 @@ fn record_failure(participant: &mut Participant, error: &AppError) {
             | AppError::AccountWorkerBusy
             | AppError::RuntimeBusy
             | AppError::TransportClosed
+            | AppError::ChatPresentationNotReady
             | AppError::DirectConversationIndexNotReady
     ) {
         participant.retryable_failures = participant.retryable_failures.saturating_add(1);
@@ -1951,6 +1953,7 @@ fn app_error(error: AppError) -> SubjectError {
         | AppError::AccountSessionBusy
         | AppError::AccountWorkerBusy
         | AppError::AccountWorkerResponseTimedOut
+        | AppError::ChatPresentationNotReady
         | AppError::DirectConversationIndexNotReady
         | AppError::RuntimeStopping
         | AppError::TransportClosed
@@ -2212,6 +2215,7 @@ mod tests {
         for failure in [
             AppError::RuntimeBusy,
             AppError::AccountWorkerResponseTimedOut,
+            AppError::ChatPresentationNotReady,
         ] {
             let resource = app_error(failure);
             assert_eq!(resource.category, SubjectFailureCategory::Resource);

--- a/crates/cgka-conformance-simulator/src/node_protocol.rs
+++ b/crates/cgka-conformance-simulator/src/node_protocol.rs
@@ -1101,6 +1101,7 @@ fn is_retryable_app_error(error: &AppError) -> bool {
             | AppError::TransportClosed
             | AppError::AccountCatchUp(_)
             | AppError::DirectConversationIndexNotReady
+            | AppError::ChatPresentationNotReady
     )
 }
 

--- a/crates/marmot-app/src/chat_presentation/maintenance.rs
+++ b/crates/marmot-app/src/chat_presentation/maintenance.rs
@@ -7,6 +7,22 @@ use storage_sqlite::{
     StoredChatPresentation,
 };
 
+/// One local preparation batch shared by the account worker and offline first reads.
+/// Storage CAS checks make overlapping callers safe; `false` alone does not establish
+/// readiness because another caller may have committed the work in the meantime.
+pub(crate) fn prepare_batch(
+    account: &SqliteAccountStorage,
+    shared: &SqliteSharedStorage,
+    local: &str,
+) -> Result<bool, AppError> {
+    let classifier = crate::MarmotApp::chat_list_mention_classifier(local);
+    let mut initialized = false;
+    for group in account.pending_chat_presentation_rows()? {
+        initialized |= account.initialize_chat_presentation_row(local, &group, &classifier)?;
+    }
+    Ok(maintain(account, shared, local)? || initialized)
+}
+
 fn prepare(
     shared: &SqliteSharedStorage,
     local: &str,

--- a/crates/marmot-app/src/chat_presentation/signals.rs
+++ b/crates/marmot-app/src/chat_presentation/signals.rs
@@ -2,8 +2,6 @@
 use storage_sqlite::ChatPresentationVersion;
 use tokio::sync::{broadcast, watch};
 
-// P3 consumes the fields; P2 publishes and tests the handoff.
-#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Clone)]
 pub(crate) struct PresentationInvalidation {
     pub(crate) account_label: String,

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -1133,6 +1133,7 @@ fn read_marker_error_code(error: &AppError) -> &'static str {
         AppError::InvalidGroupMembershipPage(_) => {
             "read_marker_failed:invalid_group_membership_page"
         }
+        AppError::ChatPresentationNotReady => "read_marker_failed:chat_presentation_not_ready",
         AppError::DirectConversationIndexNotReady => {
             "read_marker_failed:direct_conversation_index_not_ready"
         }

--- a/crates/marmot-app/src/error.rs
+++ b/crates/marmot-app/src/error.rs
@@ -79,6 +79,8 @@ pub enum AppError {
     /// account hydration/reconciliation completes; do not treat this as a miss.
     #[error("direct conversation index is not ready; retry after account hydration")]
     DirectConversationIndexNotReady,
+    #[error("chat presentation preparation is incomplete; retry after local maintenance")]
+    ChatPresentationNotReady,
     #[error("invalid cached identity page: {0}")]
     InvalidCachedIdentityPage(String),
     #[error("invalid chat pin: {0}")]
@@ -275,6 +277,7 @@ impl AppError {
             Self::GroupInviteNotPending => "group_invite_not_pending",
             Self::CreatedGroupProjectionUnavailable(_) => "created_group_projection_unavailable",
             Self::InvalidGroupMembershipPage(_) => "invalid_group_membership_page",
+            Self::ChatPresentationNotReady => "chat_presentation_not_ready",
             Self::DirectConversationIndexNotReady => "direct_conversation_index_not_ready",
             Self::InvalidCachedIdentityPage(_) => "invalid_cached_identity_page",
             Self::InvalidChatPin(_) => "invalid_chat_pin",

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -135,9 +135,12 @@ pub use runtime::{
     SignOutOutcome, StreamStartView, TimelineWindowHandle, WipeOutcome,
     default_directory_discovery_relays,
 };
+pub use runtime::{PresentedChatListUpdate, RuntimePresentedChatListSubscription};
 pub(crate) use sqlcipher::{SqlcipherDatabaseKind, remove_sqlite_file_set};
 pub use storage_sqlite::{
-    ChatPinState, TimelineMessageChange, TimelineRemoveReason, TimelineUpdateTrigger,
+    ChatPinState, ChatPresentationVersion, ConversationPresentation, PresentationResolution,
+    PresentationSource, PresentationText, PresentedChatListSnapshot, PresentedChatRow,
+    SelectedAvatar, TimelineMessageChange, TimelineRemoveReason, TimelineUpdateTrigger,
 };
 
 pub use agent_streams::{

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -64,7 +64,9 @@ mod commands;
 mod event_routing;
 mod onboarding;
 mod presentation;
+mod presented_chat_list;
 pub use onboarding::*;
+pub use presented_chat_list::{PresentedChatListUpdate, RuntimePresentedChatListSubscription};
 mod subscriptions;
 
 // Re-export the public surface so `crate::runtime::Item` and the

--- a/crates/marmot-app/src/runtime/presentation.rs
+++ b/crates/marmot-app/src/runtime/presentation.rs
@@ -11,20 +11,8 @@ impl PresentationMaintenance {
         let app = &client.app;
         let storage = app.account_storage(&client.state.label)?;
         let shared = app.shared_storage()?;
-        let result = (|| {
-            // Initialize queued legacy rows through their existing owner. Only
-            // durable completion counts as progress; a row may already exist.
-            let missing = storage.pending_chat_presentation_rows()?;
-            let classifier = crate::MarmotApp::chat_list_mention_classifier(account_id);
-            let mut initialized = false;
-            for group in &missing {
-                initialized |=
-                    storage.initialize_chat_presentation_row(account_id, group, &classifier)?;
-            }
-            let more =
-                crate::chat_presentation::maintenance::maintain(&storage, &shared, account_id)?;
-            Ok(more || initialized)
-        })();
+        let result =
+            crate::chat_presentation::maintenance::prepare_batch(&storage, &shared, account_id);
         // Inspect committed state even after a failed later step. A fresh worker always compares,
         // so interruption between a row commit and this send recovers without another message.
         let version = storage.chat_presentation_version()?;

--- a/crates/marmot-app/src/runtime/presented_chat_list.rs
+++ b/crates/marmot-app/src/runtime/presented_chat_list.rs
@@ -1,0 +1,384 @@
+//! Complete selected chat rows, with the existing chat-list event routes as invalidations.
+use super::{
+    MarmotAppRuntime, RuntimeChatListSubscription, blocking_app_task, wait_for_runtime_shutdown,
+};
+use crate::chat_presentation::signals::PresentationInvalidation;
+use crate::{AppError, MarmotApp, PresentedChatListSnapshot, PresentedChatRow};
+use storage_sqlite::ChatListQuery;
+use tokio::sync::{broadcast, watch};
+
+/// A complete replacement. Sequence orders all row changes, even at equal presentation revisions.
+#[derive(Clone, PartialEq, Eq)]
+pub struct PresentedChatListUpdate {
+    pub subscription_generation: String,
+    pub sequence: u64,
+    pub snapshot: PresentedChatListSnapshot,
+}
+impl std::fmt::Debug for PresentedChatListUpdate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PresentedChatListUpdate")
+            .field("sequence", &self.sequence)
+            .field("snapshot", &self.snapshot)
+            .finish_non_exhaustive()
+    }
+}
+
+/// The initial snapshot and an already attached subscription. Drop to cancel.
+/// Each handle is bound to one account; open a new handle when switching accounts.
+pub struct RuntimePresentedChatListSubscription {
+    pub snapshot: PresentedChatListSnapshot,
+    pub subscription_generation: String,
+    app: MarmotApp,
+    account_label: String,
+    account_id: String,
+    include_archived: bool,
+    legacy: RuntimeChatListSubscription,
+    presentation: broadcast::Receiver<PresentationInvalidation>,
+    stopping: watch::Receiver<bool>,
+    current: PresentedChatListSnapshot,
+    sequence: u64,
+    dirty: bool,
+}
+impl RuntimePresentedChatListSubscription {
+    /// Cancellation and read errors retain the refresh obligation for the next call.
+    pub async fn recv(&mut self) -> Result<Option<PresentedChatListUpdate>, AppError> {
+        loop {
+            if self.dirty {
+                let snapshot = tokio::select! {
+                    biased;
+                    _ = wait_for_runtime_shutdown(&mut self.stopping) => return Ok(None),
+                    result = prepared_snapshot(self.app.clone(), self.account_label.clone(), self.account_id.clone(), self.include_archived, None) => result?,
+                };
+                if snapshot.presentation_version.store_epoch
+                    != self.current.presentation_version.store_epoch
+                {
+                    return Ok(None);
+                }
+                self.dirty = false;
+                if snapshot != self.current {
+                    self.current = snapshot.clone();
+                    self.sequence = self
+                        .sequence
+                        .checked_add(1)
+                        .expect("subscription sequence exhausted");
+                    return Ok(Some(PresentedChatListUpdate {
+                        subscription_generation: self.subscription_generation.clone(),
+                        sequence: self.sequence,
+                        snapshot,
+                    }));
+                }
+            }
+            tokio::select! {
+                biased;
+                _ = wait_for_runtime_shutdown(&mut self.stopping) => return Ok(None),
+                update = self.legacy.recv() => {
+                    if update.is_none() { return Ok(None); }
+                    self.dirty = true;
+                }
+                update = self.presentation.recv() => match update {
+                    Ok(update) => {
+                        if update.account_label == self.account_label && update.version != self.current.presentation_version { self.dirty = true; }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(_)) => self.dirty = true,
+                    Err(broadcast::error::RecvError::Closed) => return Ok(None),
+                }
+            }
+        }
+    }
+}
+
+impl MarmotAppRuntime {
+    /// Local complete rows. First use can asynchronously prepare missing selected values;
+    /// ready reads perform no repair writes or network work.
+    pub async fn presented_chat_list(
+        &self,
+        account_ref: &str,
+        include_archived: bool,
+    ) -> Result<PresentedChatListSnapshot, AppError> {
+        self.shared.lifecycle().ensure_running()?;
+        let account = self.accounts.resolve(account_ref)?;
+        let mut stopping = self.shared.lifecycle().subscribe_shutdown();
+        tokio::select! {
+            biased;
+            _ = wait_for_runtime_shutdown(&mut stopping) => Err(AppError::RuntimeStopping),
+            result = prepared_snapshot(self.accounts.app.clone(), account.label, account.account_id_hex, include_archived, None) => result,
+        }
+    }
+
+    /// The same selected contract for creation/rebind paths; no full list is returned.
+    pub async fn presented_chat_list_row(
+        &self,
+        account_ref: &str,
+        group_id_hex: &str,
+    ) -> Result<Option<PresentedChatRow>, AppError> {
+        self.shared.lifecycle().ensure_running()?;
+        let group = crate::ids::normalize_group_id_hex_app(group_id_hex)?;
+        let account = self.accounts.resolve(account_ref)?;
+        let mut stopping = self.shared.lifecycle().subscribe_shutdown();
+        let snapshot = tokio::select! {
+            biased;
+            _ = wait_for_runtime_shutdown(&mut stopping) => return Err(AppError::RuntimeStopping),
+            result = prepared_snapshot(self.accounts.app.clone(), account.label, account.account_id_hex, true, Some(group)) => result?,
+        };
+        Ok(snapshot.rows.into_iter().next())
+    }
+
+    /// Attach both invalidation sources before reading; queued changes reconcile against fresh
+    /// local state, including lag recovery. The old row stream preserves mute expiry and all
+    /// non-presentation event routes but its payload is never used as selected display.
+    pub async fn open_presented_chat_list(
+        &self,
+        account_ref: &str,
+        include_archived: bool,
+    ) -> Result<RuntimePresentedChatListSubscription, AppError> {
+        self.shared.lifecycle().ensure_running()?;
+        let account = self.accounts.resolve(account_ref)?;
+        let presentation = self.accounts.app.presentation_signals.updates.subscribe();
+        let mut legacy = self
+            .subscribe_chat_list(&account.label, include_archived)
+            .await?;
+        let mut stopping = self.shared.lifecycle().subscribe_shutdown();
+        let snapshot = tokio::select! {
+            biased;
+            _ = wait_for_runtime_shutdown(&mut stopping) => return Err(AppError::RuntimeStopping),
+            result = prepared_snapshot(self.accounts.app.clone(), account.label.clone(), account.account_id_hex.clone(), include_archived, None) => result?,
+        };
+        // Only invalidations are consumed from the legacy handle.
+        legacy.snapshot.clear();
+        Ok(RuntimePresentedChatListSubscription {
+            current: snapshot.clone(),
+            snapshot,
+            subscription_generation: hex::encode(rand::random::<[u8; 16]>()),
+            app: self.accounts.app.clone(),
+            account_label: account.label,
+            account_id: account.account_id_hex,
+            include_archived,
+            legacy,
+            presentation,
+            stopping: self.shared.lifecycle().subscribe_shutdown(),
+            sequence: 0,
+            dirty: false,
+        })
+    }
+}
+
+async fn prepared_snapshot(
+    app: MarmotApp,
+    label: String,
+    account_id: String,
+    include_archived: bool,
+    group: Option<String>,
+) -> Result<PresentedChatListSnapshot, AppError> {
+    loop {
+        let app = app.clone();
+        let label = label.clone();
+        let account_id = account_id.clone();
+        let group = group.clone();
+        let (snapshot, progressed) = blocking_app_task(move || {
+            let account = app.account_home().account(&label)?;
+            if account.account_id_hex != account_id {
+                return Err(marmot_account::AccountHomeError::AccountIdMismatch.into());
+            }
+            app.ensure_account_state(&label)?;
+            let storage = app.account_storage(&label)?;
+            if let Some(mut snapshot) = storage
+                .read_presented_chat_list(ChatListQuery { include_archived }, group.as_deref())?
+            {
+                // Sender-preview enrichment uses the shared cache after releasing the account
+                // transaction. Revalidate selected identity before publishing that enrichment.
+                let mut rows = snapshot
+                    .rows
+                    .iter()
+                    .map(|r| r.row.clone())
+                    .collect::<Vec<_>>();
+                app.hydrate_chat_list_rows(&mut rows)?;
+                for (selected, row) in snapshot.rows.iter_mut().zip(rows) {
+                    selected.row = row;
+                }
+                if storage.chat_presentation_version()? == snapshot.presentation_version {
+                    return Ok((Some(snapshot), false));
+                }
+                return Ok((None, true));
+            }
+            let classifier = MarmotApp::chat_list_mention_classifier(&account.account_id_hex);
+            let mut progressed = false;
+            for missing in storage.pending_chat_presentation_rows()? {
+                progressed |= storage.initialize_chat_presentation_row(
+                    &account.account_id_hex,
+                    &missing,
+                    &classifier,
+                )?;
+            }
+            progressed |= crate::chat_presentation::maintenance::maintain(
+                &storage,
+                &app.shared_storage()?,
+                &account.account_id_hex,
+            )?;
+            app.presentation_signals.wake();
+            Ok((None, progressed))
+        })
+        .await?;
+        if let Some(snapshot) = snapshot {
+            return Ok(snapshot);
+        }
+        if !progressed {
+            return Err(AppError::ChatPresentationNotReady);
+        }
+        tokio::task::yield_now().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{PresentationText, tests::ScriptedPushRelayClient};
+    use marmot_account::AccountHome;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn presented_list_prepares_offline_and_orders_nonpresentation_updates() {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        AccountHome::open(dir.path()).create_account("bob").unwrap();
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+        let mut client = app.client("alice").await.unwrap();
+        let group = client.create_group("Initial name", &[]).await.unwrap();
+        let id = hex::encode(group.as_slice());
+        let runtime = MarmotAppRuntime::new(app.clone());
+        let mut sub = runtime
+            .open_presented_chat_list("alice", false)
+            .await
+            .unwrap();
+        assert_eq!(sub.snapshot.rows.len(), 1);
+        assert!(
+            matches!(&sub.snapshot.rows[0].presentation.title, PresentationText::Literal(s) if s == "Initial name")
+        );
+        let version = sub.snapshot.presentation_version.clone();
+        assert_eq!(
+            runtime.presented_chat_list_row("alice", &id).await.unwrap(),
+            Some(sub.snapshot.rows[0].clone())
+        );
+        assert!(
+            runtime
+                .presented_chat_list_row("bob", &id)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        // Mutation after open, before the consumer starts next(): no handoff gap.
+        runtime
+            .set_chat_manually_unread("alice", &id, true)
+            .unwrap();
+        let update = tokio::time::timeout(Duration::from_secs(5), sub.recv())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(update.sequence, 1);
+        assert_eq!(update.subscription_generation, sub.subscription_generation);
+        assert_eq!(
+            update.snapshot.presentation_version, version,
+            "unread changes need their own sequence"
+        );
+        assert!(update.snapshot.rows[0].row.manually_marked_unread);
+        runtime.set_chat_pinned("alice", &id, true).unwrap();
+        let update = tokio::time::timeout(Duration::from_secs(5), sub.recv())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(update.sequence, 2);
+        assert!(update.snapshot.rows[0].row.pinned);
+        // Independently owned handles never share a generation.
+        let other = runtime
+            .open_presented_chat_list("alice", false)
+            .await
+            .unwrap();
+        assert_ne!(sub.subscription_generation, other.subscription_generation);
+        runtime.shared.lifecycle().begin_shutdown();
+        assert!(sub.recv().await.unwrap().is_none());
+        drop(sub);
+        drop(other);
+        drop(client);
+        runtime.shutdown_and_close().await.unwrap();
+        drop(runtime);
+        drop(app);
+        let reopened = MarmotAppRuntime::new(
+            MarmotApp::with_relay(dir.path(), "wss://relay.example")
+                .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default())),
+        );
+        let restored = reopened.presented_chat_list("alice", false).await.unwrap();
+        assert_eq!(restored.presentation_version, version);
+        assert!(
+            matches!(&restored.rows[0].presentation.title, PresentationText::Literal(s) if s == "Initial name")
+        );
+        reopened.shutdown_and_close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn presented_list_lag_recovers_current_selection_without_raw_row_events() {
+        let dir = tempfile::tempdir().unwrap();
+        let account = AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+        let mut client = app.client("alice").await.unwrap();
+        let group = client.create_group("Before", &[]).await.unwrap();
+        let id = hex::encode(group.as_slice());
+        let runtime = MarmotAppRuntime::new(app.clone());
+        let mut sub = runtime
+            .open_presented_chat_list("alice", false)
+            .await
+            .unwrap();
+        let storage = app.account_storage("alice").unwrap();
+        let mut state = storage.load_account_projection_state("alice", 100).unwrap();
+        state.groups[0].profile_name = "After".into();
+        storage
+            .save_account_projection_state(&state, 100, 120)
+            .unwrap();
+        let mut worker = super::super::presentation::PresentationMaintenance::default();
+        while worker.run(&client, &account.account_id_hex).unwrap() {}
+        // Force presentation-channel overflow; lag must trigger a complete local refresh.
+        for _ in 0..100 {
+            let _ = app
+                .presentation_signals
+                .updates
+                .send(PresentationInvalidation {
+                    account_label: "unrelated".into(),
+                    version: storage.chat_presentation_version().unwrap(),
+                });
+        }
+        let update = tokio::time::timeout(Duration::from_secs(5), sub.recv())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(update.snapshot.rows[0].row.group_id_hex, id);
+        assert!(
+            matches!(&update.snapshot.rows[0].presentation.title, PresentationText::Literal(s) if s == "After")
+        );
+        assert_eq!(update.sequence, 1);
+        // A cancelled wait cannot close or consume a later change.
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), sub.recv())
+                .await
+                .is_err()
+        );
+        runtime
+            .set_chat_manually_unread("alice", &id, true)
+            .unwrap();
+        let update = tokio::time::timeout(Duration::from_secs(5), sub.recv())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(update.sequence, 2);
+        assert!(update.snapshot.rows[0].row.manually_marked_unread);
+        runtime.shared.lifecycle().begin_shutdown();
+    }
+}

--- a/crates/marmot-app/src/runtime/presented_chat_list.rs
+++ b/crates/marmot-app/src/runtime/presented_chat_list.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::chat_presentation::signals::PresentationInvalidation;
 use crate::{AppError, MarmotApp, PresentedChatListSnapshot, PresentedChatRow};
-use storage_sqlite::ChatListQuery;
+use storage_sqlite::{ChatListQuery, SqliteAccountStorage};
 use tokio::sync::{broadcast, watch};
 
 /// A complete replacement. Sequence orders all row changes, even at equal presentation revisions.
@@ -143,7 +143,8 @@ impl MarmotAppRuntime {
             _ = wait_for_runtime_shutdown(&mut stopping) => return Err(AppError::RuntimeStopping),
             result = prepared_snapshot(self.accounts.app.clone(), account.label.clone(), account.account_id_hex.clone(), include_archived, None) => result?,
         };
-        // Only invalidations are consumed from the legacy handle.
+        // Reusing legacy routing currently costs an extra initial row read. Discard that
+        // snapshot: only its invalidations are consumed, never its display payload.
         legacy.snapshot.clear();
         Ok(RuntimePresentedChatListSubscription {
             current: snapshot.clone(),
@@ -174,58 +175,75 @@ async fn prepared_snapshot(
         let label = label.clone();
         let account_id = account_id.clone();
         let group = group.clone();
-        let (snapshot, progressed) = blocking_app_task(move || {
+        let snapshot = blocking_app_task(move || {
             let account = app.account_home().account(&label)?;
             if account.account_id_hex != account_id {
                 return Err(marmot_account::AccountHomeError::AccountIdMismatch.into());
             }
             app.ensure_account_state(&label)?;
+            app.ensure_chat_list_projection(&account)?;
             let storage = app.account_storage(&label)?;
-            if let Some(mut snapshot) = storage
-                .read_presented_chat_list(ChatListQuery { include_archived }, group.as_deref())?
-            {
-                // Sender-preview enrichment uses the shared cache after releasing the account
-                // transaction. Revalidate selected identity before publishing that enrichment.
-                let mut rows = snapshot
-                    .rows
-                    .iter()
-                    .map(|r| r.row.clone())
-                    .collect::<Vec<_>>();
-                app.hydrate_chat_list_rows(&mut rows)?;
-                for (selected, row) in snapshot.rows.iter_mut().zip(rows) {
-                    selected.row = row;
-                }
-                if storage.chat_presentation_version()? == snapshot.presentation_version {
-                    return Ok((Some(snapshot), false));
-                }
-                return Ok((None, true));
-            }
-            let classifier = MarmotApp::chat_list_mention_classifier(&account.account_id_hex);
-            let mut progressed = false;
-            for missing in storage.pending_chat_presentation_rows()? {
-                progressed |= storage.initialize_chat_presentation_row(
-                    &account.account_id_hex,
-                    &missing,
-                    &classifier,
-                )?;
-            }
-            progressed |= crate::chat_presentation::maintenance::maintain(
+            let snapshot = read_or_prepare(
                 &storage,
-                &app.shared_storage()?,
-                &account.account_id_hex,
+                ChatListQuery { include_archived },
+                group.as_deref(),
+                || {
+                    let result = crate::chat_presentation::maintenance::prepare_batch(
+                        &storage,
+                        &app.shared_storage()?,
+                        &account.account_id_hex,
+                    );
+                    app.presentation_signals.wake();
+                    result
+                },
             )?;
-            app.presentation_signals.wake();
-            Ok((None, progressed))
+            snapshot
+                .map(|mut snapshot| {
+                    // Rows, selected identity and version are already one atomic snapshot.
+                    // Preview sender/attachment enrichment is independent of that selection.
+                    let mut rows = snapshot
+                        .rows
+                        .iter()
+                        .map(|r| r.row.clone())
+                        .collect::<Vec<_>>();
+                    app.hydrate_chat_list_rows(&mut rows)?;
+                    for (selected, row) in snapshot.rows.iter_mut().zip(rows) {
+                        selected.row = row;
+                    }
+                    Ok(snapshot)
+                })
+                .transpose()
         })
         .await?;
         if let Some(snapshot) = snapshot {
             return Ok(snapshot);
         }
-        if !progressed {
-            return Err(AppError::ChatPresentationNotReady);
-        }
         tokio::task::yield_now().await;
     }
+}
+
+/// A ready read is read-only. First-use preparation also works before account workers start.
+/// The same bounded batch implementation is used by the worker, with storage CAS protecting
+/// concurrent preparers. Re-read before interpreting its progress flag: a lost CAS can mean
+/// another caller completed the result, or advanced a multi-batch preparation.
+fn read_or_prepare(
+    storage: &SqliteAccountStorage,
+    query: ChatListQuery,
+    group: Option<&str>,
+    prepare: impl FnOnce() -> Result<bool, AppError>,
+) -> Result<Option<PresentedChatListSnapshot>, AppError> {
+    if let Some(snapshot) = storage.read_presented_chat_list(query.clone(), group)? {
+        return Ok(Some(snapshot));
+    }
+    let checkpoint = storage.chat_presentation_checkpoint()?;
+    let progressed = prepare()?;
+    if let Some(snapshot) = storage.read_presented_chat_list(query, group)? {
+        return Ok(Some(snapshot));
+    }
+    if progressed || storage.chat_presentation_checkpoint()?.generation != checkpoint.generation {
+        return Ok(None);
+    }
+    Err(AppError::ChatPresentationNotReady)
 }
 
 #[cfg(test)]
@@ -235,6 +253,97 @@ mod tests {
     use marmot_account::AccountHome;
     use std::sync::Arc;
     use std::time::Duration;
+
+    #[tokio::test]
+    async fn presented_preparation_observes_worker_progress_and_reports_stalled_work() {
+        let dir = tempfile::tempdir().unwrap();
+        let account = AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+        let mut client = app.client("alice").await.unwrap();
+        client.create_group("Pending", &[]).await.unwrap();
+        app.ensure_chat_list_projection(&account).unwrap();
+        let storage = app.account_storage("alice").unwrap();
+        let query = ChatListQuery {
+            include_archived: true,
+        };
+        assert!(
+            storage
+                .read_presented_chat_list(query.clone(), None)
+                .unwrap()
+                .is_none()
+        );
+        assert!(matches!(
+            read_or_prepare(&storage, query.clone(), None, || Ok(false)),
+            Err(AppError::ChatPresentationNotReady)
+        ));
+        // Deterministic interleaving: the owner advances the checkpoint after the reader's
+        // miss, but the reader's own stale CAS reports no progress. The result is not ready
+        // yet, so retry only because the durable checkpoint really advanced.
+        let mut worker = super::super::presentation::PresentationMaintenance::default();
+        let partial = read_or_prepare(&storage, query.clone(), None, || {
+            assert!(worker.run(&client, &account.account_id_hex)?);
+            Ok(false)
+        })
+        .unwrap();
+        assert!(partial.is_none());
+        // The owner completes before the losing preparer returns false. Re-read wins
+        // over that stale progress flag and returns the complete row without an error.
+        let ready = read_or_prepare(&storage, query.clone(), None, || {
+            while worker.run(&client, &account.account_id_hex)? {}
+            Ok(false)
+        })
+        .unwrap()
+        .unwrap();
+        assert_eq!(ready.rows.len(), 1);
+        let repeat = read_or_prepare(&storage, query, None, || {
+            panic!("ready reads must not prepare")
+        })
+        .unwrap()
+        .unwrap();
+        assert_eq!(ready, repeat);
+    }
+
+    #[tokio::test]
+    async fn presented_one_shot_warms_and_refreshes_legacy_projection() {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+        let mut client = app.client("alice").await.unwrap();
+        let group = client.create_group("Before", &[]).await.unwrap();
+        let id = hex::encode(group.as_slice());
+        let runtime = MarmotAppRuntime::new(app.clone());
+        // Neither legacy list reads nor a subscription have warmed the projection.
+        let first = runtime.presented_chat_list("alice", false).await.unwrap();
+        assert_eq!(first.rows.len(), 1);
+        assert!(
+            app.chat_list_projection_warmed
+                .lock()
+                .unwrap()
+                .contains("alice")
+        );
+        let mut state = app.load_state("alice").unwrap();
+        state.groups[0].profile.name = "After".into();
+        app.save_state(&state).unwrap();
+        let row = runtime
+            .presented_chat_list_row("alice", &id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.row.group_name, "After");
+        assert!(
+            !app.chat_list_projection_stale
+                .lock()
+                .unwrap()
+                .contains("alice")
+        );
+        runtime.shutdown_and_close().await.unwrap();
+    }
 
     #[tokio::test]
     async fn presented_list_prepares_offline_and_orders_nonpresentation_updates() {

--- a/crates/marmot-app/src/runtime/presented_chat_list.rs
+++ b/crates/marmot-app/src/runtime/presented_chat_list.rs
@@ -44,6 +44,9 @@ impl RuntimePresentedChatListSubscription {
     pub async fn recv(&mut self) -> Result<Option<PresentedChatListUpdate>, AppError> {
         loop {
             if self.dirty {
+                // These payloads are invalidations, not deltas to apply. The upcoming read
+                // includes all committed changes already queued and cancellation keeps dirty.
+                self.legacy.discard_pending_invalidations();
                 let snapshot = tokio::select! {
                     biased;
                     _ = wait_for_runtime_shutdown(&mut self.stopping) => return Ok(None),
@@ -218,7 +221,10 @@ async fn prepared_snapshot(
         if let Some(snapshot) = snapshot {
             return Ok(snapshot);
         }
-        tokio::task::yield_now().await;
+        // First-use preparation shares CAS-protected batches with the account worker.
+        // Pace retries (including lost CAS attempts) instead of immediately contending
+        // for the same connection again. Ready reads never enter this delay.
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
     }
 }
 
@@ -253,6 +259,47 @@ mod tests {
     use marmot_account::AccountHome;
     use std::sync::Arc;
     use std::time::Duration;
+
+    #[tokio::test]
+    async fn dropping_legacy_list_releases_pump_and_expired_mutes_read_correctly() {
+        let dir = tempfile::tempdir().unwrap();
+        AccountHome::open(dir.path())
+            .create_account("alice")
+            .unwrap();
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+        let mut client = app.client("alice").await.unwrap();
+        let group = client.create_group("Muted", &[]).await.unwrap();
+        let id = hex::encode(group.as_slice());
+        let runtime = MarmotAppRuntime::new(app.clone());
+        runtime.set_chat_muted("alice", &id, None).unwrap();
+        let before = runtime.events.receiver_count();
+        let sub = runtime.subscribe_chat_list("alice", false).await.unwrap();
+        assert!(sub.snapshot[0].muted);
+        assert_eq!(runtime.events.receiver_count(), before + 1);
+        drop(sub);
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while runtime.events.receiver_count() != before {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("dropping the handle must release the idle pump without another event");
+        // Install an already-expired preference directly: there is no pump to refresh
+        // the materialized row. Read-time derivation must still unmute it correctly.
+        let storage = app.account_storage("alice").unwrap();
+        storage
+            .set_chat_muted(&id, Some(crate::notifications::unix_now_ms() - 1))
+            .unwrap();
+        let row = runtime
+            .presented_chat_list_row("alice", &id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(!row.row.muted);
+        assert!(row.row.muted_until_ms.is_none());
+        runtime.shutdown_and_close().await.unwrap();
+    }
 
     #[tokio::test]
     async fn presented_preparation_observes_worker_progress_and_reports_stalled_work() {

--- a/crates/marmot-app/src/runtime/subscriptions.rs
+++ b/crates/marmot-app/src/runtime/subscriptions.rs
@@ -1304,6 +1304,7 @@ impl MarmotAppRuntime {
                 };
                 let event = tokio::select! {
                     _ = wait_for_runtime_shutdown(&mut stopping) => return,
+                    _ = updates_tx.closed() => return,
                     event = events.recv() => Some(event),
                     _ = expiry_wait => None,
                 };

--- a/crates/marmot-app/src/runtime/subscriptions.rs
+++ b/crates/marmot-app/src/runtime/subscriptions.rs
@@ -715,6 +715,16 @@ fn change_advances_chat_list(
 }
 
 impl RuntimeChatListSubscription {
+    /// Used only when the caller will replace its entire list from current storage.
+    /// Drain the queue as it stood at entry, so continuous producers cannot starve the read.
+    pub(super) fn discard_pending_invalidations(&mut self) {
+        for _ in 0..self.updates.len() {
+            if self.updates.try_recv().is_err() {
+                break;
+            }
+        }
+    }
+
     pub async fn recv(&mut self) -> Option<RuntimeChatListUpdate> {
         tokio::select! {
             update = self.updates.recv() => update,
@@ -2028,4 +2038,39 @@ pub(crate) async fn send_atomic_chat_list_snapshot(
         .send(RuntimeChatListUpdate::Snapshot { trigger, rows })
         .await
         .is_ok()
+}
+
+#[cfg(test)]
+mod presented_invalidation_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn replacement_read_discards_queued_invalidations_but_keeps_future_updates() {
+        let (tx, rx) = mpsc::channel(8);
+        let (_stopping, stopping) = watch::channel(false);
+        let mut sub = RuntimeChatListSubscription {
+            snapshot: vec![],
+            updates: rx,
+            stopping,
+        };
+        for id in ["01", "02", "03"] {
+            tx.send(RuntimeChatListUpdate::RemoveRow {
+                trigger: ChatListUpdateTrigger::SnapshotRefresh,
+                group_id_hex: id.into(),
+            })
+            .await
+            .unwrap();
+        }
+        sub.discard_pending_invalidations();
+        assert!(sub.updates.is_empty());
+        tx.send(RuntimeChatListUpdate::RemoveRow {
+            trigger: ChatListUpdateTrigger::SnapshotRefresh,
+            group_id_hex: "04".into(),
+        })
+        .await
+        .unwrap();
+        assert!(
+            matches!(sub.recv().await, Some(RuntimeChatListUpdate::RemoveRow { group_id_hex, .. }) if group_id_hex == "04")
+        );
+    }
 }

--- a/crates/marmot-c/README.md
+++ b/crates/marmot-c/README.md
@@ -95,3 +95,16 @@ just c-header
 The mirror surface is macro-generated, so header generation runs cbindgen
 with macro expansion (`RUSTC_BOOTSTRAP=1` on the stable toolchain). CI
 diff-gates the checked-in header.
+
+## Selected chat-list presentation
+
+The additive `marmot_presented_chat_list` and `marmot_presented_chat_list_row` return complete existing row fields
+plus MDK-selected title/avatar descriptors. Existing struct layouts and functions are unchanged.
+`marmot_open_presented_chat_list` returns an attached handle; take its `*_snapshot` once, then use `*_next` for
+whole-list replacements. The initial item has sequence zero. A repeated snapshot call returns CLOSED with NULL.
+
+This fallible subscription offers blocking next with timeout and typed storage/preparation errors. It has no callback
+pump: hosts drive next on their own worker and decide how to retry errors. Timeouts preserve the refresh obligation.
+Free each result with `marmot_presented_chat_list_update_free` and the handle with
+`marmot_presented_chat_list_subscription_free`. See the [shared native contract](../marmot-uniffi/README.md#selected-chat-list-presentation)
+for version ordering, localization, readiness, and account-switch behavior.

--- a/crates/marmot-c/examples/smoke.c
+++ b/crates/marmot-c/examples/smoke.c
@@ -108,6 +108,17 @@ int main(int argc, char **argv) {
     marmot_string_free(NULL);
     marmot_account_summary_list_free(NULL);
     marmot_markdown_document_free(NULL);
+    marmot_presented_chat_row_free(NULL);
+    marmot_presented_chat_list_snapshot_free(NULL);
+    marmot_presented_chat_list_update_free(NULL);
+    marmot_presented_chat_list_subscription_free(NULL);
+    check(marmot_presented_chat_list_subscription_next(NULL, 5000, NULL) ==
+              MARMOT_STATUS_NULL_POINTER,
+          "presented next validates output before reading");
+    check(marmot_open_presented_chat_list(NULL, NULL, 0, NULL) ==
+              MARMOT_STATUS_NULL_POINTER,
+          "presented open validates output before subscribing");
+
     ok("NULL frees are no-ops");
 
     /* ---- construct + lifecycle ---------------------------------------- */

--- a/crates/marmot-c/include/marmot.h
+++ b/crates/marmot-c/include/marmot.h
@@ -133,6 +133,7 @@ enum MarmotStatus
   MARMOT_STATUS_CONSENT_REQUIRED = 66,
   MARMOT_STATUS_INVALID_PRODUCT_ANALYTICS_CONFIGURATION = 67,
   MARMOT_STATUS_INVALID_PRODUCT_OBSERVATION = 68,
+  MARMOT_STATUS_CHAT_PRESENTATION_NOT_READY = 69,
 };
 #ifndef __cplusplus
 #if __STDC_VERSION__ >= 202311L
@@ -415,6 +416,20 @@ typedef enum MarmotChatConversationKind {
   MARMOT_CHAT_CONVERSATION_KIND_DIRECT,
   MARMOT_CHAT_CONVERSATION_KIND_GROUP,
 } MarmotChatConversationKind;
+
+typedef enum MarmotPresentationSource {
+  MARMOT_PRESENTATION_SOURCE_GROUP,
+  MARMOT_PRESENTATION_SOURCE_PEER_PROFILE,
+  MARMOT_PRESENTATION_SOURCE_PEER_FALLBACK,
+  MARMOT_PRESENTATION_SOURCE_GROUP_FALLBACK,
+  MARMOT_PRESENTATION_SOURCE_UNKNOWN_FALLBACK,
+} MarmotPresentationSource;
+
+typedef enum MarmotPresentationResolution {
+  MARMOT_PRESENTATION_RESOLUTION_CACHED,
+  MARMOT_PRESENTATION_RESOLUTION_LAST_KNOWN,
+  MARMOT_PRESENTATION_RESOLUTION_FALLBACK,
+} MarmotPresentationResolution;
 
 /**
  * How far an account's setup has progressed.
@@ -772,6 +787,12 @@ typedef struct MarmotNotificationsSubscription MarmotNotificationsSubscription;
  * A current onboarding snapshot followed by durable progress updates.
  */
 typedef struct MarmotOnboardingSubscription MarmotOnboardingSubscription;
+
+/**
+ * Account-bound complete chat-list snapshots. Free before the parent client.
+ * This fallible stream uses blocking next so storage errors retain their typed status.
+ */
+typedef struct MarmotPresentedChatListSubscription MarmotPresentedChatListSubscription;
 
 /**
  * Opaque handle to one conversation's materialized timeline window.
@@ -1972,6 +1993,91 @@ typedef struct MarmotChatListRowList {
   struct MarmotChatListRow *items;
   uintptr_t len;
 } MarmotChatListRowList;
+
+/**
+ * Typed text; hosts localize the fallback cases.
+ */
+typedef enum MarmotPresentationText_Tag {
+  MARMOT_PRESENTATION_TEXT_LITERAL,
+  MARMOT_PRESENTATION_TEXT_UNNAMED_GROUP,
+  MARMOT_PRESENTATION_TEXT_UNAVAILABLE_CONVERSATION,
+} MarmotPresentationText_Tag;
+
+typedef struct MarmotPresentationText_Literal_Body {
+  char *text;
+} MarmotPresentationText_Literal_Body;
+
+typedef struct MarmotPresentationText_UnnamedGroup_Body {
+  bool has_member_count;
+  uint64_t member_count;
+} MarmotPresentationText_UnnamedGroup_Body;
+
+typedef struct MarmotPresentationText {
+  MarmotPresentationText_Tag tag;
+  union {
+    MarmotPresentationText_Literal_Body LITERAL;
+    MarmotPresentationText_UnnamedGroup_Body UNNAMED_GROUP;
+  };
+} MarmotPresentationText;
+
+/**
+ * Descriptor only. Group image material remains owned by the containing result.
+ */
+typedef enum MarmotSelectedAvatar_Tag {
+  MARMOT_SELECTED_AVATAR_REMOTE_IMAGE,
+  MARMOT_SELECTED_AVATAR_ENCRYPTED_GROUP_IMAGE,
+  MARMOT_SELECTED_AVATAR_PLACEHOLDER,
+} MarmotSelectedAvatar_Tag;
+
+typedef struct MarmotSelectedAvatar_RemoteImage_Body {
+  char *url;
+  char *cache_key;
+} MarmotSelectedAvatar_RemoteImage_Body;
+
+typedef struct MarmotSelectedAvatar_EncryptedGroupImage_Body {
+  struct MarmotChatListAvatar image;
+  char *cache_key;
+} MarmotSelectedAvatar_EncryptedGroupImage_Body;
+
+typedef struct MarmotSelectedAvatar_Placeholder_Body {
+  char *stable_seed;
+  enum MarmotPresentationSource source;
+} MarmotSelectedAvatar_Placeholder_Body;
+
+typedef struct MarmotSelectedAvatar {
+  MarmotSelectedAvatar_Tag tag;
+  union {
+    MarmotSelectedAvatar_RemoteImage_Body REMOTE_IMAGE;
+    MarmotSelectedAvatar_EncryptedGroupImage_Body ENCRYPTED_GROUP_IMAGE;
+    MarmotSelectedAvatar_Placeholder_Body PLACEHOLDER;
+  };
+} MarmotSelectedAvatar;
+
+typedef struct MarmotConversationPresentation {
+  struct MarmotPresentationText title;
+  struct MarmotSelectedAvatar avatar;
+  enum MarmotPresentationSource title_source;
+  enum MarmotPresentationSource avatar_source;
+  char *peer_id;
+  enum MarmotPresentationResolution resolution;
+} MarmotConversationPresentation;
+
+typedef struct MarmotPresentedChatRow {
+  struct MarmotChatListRow row;
+  struct MarmotConversationPresentation presentation;
+} MarmotPresentedChatRow;
+
+typedef struct MarmotPresentationVersion {
+  uint8_t *account_store_epoch;
+  uintptr_t account_store_epoch_len;
+  uint64_t revision;
+} MarmotPresentationVersion;
+
+typedef struct MarmotPresentedChatListSnapshot {
+  struct MarmotPresentedChatRow *rows;
+  uintptr_t rows_len;
+  struct MarmotPresentationVersion presentation_version;
+} MarmotPresentedChatListSnapshot;
 
 /**
  * The account's pinned chats, in display order.
@@ -3863,6 +3969,12 @@ typedef void (*MarmotUserSearchUpdateCallback)(const struct MarmotUserSearchUpda
 typedef void (*MarmotOnboardingCallback)(const struct MarmotOnboardingSnapshot *item,
                                          void *user_data);
 
+typedef struct MarmotPresentedChatListUpdate {
+  char *subscription_generation;
+  uint64_t sequence;
+  struct MarmotPresentedChatListSnapshot snapshot;
+} MarmotPresentedChatListUpdate;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -5147,6 +5259,34 @@ MarmotStatus marmot_chat_list(const struct MarmotClient *client,
                               const char *account_ref,
                               uint8_t include_archived,
                               struct MarmotChatListRowList **out);
+
+/**
+ * Complete local rows with selected title/avatar. Free with marmot_presented_chat_list_snapshot_free.
+ *
+ * # Safety
+ * `client` must be a live handle; string arguments must be valid
+ * NUL-terminated strings (nullable ones may be NULL); array
+ * arguments must hold their stated length (or be NULL with
+ * length 0); out-pointers must be valid.
+ */
+MarmotStatus marmot_presented_chat_list(const struct MarmotClient *client,
+                                        const char *account_ref,
+                                        uint8_t include_archived,
+                                        struct MarmotPresentedChatListSnapshot **out);
+
+/**
+ * Keyed complete row; missing groups return NULL. Free with marmot_presented_chat_row_free.
+ *
+ * # Safety
+ * `client` must be a live handle; string arguments must be valid
+ * NUL-terminated strings (nullable ones may be NULL); array
+ * arguments must hold their stated length (or be NULL with
+ * length 0); out-pointers must be valid.
+ */
+MarmotStatus marmot_presented_chat_list_row(const struct MarmotClient *client,
+                                            const char *account_ref,
+                                            const char *group_id_hex,
+                                            struct MarmotPresentedChatRow **out);
 
 /**
  * Initialize read state for a conversation being opened; writes the
@@ -7491,6 +7631,44 @@ MarmotStatus marmot_onboarding_subscription_snapshot(const struct MarmotOnboardi
                                                      struct MarmotOnboardingSnapshot **out);
 
 /**
+ * Open a complete chat list with both invalidation sources already attached.
+ * Take the initial snapshot once, then call next. Free with marmot_presented_chat_list_subscription_free.
+ * # Safety
+ * Client and string must be valid; out_sub must be writable.
+ */
+MarmotStatus marmot_open_presented_chat_list(const struct MarmotClient *client,
+                                             const char *account_ref,
+                                             uint8_t include_archived,
+                                             struct MarmotPresentedChatListSubscription **out_sub);
+
+/**
+ * Take the initial snapshot with sequence zero. A second call returns CLOSED and NULL.
+ * Free the result with marmot_presented_chat_list_update_free.
+ * # Safety
+ * sub must be live; out must be writable.
+ */
+MarmotStatus marmot_presented_chat_list_subscription_snapshot(const struct MarmotPresentedChatListSubscription *sub,
+                                                              struct MarmotPresentedChatListUpdate **out);
+
+/**
+ * Read a whole replacement. timeout_ms zero waits indefinitely. Timeout/closed/error leave
+ * out NULL; timeout or a storage error does not discard the pending refresh. Retry according
+ * to the typed status. Free results with marmot_presented_chat_list_update_free.
+ * # Safety
+ * sub must be live; out must be writable.
+ */
+MarmotStatus marmot_presented_chat_list_subscription_next(const struct MarmotPresentedChatListSubscription *sub,
+                                                          uint32_t timeout_ms,
+                                                          struct MarmotPresentedChatListUpdate **out);
+
+/**
+ * Cancel and free a presented-list handle. NULL is a no-op.
+ * # Safety
+ * sub must be NULL or a live library-owned handle not in use by another call.
+ */
+void marmot_presented_chat_list_subscription_free(struct MarmotPresentedChatListSubscription *sub);
+
+/**
  * Free a value of this type returned by this library. NULL
  * is a no-op.
  *
@@ -8302,6 +8480,36 @@ void marmot_usage_diagnostics_settings_free(struct MarmotUsageDiagnosticsSetting
  * this library.
  */
 void marmot_usage_diagnostics_status_free(struct MarmotUsageDiagnosticsStatus *ptr);
+
+/**
+ * Free a value of this type returned by this library. NULL
+ * is a no-op.
+ *
+ * # Safety
+ * The pointer must be NULL or an unfreed pointer returned by
+ * this library.
+ */
+void marmot_presented_chat_row_free(struct MarmotPresentedChatRow *ptr);
+
+/**
+ * Free a value of this type returned by this library. NULL
+ * is a no-op.
+ *
+ * # Safety
+ * The pointer must be NULL or an unfreed pointer returned by
+ * this library.
+ */
+void marmot_presented_chat_list_snapshot_free(struct MarmotPresentedChatListSnapshot *ptr);
+
+/**
+ * Free a value of this type returned by this library. NULL
+ * is a no-op.
+ *
+ * # Safety
+ * The pointer must be NULL or an unfreed pointer returned by
+ * this library.
+ */
+void marmot_presented_chat_list_update_free(struct MarmotPresentedChatListUpdate *ptr);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/crates/marmot-c/src/commands.rs
+++ b/crates/marmot-c/src/commands.rs
@@ -830,7 +830,6 @@ c_cmd! {
     /// Keyed complete row; missing groups return NULL. Free with marmot_presented_chat_row_free.
     async fn marmot_presented_chat_list_row(account_ref: str, group_id_hex: str) -> opt_rec(MarmotPresentedChatRow) = presented_chat_list_row;
 
-
     /// Initialize read state for a conversation being opened; writes the
     /// refreshed row, or NULL with `MARMOT_STATUS_OK` when the group has
     /// no row. Free with `marmot_chat_list_row_free`.

--- a/crates/marmot-c/src/commands.rs
+++ b/crates/marmot-c/src/commands.rs
@@ -15,6 +15,7 @@
 //! Commands with struct/byte inputs are written by hand below the macro
 //! block.
 
+use crate::types::presentation::{MarmotPresentedChatListSnapshot, MarmotPresentedChatRow};
 use std::ffi::c_char;
 
 use marmot_uniffi::MarmotKitError;
@@ -824,6 +825,11 @@ c_cmd! {
     /// The account's chat list rows. Free with
     /// `marmot_chat_list_row_list_free`.
     sync fn marmot_chat_list(account_ref: str, include_archived: flag) -> rec(MarmotChatListRowList) = chat_list;
+    /// Complete local rows with selected title/avatar. Free with marmot_presented_chat_list_snapshot_free.
+    async fn marmot_presented_chat_list(account_ref: str, include_archived: flag) -> rec(MarmotPresentedChatListSnapshot) = presented_chat_list;
+    /// Keyed complete row; missing groups return NULL. Free with marmot_presented_chat_row_free.
+    async fn marmot_presented_chat_list_row(account_ref: str, group_id_hex: str) -> opt_rec(MarmotPresentedChatRow) = presented_chat_list_row;
+
 
     /// Initialize read state for a conversation being opened; writes the
     /// refreshed row, or NULL with `MARMOT_STATUS_OK` when the group has

--- a/crates/marmot-c/src/status.rs
+++ b/crates/marmot-c/src/status.rs
@@ -101,6 +101,7 @@ pub enum MarmotStatus {
     ConsentRequired = 66,
     InvalidProductAnalyticsConfiguration = 67,
     InvalidProductObservation = 68,
+    ChatPresentationNotReady = 69,
 }
 
 thread_local! {
@@ -188,6 +189,7 @@ pub(crate) fn status_from_error(err: &MarmotKitError) -> MarmotStatus {
             MarmotStatus::CreatedGroupProjectionUnavailable
         }
         MarmotKitError::InvalidCachedIdentityPage { .. } => MarmotStatus::InvalidCachedIdentityPage,
+        MarmotKitError::ChatPresentationNotReady => MarmotStatus::ChatPresentationNotReady,
         MarmotKitError::DirectConversationIndexNotReady => {
             MarmotStatus::DirectConversationIndexNotReady
         }

--- a/crates/marmot-c/src/subscriptions.rs
+++ b/crates/marmot-c/src/subscriptions.rs
@@ -1215,3 +1215,93 @@ pub unsafe extern "C" fn marmot_onboarding_subscription_snapshot(
         unsafe { deliver(Ok::<_, MarmotKitError>(sub.inner.snapshot()), out) }
     })
 }
+
+/// Account-bound complete chat-list snapshots. Free before the parent client.
+/// This fallible stream uses blocking next so storage errors retain their typed status.
+pub struct MarmotPresentedChatListSubscription {
+    core: SubscriptionCore,
+    inner: Arc<marmot_uniffi::PresentedChatListSubscription>,
+}
+/// Open a complete chat list with both invalidation sources already attached.
+/// Take the initial snapshot once, then call next. Free with marmot_presented_chat_list_subscription_free.
+/// # Safety
+/// Client and string must be valid; out_sub must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn marmot_open_presented_chat_list(
+    client: *const MarmotClient,
+    account_ref: *const std::ffi::c_char,
+    include_archived: u8,
+    out_sub: *mut *mut MarmotPresentedChatListSubscription,
+) -> MarmotStatus {
+    ffi_guard(|| {
+        try_arg!(unsafe { preflight_out_ptr(out_sub) });
+        let client = try_arg!(unsafe { client_ref(client) });
+        let account_ref = try_arg!(unsafe { required_str(account_ref) });
+        match client.block_on(
+            client
+                .marmot
+                .open_presented_chat_list(account_ref, crate::memory::c_bool(include_archived)),
+        ) {
+            Ok(inner) => unsafe {
+                write_handle(
+                    MarmotPresentedChatListSubscription {
+                        core: SubscriptionCore::new(client.runtime.handle().clone()),
+                        inner,
+                    },
+                    out_sub,
+                )
+            },
+            Err(err) => status_from_error(&err),
+        }
+    })
+}
+/// Take the initial snapshot with sequence zero. A second call returns CLOSED and NULL.
+/// Free the result with marmot_presented_chat_list_update_free.
+/// # Safety
+/// sub must be live; out must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn marmot_presented_chat_list_subscription_snapshot(
+    sub: *const MarmotPresentedChatListSubscription,
+    out: *mut *mut crate::types::presentation::MarmotPresentedChatListUpdate,
+) -> MarmotStatus {
+    ffi_guard(|| {
+        try_arg!(unsafe { preflight_out_ptr(out) });
+        let sub = try_arg!(unsafe { sub_ref(sub) });
+        unsafe { deliver_next(Ok(sub.inner.snapshot()), out) }
+    })
+}
+/// Read a whole replacement. timeout_ms zero waits indefinitely. Timeout/closed/error leave
+/// out NULL; timeout or a storage error does not discard the pending refresh. Retry according
+/// to the typed status. Free results with marmot_presented_chat_list_update_free.
+/// # Safety
+/// sub must be live; out must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn marmot_presented_chat_list_subscription_next(
+    sub: *const MarmotPresentedChatListSubscription,
+    timeout_ms: u32,
+    out: *mut *mut crate::types::presentation::MarmotPresentedChatListUpdate,
+) -> MarmotStatus {
+    ffi_guard(|| {
+        try_arg!(unsafe { preflight_out_ptr(out) });
+        let sub = try_arg!(unsafe { sub_ref(sub) });
+        let result = match sub
+            .core
+            .block_next(timeout_ms, async { Some(sub.inner.next().await) })
+        {
+            Ok(Some(Ok(item))) => Ok(item),
+            Ok(Some(Err(err))) => Err(status_from_error(&err)),
+            Ok(None) => Ok(None),
+            Err(status) => Err(status),
+        };
+        unsafe { deliver_next(result, out) }
+    })
+}
+/// Cancel and free a presented-list handle. NULL is a no-op.
+/// # Safety
+/// sub must be NULL or a live library-owned handle not in use by another call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn marmot_presented_chat_list_subscription_free(
+    sub: *mut MarmotPresentedChatListSubscription,
+) {
+    crate::memory::free_guard(|| unsafe { free_plain(sub) });
+}

--- a/crates/marmot-c/src/types/mod.rs
+++ b/crates/marmot-c/src/types/mod.rs
@@ -28,3 +28,5 @@ pub mod timeline;
 pub mod onboarding;
 
 pub mod product_analytics;
+
+pub mod presentation;

--- a/crates/marmot-c/src/types/presentation.rs
+++ b/crates/marmot-c/src/types/presentation.rs
@@ -1,0 +1,244 @@
+//! Additive selected-presentation mirrors. Existing chat-row layouts remain stable.
+use super::chat_list::{MarmotChatListAvatar, MarmotChatListRow};
+use crate::macros::{c_enum, c_mirror};
+use crate::memory::{CFree, free_c_string, owned_c_string};
+use marmot_uniffi::conversions::*;
+use std::ffi::c_char;
+
+c_enum! { MarmotPresentationSource from PresentationSourceFfi { Group, PeerProfile, PeerFallback, GroupFallback, UnknownFallback, } }
+c_enum! { MarmotPresentationResolution from PresentationResolutionFfi { Cached, LastKnown, Fallback, } }
+/// Typed text; hosts localize the fallback cases.
+#[repr(C)]
+pub enum MarmotPresentationText {
+    Literal {
+        text: *mut c_char,
+    },
+    UnnamedGroup {
+        has_member_count: bool,
+        member_count: u64,
+    },
+    UnavailableConversation,
+}
+impl From<PresentationTextFfi> for MarmotPresentationText {
+    fn from(v: PresentationTextFfi) -> Self {
+        match v {
+            PresentationTextFfi::Literal { text } => Self::Literal {
+                text: owned_c_string(text),
+            },
+            PresentationTextFfi::UnnamedGroup { member_count } => Self::UnnamedGroup {
+                has_member_count: member_count.is_some(),
+                member_count: member_count.unwrap_or_default(),
+            },
+            PresentationTextFfi::UnavailableConversation => Self::UnavailableConversation,
+        }
+    }
+}
+impl CFree for MarmotPresentationText {
+    unsafe fn free_in_place(&mut self) {
+        if let Self::Literal { text } = self {
+            unsafe { free_c_string(*text) };
+        }
+    }
+}
+/// Descriptor only. Group image material remains owned by the containing result.
+#[repr(C)]
+pub enum MarmotSelectedAvatar {
+    RemoteImage {
+        url: *mut c_char,
+        cache_key: *mut c_char,
+    },
+    EncryptedGroupImage {
+        image: MarmotChatListAvatar,
+        cache_key: *mut c_char,
+    },
+    Placeholder {
+        stable_seed: *mut c_char,
+        source: MarmotPresentationSource,
+    },
+}
+impl From<SelectedAvatarFfi> for MarmotSelectedAvatar {
+    fn from(v: SelectedAvatarFfi) -> Self {
+        match v {
+            SelectedAvatarFfi::RemoteImage { url, cache_key } => Self::RemoteImage {
+                url: owned_c_string(url),
+                cache_key: owned_c_string(cache_key),
+            },
+            SelectedAvatarFfi::EncryptedGroupImage { image, cache_key } => {
+                Self::EncryptedGroupImage {
+                    image: image.into(),
+                    cache_key: owned_c_string(cache_key),
+                }
+            }
+            SelectedAvatarFfi::Placeholder {
+                stable_seed,
+                source,
+            } => Self::Placeholder {
+                stable_seed: owned_c_string(stable_seed),
+                source: source.into(),
+            },
+        }
+    }
+}
+impl CFree for MarmotSelectedAvatar {
+    unsafe fn free_in_place(&mut self) {
+        unsafe {
+            match self {
+                Self::RemoteImage { url, cache_key } => {
+                    free_c_string(*url);
+                    free_c_string(*cache_key);
+                }
+                Self::EncryptedGroupImage { image, cache_key } => {
+                    image.free_in_place();
+                    free_c_string(*cache_key);
+                }
+                Self::Placeholder { stable_seed, .. } => free_c_string(*stable_seed),
+            }
+        }
+    }
+}
+c_mirror! { MarmotConversationPresentation from ConversationPresentationFfi {
+    rec title: MarmotPresentationText,
+    rec avatar: MarmotSelectedAvatar,
+    copy title_source: MarmotPresentationSource,
+    copy avatar_source: MarmotPresentationSource,
+    opt_str peer_id,
+    copy resolution: MarmotPresentationResolution,
+} }
+c_mirror! { MarmotPresentationVersion from PresentationVersionFfi {
+    bytes account_store_epoch/account_store_epoch_len,
+    copy revision: u64,
+} }
+c_mirror! { MarmotPresentedChatRow from PresentedChatRowFfi, free marmot_presented_chat_row_free {
+    rec row: MarmotChatListRow,
+    rec presentation: MarmotConversationPresentation,
+} }
+c_mirror! { MarmotPresentedChatListSnapshot from PresentedChatListSnapshotFfi, free marmot_presented_chat_list_snapshot_free {
+    vec rows/rows_len: MarmotPresentedChatRow,
+    rec presentation_version: MarmotPresentationVersion,
+} }
+c_mirror! { MarmotPresentedChatListUpdate from PresentedChatListUpdateFfi, free marmot_presented_chat_list_update_free {
+    str subscription_generation,
+    copy sequence: u64,
+    rec snapshot: MarmotPresentedChatListSnapshot,
+} }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::{audit, boxed};
+    fn image() -> ChatListAvatarFfi {
+        ChatListAvatarFfi {
+            image_hash_hex: "hash".into(),
+            image_key_hex: "secret".into(),
+            image_nonce_hex: "nonce".into(),
+            image_upload_key_hex: "upload-secret".into(),
+            media_type: Some("image/png".into()),
+        }
+    }
+    #[test]
+    fn presented_results_deep_free_every_selected_variant() {
+        let _guard = audit::test_lock();
+        #[cfg(feature = "alloc-audit")]
+        let before = audit::live_allocations();
+        let variants = [
+            (
+                PresentationTextFfi::Literal {
+                    text: "Name".into(),
+                },
+                SelectedAvatarFfi::EncryptedGroupImage {
+                    image: image(),
+                    cache_key: "encrypted-cache".into(),
+                },
+            ),
+            (
+                PresentationTextFfi::UnnamedGroup {
+                    member_count: Some(3),
+                },
+                SelectedAvatarFfi::RemoteImage {
+                    url: "https://example.org/avatar".into(),
+                    cache_key: "remote-cache".into(),
+                },
+            ),
+            (
+                PresentationTextFfi::UnavailableConversation,
+                SelectedAvatarFfi::Placeholder {
+                    stable_seed: "seed".into(),
+                    source: PresentationSourceFfi::UnknownFallback,
+                },
+            ),
+        ];
+        for (title, avatar) in variants {
+            let presentation = ConversationPresentationFfi {
+                title,
+                avatar,
+                title_source: PresentationSourceFfi::Group,
+                avatar_source: PresentationSourceFfi::Group,
+                peer_id: Some("peer".into()),
+                resolution: PresentationResolutionFfi::LastKnown,
+            };
+            let row = row();
+            let update = PresentedChatListUpdateFfi {
+                subscription_generation: "generation".into(),
+                sequence: 3,
+                snapshot: PresentedChatListSnapshotFfi {
+                    rows: vec![PresentedChatRowFfi { row, presentation }],
+                    presentation_version: PresentationVersionFfi {
+                        account_store_epoch: vec![1; 16],
+                        revision: 2,
+                    },
+                },
+            };
+            let mirror: MarmotPresentedChatListUpdate = update.into();
+            assert_eq!(mirror.sequence, 3);
+            assert_eq!(mirror.snapshot.rows_len, 1);
+            assert_eq!(
+                mirror.snapshot.presentation_version.account_store_epoch_len,
+                16
+            );
+            unsafe {
+                marmot_presented_chat_list_update_free(boxed(mirror));
+            }
+        }
+        unsafe {
+            marmot_presented_chat_list_update_free(std::ptr::null_mut());
+            marmot_presented_chat_row_free(std::ptr::null_mut());
+            marmot_presented_chat_list_snapshot_free(std::ptr::null_mut());
+        }
+        #[cfg(feature = "alloc-audit")]
+        assert_eq!(audit::live_allocations(), before);
+    }
+    fn row() -> ChatListRowFfi {
+        ChatListRowFfi {
+            group_id_hex: "fixture".into(),
+            pinned: false,
+            pinned_position: None,
+            archived: false,
+            pending_confirmation: false,
+            lifecycle_state: GroupLifecycleStateFfi::Stable,
+            disbanding: false,
+            disband_request: None,
+            title: "fixture".into(),
+            group_name: "fixture".into(),
+            avatar_url: None,
+            avatar: Some(image()),
+            last_message: None,
+            unread_count: 0,
+            has_unread: false,
+            manually_marked_unread: false,
+            unread_mention_count: 0,
+            unread_mention: false,
+            first_unread_message_id_hex: None,
+            last_read_message_id_hex: None,
+            last_read_timeline_at: None,
+            conversation_created_at: 0,
+            activity_sort_at: 0,
+            updated_at: 0,
+            self_membership: SelfMembershipFfi::Member,
+            conversation_kind: ChatConversationKindFfi::Group,
+            muted: false,
+            muted_until_ms: None,
+            leave_request_pending: false,
+            leave_requested_at_ms: None,
+        }
+    }
+}

--- a/crates/marmot-uniffi/README.md
+++ b/crates/marmot-uniffi/README.md
@@ -262,3 +262,21 @@ edited Markdown message per update. Results include source cloning, conversion,
 and UniFFI serialization: p50/p95 over 100 samples after 10 warm-up iterations,
 plus serialized byte counts. They exclude storage, runtime window application,
 FFI scheduling, and Swift/Kotlin decoding and rendering.
+
+## Selected chat-list presentation
+
+`openPresentedChatList(accountRef, includeArchived)` returns an account-bound subscription.
+Take `snapshot()` once (generation plus sequence zero), then consume `next()` as complete replacement snapshots.
+Each row contains the existing chat-list fields and MDK's selected title/avatar; hosts render the typed fallback text
+with their own localization and load the selected avatar descriptor without a roster/profile lookup.
+`presentedChatList` and `presentedChatListRow` provide the same local contract for one-shot and creation/rebind paths.
+
+First use can await bounded local preparation. `ChatPresentationNotReady` means preparation did not advance and may be
+retried after maintenance; it is not an empty list or missing group. Storage errors remain errors. Ready reads do no
+network fetching or repair writes. Selected values survive offline reopen; avatar bytes still use the existing loaders.
+
+Order updates by the handle's generation and sequence. `presentationVersion` only versions selected presentation:
+an unread, pin, archive or mute update can have the same presentation revision. Drop the old handle when changing
+accounts; cancellation preserves a pending refresh, and shutdown ends the stream. Account-store replacement requires
+opening a new handle. Do not log rows or avatar material, including generated host-language record stringification.
+Existing chat-list APIs remain available during client migration. Android/iOS adoption is a separate delivery step.

--- a/crates/marmot-uniffi/src/commands/mod.rs
+++ b/crates/marmot-uniffi/src/commands/mod.rs
@@ -32,3 +32,5 @@ pub use media::parse_media_imeta_tag;
 pub use onboarding::OnboardingSubscription;
 
 mod product_analytics;
+
+mod presentation;

--- a/crates/marmot-uniffi/src/commands/presentation.rs
+++ b/crates/marmot-uniffi/src/commands/presentation.rs
@@ -48,10 +48,160 @@ impl Marmot {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::conversions::PresentationTextFfi;
+    use crate::conversions::{
+        PresentationResolutionFfi, PresentationSourceFfi, PresentationTextFfi, SelectedAvatarFfi,
+    };
     use cgka_traits::TransportEndpoint;
     use marmot_app::{AccountSetupRequest, MarmotApp};
     use nostr_relay_builder::MockRelay;
+
+    #[tokio::test]
+    async fn presented_peer_and_fallback_survive_native_offline_reopen() {
+        let relay = MockRelay::run().await.unwrap();
+        let relay_url = relay.url().await.to_string();
+        let dir = tempfile::tempdir().unwrap();
+        let app = MarmotApp::with_relays(dir.path(), vec![relay_url.clone()]);
+        let kit = Marmot {
+            runtime: app.runtime(),
+            app,
+        };
+        let request = || AccountSetupRequest {
+            default_relays: vec![TransportEndpoint(relay_url.clone())],
+            bootstrap_relays: vec![TransportEndpoint(relay_url.clone())],
+            publish_missing_relay_lists: true,
+            publish_initial_key_package: true,
+            ..Default::default()
+        };
+        let alice = kit
+            .runtime
+            .create_identity(request())
+            .await
+            .unwrap()
+            .account
+            .account_id_hex;
+        let bob = kit
+            .runtime
+            .create_identity(request())
+            .await
+            .unwrap()
+            .account
+            .account_id_hex;
+        kit.runtime
+            .publish_user_profile(
+                &bob,
+                marmot_app::UserProfileMetadata {
+                    display_name: Some("Cached peer".into()),
+                    picture: Some("https://example.com/peer.png".into()),
+                    ..Default::default()
+                },
+                marmot_app::AccountRelayListBootstrap::new(
+                    vec![TransportEndpoint(relay_url.clone())],
+                    vec![TransportEndpoint(relay_url.clone())],
+                ),
+            )
+            .await
+            .unwrap();
+        kit.refresh_profile(bob.clone(), vec![relay_url.clone()])
+            .await
+            .unwrap();
+        let direct = kit
+            .create_group(alice.clone(), String::new(), vec![bob.clone()], None)
+            .await
+            .unwrap();
+        let named = kit
+            .create_group(alice.clone(), "Custom pair".into(), vec![bob.clone()], None)
+            .await
+            .unwrap();
+        let fallback = kit
+            .create_group(alice.clone(), String::new(), vec![], None)
+            .await
+            .unwrap();
+        kit.runtime.shutdown_and_close().await.unwrap();
+        drop(kit);
+        drop(relay);
+
+        // No runtime workers or relay are started on reopen: this is the cached first read.
+        let app = MarmotApp::with_relays(dir.path(), vec![relay_url]);
+        let kit = Marmot {
+            runtime: app.runtime(),
+            app,
+        };
+        let list = kit.presented_chat_list(alice.clone(), false).await.unwrap();
+        assert_eq!(list.rows.len(), 3);
+        let peer = &list
+            .rows
+            .iter()
+            .find(|r| r.row.group_id_hex == direct)
+            .unwrap()
+            .presentation;
+        assert!(
+            matches!(&peer.title, PresentationTextFfi::Literal { text } if text == "Cached peer")
+        );
+        assert_eq!(peer.peer_id.as_deref(), Some(bob.as_str()));
+        assert!(matches!(
+            peer.title_source,
+            PresentationSourceFfi::PeerProfile
+        ));
+        assert!(matches!(
+            peer.avatar_source,
+            PresentationSourceFfi::PeerProfile
+        ));
+        assert!(matches!(peer.resolution, PresentationResolutionFfi::Cached));
+        let SelectedAvatarFfi::RemoteImage { url, cache_key } = &peer.avatar else {
+            panic!("cached peer avatar descriptor");
+        };
+        assert_eq!(url, "https://example.com/peer.png");
+        assert_eq!(cache_key.len(), 64);
+        let key = cache_key.clone();
+        let pair = kit
+            .presented_chat_list_row(alice.clone(), named)
+            .await
+            .unwrap()
+            .unwrap()
+            .presentation;
+        assert!(
+            matches!(&pair.title, PresentationTextFfi::Literal { text } if text == "Custom pair")
+        );
+        assert!(matches!(pair.title_source, PresentationSourceFfi::Group));
+        assert!(matches!(
+            pair.avatar_source,
+            PresentationSourceFfi::PeerProfile
+        ));
+        assert_eq!(pair.peer_id.as_deref(), Some(bob.as_str()));
+        let empty = &list
+            .rows
+            .iter()
+            .find(|r| r.row.group_id_hex == fallback)
+            .unwrap()
+            .presentation;
+        assert!(matches!(
+            empty.title,
+            PresentationTextFfi::UnnamedGroup {
+                member_count: Some(1)
+            }
+        ));
+        assert!(matches!(
+            empty.resolution,
+            PresentationResolutionFfi::Fallback
+        ));
+        assert!(empty.peer_id.is_none());
+        assert!(
+            matches!(&empty.avatar, SelectedAvatarFfi::Placeholder { stable_seed, source: PresentationSourceFfi::GroupFallback } if !stable_seed.is_empty())
+        );
+        let sub = kit.open_presented_chat_list(alice, false).await.unwrap();
+        let attached = sub.snapshot().unwrap();
+        let peer = &attached
+            .snapshot
+            .rows
+            .iter()
+            .find(|r| r.row.group_id_hex == direct)
+            .unwrap()
+            .presentation;
+        assert!(
+            matches!(&peer.avatar, SelectedAvatarFfi::RemoteImage { cache_key, .. } if cache_key == &key)
+        );
+        kit.runtime.shutdown_and_close().await.unwrap();
+    }
 
     #[tokio::test]
     async fn presented_contract_round_trips_snapshot_and_updates_to_native() {

--- a/crates/marmot-uniffi/src/commands/presentation.rs
+++ b/crates/marmot-uniffi/src/commands/presentation.rs
@@ -1,0 +1,143 @@
+//! Complete chat-list display reads and the snapshot/subscription handoff.
+use crate::conversions::{PresentedChatListSnapshotFfi, PresentedChatRowFfi};
+use crate::subscriptions::PresentedChatListSubscription;
+use crate::{Marmot, MarmotKitError};
+use std::sync::Arc;
+
+#[uniffi::export(async_runtime = "tokio")]
+impl Marmot {
+    /// Local whole rows, including selected title/avatar. First use may await local preparation.
+    pub async fn presented_chat_list(
+        &self,
+        account_ref: String,
+        include_archived: bool,
+    ) -> Result<PresentedChatListSnapshotFfi, MarmotKitError> {
+        Ok(self
+            .runtime
+            .presented_chat_list(&account_ref, include_archived)
+            .await?
+            .into())
+    }
+    /// One complete row for creation/rebind; missing local groups return None.
+    pub async fn presented_chat_list_row(
+        &self,
+        account_ref: String,
+        group_id_hex: String,
+    ) -> Result<Option<PresentedChatRowFfi>, MarmotKitError> {
+        Ok(self
+            .runtime
+            .presented_chat_list_row(&account_ref, &group_id_hex)
+            .await?
+            .map(Into::into))
+    }
+    /// Returns an attached handle containing the initial snapshot. Take its snapshot once,
+    /// then consume whole replacement updates; dispose the old handle on account switch.
+    pub async fn open_presented_chat_list(
+        &self,
+        account_ref: String,
+        include_archived: bool,
+    ) -> Result<Arc<PresentedChatListSubscription>, MarmotKitError> {
+        Ok(PresentedChatListSubscription::new(
+            self.runtime
+                .open_presented_chat_list(&account_ref, include_archived)
+                .await?,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conversions::PresentationTextFfi;
+    use cgka_traits::TransportEndpoint;
+    use marmot_app::{AccountSetupRequest, MarmotApp};
+    use nostr_relay_builder::MockRelay;
+
+    #[tokio::test]
+    async fn presented_contract_round_trips_snapshot_and_updates_to_native() {
+        let relay = MockRelay::run().await.unwrap();
+        let relay_url = relay.url().await.to_string();
+        let dir = tempfile::tempdir().unwrap();
+        let app = MarmotApp::with_relays(dir.path(), vec![relay_url.clone()]);
+        let kit = Marmot {
+            runtime: app.runtime(),
+            app,
+        };
+        let endpoint = TransportEndpoint(relay_url);
+        let account = kit
+            .runtime
+            .create_identity(AccountSetupRequest {
+                default_relays: vec![endpoint.clone()],
+                bootstrap_relays: vec![endpoint],
+                publish_missing_relay_lists: true,
+                publish_initial_key_package: true,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let label = account.account.account_id_hex;
+        let group = kit
+            .create_group(label.clone(), "Native name".into(), vec![], None)
+            .await
+            .unwrap();
+        let sub = kit
+            .open_presented_chat_list(label.clone(), false)
+            .await
+            .unwrap();
+        let initial = sub.snapshot().unwrap();
+        assert!(sub.snapshot().is_none());
+        assert_eq!(initial.sequence, 0);
+        assert_eq!(initial.snapshot.rows.len(), 1);
+        assert!(
+            matches!(&initial.snapshot.rows[0].presentation.title, PresentationTextFfi::Literal { text } if text == "Native name")
+        );
+        let one = kit
+            .presented_chat_list_row(label.clone(), group.clone())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            one.row.group_id_hex,
+            initial.snapshot.rows[0].row.group_id_hex
+        );
+        kit.set_chat_manually_unread(label.clone(), group.clone(), true)
+            .unwrap();
+        let update = tokio::time::timeout(std::time::Duration::from_secs(5), sub.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            update.subscription_generation,
+            initial.subscription_generation
+        );
+        assert_eq!(update.sequence, 1);
+        assert!(update.snapshot.rows[0].row.manually_marked_unread);
+        assert!(matches!(
+            kit.presented_chat_list_row(label.clone(), "not hex".into())
+                .await,
+            Err(MarmotKitError::InvalidHex { .. })
+        ));
+        kit.set_group_archived(label.clone(), group.clone(), true)
+            .await
+            .unwrap();
+        let removed = tokio::time::timeout(std::time::Duration::from_secs(5), sub.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert!(removed.snapshot.rows.is_empty());
+        let archived = kit.presented_chat_list(label.clone(), true).await.unwrap();
+        assert_eq!(archived.rows.len(), 1);
+        assert!(archived.rows[0].row.archived);
+        kit.set_group_archived(label, group, false).await.unwrap();
+        let restored = tokio::time::timeout(std::time::Duration::from_secs(5), sub.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(restored.snapshot.rows.len(), 1);
+        kit.runtime.shutdown().await;
+        assert!(sub.next().await.unwrap().is_none());
+    }
+}

--- a/crates/marmot-uniffi/src/conversions/mod.rs
+++ b/crates/marmot-uniffi/src/conversions/mod.rs
@@ -740,3 +740,6 @@ mod tests {
         );
     }
 }
+
+mod presentation;
+pub use presentation::*;

--- a/crates/marmot-uniffi/src/conversions/presentation.rs
+++ b/crates/marmot-uniffi/src/conversions/presentation.rs
@@ -68,12 +68,12 @@ pub struct PresentedChatListUpdateFfi {
     pub snapshot: PresentedChatListSnapshotFfi,
 }
 
-macro_rules! redacted_debug {
+macro_rules! impl_redacted_fmt {
     ($($ty:ty),* $(,)?) => {$(impl std::fmt::Debug for $ty {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { f.debug_struct(stringify!($ty)).finish_non_exhaustive() }
     })*};
 }
-redacted_debug!(
+impl_redacted_fmt!(
     PresentationTextFfi,
     SelectedAvatarFfi,
     ConversationPresentationFfi,

--- a/crates/marmot-uniffi/src/conversions/presentation.rs
+++ b/crates/marmot-uniffi/src/conversions/presentation.rs
@@ -1,0 +1,182 @@
+//! Mechanical mappings of MDK's selected presentation; localization stays on the host.
+use super::{ChatListAvatarFfi, ChatListRowFfi};
+use marmot_app as app;
+
+#[derive(Clone, uniffi::Enum)]
+pub enum PresentationTextFfi {
+    Literal { text: String },
+    UnnamedGroup { member_count: Option<u64> },
+    UnavailableConversation,
+}
+#[derive(Clone, Copy, Debug, uniffi::Enum)]
+pub enum PresentationSourceFfi {
+    Group,
+    PeerProfile,
+    PeerFallback,
+    GroupFallback,
+    UnknownFallback,
+}
+#[derive(Clone, Copy, Debug, uniffi::Enum)]
+pub enum PresentationResolutionFfi {
+    Cached,
+    LastKnown,
+    Fallback,
+}
+#[derive(Clone, uniffi::Enum)]
+pub enum SelectedAvatarFfi {
+    RemoteImage {
+        url: String,
+        cache_key: String,
+    },
+    EncryptedGroupImage {
+        image: ChatListAvatarFfi,
+        cache_key: String,
+    },
+    Placeholder {
+        stable_seed: String,
+        source: PresentationSourceFfi,
+    },
+}
+#[derive(Clone, uniffi::Record)]
+pub struct ConversationPresentationFfi {
+    pub title: PresentationTextFfi,
+    pub avatar: SelectedAvatarFfi,
+    pub title_source: PresentationSourceFfi,
+    pub avatar_source: PresentationSourceFfi,
+    pub peer_id: Option<String>,
+    pub resolution: PresentationResolutionFfi,
+}
+#[derive(Clone, uniffi::Record)]
+pub struct PresentationVersionFfi {
+    pub account_store_epoch: Vec<u8>,
+    pub revision: u64,
+}
+#[derive(Clone, uniffi::Record)]
+pub struct PresentedChatRowFfi {
+    pub row: ChatListRowFfi,
+    pub presentation: ConversationPresentationFfi,
+}
+#[derive(Clone, uniffi::Record)]
+pub struct PresentedChatListSnapshotFfi {
+    pub rows: Vec<PresentedChatRowFfi>,
+    pub presentation_version: PresentationVersionFfi,
+}
+#[derive(Clone, uniffi::Record)]
+pub struct PresentedChatListUpdateFfi {
+    pub subscription_generation: String,
+    pub sequence: u64,
+    pub snapshot: PresentedChatListSnapshotFfi,
+}
+
+macro_rules! redacted_debug {
+    ($($ty:ty),* $(,)?) => {$(impl std::fmt::Debug for $ty {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { f.debug_struct(stringify!($ty)).finish_non_exhaustive() }
+    })*};
+}
+redacted_debug!(
+    PresentationTextFfi,
+    SelectedAvatarFfi,
+    ConversationPresentationFfi,
+    PresentationVersionFfi,
+    PresentedChatRowFfi,
+    PresentedChatListSnapshotFfi,
+    PresentedChatListUpdateFfi
+);
+impl From<app::PresentationText> for PresentationTextFfi {
+    fn from(v: app::PresentationText) -> Self {
+        match v {
+            app::PresentationText::Literal(text) => Self::Literal { text },
+            app::PresentationText::UnnamedGroup { member_count } => {
+                Self::UnnamedGroup { member_count }
+            }
+            app::PresentationText::UnavailableConversation => Self::UnavailableConversation,
+        }
+    }
+}
+impl From<app::PresentationSource> for PresentationSourceFfi {
+    fn from(v: app::PresentationSource) -> Self {
+        match v {
+            app::PresentationSource::Group => Self::Group,
+            app::PresentationSource::PeerProfile => Self::PeerProfile,
+            app::PresentationSource::PeerFallback => Self::PeerFallback,
+            app::PresentationSource::GroupFallback => Self::GroupFallback,
+            app::PresentationSource::UnknownFallback => Self::UnknownFallback,
+        }
+    }
+}
+impl From<app::PresentationResolution> for PresentationResolutionFfi {
+    fn from(v: app::PresentationResolution) -> Self {
+        match v {
+            app::PresentationResolution::Cached => Self::Cached,
+            app::PresentationResolution::LastKnown => Self::LastKnown,
+            app::PresentationResolution::Fallback => Self::Fallback,
+        }
+    }
+}
+impl From<app::SelectedAvatar> for SelectedAvatarFfi {
+    fn from(v: app::SelectedAvatar) -> Self {
+        match v {
+            app::SelectedAvatar::RemoteImage { url, cache_key } => {
+                Self::RemoteImage { url, cache_key }
+            }
+            app::SelectedAvatar::EncryptedGroupImage { image, cache_key } => {
+                Self::EncryptedGroupImage {
+                    image: image.into(),
+                    cache_key,
+                }
+            }
+            app::SelectedAvatar::Placeholder {
+                stable_seed,
+                source,
+            } => Self::Placeholder {
+                stable_seed,
+                source: source.into(),
+            },
+        }
+    }
+}
+impl From<app::ConversationPresentation> for ConversationPresentationFfi {
+    fn from(v: app::ConversationPresentation) -> Self {
+        Self {
+            title: v.title.into(),
+            avatar: v.avatar.into(),
+            title_source: v.title_source.into(),
+            avatar_source: v.avatar_source.into(),
+            peer_id: v.peer_id,
+            resolution: v.resolution.into(),
+        }
+    }
+}
+impl From<app::ChatPresentationVersion> for PresentationVersionFfi {
+    fn from(v: app::ChatPresentationVersion) -> Self {
+        Self {
+            account_store_epoch: v.store_epoch,
+            revision: v.revision,
+        }
+    }
+}
+impl From<app::PresentedChatRow> for PresentedChatRowFfi {
+    fn from(v: app::PresentedChatRow) -> Self {
+        Self {
+            row: v.row.into(),
+            presentation: v.presentation.into(),
+        }
+    }
+}
+impl From<app::PresentedChatListSnapshot> for PresentedChatListSnapshotFfi {
+    fn from(v: app::PresentedChatListSnapshot) -> Self {
+        Self {
+            rows: v.rows.into_iter().map(Into::into).collect(),
+            presentation_version: v.presentation_version.into(),
+        }
+    }
+}
+impl From<app::PresentedChatListUpdate> for PresentedChatListUpdateFfi {
+    fn from(v: app::PresentedChatListUpdate) -> Self {
+        Self {
+            subscription_generation: v.subscription_generation,
+            sequence: v.sequence,
+            snapshot: v.snapshot.into(),
+        }
+    }
+}

--- a/crates/marmot-uniffi/src/conversions/presentation.rs
+++ b/crates/marmot-uniffi/src/conversions/presentation.rs
@@ -180,3 +180,59 @@ impl From<app::PresentedChatListUpdate> for PresentedChatListUpdateFfi {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unavailable_and_encrypted_last_known_presentation_preserve_native_fields() {
+        let value = ConversationPresentationFfi::from(app::ConversationPresentation {
+            title: app::PresentationText::UnavailableConversation,
+            avatar: app::SelectedAvatar::EncryptedGroupImage {
+                image: app::ChatListAvatar {
+                    image_hash_hex: "11".repeat(32),
+                    image_key_hex: "22".repeat(32),
+                    image_nonce_hex: "33".repeat(12),
+                    image_upload_key_hex: "44".repeat(32),
+                    media_type: Some("image/png".into()),
+                },
+                cache_key: "encrypted-cache-key".into(),
+            },
+            title_source: app::PresentationSource::UnknownFallback,
+            avatar_source: app::PresentationSource::Group,
+            peer_id: None,
+            resolution: app::PresentationResolution::LastKnown,
+        });
+        assert!(matches!(
+            value.title,
+            PresentationTextFfi::UnavailableConversation
+        ));
+        assert!(matches!(
+            value.title_source,
+            PresentationSourceFfi::UnknownFallback
+        ));
+        assert!(matches!(value.avatar_source, PresentationSourceFfi::Group));
+        assert!(matches!(
+            value.resolution,
+            PresentationResolutionFfi::LastKnown
+        ));
+        assert!(value.peer_id.is_none());
+        let SelectedAvatarFfi::EncryptedGroupImage { image, cache_key } = value.avatar else {
+            panic!("encrypted descriptor must retain its native variant");
+        };
+        assert_eq!(cache_key, "encrypted-cache-key");
+        assert_eq!(image.image_hash_hex, "11".repeat(32));
+        assert_eq!(image.image_key_hex, "22".repeat(32));
+        assert_eq!(image.image_nonce_hex, "33".repeat(12));
+        assert_eq!(image.image_upload_key_hex, "44".repeat(32));
+        assert_eq!(image.media_type.as_deref(), Some("image/png"));
+        let peer = SelectedAvatarFfi::from(app::SelectedAvatar::Placeholder {
+            stable_seed: "peer-seed".into(),
+            source: app::PresentationSource::PeerFallback,
+        });
+        assert!(
+            matches!(peer, SelectedAvatarFfi::Placeholder { stable_seed, source: PresentationSourceFfi::PeerFallback } if stable_seed == "peer-seed")
+        );
+    }
+}

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -41,6 +41,8 @@ pub enum MarmotKitError {
     /// direct conversation.
     #[error("direct conversation index is not ready; retry after account hydration")]
     DirectConversationIndexNotReady,
+    #[error("chat presentation preparation is incomplete; retry after local maintenance")]
+    ChatPresentationNotReady,
     #[error("invalid chat pin: {details}")]
     InvalidChatPin { details: String },
     /// Host-supplied draft attachment metadata is malformed.
@@ -308,6 +310,7 @@ impl From<AppError> for MarmotKitError {
             AppError::InvalidGroupMembershipPage(_) => Self::InvalidGroupMembershipPage {
                 max_groups: marmot_app::MAX_GROUP_MEMBER_IDS_PAGE_SIZE as u64,
             },
+            AppError::ChatPresentationNotReady => Self::ChatPresentationNotReady,
             AppError::DirectConversationIndexNotReady => Self::DirectConversationIndexNotReady,
             AppError::InvalidCachedIdentityPage(_) => Self::InvalidCachedIdentityPage {
                 max_accounts: marmot_app::MAX_CACHED_IDENTITY_PAGE_SIZE as u64,

--- a/crates/marmot-uniffi/src/lib.rs
+++ b/crates/marmot-uniffi/src/lib.rs
@@ -350,6 +350,8 @@ impl Marmot {
     }
 }
 
+pub use subscriptions::PresentedChatListSubscription;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/marmot-uniffi/src/subscriptions.rs
+++ b/crates/marmot-uniffi/src/subscriptions.rs
@@ -442,3 +442,40 @@ impl AgentStreamSubscription {
         inner.recv().await.map(Into::into)
     }
 }
+
+/// Snapshot and ordered whole-list updates. Drop to cancel; read errors are retryable
+/// according to their typed error, and do not consume the pending refresh.
+#[derive(uniffi::Object)]
+pub struct PresentedChatListSubscription {
+    snapshot: StdMutex<Option<crate::conversions::PresentedChatListUpdateFfi>>,
+    inner: Mutex<marmot_app::RuntimePresentedChatListSubscription>,
+}
+impl PresentedChatListSubscription {
+    pub(crate) fn new(mut inner: marmot_app::RuntimePresentedChatListSubscription) -> Arc<Self> {
+        let snapshot = crate::conversions::PresentedChatListUpdateFfi {
+            subscription_generation: inner.subscription_generation.clone(),
+            sequence: 0,
+            snapshot: marmot_app::PresentedChatListSnapshot {
+                rows: std::mem::take(&mut inner.snapshot.rows),
+                presentation_version: inner.snapshot.presentation_version.clone(),
+            }
+            .into(),
+        };
+        Arc::new(Self {
+            snapshot: StdMutex::new(Some(snapshot)),
+            inner: Mutex::new(inner),
+        })
+    }
+}
+#[uniffi::export(async_runtime = "tokio")]
+impl PresentedChatListSubscription {
+    /// Take the initial snapshot once, with generation and sequence zero.
+    pub fn snapshot(&self) -> Option<crate::conversions::PresentedChatListUpdateFfi> {
+        take_snapshot(&self.snapshot)
+    }
+    pub async fn next(
+        &self,
+    ) -> Result<Option<crate::conversions::PresentedChatListUpdateFfi>, MarmotKitError> {
+        Ok(self.inner.lock().await.recv().await?.map(Into::into))
+    }
+}

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -2312,7 +2312,10 @@ fn read_state_tx(
     .storage()
 }
 
-fn chat_list_rows_tx(tx: &Connection, query: ChatListQuery) -> StorageResult<Vec<ChatListRow>> {
+pub(crate) fn chat_list_rows_tx(
+    tx: &Connection,
+    query: ChatListQuery,
+) -> StorageResult<Vec<ChatListRow>> {
     let sql = if query.include_archived {
         format!(
             "{CHAT_LIST_ROW_SELECT_AND_JOINS}
@@ -2403,7 +2406,10 @@ fn direct_conversation_candidate_rows_tx(
     Ok(rows)
 }
 
-fn chat_list_row_tx(tx: &Connection, group_id_hex: &str) -> StorageResult<Option<ChatListRow>> {
+pub(crate) fn chat_list_row_tx(
+    tx: &Connection,
+    group_id_hex: &str,
+) -> StorageResult<Option<ChatListRow>> {
     let now_ms = unix_now_ms();
     let sql = format!(
         "{CHAT_LIST_ROW_SELECT_AND_JOINS}

--- a/crates/storage-sqlite/src/chat_presentation.rs
+++ b/crates/storage-sqlite/src/chat_presentation.rs
@@ -553,6 +553,10 @@ impl SqliteAccountStorage {
         group: Option<&str>,
     ) -> StorageResult<Option<PresentedChatListSnapshot>> {
         let conn = self.lock()?;
+        // Keep this guard until the read transaction ends and use only `tx` below:
+        // never release/reacquire the account lock or call another storage method here.
+        // A deferred read snapshot avoids with_transaction's BEGIN IMMEDIATE write
+        // reservation, while the guard excludes interleaving users of this connection.
         let tx = conn.unchecked_transaction().storage()?;
         let pending: bool = match group {
             Some(group) => tx.query_row(

--- a/crates/storage-sqlite/src/chat_presentation.rs
+++ b/crates/storage-sqlite/src/chat_presentation.rs
@@ -511,3 +511,90 @@ fn valid_member_identity(raw: &str) -> bool {
 
 #[cfg(test)]
 mod tests;
+
+/// A complete existing row with MDK-selected display; callers need no peer lookup.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PresentedChatRow {
+    pub row: crate::ChatListRow,
+    pub presentation: ConversationPresentation,
+}
+impl std::fmt::Debug for PresentedChatRow {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PresentedChatRow")
+            .field("presentation", &self.presentation)
+            .finish_non_exhaustive()
+    }
+}
+/// The version describes selected presentation only, not unread or other row fields.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PresentedChatListSnapshot {
+    pub rows: Vec<PresentedChatRow>,
+    pub presentation_version: ChatPresentationVersion,
+}
+impl std::fmt::Debug for PresentedChatListSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PresentedChatListSnapshot")
+            .field("row_count", &self.rows.len())
+            .field("presentation_version", &self.presentation_version)
+            .finish()
+    }
+}
+impl SqliteAccountStorage {
+    /// Read existing row fields, selection and version in one local read transaction.
+    /// `None` means preparation is required, never an empty successful cache miss.
+    /// A keyed read with no group returns a ready snapshot with zero rows.
+    pub fn read_presented_chat_list(
+        &self,
+        query: crate::ChatListQuery,
+        group: Option<&str>,
+    ) -> StorageResult<Option<PresentedChatListSnapshot>> {
+        let conn = self.lock()?;
+        let tx = conn.unchecked_transaction().storage()?;
+        let pending: bool = match group {
+            Some(group) => tx.query_row(
+                "SELECT EXISTS(SELECT 1 FROM chat_presentation_row_work WHERE group_id_hex = ?1)",
+                [group], |r| r.get(0)).storage()?,
+            None => tx.query_row("SELECT EXISTS(SELECT 1 FROM chat_presentation_row_work)", [], |r| r.get(0)).storage()?,
+        };
+        if pending {
+            return Ok(None);
+        }
+        let rows = match group {
+            Some(group) => crate::chat_list::chat_list_row_tx(&tx, group)?
+                .into_iter()
+                .collect(),
+            None => crate::chat_list::chat_list_rows_tx(&tx, query)?,
+        };
+        let mut presented = Vec::with_capacity(rows.len());
+        for row in rows {
+            let (bytes, dirty): (Option<Vec<u8>>, bool) = tx.query_row(
+                "SELECT presentation_json, presentation_applied_source_revision != presentation_source_revision FROM chat_list_rows WHERE group_id_hex = ?1",
+                [&row.group_id_hex], |r| Ok((r.get(0)?, r.get(1)?))).storage()?;
+            let Some(bytes) = bytes else {
+                return Ok(None);
+            };
+            let mut presentation = decode_envelope(&bytes)?.value.presentation;
+            if dirty {
+                presentation.resolution = PresentationResolution::LastKnown;
+            }
+            presented.push(PresentedChatRow { row, presentation });
+        }
+        let presentation_version = tx
+            .query_row(
+                "SELECT store_epoch, revision FROM chat_presentation_meta WHERE id = 1",
+                [],
+                |r| {
+                    Ok(ChatPresentationVersion {
+                        store_epoch: r.get(0)?,
+                        revision: nonnegative(r, 1)?,
+                    })
+                },
+            )
+            .storage()?;
+        tx.commit().storage()?;
+        Ok(Some(PresentedChatListSnapshot {
+            rows: presented,
+            presentation_version,
+        }))
+    }
+}

--- a/crates/storage-sqlite/src/chat_presentation.rs
+++ b/crates/storage-sqlite/src/chat_presentation.rs
@@ -146,6 +146,14 @@ fn decode_envelope(bytes: &[u8]) -> StorageResult<Envelope> {
     }
     Ok(envelope)
 }
+// Preserve the absence of usable evidence while a fallback is dirty.
+fn decode_retained(bytes: &[u8], dirty: bool) -> StorageResult<StoredChatPresentation> {
+    let mut value = decode_envelope(bytes)?.value;
+    if dirty && value.presentation.resolution == PresentationResolution::Cached {
+        value.presentation.resolution = PresentationResolution::LastKnown;
+    }
+    Ok(value)
+}
 fn invalid(detail: &str) -> StorageError {
     StorageError::Serialization(detail.to_owned())
 }
@@ -182,13 +190,9 @@ impl SqliteAccountStorage {
         match row {
             None => Ok(ChatPresentationRead::Missing),
             Some((None, _)) => Ok(ChatPresentationRead::Pending),
-            Some((Some(bytes), dirty)) => {
-                let mut envelope = decode_envelope(&bytes)?;
-                if dirty {
-                    envelope.value.presentation.resolution = PresentationResolution::LastKnown;
-                }
-                Ok(ChatPresentationRead::Ready(Box::new(envelope.value)))
-            }
+            Some((Some(bytes), dirty)) => Ok(ChatPresentationRead::Ready(Box::new(
+                decode_retained(&bytes, dirty)?,
+            ))),
         }
     }
     /// The pending partial index is the durable backfill worklist. Committed rows leave it;
@@ -563,20 +567,32 @@ impl SqliteAccountStorage {
             Some(group) => crate::chat_list::chat_list_row_tx(&tx, group)?
                 .into_iter()
                 .collect(),
-            None => crate::chat_list::chat_list_rows_tx(&tx, query)?,
+            None => crate::chat_list::chat_list_rows_tx(&tx, query.clone())?,
         };
+        // One cached query for all selected envelopes; keyed reads retain an indexed lookup.
+        let mut statement = tx.prepare_cached(match group {
+            Some(_) => "SELECT group_id_hex, presentation_json, presentation_applied_source_revision != presentation_source_revision FROM chat_list_rows WHERE group_id_hex = ?1",
+            None if query.include_archived => "SELECT group_id_hex, presentation_json, presentation_applied_source_revision != presentation_source_revision FROM chat_list_rows",
+            None => "SELECT group_id_hex, presentation_json, presentation_applied_source_revision != presentation_source_revision FROM chat_list_rows WHERE archived = 0",
+        }).storage()?;
+        let parameters: Vec<&str> = group.into_iter().collect();
+        let mut selections = statement
+            .query_map(rusqlite::params_from_iter(parameters), |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    (r.get::<_, Option<Vec<u8>>>(1)?, r.get::<_, bool>(2)?),
+                ))
+            })
+            .storage()?
+            .collect::<rusqlite::Result<std::collections::HashMap<_, _>>>()
+            .storage()?;
+        drop(statement);
         let mut presented = Vec::with_capacity(rows.len());
         for row in rows {
-            let (bytes, dirty): (Option<Vec<u8>>, bool) = tx.query_row(
-                "SELECT presentation_json, presentation_applied_source_revision != presentation_source_revision FROM chat_list_rows WHERE group_id_hex = ?1",
-                [&row.group_id_hex], |r| Ok((r.get(0)?, r.get(1)?))).storage()?;
-            let Some(bytes) = bytes else {
+            let Some((Some(bytes), dirty)) = selections.remove(&row.group_id_hex) else {
                 return Ok(None);
             };
-            let mut presentation = decode_envelope(&bytes)?.value.presentation;
-            if dirty {
-                presentation.resolution = PresentationResolution::LastKnown;
-            }
+            let presentation = decode_retained(&bytes, dirty)?.presentation;
             presented.push(PresentedChatRow { row, presentation });
         }
         let presentation_version = tx

--- a/crates/storage-sqlite/src/chat_presentation/tests.rs
+++ b/crates/storage-sqlite/src/chat_presentation/tests.rs
@@ -696,3 +696,62 @@ fn initialization_completes_a_new_row_and_ignores_deleted_work() {
     );
     assert!(store.chat_list_row("22").unwrap().is_none());
 }
+
+#[test]
+fn presented_snapshot_is_complete_read_only_and_clears_replaced_peer() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    seed(&store, "11");
+    let query = crate::ChatListQuery {
+        include_archived: true,
+    };
+    assert!(
+        store
+            .read_presented_chat_list(query.clone(), None)
+            .unwrap()
+            .is_none()
+    );
+    let input = store.chat_presentation_input("11").unwrap().unwrap();
+    store
+        .store_chat_presentation(&input, &value("bb", "Peer", 1))
+        .unwrap();
+    let before: i64 = store
+        .lock()
+        .unwrap()
+        .query_row("SELECT total_changes()", [], |r| r.get(0))
+        .unwrap();
+    let snapshot = store
+        .read_presented_chat_list(query.clone(), None)
+        .unwrap()
+        .unwrap();
+    assert_eq!(snapshot.rows.len(), 1);
+    assert_eq!(snapshot.rows[0].row.activity_sort_at, 19);
+    assert_eq!(snapshot.rows[0].presentation.peer_id, Some("bb".repeat(32)));
+    assert_eq!(
+        snapshot.presentation_version,
+        store.chat_presentation_version().unwrap()
+    );
+    assert!(
+        store
+            .read_presented_chat_list(query.clone(), Some("22"))
+            .unwrap()
+            .unwrap()
+            .rows
+            .is_empty()
+    );
+    let after: i64 = store
+        .lock()
+        .unwrap()
+        .query_row("SELECT total_changes()", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(before, after, "ready reads must not repair or write");
+    store
+        .set_chat_presentation_members("11", &["aa".repeat(32), "cc".repeat(32)])
+        .unwrap();
+    assert!(
+        store
+            .read_presented_chat_list(query, None)
+            .unwrap()
+            .is_none(),
+        "a new peer must not inherit the old selection"
+    );
+}

--- a/crates/storage-sqlite/src/chat_presentation/tests.rs
+++ b/crates/storage-sqlite/src/chat_presentation/tests.rs
@@ -755,3 +755,38 @@ fn presented_snapshot_is_complete_read_only_and_clears_replaced_peer() {
         "a new peer must not inherit the old selection"
     );
 }
+
+#[test]
+fn dirty_fallback_remains_fallback_in_both_presentation_reads() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    seed(&store, "11");
+    let input = store.chat_presentation_input("11").unwrap().unwrap();
+    let mut fallback = value("bb", "Peer", 1);
+    fallback.presentation.resolution = PresentationResolution::Fallback;
+    fallback.presentation.title_source = PresentationSource::PeerFallback;
+    store.store_chat_presentation(&input, &fallback).unwrap();
+    store.lock().unwrap().execute(
+        "UPDATE chat_list_rows SET presentation_source_revision = presentation_source_revision + 1",
+        [],
+    ).unwrap();
+    let ChatPresentationRead::Ready(retained) = store.chat_presentation("11").unwrap() else {
+        panic!("same-subject fallback remains renderable");
+    };
+    assert_eq!(
+        retained.presentation.resolution,
+        PresentationResolution::Fallback
+    );
+    let snapshot = store
+        .read_presented_chat_list(
+            crate::ChatListQuery {
+                include_archived: true,
+            },
+            None,
+        )
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        snapshot.rows[0].presentation.resolution,
+        PresentationResolution::Fallback
+    );
+}

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -39,8 +39,8 @@ pub use chat_presentation::{
     CHAT_PRESENTATION_BATCH_LIMIT, ChatPresentationActivePeer, ChatPresentationCatchUp,
     ChatPresentationCheckpoint, ChatPresentationInput, ChatPresentationRead,
     ChatPresentationVersion, ChatPresentationWrite, ConversationPresentation,
-    PresentationResolution, PresentationSource, PresentationText, SelectedAvatar,
-    StoredChatPresentation,
+    PresentationResolution, PresentationSource, PresentationText, PresentedChatListSnapshot,
+    PresentedChatRow, SelectedAvatar, StoredChatPresentation,
 };
 #[allow(deprecated)]
 pub use connection::SqliteStorage;

--- a/docs/marmot-architecture/overview/current-state.md
+++ b/docs/marmot-architecture/overview/current-state.md
@@ -1,7 +1,7 @@
 ---
 title: "Current State — Implementations & Spec"
 created: 2026-04-19
-updated: 2026-09-07
+updated: 2026-09-08
 tags: [marmot, overview, current-state, implementations]
 status: overview
 ---
@@ -18,6 +18,11 @@ status: overview
 > explicit group evolution.
 
 # Current State — Implementations & Spec
+
+The additive presented-chat-list contract exposes complete existing rows plus durable MDK-selected title/avatar
+through Rust, UniFFI and C. An attached initial snapshot and ordered replacement updates cover both presentation and
+ordinary row changes. Android/iOS adoption remains separate; see the
+[native integration contract](../../../crates/marmot-uniffi/README.md#selected-chat-list-presentation).
 
 Deferred transport resource release now preserves app replay eligibility across
 lost engine effects and restart. SQLCipher records release evidence atomically

--- a/docs/marmot-architecture/runtime-state-bounds.md
+++ b/docs/marmot-architecture/runtime-state-bounds.md
@@ -1,7 +1,7 @@
 ---
 title: "Long-lived runtime state — bounds and reclamation"
 created: 2026-07-02
-updated: 2026-08-15
+updated: 2026-09-08
 tags: [marmot, architecture, runtime, daemon, broker, memory]
 ---
 
@@ -51,6 +51,13 @@ Tracking issue: marmot-protocol/mdk#381.
 | --- | --- | --- |
 | `AgentStreamWatchManager.watches` | 256 (`AGENT_STREAM_WATCH_RETAIN_LIMIT`), including `running` watches | Enforced on both start and finish. Finished watches evict oldest-first; when running watches alone exceed the cap (a finish that never arrives), the oldest running watches evict too (mdk#343). |
 | `recent_updates` replay ring | 256 (`AGENT_STREAM_UPDATE_REPLAY_LIMIT`) | Oldest popped on publish. |
+
+### Presented chat-list subscriptions (`marmot-app/src/runtime/presented_chat_list.rs`)
+
+| Structure | Bound | Reclamation |
+| --- | --- | --- |
+| Initial and current complete snapshots | Existing account-list cardinality; no history retained | Current snapshot is replaced, never appended. UniFFI transfers the initial snapshot once. Dropping the handle releases both and closes the underlying list consumer; shutdown terminates reads. C4 owns future bounded paging. |
+| Invalidation receivers | Existing bounded chat-list queue plus the shared 64-entry presentation broadcast | Lag rebuilds current local state. No per-subscriber presentation timer or durable event log. |
 
 ### `marmot-app` (`src/sqlcipher.rs`)
 


### PR DESCRIPTION
Native clients still receive group-only display fields from the existing chat-list APIs, even though P1/P2 persist and maintain MDK's selected conversation presentation. This exposes complete presented rows through Rust, UniFFI (Swift/Kotlin), and C so clients can render titles and avatars without per-row roster/profile lookups.

Part of #1517, **P3**, following #1753 and #1755. Keep #1517 open for the released binding artifact and client adoption handoff.

- Add local list/keyed-row reads and an attached initial snapshot with complete replacement updates. Capture rows, selected values and version in one account read transaction. First use prepares bounded local batches asynchronously, with 25 ms between incomplete steps; ready reads add no delay or repair writes.
- Order updates by subscription generation/sequence, independently of presentation revision. Preserve unread, pin, archive and mute-expiry event routes; coalesce queued legacy invalidations, reconcile lag from storage, and retain pending refreshes across cancellation/errors.
- Release the existing chat-list pump when its handle is dropped, so presented subscriptions do not retain a pump/event receiver after disposal. Expired mutes remain correct through read-time derivation without an active pump.
- Keep existing APIs and C layouts unchanged. Add deep-free functions and a fallible blocking C subscription with timeout/status handling. Localization stays on clients; this exposes avatar descriptors, not a new byte cache.

Validation:

- Pinned Rust 1.97.1 `just fast-ci` and all four repo-wide tracing/output audit tests.
- App CI configuration: 1,122 tests passed (`test-policy-overrides`, excluding the dedicated `relay_runtime` lane). Coverage includes offline reopen, account isolation, equal-version unread updates, lag/cancellation, preparation races, projection warm/stale refresh, invalidation coalescing and pump cleanup.
- UniFFI: 139 unit and 31 integration tests passed. Native API tests cover cached peer title/avatar on offline reopen, independent title/avatar sources, typed fallbacks, snapshot ownership, unread, archive and restore. Conversion tests cover encrypted avatar fields and last-known resolution.
- Storage: 540 unit and two integration tests passed in the preceding follow-up; this follow-up changes only its transaction comment. C allocation audit: all 36 tests, generated-header parity and dynamic/static smoke passed before this follow-up, which changes only C whitespace.
- Native packaging/compilation/linking passed on `e0c50478`: Android arm64/x86_64 libraries and generated Kotlin, iOS device/simulator XCFramework and SwiftPM, and macOS XCFramework and SwiftPM. Subsequent changes preserve the public binding contract. No binding artifact has been published.
- Claude Opus and Cursor Grok completed the requested self-review; actionable findings are addressed in one follow-up pass.
