### PR TITLE
fix(app): latch a bare 413 as too-large instead of re-posting the audit file forever

### DIFF
--- a/crates/marmot-app/AGENTS.md
+++ b/crates/marmot-app/AGENTS.md
@@ -58,7 +58,13 @@ App runtime bridge for the first real Marmot app surfaces.
   minutes; authentication failures wait at least five minutes, and Retry-After can extend the delay up to five minutes.
   Stop automatic passes on endpoint-wide failures
   (authentication, rate limits, server/transport failures); file-specific failures and oversized files must not block
-  the files behind them. Shutdown cancels pending or in-flight automatic work; unacknowledged files remain on disk.
+  the files behind them.
+  Treat a `413` with no `Retry-After` as the endpoint's verdict on that file (RFC 9110 15.5.14 has a server send the
+  header when the refusal is temporary): acknowledge it as too-large so it is reported once and never re-posted. Unlike
+  the local ceiling this verdict is escapable: it is keyed on the file's size and mtime, deleting the sidecar clears it,
+  and a manual per-file upload never consults it. A `413` carrying any `Retry-After`, parseable or not, is a cooldown
+  and retries like any other rejection.
+  Shutdown cancels pending or in-flight automatic work; unacknowledged files remain on disk.
   Tests may shorten the window per runtime via `test-policy-overrides`; paused-clock tests pin the production default.
   Retention/deletion of sealed segments is mdk#1014, not this contract.
 - Keep the upload checkpoint's cost proportional to the account's *live* audit files, not to its history. `retain_present`

--- a/crates/marmot-app/src/audit_log.rs
+++ b/crates/marmot-app/src/audit_log.rs
@@ -153,9 +153,14 @@ impl AuditUploadSnapshot {
 pub(crate) enum AuditUploadOutcome {
     /// The endpoint accepted the file's whole content.
     Uploaded,
-    /// The file is larger than the endpoint's per-request ceiling, so no
-    /// automatic upload can ever accept it. Recorded so the tracker reports it
-    /// once instead of re-attempting on every trigger.
+    /// The tracker will not re-post this file's content: it is over the local
+    /// `AUDIT_LOG_UPLOAD_MAX_BYTES` ceiling, or the endpoint answered `413`
+    /// without `Retry-After` (RFC 9110 15.5.14 has a server send that header
+    /// when the refusal is temporary). Recorded so the tracker reports it once
+    /// instead of re-attempting on every trigger. Like every checkpoint entry
+    /// it is keyed on the file's size and mtime, so deleting the sidecar clears
+    /// it, and a manual per-file upload never consults it. A `413` that
+    /// carries `Retry-After` is a cooldown, not this outcome.
     TooLargeToUpload,
 }
 

--- a/crates/marmot-app/src/audit_log.rs
+++ b/crates/marmot-app/src/audit_log.rs
@@ -614,7 +614,7 @@ impl MarmotApp {
                     response
                         .headers()
                         .get(reqwest::header::RETRY_AFTER)
-                        .and_then(|v| v.to_str().ok()),
+                        .map(|value| value.to_str().unwrap_or_default()),
                     SystemTime::now(),
                 ),
             });
@@ -920,7 +920,7 @@ mod tests {
             Some(Duration::from_secs(300))
         );
         assert_eq!(audit_retry_after(None, now), None);
-        for malformed in ["nonsense", "-1"] {
+        for malformed in ["nonsense", "-1", ""] {
             assert_eq!(
                 audit_retry_after(Some(malformed), now),
                 Some(Duration::ZERO),

--- a/crates/marmot-app/src/audit_log.rs
+++ b/crates/marmot-app/src/audit_log.rs
@@ -94,6 +94,8 @@ pub(crate) enum AuditUploadAttempt {
 
 /// Retry-After accepts either delta seconds or an HTTP date. Bound untrusted
 /// deadlines to five minutes so one response cannot silence incident evidence for a day.
+/// `None` means the header was absent. A header we cannot parse is still a
+/// request to retry, so it yields a zero minimum instead of disappearing.
 fn audit_retry_after(value: Option<&str>, now: SystemTime) -> Option<Duration> {
     let value = value?.trim();
     let delay = value
@@ -104,7 +106,8 @@ fn audit_retry_after(value: Option<&str>, now: SystemTime) -> Option<Duration> {
             httpdate::parse_http_date(value)
                 .ok()
                 .map(|date| date.duration_since(now).unwrap_or_default())
-        })?;
+        })
+        .unwrap_or_default();
     Some(delay.min(Duration::from_secs(5 * 60)))
 }
 
@@ -911,8 +914,13 @@ mod tests {
             audit_retry_after(Some("18446744073709551615"), now),
             Some(Duration::from_secs(300))
         );
-        for value in [None, Some("nonsense"), Some("-1")] {
-            assert_eq!(audit_retry_after(value, now), None);
+        assert_eq!(audit_retry_after(None, now), None);
+        for malformed in ["nonsense", "-1"] {
+            assert_eq!(
+                audit_retry_after(Some(malformed), now),
+                Some(Duration::ZERO),
+                "a malformed Retry-After is still a request to retry"
+            );
         }
     }
 

--- a/crates/marmot-app/src/runtime/audit_tracker.rs
+++ b/crates/marmot-app/src/runtime/audit_tracker.rs
@@ -401,6 +401,35 @@ async fn post_audit_log_tracker_update(
                 }
                 // No complete row yet: no request, checkpoint, or failure warning.
                 Ok(AuditUploadAttempt::Deferred) => {}
+                // The endpoint refused this content outright. RFC 9110 15.5.14
+                // has a server send Retry-After when a 413 is temporary, so its
+                // absence is read as a verdict on this file, not a cooldown:
+                // take the same acknowledgment as the local ceiling above, which
+                // is what stops the retry timer from re-posting identical bytes
+                // forever. Unlike the ceiling, the verdict is escapable — the
+                // sidecar is not durable state, and a manual per-file upload
+                // never consults it. A 413 *with* Retry-After, parseable or
+                // not, is a request to try later and stays a generic rejection.
+                Ok(AuditUploadAttempt::Rejected {
+                    status: status @ 413,
+                    retry_after: None,
+                }) => {
+                    too_large_recorded += 1;
+                    checkpoint.acknowledge(
+                        file,
+                        file.size_bytes,
+                        AuditUploadOutcome::TooLargeToUpload,
+                    );
+                    checkpoint_changed = true;
+                    tracing::warn!(
+                        target: "marmot_app::audit_log",
+                        method = "post_audit_log_tracker_update",
+                        http_status = status,
+                        file_index,
+                        size_bytes = file.size_bytes,
+                        "forensic audit log file refused as too large by the tracker endpoint"
+                    );
+                }
                 Ok(AuditUploadAttempt::Rejected {
                     status,
                     retry_after: minimum,

--- a/crates/marmot-app/src/runtime/audit_tracker_tests.rs
+++ b/crates/marmot-app/src/runtime/audit_tracker_tests.rs
@@ -271,7 +271,9 @@ async fn automatic_pass_stops_on_auth_rate_limit_and_server_failure() {
 
 #[tokio::test]
 async fn bare_413_latches_the_file_while_any_retry_after_keeps_it_retryable() {
-    for (retry_after, latched) in [(None, true), (Some("soon"), false)] {
+    // "\u{e9}" is obs-text: hyper accepts it, but `HeaderValue::to_str` does
+    // not, so the header must count as present even without a readable value.
+    for (retry_after, latched) in [(None, true), (Some("soon"), false), (Some("\u{e9}"), false)] {
         let tmp = tempfile::tempdir().unwrap();
         let app = two_file_audit_app(tmp.path());
         let (server, endpoint, mut observed) = status_server(413, retry_after).await;

--- a/crates/marmot-app/src/runtime/audit_tracker_tests.rs
+++ b/crates/marmot-app/src/runtime/audit_tracker_tests.rs
@@ -174,53 +174,78 @@ async fn shutdown_cancels_pending_and_in_flight_passes() {
 
 /// Real HTTP path: endpoint-wide failures stop automatic passes, but the manual
 /// API remains immediate and continues through the retained files.
+/// Answers every request with `status` and reports each one on the returned
+/// channel. The response carries `Retry-After` only when one is given.
+async fn status_server(
+    status: u16,
+    retry_after: Option<&'static str>,
+) -> (JoinHandle<()>, String, mpsc::UnboundedReceiver<()>) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let endpoint = format!("http://{}/ingest", listener.local_addr().unwrap());
+    let (requests, observed) = mpsc::unbounded_channel();
+    let retry_after =
+        retry_after.map_or(String::new(), |value| format!("Retry-After: {value}\r\n"));
+    let server = tokio::spawn(async move {
+        loop {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut bytes = Vec::new();
+            let mut buf = [0; 2048];
+            loop {
+                let n = stream.read(&mut buf).await.unwrap();
+                assert!(n > 0);
+                bytes.extend_from_slice(&buf[..n]);
+                if let Some(end) = bytes.windows(4).position(|x| x == b"\r\n\r\n")
+                    && bytes.len() >= end + 4 + 3
+                {
+                    break;
+                }
+            }
+            requests.send(()).unwrap();
+            let response = format!(
+                "HTTP/1.1 {status} Test\r\n{retry_after}Content-Length: 0\r\nConnection: close\r\n\r\n"
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        }
+    });
+    (server, endpoint, observed)
+}
+
+fn two_file_audit_app(root: &std::path::Path) -> MarmotApp {
+    let home = marmot_account::AccountHome::open(root);
+    home.create_account("alice").unwrap();
+    for name in ["audit-a.jsonl", "audit-b.jsonl"] {
+        std::fs::write(home.account_dir("alice").join(name), b"{}\n").unwrap();
+    }
+    let app = MarmotApp::with_relay(root, "wss://relay.example");
+    app.set_audit_log_settings(crate::AuditLogSettings { enabled: true })
+        .unwrap();
+    app
+}
+
+fn tracker_config(endpoint: String) -> AuditLogTrackerConfig {
+    AuditLogTrackerConfig {
+        endpoint: Some(endpoint),
+        authorization_bearer_token: Some("test-token".into()),
+        ..Default::default()
+    }
+}
+
 #[tokio::test]
 async fn automatic_pass_stops_on_auth_rate_limit_and_server_failure() {
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    for status in [401, 403, 429, 503, 400] {
+    // 400 and 413 are the file-specific controls: with Retry-After present,
+    // both are ordinary rejections, so the pass continues and the cooldown
+    // applies. The bare-413 latch is pinned separately below.
+    for status in [401, 403, 429, 503, 400, 413] {
         let tmp = tempfile::tempdir().unwrap();
-        let home = marmot_account::AccountHome::open(tmp.path());
-        home.create_account("alice").unwrap();
-        for name in ["audit-a.jsonl", "audit-b.jsonl"] {
-            std::fs::write(home.account_dir("alice").join(name), b"{}\n").unwrap();
-        }
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let config = AuditLogTrackerConfig {
-            endpoint: Some(format!("http://{}/ingest", listener.local_addr().unwrap())),
-            authorization_bearer_token: Some("test-token".into()),
-            ..Default::default()
-        };
-        let (requests, mut observed) = mpsc::unbounded_channel();
-        let server = tokio::spawn(async move {
-            loop {
-                let (mut stream, _) = listener.accept().await.unwrap();
-                let mut bytes = Vec::new();
-                let mut buf = [0; 2048];
-                loop {
-                    let n = stream.read(&mut buf).await.unwrap();
-                    assert!(n > 0);
-                    bytes.extend_from_slice(&buf[..n]);
-                    if let Some(end) = bytes.windows(4).position(|x| x == b"\r\n\r\n")
-                        && bytes.len() >= end + 4 + 3
-                    {
-                        break;
-                    }
-                }
-                requests.send(()).unwrap();
-                let response = format!(
-                    "HTTP/1.1 {status} Test\r\nRetry-After: 120\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
-                );
-                stream.write_all(response.as_bytes()).await.unwrap();
-            }
-        });
-        let app = MarmotApp::with_relay(tmp.path(), "wss://relay.example");
-        app.set_audit_log_settings(crate::AuditLogSettings { enabled: true })
-            .unwrap();
+        let app = two_file_audit_app(tmp.path());
+        let (server, endpoint, mut observed) = status_server(status, Some("120")).await;
+        let config = tracker_config(endpoint);
         let mut schedule = AuditPassSchedule::default();
         post_audit_log_tracker_update(&app, config.clone(), true, &mut schedule)
             .await
             .unwrap();
-        let count = if status == 400 { 2 } else { 1 };
+        let count = if matches!(status, 400 | 413) { 2 } else { 1 };
         for _ in 0..count {
             observed.try_recv().unwrap();
         }
@@ -240,6 +265,37 @@ async fn automatic_pass_stops_on_auth_rate_limit_and_server_failure() {
             observed.try_recv().unwrap();
         }
         assert!(observed.try_recv().is_err());
+        server.abort();
+    }
+}
+
+#[tokio::test]
+async fn bare_413_latches_the_file_while_any_retry_after_keeps_it_retryable() {
+    for (retry_after, latched) in [(None, true), (Some("soon"), false)] {
+        let tmp = tempfile::tempdir().unwrap();
+        let app = two_file_audit_app(tmp.path());
+        let (server, endpoint, mut observed) = status_server(413, retry_after).await;
+        let config = tracker_config(endpoint);
+        let mut schedule = AuditPassSchedule::default();
+        post_audit_log_tracker_update(&app, config.clone(), true, &mut schedule)
+            .await
+            .unwrap();
+        // A refusal never blocks the file behind it.
+        for _ in 0..2 {
+            observed.try_recv().unwrap();
+        }
+        assert!(observed.try_recv().is_err());
+        assert_eq!(
+            schedule.retry_after.is_none(),
+            latched,
+            "only a bare 413 leaves the retry timer unarmed"
+        );
+
+        post_audit_log_tracker_update_for_app(&app, config)
+            .await
+            .unwrap();
+        let re_posted = std::iter::from_fn(|| observed.try_recv().ok()).count();
+        assert_eq!(re_posted, if latched { 0 } else { 2 });
         server.abort();
     }
 }

--- a/crates/marmot-app/tests/audit_logs.rs
+++ b/crates/marmot-app/tests/audit_logs.rs
@@ -945,6 +945,58 @@ async fn oversized_legacy_file_is_reported_once_and_never_wedges_other_uploads()
 }
 
 #[tokio::test]
+async fn endpoint_too_large_verdict_is_recorded_once_and_never_re_posted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(tmp.path());
+    let account = home.create_account("alice").unwrap();
+    let dir = home.account_dir(&account.label);
+    // Under the local ceiling, so only the endpoint can refuse it. A 413
+    // without Retry-After is a permanent verdict on this entity (RFC 9110
+    // 15.5.14), not a cooldown.
+    let refused = b"{\"seq\":1}\n";
+    let accepted = b"{\"seq\":2}\n";
+    std::fs::write(dir.join("audit-engine-v3-seg000001.jsonl"), refused).unwrap();
+    std::fs::write(dir.join("audit-engine-v3-seg000002.jsonl"), accepted).unwrap();
+
+    let sink = CaptureSink::start().await;
+    sink.script(&[413, 204]);
+    let runtime = tracker_runtime(tmp.path(), &sink.endpoint());
+
+    let first = runtime.post_audit_log_tracker_update().await.unwrap();
+    assert_eq!(first.uploaded.len(), 1);
+    assert_eq!(
+        sink.take_bodies(),
+        vec![refused.to_vec(), accepted.to_vec()],
+        "the refusal must not wedge the file behind it"
+    );
+
+    // The sidecar pins which verdict was recorded; the second pass below pins
+    // that it holds.
+    let checkpoint = std::fs::read_to_string(checkpoint_path(&home, &account.label))
+        .expect("checkpoint written");
+    let checkpoint: serde_json::Value = serde_json::from_str(&checkpoint).unwrap();
+    assert_eq!(
+        checkpoint["files"]["audit-engine-v3-seg000001.jsonl"]["outcome"],
+        serde_json::json!("too_large_to_upload")
+    );
+    assert_eq!(
+        checkpoint["files"]["audit-engine-v3-seg000002.jsonl"]["outcome"],
+        serde_json::json!("uploaded")
+    );
+
+    // A second run neither retries the refused file nor re-posts the one it
+    // already acknowledged.
+    runtime.post_audit_log_tracker_update().await.unwrap();
+    assert!(sink.take_bodies().is_empty());
+
+    // Never deleted or truncated: retention is mdk#1014's contract.
+    assert_eq!(
+        std::fs::read(dir.join("audit-engine-v3-seg000001.jsonl")).unwrap(),
+        refused.to_vec()
+    );
+}
+
+#[tokio::test]
 async fn recorder_segments_upload_once_each_and_stay_under_the_request_ceiling() {
     let tmp = tempfile::tempdir().unwrap();
     let home = AccountHome::open(tmp.path());


### PR DESCRIPTION
A server `413` fell into the audit tracker's generic rejection arm, armed the retry timer, and re-posted the identical body every 60 s to 5 min for as long as the device lived. In the field that is roughly 64 MB every five minutes per device carrying a legacy oversized audit segment.

### Changes

- Acknowledge a `413` **without** `Retry-After` as `TooLargeToUpload`, the verdict the local `AUDIT_LOG_UPLOAD_MAX_BYTES` ceiling already records, so it is reported once and never re-posted. RFC 9110 §15.5.14 has a server send `Retry-After` when the refusal is temporary; its absence is read as a verdict on that file.
- A `413` carrying **any** `Retry-After` stays a cooldown. `audit_retry_after` now distinguishes an absent header (`None`) from one it cannot parse (zero minimum), so a malformed header cannot latch a file. Every caller unwrapped to the default, so behavior elsewhere is unchanged.
- Unlike the local ceiling this verdict is escapable: it is keyed on the file's size and mtime, deleting the checkpoint sidecar clears it, and a manual per-file upload never consults it. The enum doc and the `marmot-app` AGENTS.md upload contract say so.
- `audit_upload_stops_batch` is untouched: a `413` never blocks the files behind it.

### Trade-off

A segment refused by a misconfigured proxy is now latched rather than retried until the proxy is fixed. The per-file warn still fires once per newly refused file, and deleting the sidecar recovers everything. Goggles raising its edge cap to the client's 64 MiB ceiling removes the field trigger.

Considered and declined: surfacing the too-large count on `AuditLogTrackerUpdateResult`. It would ripple through the UniFFI and C types for a signal the per-file warn already carries with its cause.

### Tests

- `tests/audit_logs.rs`: scripted `413` then `204`; asserts the pass continues, the sidecar records the verdict, a second pass posts nothing, and the file is untouched on disk.
- `runtime/audit_tracker_tests.rs`: `413` with `Retry-After` joins the status sweep as a file-specific rejection; a new case pins that only a bare `413` leaves the retry timer unarmed while a malformed `Retry-After` keeps the file retryable. A mutation probe against the old parser fails that case for the right reason.
- `audit_log.rs`: the Retry-After unit test now asserts malformed values yield a zero minimum.

### Validation

- `just fast-ci`: green on the rebased tree.
- `cargo nextest run -p marmot-app --features test-policy-overrides --test audit_logs`: 23 passed.
- Tracker and Retry-After unit tests: 14 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* **Bug Fixes**
  * Audit uploads now treat HTTP 413 responses without a `Retry-After` header as permanently too large for the current checkpoint.
  * Oversized files are acknowledged and skipped on future automatic retries, while subsequent files continue uploading.
  * HTTP 413 responses with `Retry-After` remain retryable after the specified cooldown.
  * Malformed `Retry-After` headers now trigger an immediate retry.
  * Manual per-file uploads can bypass the oversized-file state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->