### PR TITLE
Harden simulator refusal tests for later action IDs

### DIFF
--- a/crates/cgka-conformance-simulator/RUNNING_CAMPAIGNS.md
+++ b/crates/cgka-conformance-simulator/RUNNING_CAMPAIGNS.md
@@ -165,6 +165,16 @@ Run `cargo test -p cgka-conformance-simulator --test large_group_family --locked
 application and retained-join canaries. Prefer the isolated file-backed campaign runner for broader execution;
 generator tests already compile all 54 shapes without running the expensive large/xlarge blocks.
 
+The 64-member Welcome-refusal boundary (`seed=8001`, `case_index=30`) is an explicit opt-in:
+
+```sh
+cargo test -p cgka-conformance-simulator --locked --bin cgka-conformance-campaign -- \
+  --ignored --exact tests::large_group_pressure_8001_30_reports_create_refusal
+```
+
+Use a fresh `--out` directory. The worker must exit 1 with a report, fixture candidate, and portable capsule; a
+panic exit 101 means the refusal was not converted into a failed scenario step.
+
 For `offline-catchup-pressure/v1`, six consecutive cases form one volume block: 24, 96, 384, then 1,024 application
 messages, interleaved with 4, 8, 12, then 16 commit rounds. Each block covers natural full history, reverse history,
 reverse history with three copies, natural two-copy incremental followed by full repair, reverse two-copy restart after

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -871,6 +871,19 @@ exercises the retained-join pending-work condition. Generator tests compile the 
 executing the expensive large/xlarge cases. Run 32/64-member blocks in nightly isolated workers and keep
 128/200-member execution scheduled or manual until measured budgets justify wider promotion.
 
+A refused engine create, including the large-Welcome wrap refusal on case `8001/30` (`large-anchor-64` bulk
+application fanout), is a serializable subject-step failure. Default regressions inject that refusal through a
+test-only peeler wrapper in `subject::tests`. The real 64-member report/campaign boundary is ignored by default:
+
+```sh
+cargo test -p cgka-conformance-simulator --locked --bin cgka-conformance-campaign -- \
+  --ignored --exact tests::large_group_pressure_8001_30_reports_create_refusal
+```
+
+That fixture persists `GeneratedScenarioInputV1` first, then replays it with the campaign worker
+(`--worker --input FILE --storage file --out NEW_DIR`) and checks the report, fixture candidate, and portable
+`synthetic_shareable` capsule. Do not commit generated replay artifacts or checkpoints.
+
 ### `convergence-chaos/v1`
 
 - Generator: `generate_convergence_chaos_family` (generator version `6`).

--- a/crates/cgka-conformance-simulator/src/bin/cgka-conformance-campaign.rs
+++ b/crates/cgka-conformance-simulator/src/bin/cgka-conformance-campaign.rs
@@ -1150,6 +1150,138 @@ mod tests {
         assert!(usage.signal.is_some());
     }
 
+    #[test]
+    fn large_group_pressure_8001_30_identity_is_the_reported_bulk_fanout() {
+        let case = cgka_conformance_simulator::generate_large_group_pressure_case(8001, 30);
+        assert_eq!(case.family_name, "large-group-pressure/v1");
+        assert_eq!(case.generator_version, "1");
+        let profile = case
+            .workload_profile
+            .as_ref()
+            .expect("large-group cases carry a workload profile");
+        assert_eq!(profile.version, "1");
+        assert_eq!(profile.member_count, 64);
+        assert_eq!(profile.traffic_profile, "application-heavy");
+        assert_eq!(
+            case.scenario.name,
+            "large-group-pressure/v1/case-30/bulk-application-fanout"
+        );
+        assert!(profile.name.contains("large-anchor-64"));
+        assert!(profile.name.contains("bulk-application-fanout"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[ignore = "64-member Welcome-refusal boundary; run: cargo test -p cgka-conformance-simulator --locked --bin cgka-conformance-campaign -- --ignored --exact tests::large_group_pressure_8001_30_reports_create_refusal"]
+    fn large_group_pressure_8001_30_reports_create_refusal() {
+        let root = tempfile::tempdir().expect("temporary campaign root");
+        let out = root.path().join("boundary");
+        fs_private::create_dir_all_private(&out).expect("private output directory");
+        let case = cgka_conformance_simulator::generate_large_group_pressure_case(8001, 30);
+        let paths = case_artifact_paths(&out, &case);
+        let input = GeneratedScenarioInputV1::new(case.clone());
+        fs_private::write_private(
+            &paths.generated_input,
+            &serde_json::to_vec_pretty(&input).expect("generated input serializes"),
+        )
+        .expect("generated input writes");
+
+        let started = Instant::now();
+        let child = Command::new(std::env::current_exe().expect("test executable path"))
+            .args([
+                "--ignored",
+                "--exact",
+                "tests::large_group_pressure_8001_30_worker_fixture",
+            ])
+            .env("CGKA_LARGE_GROUP_WORKER_INPUT", &paths.generated_input)
+            .env("CGKA_LARGE_GROUP_WORKER_OUT", &out)
+            .spawn()
+            .expect("worker fixture starts");
+        let worker_pid = child.id();
+        let usage = wait_with_usage(child, Duration::from_secs(180)).expect("worker is reaped");
+        assert!(!usage.timed_out, "boundary worker must not time out");
+        assert!(
+            usage.signal.is_none(),
+            "boundary worker must not be signaled"
+        );
+        assert_eq!(
+            usage.exit_code,
+            Some(1),
+            "failed scenario is exit 1, not panic 101"
+        );
+
+        let mut inspection = inspect_case_artifacts(&case, &paths, &usage);
+        inspection
+            .integrity_errors
+            .extend(cleanup_worker_temporary_artifacts(&paths, worker_pid));
+        assert_eq!(inspection.integrity_errors, Vec::<String>::new());
+        let measurement = build_case_measurement(30, paths, usage, inspection, started.elapsed());
+        assert!(measurement.fixture_candidate.is_some());
+        assert!(measurement.failure_capsule.is_some());
+        assert_eq!(measurement.artifact_integrity_errors, Vec::<String>::new());
+
+        let report: ScenarioReport = serde_json::from_slice(
+            &std::fs::read(&measurement.report).expect("scenario report reads"),
+        )
+        .expect("scenario report parses");
+        let first = report
+            .step_log
+            .first()
+            .expect("failed create leaves a step log");
+        assert_eq!(first.step_type, "create_group");
+        match &first.status {
+            cgka_conformance_simulator::ScenarioStepStatus::Failed { kind, .. } => {
+                assert_eq!(kind, "peeler");
+            }
+            other => panic!("first step must fail, got {other:?}"),
+        }
+
+        let capsule = cgka_conformance_simulator::read_failure_capsule(
+            measurement
+                .failure_capsule
+                .as_ref()
+                .expect("failure capsule path"),
+        )
+        .expect("portable capsule reads");
+        assert_eq!(
+            capsule.sensitivity,
+            cgka_conformance_simulator::FailureCapsuleSensitivity::SyntheticShareable
+        );
+        assert!(capsule.byte_replay.is_none());
+        assert_eq!(capsule.failure.failure_kind, "scenario_step_failed:peeler");
+        assert_eq!(
+            capsule.failure.first_failing_action_id.as_deref(),
+            Some("step-0:create_group")
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    #[ignore = "process fixture launched by large_group_pressure_8001_30_reports_create_refusal"]
+    async fn large_group_pressure_8001_30_worker_fixture() {
+        let input = PathBuf::from(
+            std::env::var_os("CGKA_LARGE_GROUP_WORKER_INPUT").expect("worker fixture input path"),
+        );
+        let out = PathBuf::from(
+            std::env::var_os("CGKA_LARGE_GROUP_WORKER_OUT").expect("worker fixture output path"),
+        );
+        let code = run_worker(&Args {
+            family: "large-group-pressure/v1".into(),
+            seed: 8001,
+            cases: 1,
+            out,
+            storage: HarnessStorageMode::TempFileBackedSqlite,
+            case_timeout: Duration::from_secs(180),
+            minimization_budget: GeneratedScenarioMinimizationBudget::default(),
+            input: Some(input),
+            capture_sensitive_replay: false,
+            worker: true,
+        })
+        .await
+        .expect("worker returns an exit code");
+        std::process::exit(if code == ExitCode::FAILURE { 1 } else { 0 });
+    }
+
     #[cfg(unix)]
     #[test]
     fn preserves_a_workers_nonzero_exit_code() {

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -819,11 +819,12 @@ mod tests {
                 .any(|id| id == "refused-remove" || id == "refused-admin"),
             "refused mutations must not overwrite later action ids"
         );
-        assert!(
-            ids.iter()
-                .any(|id| id == "profile-after-remove" || id == "self-update-after-admin"),
-            "later named successes must keep their own action ids: {ids:?}"
-        );
+        for expected in ["profile-after-remove", "self-update-after-admin"] {
+            assert!(
+                ids.iter().any(|id| id == expected),
+                "later named success must keep action id {expected}: {ids:?}"
+            );
+        }
     }
 
     /// Wraps a scripted drain in a real `HarnessClient` tick surface.

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -22,22 +22,34 @@ use cgka_traits::app_components::{
     default_group_components, encode_nostr_routing_v1,
 };
 use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MarmotAppEvent};
+#[cfg(test)]
+use cgka_traits::engine::WelcomeMetadata;
 use cgka_traits::engine::{
     CgkaEngine, CreateGroupRequest, GroupEvent, KeyPackage, SendIntent, SendResult,
 };
 use cgka_traits::engine_state::PendingStateRef;
 use cgka_traits::error::EngineError;
+#[cfg(test)]
+use cgka_traits::error::PeelerError;
 use cgka_traits::group::ProtocolProfile;
 use cgka_traits::group_context::GroupContextSnapshot;
+#[cfg(test)]
+use cgka_traits::ingest::PeeledMessage;
 use cgka_traits::ingest::{IngestOutcome, PeeledContent};
+#[cfg(test)]
+use cgka_traits::peeler::GroupMessageMetadata;
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{ConvergencePassStorage, MessageStorage, StorageProvider};
+#[cfg(test)]
+use cgka_traits::transport::EncryptedPayload;
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
 use cgka_traits::{ConvergenceCutoffCause, ConvergencePassPhase, DurableConvergencePass};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 use storage_sqlite::{SqlCipherKey, SqliteAccountStorage, SqliteStorageOptions};
@@ -47,6 +59,10 @@ const STORAGE_MODE_ENV: &str = "MDK_CONFORMANCE_SQLITE_STORAGE";
 const TEMP_FILE_KEY: &str = "marmot-conformance-sqlite-temp-key";
 const HARNESS_CONVERGENCE_SETTLED_AT_MS: u64 = 1_000_000;
 const HARNESS_CONVERGENCE_DRAIN_PASSES: usize = 8;
+const MISSING_DEFAULT_GROUP: &str = "must create or join a group first";
+#[cfg(test)]
+pub(crate) const WELCOME_WRAP_REFUSAL_MARKER: &str =
+    "cgka-conformance-synthetic-welcome-wrap-refusal";
 
 pub struct HarnessClient {
     engine: Option<Engine<SqliteAccountStorage>>,
@@ -83,6 +99,8 @@ pub struct HarnessClient {
     convergence_checkpoints: HashMap<String, (GroupId, DurableConvergencePass)>,
     #[cfg(test)]
     scripted_convergence_drain: Option<ScriptedConvergenceDrain>,
+    #[cfg(test)]
+    welcome_wrap_refusal: Option<Arc<AtomicBool>>,
 }
 
 #[cfg(test)]
@@ -680,6 +698,134 @@ mod tests {
         }
     }
 
+    fn pad32(name: &[u8]) -> Vec<u8> {
+        let mut out = vec![0; 32];
+        out[..name.len()].copy_from_slice(name);
+        out
+    }
+
+    #[tokio::test]
+    async fn missing_group_preconditions_release_named_reservations() {
+        let bus = TransportBus::ordered();
+        let mut alice = ClientBuilder::new(pad32(b"alice")).attach(&bus);
+        alice.name_next_scenario_input("missing-group-invite");
+        alice
+            .try_invite(Vec::new())
+            .await
+            .expect_err("invite without a group is refused");
+        alice.name_next_scenario_input("missing-group-profile");
+        alice
+            .try_update_group_profile(Some("name".into()), None)
+            .await
+            .expect_err("profile update without a group is refused");
+        alice.name_next_scenario_input("missing-group-remove");
+        alice
+            .try_remove_members(Vec::new())
+            .await
+            .expect_err("remove without a group is refused");
+        alice.name_next_scenario_input("missing-group-self-update");
+        alice
+            .try_self_update()
+            .await
+            .expect_err("self-update without a group is refused");
+        alice.name_next_scenario_input("missing-group-admin");
+        alice
+            .update_admin_policy(Vec::new())
+            .await
+            .expect_err("admin policy without a group is refused");
+        alice.name_next_scenario_input("missing-group-send");
+        alice
+            .try_send_app(b"no-group".to_vec())
+            .await
+            .expect_err("application send without a group is refused");
+        alice.name_next_scenario_input("post-missing-group");
+    }
+
+    #[tokio::test]
+    async fn successful_create_forms_and_invite_refusal_preserve_action_ids() {
+        let refuse = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let bus = TransportBus::ordered();
+        let mut alice = ClientBuilder::new(pad32(b"alice"))
+            .protocol_profile(ProtocolProfile::Current)
+            .welcome_wrap_refusal(refuse.clone())
+            .attach(&bus);
+        let mut bob = ClientBuilder::new(pad32(b"bob"))
+            .protocol_profile(ProtocolProfile::Current)
+            .attach(&bus);
+        let bob_kp = bob.fresh_key_package().await;
+        alice.name_next_scenario_input("refused-create");
+        alice
+            .try_create_group_with_admins_maybe_pending("room", vec![bob_kp], vec![], vec![])
+            .await
+            .expect_err("Welcome wrap refusal must surface");
+        assert!(alice.default_group.is_none());
+        assert!(alice.pending_publication_artifacts.is_empty());
+        refuse.store(false, std::sync::atomic::Ordering::SeqCst);
+        let mut carol = ClientBuilder::new(pad32(b"carol"))
+            .protocol_profile(ProtocolProfile::Current)
+            .attach(&bus);
+        let carol_kp = carol.fresh_key_package().await;
+        alice.name_next_scenario_input("recovered-create");
+        let (group_id, pending) = alice
+            .try_create_group_with_admins_maybe_pending("room-2", vec![carol_kp], vec![], vec![])
+            .await
+            .expect("later create succeeds");
+        assert!(pending.is_none(), "current founding create has no pending");
+        assert_eq!(alice.default_group.as_ref(), Some(&group_id));
+
+        let mut dave = ClientBuilder::new(pad32(b"dave"))
+            .protocol_profile(ProtocolProfile::Current)
+            .attach(&bus);
+        let dave_kp = dave.fresh_key_package().await;
+        refuse.store(true, std::sync::atomic::Ordering::SeqCst);
+        alice.name_next_scenario_input("refused-invite");
+        alice
+            .try_invite(vec![dave_kp])
+            .await
+            .expect_err("invite Welcome wrap refusal is typed");
+
+        let unknown = MemberId::new(vec![0x11; 32]);
+        alice.name_next_scenario_input("refused-remove");
+        alice
+            .try_remove_members(vec![unknown.clone()])
+            .await
+            .expect_err("unknown-member remove is a typed refusal");
+        alice.name_next_scenario_input("profile-after-remove");
+        let profile = alice
+            .try_update_group_profile(Some("renamed".into()), None)
+            .await
+            .expect("named profile update succeeds after refused remove");
+        alice.confirm(profile).await;
+
+        alice.name_next_scenario_input("refused-admin");
+        alice
+            .update_admin_policy(vec![unknown])
+            .await
+            .expect_err("admin policy naming a non-member is a typed refusal");
+        alice.name_next_scenario_input("self-update-after-admin");
+        let self_update = alice
+            .try_self_update()
+            .await
+            .expect("named self-update succeeds after refused admin policy");
+        alice.confirm(self_update).await;
+
+        let ids = alice
+            .scenario_input_ledger()
+            .into_iter()
+            .map(|entry| entry.scenario_id)
+            .collect::<Vec<_>>();
+        assert!(
+            !ids.iter()
+                .any(|id| id == "refused-remove" || id == "refused-admin"),
+            "refused mutations must not overwrite later action ids"
+        );
+        assert!(
+            ids.iter()
+                .any(|id| id == "profile-after-remove" || id == "self-update-after-admin"),
+            "later named successes must keep their own action ids: {ids:?}"
+        );
+    }
+
     /// Wraps a scripted drain in a real `HarnessClient` tick surface.
     fn scripted_client(script: ScriptedConvergenceDrain) -> HarnessClient {
         let bus = TransportBus::ordered();
@@ -717,6 +863,8 @@ pub struct ClientBuilder {
     disable_app_witnesses_for_tests: bool,
     replay_probe_budget_override: Option<u64>,
     deferred_peel_limits_override: Option<(usize, usize, usize)>,
+    #[cfg(test)]
+    welcome_wrap_refusal: Option<Arc<AtomicBool>>,
 }
 
 pub(crate) enum HarnessPublicationError {
@@ -858,6 +1006,8 @@ impl ClientBuilder {
             disable_app_witnesses_for_tests: false,
             replay_probe_budget_override: None,
             deferred_peel_limits_override: None,
+            #[cfg(test)]
+            welcome_wrap_refusal: None,
         }
     }
 
@@ -926,6 +1076,14 @@ impl ClientBuilder {
         self
     }
 
+    /// Test-only Welcome wrap refusal. The flag is per-instance and can be
+    /// cleared after a refused create so the same client can create again.
+    #[cfg(test)]
+    pub(crate) fn welcome_wrap_refusal(mut self, refuse: Arc<AtomicBool>) -> Self {
+        self.welcome_wrap_refusal = Some(refuse);
+        self
+    }
+
     pub fn attach(self, bus: &TransportBus) -> HarnessClient {
         let storage_backing = match self.explicit_file_storage {
             Some(explicit) => HarnessStorageBacking::from_explicit(explicit),
@@ -946,6 +1104,8 @@ impl ClientBuilder {
                 disable_app_witnesses_for_tests: self.disable_app_witnesses_for_tests,
                 replay_probe_budget_override: self.replay_probe_budget_override,
                 deferred_peel_limits_override: self.deferred_peel_limits_override,
+                #[cfg(test)]
+                welcome_wrap_refusal: self.welcome_wrap_refusal.as_ref(),
             },
         );
         let bus_id = bus.attach(MemberId::new(self.identity.clone()));
@@ -981,6 +1141,8 @@ impl ClientBuilder {
             convergence_checkpoints: HashMap::new(),
             #[cfg(test)]
             scripted_convergence_drain: None,
+            #[cfg(test)]
+            welcome_wrap_refusal: self.welcome_wrap_refusal,
         }
     }
 }
@@ -994,6 +1156,8 @@ struct HarnessEngineOptions<'a> {
     disable_app_witnesses_for_tests: bool,
     replay_probe_budget_override: Option<u64>,
     deferred_peel_limits_override: Option<(usize, usize, usize)>,
+    #[cfg(test)]
+    welcome_wrap_refusal: Option<&'a Arc<AtomicBool>>,
 }
 
 fn build_harness_engine(
@@ -1014,7 +1178,17 @@ fn build_harness_engine(
         ProtocolProfile::Legacy,
         "the legacy harness protocol profile is unavailable in release builds"
     );
-    let peeler = NostrMlsPeeler::new().with_welcome_signer(signer.clone());
+    let inner_peeler = NostrMlsPeeler::new().with_welcome_signer(signer.clone());
+    #[cfg(test)]
+    let peeler: Box<dyn TransportPeeler> = match options.welcome_wrap_refusal {
+        Some(flag) => Box::new(WelcomeWrapRefusalPeeler {
+            inner: inner_peeler,
+            refuse: flag.clone(),
+        }),
+        None => Box::new(inner_peeler),
+    };
+    #[cfg(not(test))]
+    let peeler: Box<dyn TransportPeeler> = Box::new(inner_peeler);
     let mut builder = EngineBuilder::new(storage.clone())
         .identity(identity.to_vec())
         .account_identity_proof_signer(Arc::new(NostrAccountIdentityProofSigner {
@@ -1023,7 +1197,7 @@ fn build_harness_engine(
         .protocol_profile(protocol_profile)
         .feature_registry(registry.clone())
         .supported_app_components(harness_supported_app_components())
-        .peeler(Box::new(peeler))
+        .peeler(peeler)
         .recorder(Box::new(CapturingRecorder::new(audit_capture.clone())));
     #[cfg(debug_assertions)]
     if protocol_profile == ProtocolProfile::Legacy {
@@ -1112,6 +1286,78 @@ fn key_package_with_harness_source(key_package: KeyPackage) -> KeyPackage {
         MessageId::new(hasher.finalize().to_vec()),
     )
     .with_protocol_profile(protocol_profile)
+}
+
+/// Test-only peeler that delegates to the real signed Nostr peeler except for
+/// Welcome wrap. The refusal is per-instance and can be switched off.
+#[cfg(test)]
+struct WelcomeWrapRefusalPeeler {
+    inner: NostrMlsPeeler,
+    refuse: Arc<AtomicBool>,
+}
+
+#[cfg(test)]
+#[async_trait::async_trait]
+impl TransportPeeler for WelcomeWrapRefusalPeeler {
+    async fn peel_group_message(
+        &self,
+        msg: &TransportMessage,
+        ctx: &GroupContextSnapshot,
+    ) -> Result<PeeledMessage, PeelerError> {
+        self.inner.peel_group_message(msg, ctx).await
+    }
+
+    async fn peel_welcome(&self, msg: &TransportMessage) -> Result<PeeledMessage, PeelerError> {
+        self.inner.peel_welcome(msg).await
+    }
+
+    async fn wrap_group_message(
+        &self,
+        payload: &EncryptedPayload,
+        ctx: &GroupContextSnapshot,
+    ) -> Result<TransportMessage, PeelerError> {
+        self.inner.wrap_group_message(payload, ctx).await
+    }
+
+    async fn wrap_group_message_with_metadata(
+        &self,
+        payload: &EncryptedPayload,
+        ctx: &GroupContextSnapshot,
+        metadata: &GroupMessageMetadata,
+    ) -> Result<TransportMessage, PeelerError> {
+        self.inner
+            .wrap_group_message_with_metadata(payload, ctx, metadata)
+            .await
+    }
+
+    async fn wrap_welcome(
+        &self,
+        payload: &EncryptedPayload,
+        recipient: &MemberId,
+    ) -> Result<TransportMessage, PeelerError> {
+        if self.refuse.load(Ordering::SeqCst) {
+            return Err(PeelerError::WrapFailed(
+                WELCOME_WRAP_REFUSAL_MARKER.to_owned(),
+            ));
+        }
+        self.inner.wrap_welcome(payload, recipient).await
+    }
+
+    async fn wrap_welcome_with_metadata(
+        &self,
+        payload: &EncryptedPayload,
+        recipient: &MemberId,
+        metadata: &WelcomeMetadata,
+    ) -> Result<TransportMessage, PeelerError> {
+        if self.refuse.load(Ordering::SeqCst) {
+            return Err(PeelerError::WrapFailed(
+                WELCOME_WRAP_REFUSAL_MARKER.to_owned(),
+            ));
+        }
+        self.inner
+            .wrap_welcome_with_metadata(payload, recipient, metadata)
+            .await
+    }
 }
 
 /// Stable variant name for unexpected-result errors. Debug-formatting a
@@ -1340,6 +1586,8 @@ impl HarnessClient {
                 disable_app_witnesses_for_tests: self.disable_app_witnesses_for_tests,
                 replay_probe_budget_override: self.replay_probe_budget_override,
                 deferred_peel_limits_override: self.deferred_peel_limits_override,
+                #[cfg(test)]
+                welcome_wrap_refusal: self.welcome_wrap_refusal.as_ref(),
             },
         );
         engine
@@ -1487,9 +1735,32 @@ impl HarnessClient {
         self.next_scenario_input_id = Some(scenario_id.into());
     }
 
+    fn release_unconsumed_scenario_input_on_err<T>(
+        &mut self,
+        result: Result<T, EngineError>,
+    ) -> Result<T, EngineError> {
+        if result.is_err() {
+            self.next_scenario_input_id = None;
+        }
+        result
+    }
+
+    fn missing_default_group() -> EngineError {
+        EngineError::Other(MISSING_DEFAULT_GROUP.into())
+    }
+
     pub async fn fresh_key_package(&mut self) -> KeyPackage {
-        let key_package = self.engine_mut().fresh_key_package().await.expect("kp");
-        key_package_with_harness_source(key_package)
+        self.try_fresh_key_package().await.expect("kp")
+    }
+
+    pub(crate) async fn try_fresh_key_package(&mut self) -> Result<KeyPackage, EngineError> {
+        let result = self.try_fresh_key_package_inner().await;
+        self.release_unconsumed_scenario_input_on_err(result)
+    }
+
+    async fn try_fresh_key_package_inner(&mut self) -> Result<KeyPackage, EngineError> {
+        let key_package = self.engine_mut().fresh_key_package().await?;
+        Ok(key_package_with_harness_source(key_package))
     }
 
     /// Create a new group with the given members + features.
@@ -1555,7 +1826,25 @@ impl HarnessClient {
         .expect("create_group")
     }
 
-    async fn try_create_group_with_admins_maybe_pending(
+    pub(crate) async fn try_create_group_with_admins_maybe_pending(
+        &mut self,
+        name: &str,
+        invitees: Vec<KeyPackage>,
+        required_features: Vec<cgka_traits::capabilities::Feature>,
+        initial_admins: Vec<MemberId>,
+    ) -> Result<(GroupId, Option<PendingStateRef>), EngineError> {
+        let result = self
+            .try_create_group_with_admins_maybe_pending_inner(
+                name,
+                invitees,
+                required_features,
+                initial_admins,
+            )
+            .await;
+        self.release_unconsumed_scenario_input_on_err(result)
+    }
+
+    async fn try_create_group_with_admins_maybe_pending_inner(
         &mut self,
         name: &str,
         invitees: Vec<KeyPackage>,
@@ -1579,7 +1868,8 @@ impl HarnessClient {
             (gid, SendResult::FoundingGroupCreated { welcomes }) => (gid, None, welcomes),
             (_, other) => {
                 return Err(EngineError::Other(format!(
-                    "expected group creation result, got {other:?}"
+                    "expected group creation result, got {}",
+                    send_result_kind(&other)
                 )));
             }
         };
@@ -1733,7 +2023,29 @@ impl HarnessClient {
         name: Option<String>,
         description: Option<String>,
     ) -> PendingStateRef {
-        let gid = self.default_group.clone().expect("group");
+        self.try_update_group_profile(name, description)
+            .await
+            .expect("update group profile")
+    }
+
+    pub(crate) async fn try_update_group_profile(
+        &mut self,
+        name: Option<String>,
+        description: Option<String>,
+    ) -> Result<PendingStateRef, EngineError> {
+        let result = self.try_update_group_profile_inner(name, description).await;
+        self.release_unconsumed_scenario_input_on_err(result)
+    }
+
+    async fn try_update_group_profile_inner(
+        &mut self,
+        name: Option<String>,
+        description: Option<String>,
+    ) -> Result<PendingStateRef, EngineError> {
+        let gid = self
+            .default_group
+            .clone()
+            .ok_or_else(Self::missing_default_group)?;
         let res = self
             .engine_mut()
             .send(SendIntent::UpdateGroupData {
@@ -1741,35 +2053,64 @@ impl HarnessClient {
                 name,
                 description,
             })
-            .await
-            .expect("update group profile");
+            .await?;
         self.publish_group_evolution(res, &gid, "update_group_profile")
             .await
     }
 
     pub async fn remove_members(&mut self, members: Vec<MemberId>) -> PendingStateRef {
-        let gid = self.default_group.clone().expect("group");
+        self.try_remove_members(members)
+            .await
+            .expect("remove members")
+    }
+
+    pub(crate) async fn try_remove_members(
+        &mut self,
+        members: Vec<MemberId>,
+    ) -> Result<PendingStateRef, EngineError> {
+        let result = self.try_remove_members_inner(members).await;
+        self.release_unconsumed_scenario_input_on_err(result)
+    }
+
+    async fn try_remove_members_inner(
+        &mut self,
+        members: Vec<MemberId>,
+    ) -> Result<PendingStateRef, EngineError> {
+        let gid = self
+            .default_group
+            .clone()
+            .ok_or_else(Self::missing_default_group)?;
         let result = self
             .engine_mut()
             .send(SendIntent::RemoveMembers {
                 group_id: gid.clone(),
                 members,
             })
-            .await
-            .expect("remove members");
+            .await?;
         self.publish_group_evolution(result, &gid, "remove_members")
             .await
     }
 
     pub async fn self_update(&mut self) -> PendingStateRef {
-        let gid = self.default_group.clone().expect("group");
+        self.try_self_update().await.expect("self update")
+    }
+
+    pub(crate) async fn try_self_update(&mut self) -> Result<PendingStateRef, EngineError> {
+        let result = self.try_self_update_inner().await;
+        self.release_unconsumed_scenario_input_on_err(result)
+    }
+
+    async fn try_self_update_inner(&mut self) -> Result<PendingStateRef, EngineError> {
+        let gid = self
+            .default_group
+            .clone()
+            .ok_or_else(Self::missing_default_group)?;
         let result = self
             .engine_mut()
             .send(SendIntent::SelfUpdate {
                 group_id: gid.clone(),
             })
-            .await
-            .expect("self update");
+            .await?;
         self.publish_group_evolution(result, &gid, "self_update")
             .await
     }
@@ -1779,25 +2120,29 @@ impl HarnessClient {
         result: SendResult,
         group_id: &GroupId,
         operation: &str,
-    ) -> PendingStateRef {
+    ) -> Result<PendingStateRef, EngineError> {
         match result {
             SendResult::GroupEvolution {
                 msg,
                 welcomes,
                 pending,
             } => {
-                assert!(
-                    welcomes.is_empty(),
-                    "{operation} should not create welcomes"
-                );
+                if !welcomes.is_empty() {
+                    return Err(EngineError::Other(format!(
+                        "{operation} should not create welcomes"
+                    )));
+                }
                 let routed = route(msg, group_id);
                 self.remember_pending_publication(pending, std::iter::once(routed.id.clone()));
                 self.remember_pending_confirmation(pending, std::iter::once(routed.id.clone()));
                 self.publish_commit_scenario_input(&routed, pending).await;
                 self.bus.send(self.bus_id, routed);
-                pending
+                Ok(pending)
             }
-            other => panic!("expected GroupEvolution from {operation}, got {other:?}"),
+            other => Err(EngineError::Other(format!(
+                "expected GroupEvolution from {operation}, got {}",
+                send_result_kind(&other)
+            ))),
         }
     }
 
@@ -1805,7 +2150,18 @@ impl HarnessClient {
         &mut self,
         admins: Vec<MemberId>,
     ) -> Result<PendingStateRef, EngineError> {
-        let gid = self.default_group.clone().expect("group");
+        let result = self.update_admin_policy_inner(admins).await;
+        self.release_unconsumed_scenario_input_on_err(result)
+    }
+
+    async fn update_admin_policy_inner(
+        &mut self,
+        admins: Vec<MemberId>,
+    ) -> Result<PendingStateRef, EngineError> {
+        let gid = self
+            .default_group
+            .clone()
+            .ok_or_else(Self::missing_default_group)?;
         let data = encode_admin_policy(admins)?;
         let res = self
             .engine_mut()
@@ -1823,10 +2179,11 @@ impl HarnessClient {
                 welcomes,
                 pending,
             } => {
-                assert!(
-                    welcomes.is_empty(),
-                    "admin policy update should not create welcomes"
-                );
+                if !welcomes.is_empty() {
+                    return Err(EngineError::Backend(
+                        "admin policy update should not create welcomes".into(),
+                    ));
+                }
                 let routed = route(msg, &gid);
                 self.remember_pending_publication(pending, std::iter::once(routed.id.clone()));
                 self.remember_pending_confirmation(pending, std::iter::once(routed.id.clone()));
@@ -1835,7 +2192,8 @@ impl HarnessClient {
                 Ok(pending)
             }
             other => Err(EngineError::Backend(format!(
-                "expected GroupEvolution from update_admin_policy, got {other:?}"
+                "expected GroupEvolution from update_admin_policy, got {}",
+                send_result_kind(&other)
             ))),
         }
     }
@@ -1915,10 +2273,18 @@ impl HarnessClient {
         &mut self,
         payload: impl Into<Vec<u8>>,
     ) -> Result<(DecryptabilityProbeSendStatus, String), EngineError> {
+        let result = self.try_send_app_inner(payload).await;
+        self.release_unconsumed_scenario_input_on_err(result)
+    }
+
+    async fn try_send_app_inner(
+        &mut self,
+        payload: impl Into<Vec<u8>>,
+    ) -> Result<(DecryptabilityProbeSendStatus, String), EngineError> {
         let gid = self
             .default_group
             .clone()
-            .ok_or_else(|| EngineError::Other("must create or join a group first".into()))?;
+            .ok_or_else(Self::missing_default_group)?;
         let payload = self.next_app_payload(payload.into());
         let (logical_id, logical_payload) = logical_message_fields(&payload);
         let scenario_input = self.next_scenario_input_metadata(
@@ -1951,7 +2317,8 @@ impl HarnessClient {
                 Ok((DecryptabilityProbeSendStatus::Queued, logical_id))
             }
             other => Err(EngineError::Backend(format!(
-                "expected ApplicationMessage or Queued, got {other:?}"
+                "expected ApplicationMessage or Queued, got {}",
+                send_result_kind(&other)
             ))),
         }
     }
@@ -1969,7 +2336,18 @@ impl HarnessClient {
         &mut self,
         kps: Vec<KeyPackage>,
     ) -> Result<PendingStateRef, EngineError> {
-        let gid = self.default_group.clone().expect("group");
+        let result = self.try_invite_inner(kps).await;
+        self.release_unconsumed_scenario_input_on_err(result)
+    }
+
+    async fn try_invite_inner(
+        &mut self,
+        kps: Vec<KeyPackage>,
+    ) -> Result<PendingStateRef, EngineError> {
+        let gid = self
+            .default_group
+            .clone()
+            .ok_or_else(Self::missing_default_group)?;
         let res = self
             .engine_mut()
             .send(SendIntent::Invite {
@@ -2004,7 +2382,8 @@ impl HarnessClient {
                 Ok(pending)
             }
             other => Err(EngineError::Other(format!(
-                "expected GroupEvolution, got {other:?}"
+                "expected GroupEvolution, got {}",
+                send_result_kind(&other)
             ))),
         }
     }
@@ -2032,7 +2411,7 @@ impl HarnessClient {
         let gid = self
             .default_group
             .clone()
-            .ok_or_else(|| EngineError::Other("must create or join a group first".into()))?;
+            .ok_or_else(Self::missing_default_group)?;
         let res = self
             .engine_mut()
             .send(SendIntent::Leave {

--- a/crates/cgka-conformance-simulator/src/retained_relay.rs
+++ b/crates/cgka-conformance-simulator/src/retained_relay.rs
@@ -249,6 +249,24 @@ impl RetainedRelaySubject {
         })
     }
 
+    #[cfg(test)]
+    pub(crate) fn from_engine_for_tests(
+        engine: EngineHarnessSubject,
+        clients: &[String],
+    ) -> Result<Self, SubjectError> {
+        Self::new_with_deferred_peel_limits(
+            clients,
+            &ScenarioTopologyV2::default(),
+            ProtocolProfile::Current,
+            HarnessStorageMode::InMemorySqlite,
+            None,
+        )
+        .map(|mut subject| {
+            subject.engine = engine;
+            subject
+        })
+    }
+
     /// Bounded append-only transport evidence captured by the wrapped engine
     /// subject. Generated retained-history campaigns use this for the same
     /// failure-capsule diagnostics as packet-bus campaigns.

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -774,6 +774,7 @@ impl EngineHarnessSubject {
             storage_mode,
             false,
             None,
+            None,
         )
     }
 
@@ -792,6 +793,7 @@ impl EngineHarnessSubject {
             protocol_profile,
             storage_mode,
             true,
+            None,
             None,
         )
     }
@@ -815,6 +817,25 @@ impl EngineHarnessSubject {
             storage_mode,
             false,
             Some((rows_per_group, bytes_per_group, bytes_per_account)),
+            None,
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_with_welcome_wrap_refusal(
+        clients: &[String],
+        protocol_profile: ProtocolProfile,
+        storage_mode: HarnessStorageMode,
+        refuse_welcome_wrap: Arc<std::sync::atomic::AtomicBool>,
+    ) -> Result<Self, SubjectError> {
+        Self::new_with_topology_and_witness_mode(
+            clients,
+            &crate::ScenarioTopologyV2::default(),
+            protocol_profile,
+            storage_mode,
+            false,
+            None,
+            Some(refuse_welcome_wrap),
         )
     }
 
@@ -825,6 +846,7 @@ impl EngineHarnessSubject {
         storage_mode: HarnessStorageMode,
         disable_app_witnesses_for_tests: bool,
         deferred_peel_limits_override: Option<(usize, usize, usize)>,
+        welcome_wrap_refusal: Option<Arc<std::sync::atomic::AtomicBool>>,
     ) -> Result<Self, SubjectError> {
         let bus = TransportBus::ordered();
         let convergence_clock = ManualConvergenceClock::new(0, 0);
@@ -866,6 +888,14 @@ impl EngineHarnessSubject {
                 .protocol_profile(protocol_profile)
                 .storage_mode(storage_mode)
                 .convergence_clock(Arc::new(convergence_clock.clone()));
+            #[cfg(test)]
+            let builder = if let Some(flag) = welcome_wrap_refusal.clone() {
+                builder.welcome_wrap_refusal(flag)
+            } else {
+                builder
+            };
+            #[cfg(not(test))]
+            let _ = &welcome_wrap_refusal;
             #[cfg(feature = "test-policy-overrides")]
             let builder = if disable_app_witnesses_for_tests {
                 builder.without_app_witnesses_for_tests()
@@ -1155,7 +1185,12 @@ impl EngineHarnessSubject {
     ) -> Result<Vec<KeyPackage>, SubjectError> {
         let mut key_packages = Vec::with_capacity(labels.len());
         for label in labels {
-            key_packages.push(self.client_mut(label)?.fresh_key_package().await);
+            key_packages.push(
+                self.client_mut(label)?
+                    .try_fresh_key_package()
+                    .await
+                    .map_err(subject_engine_error)?,
+            );
         }
         Ok(key_packages)
     }
@@ -1433,13 +1468,14 @@ impl ConvergenceSubject for EngineHarnessSubject {
         let creator = self.client_mut(action.creator)?;
         creator.name_next_scenario_input(action.action_id);
         let (group_id, pending_ref) = creator
-            .create_group_with_admins_maybe_pending(
+            .try_create_group_with_admins_maybe_pending(
                 action.name,
                 key_packages,
                 required_features,
                 initial_admins,
             )
-            .await;
+            .await
+            .map_err(subject_engine_error)?;
         if let Some(group) = &self.active_scenario_group {
             self.scenario_groups.insert(group.clone(), group_id.clone());
         }
@@ -1465,7 +1501,10 @@ impl ConvergenceSubject for EngineHarnessSubject {
         let key_packages = self.fresh_key_packages(action.invitees).await?;
         let inviter = self.client_mut(action.inviter)?;
         inviter.name_next_scenario_input(action.action_id);
-        let pending_ref = inviter.invite(key_packages).await;
+        let pending_ref = inviter
+            .try_invite(key_packages)
+            .await
+            .map_err(subject_engine_error)?;
         self.insert_pending(action.pending, action.inviter, pending_ref)
     }
 
@@ -1476,11 +1515,12 @@ impl ConvergenceSubject for EngineHarnessSubject {
         let client = self.client_mut(action.client)?;
         client.name_next_scenario_input(action.action_id);
         let pending_ref = client
-            .update_group_profile(
+            .try_update_group_profile(
                 action.name.map(str::to_owned),
                 action.description.map(str::to_owned),
             )
-            .await;
+            .await
+            .map_err(subject_engine_error)?;
         self.insert_pending(action.pending, action.client, pending_ref)
     }
 
@@ -1491,14 +1531,20 @@ impl ConvergenceSubject for EngineHarnessSubject {
         let member_ids = self.member_ids(action.members)?;
         let remover = self.client_mut(action.remover)?;
         remover.name_next_scenario_input(action.action_id);
-        let pending_ref = remover.remove_members(member_ids).await;
+        let pending_ref = remover
+            .try_remove_members(member_ids)
+            .await
+            .map_err(subject_engine_error)?;
         self.insert_pending(action.pending, action.remover, pending_ref)
     }
 
     async fn self_update(&mut self, action: SubjectSelfUpdate<'_>) -> Result<(), SubjectError> {
         let client = self.client_mut(action.client)?;
         client.name_next_scenario_input(action.action_id);
-        let pending_ref = client.self_update().await;
+        let pending_ref = client
+            .try_self_update()
+            .await
+            .map_err(subject_engine_error)?;
         self.insert_pending(action.pending, action.client, pending_ref)
     }
 
@@ -2314,7 +2360,11 @@ pub(crate) fn classify_engine_error(error: &EngineError) -> (SubjectFailureCateg
 
 fn subject_engine_error(error: EngineError) -> SubjectError {
     let (category, code) = classify_engine_error(&error);
-    SubjectError::classified(category, code, error.to_string())
+    SubjectError::classified(
+        category,
+        code.clone(),
+        format!("engine operation failed ({code})"),
+    )
 }
 
 fn ensure_tick_succeeded(
@@ -2574,7 +2624,8 @@ mod tests {
         .expect_err("tick must not discard the engine failure");
         assert_eq!(error.code, "backend");
         assert_eq!(error.category, SubjectFailureCategory::Resource);
-        assert!(error.message.contains("converge buffered group"));
+        assert_eq!(error.message, "engine operation failed (backend)");
+        assert!(!error.message.contains("converge buffered group"));
     }
 
     #[test]
@@ -3976,6 +4027,392 @@ mod tests {
                 .final_progress
                 .blocking_subsystems()
                 .contains(&"transport_delayed")
+        );
+    }
+
+    fn two_client_create_then_send(name: &str) -> crate::ScenarioSpec {
+        crate::ScenarioSpec {
+            name: name.to_owned(),
+            spec_version: "2".to_owned(),
+            topology: Default::default(),
+            clients: vec!["alice".into(), "bob".into()],
+            steps: vec![
+                crate::ScenarioStep::CreateGroup {
+                    creator: "alice".into(),
+                    name: "room".into(),
+                    invitees: vec!["bob".into()],
+                    required_features: Vec::new(),
+                    initial_admins: None,
+                    pending: "create".into(),
+                },
+                crate::ScenarioStep::SendAppMessage {
+                    sender: "alice".into(),
+                    payload: "must-not-run".into(),
+                },
+            ],
+        }
+    }
+
+    fn assert_no_welcome_marker(value: &impl serde::Serialize) {
+        let encoded = serde_json::to_string(value).expect("value serializes");
+        assert!(
+            !encoded.contains(crate::client::WELCOME_WRAP_REFUSAL_MARKER),
+            "serialized evidence leaked the synthetic Welcome marker"
+        );
+    }
+
+    async fn refused_welcome_create_report(
+        protocol_profile: ProtocolProfile,
+        storage_mode: HarnessStorageMode,
+    ) -> (
+        EngineHarnessSubject,
+        std::sync::Arc<std::sync::atomic::AtomicBool>,
+        crate::ScenarioReport,
+    ) {
+        let refuse = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let labels = vec!["alice".to_owned(), "bob".to_owned()];
+        let mut subject = EngineHarnessSubject::new_with_welcome_wrap_refusal(
+            &labels,
+            protocol_profile,
+            storage_mode,
+            refuse.clone(),
+        )
+        .expect("subject constructs");
+        let spec = two_client_create_then_send("refused-welcome-create/v1");
+        let report = crate::run_scenario_report_with_subject(&spec, None, Vec::new(), &mut subject)
+            .await
+            .expect("refused create remains a serializable report");
+        (subject, refuse, report)
+    }
+
+    fn assert_create_refused_without_marker(report: &crate::ScenarioReport) {
+        assert_eq!(report.step_log.len(), 1);
+        let crate::ScenarioStepStatus::Failed {
+            kind,
+            category,
+            message,
+        } = &report.step_log[0].status
+        else {
+            panic!("first step must fail");
+        };
+        assert_eq!(report.step_log[0].step_type, "create_group");
+        assert_eq!(kind, "peeler");
+        assert_eq!(*category, SubjectFailureCategory::Protocol);
+        assert_eq!(message, "engine operation failed (peeler)");
+        assert!(!message.contains(crate::client::WELCOME_WRAP_REFUSAL_MARKER));
+        assert_no_welcome_marker(report);
+    }
+
+    #[tokio::test]
+    async fn refused_welcome_create_is_reportable_for_both_protocol_profiles() {
+        for protocol_profile in [ProtocolProfile::Legacy, ProtocolProfile::Current] {
+            let (subject, _, report) =
+                refused_welcome_create_report(protocol_profile, HarnessStorageMode::InMemorySqlite)
+                    .await;
+            assert_create_refused_without_marker(&report);
+            assert!(subject.scenario_groups.is_empty());
+            assert!(subject.pending_refs.is_empty());
+            assert!(subject.outbound_records.is_empty());
+
+            let capsule = crate::FailureCapsuleV1::from_report(
+                report.clone(),
+                crate::FailureCapsuleSensitivity::SyntheticShareable,
+                Vec::new(),
+                None,
+            )
+            .expect("portable capsule builds");
+            assert_eq!(
+                capsule.sensitivity,
+                crate::FailureCapsuleSensitivity::SyntheticShareable
+            );
+            assert!(capsule.byte_replay.is_none());
+            assert_eq!(capsule.failure.failure_kind, "scenario_step_failed:peeler");
+            assert_eq!(
+                capsule.failure.first_failing_action_id.as_deref(),
+                Some("step-0:create_group")
+            );
+            assert_eq!(
+                capsule.failure.classification,
+                crate::TerminalOutcomeClassification::TerminalProtocolFailure
+            );
+            assert_no_welcome_marker(&capsule);
+            let capsule_dir = tempfile::tempdir().expect("capsule dir");
+            let capsule_path = capsule_dir.path().join("failure-capsule.v1.json");
+            crate::write_failure_capsule(&capsule_path, &capsule).expect("capsule writes");
+            let restored = crate::read_failure_capsule(&capsule_path).expect("capsule validates");
+            assert!(restored.byte_replay.is_none());
+            assert_no_welcome_marker(&restored);
+
+            let spec = two_client_create_then_send("refused-welcome-create-trace/v1");
+            let refuse = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+            let mut refused = EngineHarnessSubject::new_with_welcome_wrap_refusal(
+                &["alice".into(), "bob".into()],
+                protocol_profile,
+                HarnessStorageMode::InMemorySqlite,
+                refuse,
+            )
+            .expect("refused subject constructs");
+            let error = crate::run_scenario_spec_with_subject(&spec, &mut refused)
+                .await
+                .expect_err("trace-only API maps the failed create");
+            assert_eq!(error.kind, "peeler");
+            assert_eq!(error.category, SubjectFailureCategory::Protocol);
+            assert_eq!(error.message, "engine operation failed (peeler)");
+            assert!(
+                !error
+                    .message
+                    .contains(crate::client::WELCOME_WRAP_REFUSAL_MARKER)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn refused_welcome_create_reduction_preserves_original_failure_identity() {
+        let (_, _, original) = refused_welcome_create_report(
+            ProtocolProfile::Current,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .await;
+        assert_create_refused_without_marker(&original);
+        let original_fingerprint = crate::fingerprint_report_failure(&original)
+            .expect("failed create report fingerprints before reduction");
+        let original_identity = original_fingerprint.semantic_identity();
+        assert_eq!(original_identity.failing_action_type, "create_group");
+        assert_eq!(
+            original_identity.failure_kind,
+            "scenario_step_failed:peeler"
+        );
+        let original_capsule = crate::FailureCapsuleV1::from_report(
+            original.clone(),
+            crate::FailureCapsuleSensitivity::SyntheticShareable,
+            Vec::new(),
+            None,
+        )
+        .expect("original portable capsule builds before reduction");
+        assert_no_welcome_marker(&original);
+        assert_no_welcome_marker(&original_capsule);
+
+        let reduced_spec = crate::ScenarioSpec {
+            name: "refused-welcome-create-reduced/v1".to_owned(),
+            spec_version: "2".to_owned(),
+            topology: Default::default(),
+            clients: vec!["alice".into(), "bob".into()],
+            steps: vec![crate::ScenarioStep::CreateGroup {
+                creator: "alice".into(),
+                name: "room".into(),
+                invitees: vec!["bob".into()],
+                required_features: Vec::new(),
+                initial_admins: None,
+                pending: "create".into(),
+            }],
+        };
+        let refuse = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let mut reduced_subject = EngineHarnessSubject::new_with_welcome_wrap_refusal(
+            &["alice".into(), "bob".into()],
+            ProtocolProfile::Current,
+            HarnessStorageMode::InMemorySqlite,
+            refuse,
+        )
+        .expect("reduced subject constructs");
+        let reduced = crate::run_scenario_report_with_subject(
+            &reduced_spec,
+            None,
+            Vec::new(),
+            &mut reduced_subject,
+        )
+        .await
+        .expect("create-only reduction remains a serializable report");
+        assert_create_refused_without_marker(&reduced);
+        let reduced_identity = crate::fingerprint_report_failure(&reduced)
+            .expect("reduced create report fingerprints")
+            .semantic_identity();
+        assert_eq!(reduced_identity, original_identity);
+        assert_eq!(
+            crate::fingerprint_report_failure(&original)
+                .expect("original fingerprint remains computable")
+                .semantic_identity(),
+            original_identity
+        );
+        assert_no_welcome_marker(&original);
+        assert_no_welcome_marker(&original_capsule);
+    }
+
+    #[tokio::test]
+    async fn refused_create_releases_reservation_and_allows_a_later_named_create() {
+        for storage_mode in [
+            HarnessStorageMode::InMemorySqlite,
+            HarnessStorageMode::TempFileBackedSqlite,
+        ] {
+            let refuse = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+            let labels = vec!["alice".to_owned(), "bob".to_owned()];
+            let mut subject = EngineHarnessSubject::new_with_welcome_wrap_refusal(
+                &labels,
+                ProtocolProfile::Current,
+                storage_mode,
+                refuse.clone(),
+            )
+            .expect("subject constructs");
+            let first = subject
+                .create_group(SubjectCreateGroup {
+                    action_id: "refused-create",
+                    creator: "alice",
+                    name: "first",
+                    invitees: &labels[1..],
+                    required_features: &[],
+                    initial_admins: &[],
+                    pending: "unused-first",
+                })
+                .await
+                .expect_err("injected Welcome wrap must refuse create");
+            assert_eq!(first.code, "peeler");
+            assert!(subject.scenario_groups.is_empty());
+            assert!(subject.pending_refs.is_empty());
+            assert!(subject.outbound_records.is_empty());
+
+            refuse.store(false, std::sync::atomic::Ordering::SeqCst);
+            subject
+                .create_group(SubjectCreateGroup {
+                    action_id: "recovered-create",
+                    creator: "alice",
+                    name: "second",
+                    invitees: &labels[1..],
+                    required_features: &[],
+                    initial_admins: &[],
+                    pending: "unused-second",
+                })
+                .await
+                .expect("later named create succeeds after the refusal is cleared");
+            assert_eq!(subject.scenario_groups.len(), 0);
+            assert!(subject.pending_refs.is_empty());
+            let ledger = subject
+                .client_mut("alice")
+                .expect("creator")
+                .scenario_input_ledger();
+            assert!(
+                ledger
+                    .iter()
+                    .all(|entry| entry.scenario_id != "refused-create"),
+                "refused create must not leave a successful ledger row"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn successful_create_forms_preserve_legacy_pending_and_current_empty_publication() {
+        let current_bus = crate::TransportBus::ordered();
+        let mut current = crate::ClientBuilder::new(pad32(b"alice"))
+            .protocol_profile(ProtocolProfile::Current)
+            .attach(&current_bus);
+        let (_, current_pending) = current
+            .try_create_group_with_admins_maybe_pending("empty-current", vec![], vec![], vec![])
+            .await
+            .expect("zero-invitee current create succeeds");
+        assert!(
+            current_pending.is_none(),
+            "current founding create has no pending"
+        );
+
+        let legacy_bus = crate::TransportBus::ordered();
+        let mut legacy = crate::ClientBuilder::new(pad32(b"alice-legacy"))
+            .protocol_profile(ProtocolProfile::Legacy)
+            .attach(&legacy_bus);
+        let (_, legacy_pending) = legacy
+            .try_create_group_with_admins_maybe_pending("empty-legacy", vec![], vec![], vec![])
+            .await
+            .expect("zero-invitee legacy create succeeds");
+        let pending = legacy_pending.expect("legacy create still returns pending");
+        assert!(
+            legacy
+                .confirm_empty_publication(pending)
+                .await
+                .expect("empty publication is confirmable")
+        );
+    }
+
+    #[test]
+    fn subject_engine_error_uses_fixed_text_for_nested_and_identifier_errors() {
+        let cases = [
+            (
+                EngineError::Peeler(cgka_traits::error::PeelerError::WrapFailed(format!(
+                    "{} nested free-form",
+                    crate::client::WELCOME_WRAP_REFUSAL_MARKER
+                ))),
+                SubjectFailureCategory::Protocol,
+                "peeler",
+            ),
+            (
+                EngineError::Backend(format!(
+                    "backend {} with identifier aabbccddeeff",
+                    crate::client::WELCOME_WRAP_REFUSAL_MARKER
+                )),
+                SubjectFailureCategory::Resource,
+                "backend",
+            ),
+            (
+                EngineError::Storage(cgka_traits::storage::StorageError::Backend(format!(
+                    "storage {} path=/tmp/secret.sqlite",
+                    crate::client::WELCOME_WRAP_REFUSAL_MARKER
+                ))),
+                SubjectFailureCategory::Resource,
+                "storage",
+            ),
+            (
+                EngineError::Other(format!(
+                    "other {} bytes=0xdeadbeef",
+                    crate::client::WELCOME_WRAP_REFUSAL_MARKER
+                )),
+                SubjectFailureCategory::Protocol,
+                "other",
+            ),
+            (
+                EngineError::UnknownGroup(cgka_traits::GroupId::new(vec![0xAA; 16])),
+                SubjectFailureCategory::ExpectedRefusal,
+                "unknown_group",
+            ),
+        ];
+        for (error, category, code) in cases {
+            let mapped = subject_engine_error(error);
+            assert_eq!(mapped.category, category);
+            assert_eq!(mapped.code, code);
+            assert_eq!(mapped.message, format!("engine operation failed ({code})"));
+            assert!(
+                !mapped
+                    .message
+                    .contains(crate::client::WELCOME_WRAP_REFUSAL_MARKER)
+            );
+            assert!(!mapped.message.contains("aabbccddeeff"));
+            assert!(!mapped.message.contains("0xdeadbeef"));
+            assert!(!mapped.message.contains("/tmp/secret.sqlite"));
+            let encoded = format!("{mapped:?}");
+            assert!(!encoded.contains(crate::client::WELCOME_WRAP_REFUSAL_MARKER));
+        }
+    }
+
+    #[tokio::test]
+    async fn retained_relay_subject_inherits_engine_create_refusal() {
+        let refuse = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let labels = vec!["alice".to_owned(), "bob".to_owned()];
+        let engine = EngineHarnessSubject::new_with_welcome_wrap_refusal(
+            &labels,
+            ProtocolProfile::Current,
+            HarnessStorageMode::InMemorySqlite,
+            refuse,
+        )
+        .expect("engine subject constructs");
+        let mut retained = crate::RetainedRelaySubject::from_engine_for_tests(engine, &labels)
+            .expect("retained subject wraps the engine subject");
+        let error = crate::run_scenario_spec_with_subject(
+            &two_client_create_then_send("retained-refused-create/v1"),
+            &mut retained,
+        )
+        .await
+        .expect_err("retained relay must inherit the engine create refusal");
+        assert_eq!(error.kind, "peeler");
+        assert_eq!(error.message, "engine operation failed (peeler)");
+        assert!(
+            !error
+                .message
+                .contains(crate::client::WELCOME_WRAP_REFUSAL_MARKER)
         );
     }
 }

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -4298,6 +4298,136 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn profile_and_self_update_engine_refusals_recover_on_memory_and_file() {
+        for storage_mode in [
+            HarnessStorageMode::InMemorySqlite,
+            HarnessStorageMode::TempFileBackedSqlite,
+        ] {
+            let labels = vec!["alice".to_owned(), "bob".to_owned()];
+            let mut subject =
+                EngineHarnessSubject::new(&labels, ProtocolProfile::Current, storage_mode)
+                    .expect("subject constructs");
+
+            let prejoin_profile = subject
+                .update_group_data(SubjectUpdateGroupData {
+                    action_id: "prejoin-profile",
+                    client: "alice",
+                    name: Some("too-early"),
+                    description: None,
+                    pending: "unused-prejoin-profile",
+                })
+                .await
+                .expect_err("profile update before create is a typed engine refusal");
+            assert_eq!(prejoin_profile.code, "other");
+            assert_eq!(prejoin_profile.category, SubjectFailureCategory::Protocol);
+            assert_eq!(prejoin_profile.message, "engine operation failed (other)");
+            assert!(!prejoin_profile.message.contains("must create or join"));
+            assert!(subject.pending_refs.is_empty());
+            assert!(subject.outbound_records.is_empty());
+
+            let prejoin_self_update = subject
+                .self_update(SubjectSelfUpdate {
+                    action_id: "prejoin-self-update",
+                    client: "alice",
+                    pending: "unused-prejoin-self-update",
+                })
+                .await
+                .expect_err("self-update before create is a typed engine refusal");
+            assert_eq!(prejoin_self_update.code, "other");
+            assert_eq!(
+                prejoin_self_update.category,
+                SubjectFailureCategory::Protocol
+            );
+            assert_eq!(
+                prejoin_self_update.message,
+                "engine operation failed (other)"
+            );
+            assert!(!prejoin_self_update.message.contains("must create or join"));
+            assert!(subject.pending_refs.is_empty());
+            assert!(subject.outbound_records.is_empty());
+
+            create_current_group_and_join(&mut subject, "alice", &labels[1..]).await;
+            let outbound_after_join = subject.outbound_records.len();
+            let pending_after_join = subject.pending_refs.len();
+
+            let denied_profile = subject
+                .update_group_data(SubjectUpdateGroupData {
+                    action_id: "nonadmin-profile",
+                    client: "bob",
+                    name: Some("denied"),
+                    description: None,
+                    pending: "unused-nonadmin-profile",
+                })
+                .await
+                .expect_err("non-admin profile update is a typed engine refusal");
+            assert_eq!(denied_profile.code, "not_group_admin");
+            assert_eq!(
+                denied_profile.category,
+                SubjectFailureCategory::ExpectedRefusal
+            );
+            assert_eq!(
+                denied_profile.message,
+                "engine operation failed (not_group_admin)"
+            );
+            assert!(!subject.pending_refs.contains_key("unused-nonadmin-profile"));
+            assert_eq!(subject.outbound_records.len(), outbound_after_join);
+            assert_eq!(subject.pending_refs.len(), pending_after_join);
+
+            subject
+                .update_group_data(SubjectUpdateGroupData {
+                    action_id: "recovered-profile",
+                    client: "alice",
+                    name: Some("renamed"),
+                    description: None,
+                    pending: "recovered-profile",
+                })
+                .await
+                .expect("admin profile update succeeds after sibling refusals");
+            subject
+                .self_update(SubjectSelfUpdate {
+                    action_id: "recovered-self-update",
+                    client: "bob",
+                    pending: "recovered-self-update",
+                })
+                .await
+                .expect("member self-update succeeds after sibling refusals");
+
+            let alice_ids = subject
+                .client_mut("alice")
+                .expect("alice")
+                .scenario_input_ledger()
+                .into_iter()
+                .map(|entry| entry.scenario_id)
+                .collect::<Vec<_>>();
+            let bob_ids = subject
+                .client_mut("bob")
+                .expect("bob")
+                .scenario_input_ledger()
+                .into_iter()
+                .map(|entry| entry.scenario_id)
+                .collect::<Vec<_>>();
+            for refused in ["prejoin-profile", "prejoin-self-update"] {
+                assert!(
+                    !alice_ids.iter().any(|id| id == refused),
+                    "refused {refused} must not leave a successful alice ledger row: {alice_ids:?}"
+                );
+            }
+            assert!(
+                alice_ids.iter().any(|id| id == "recovered-profile"),
+                "later named profile must keep its action id: {alice_ids:?}"
+            );
+            assert!(
+                !bob_ids.iter().any(|id| id == "nonadmin-profile"),
+                "refused non-admin profile must not leave a successful bob ledger row: {bob_ids:?}"
+            );
+            assert!(
+                bob_ids.iter().any(|id| id == "recovered-self-update"),
+                "later named self-update must keep its action id: {bob_ids:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn successful_create_forms_preserve_legacy_pending_and_current_empty_publication() {
         let current_bus = crate::TransportBus::ordered();
         let mut current = crate::ClientBuilder::new(pad32(b"alice"))

--- a/crates/cgka-conformance-simulator/tests/process_campaign_runner.rs
+++ b/crates/cgka-conformance-simulator/tests/process_campaign_runner.rs
@@ -1,7 +1,8 @@
 use cgka_conformance_simulator::{
-    GeneratedScenarioInputV1, ScenarioReport, generate_convergence_e2e_delivery_case,
-    resolve_scenario_input_bytes,
+    GeneratedScenarioInputV1, ScenarioReport, ScenarioStepStatus,
+    generate_convergence_e2e_delivery_case, resolve_scenario_input_bytes,
 };
+use std::path::Path;
 use std::process::Command;
 
 fn campaign_binary() -> &'static str {
@@ -172,19 +173,38 @@ fn large_group_pressure_8001_30_report_and_campaign_worker_exit_failed_scenario(
     assert_eq!(campaign_status.code(), Some(1));
 
     let stem = "large-group-pressure-v1-seed-8001-case-30";
-    let report_path = campaign_out.join(format!("{stem}.json"));
-    let fixture_path = campaign_out.join(format!("{stem}-fixture.v1.json"));
-    let capsule_path = campaign_out.join(format!("{stem}-failure-capsule.v1.json"));
+    assert_create_refusal_artifacts(&report_out, stem);
+    assert_create_refusal_artifacts(&campaign_out, stem);
+}
+
+fn assert_create_refusal_artifacts(out: &Path, stem: &str) {
+    let report_path = out.join(format!("{stem}.json"));
+    let fixture_path = out.join(format!("{stem}-fixture.v1.json"));
+    let capsule_path = out.join(format!("{stem}-failure-capsule.v1.json"));
     let report: ScenarioReport =
-        serde_json::from_slice(&std::fs::read(&report_path).expect("campaign report reads"))
-            .expect("campaign report parses");
-    assert!(fixture_path.is_file());
-    let capsule =
-        cgka_conformance_simulator::read_failure_capsule(&capsule_path).expect("capsule reads");
+        serde_json::from_slice(&std::fs::read(&report_path).expect("create-refusal report reads"))
+            .expect("create-refusal report parses");
+    assert!(
+        fixture_path.is_file(),
+        "missing fixture {}",
+        fixture_path.display()
+    );
+    let capsule = cgka_conformance_simulator::read_failure_capsule(&capsule_path)
+        .expect("create-refusal capsule reads");
     assert_eq!(
         capsule.sensitivity,
         cgka_conformance_simulator::FailureCapsuleSensitivity::SyntheticShareable
     );
     assert!(capsule.byte_replay.is_none());
-    assert_eq!(report.step_log[0].step_type, "create_group");
+    let first = report
+        .step_log
+        .first()
+        .expect("failed create leaves a step log");
+    assert_eq!(first.step_type, "create_group");
+    match &first.status {
+        ScenarioStepStatus::Failed { kind, .. } => {
+            assert_eq!(kind, "peeler");
+        }
+        other => panic!("first step must fail with peeler, got {other:?}"),
+    }
 }

--- a/crates/cgka-conformance-simulator/tests/process_campaign_runner.rs
+++ b/crates/cgka-conformance-simulator/tests/process_campaign_runner.rs
@@ -129,3 +129,62 @@ fn strict_worker_failure_writes_a_portable_capsule() {
             .is_file()
     );
 }
+
+#[test]
+#[ignore = "64-member Welcome-refusal boundary; prefer the campaign-bin fixture tests::large_group_pressure_8001_30_reports_create_refusal"]
+fn large_group_pressure_8001_30_report_and_campaign_worker_exit_failed_scenario() {
+    let temp = tempfile::tempdir().expect("temporary campaign root");
+    let case = cgka_conformance_simulator::generate_large_group_pressure_case(8001, 30);
+    let input = GeneratedScenarioInputV1::new(case);
+    let campaign_out = temp.path().join("campaign");
+    let report_out = temp.path().join("report");
+    fs_private::create_dir_all_private(&campaign_out).expect("campaign out");
+    fs_private::create_dir_all_private(&report_out).expect("report out");
+    let input_path =
+        campaign_out.join("large-group-pressure-v1-seed-8001-case-30-generated-input.json");
+    fs_private::write_private(
+        &input_path,
+        &serde_json::to_vec_pretty(&input).expect("generated input serializes"),
+    )
+    .expect("generated input writes");
+
+    let report_status = Command::new(env!("CARGO_BIN_EXE_cgka-conformance-simulator-report"))
+        .arg("--generated-input")
+        .arg(&input_path)
+        .arg("--out")
+        .arg(&report_out)
+        .args(["--storage", "file"])
+        .env("RUST_MIN_STACK", "4194304")
+        .status()
+        .expect("report binary starts");
+    assert_eq!(report_status.code(), Some(1));
+
+    let campaign_status = Command::new(campaign_binary())
+        .arg("--worker")
+        .arg("--input")
+        .arg(&input_path)
+        .arg("--out")
+        .arg(&campaign_out)
+        .args(["--storage", "file"])
+        .env("RUST_MIN_STACK", "4194304")
+        .status()
+        .expect("campaign worker starts");
+    assert_eq!(campaign_status.code(), Some(1));
+
+    let stem = "large-group-pressure-v1-seed-8001-case-30";
+    let report_path = campaign_out.join(format!("{stem}.json"));
+    let fixture_path = campaign_out.join(format!("{stem}-fixture.v1.json"));
+    let capsule_path = campaign_out.join(format!("{stem}-failure-capsule.v1.json"));
+    let report: ScenarioReport =
+        serde_json::from_slice(&std::fs::read(&report_path).expect("campaign report reads"))
+            .expect("campaign report parses");
+    assert!(fixture_path.is_file());
+    let capsule =
+        cgka_conformance_simulator::read_failure_capsule(&capsule_path).expect("capsule reads");
+    assert_eq!(
+        capsule.sensitivity,
+        cgka_conformance_simulator::FailureCapsuleSensitivity::SyntheticShareable
+    );
+    assert!(capsule.byte_replay.is_none());
+    assert_eq!(report.step_log[0].step_type, "create_group");
+}

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -29,6 +29,11 @@ versioning through the workspace version in the root `Cargo.toml`.
   uncertain publications. Explicit recovery retains opaque historical bytes
   and starts a fresh approval epoch; Swift/Kotlin/C hosts use the epoch-aware
   approval APIs for recovered attempts.
+- Simulator engine-subject group-action refusals now stay on the existing
+  report, fixture, and portable capsule path instead of panicking. Failed
+  create, invite, profile, remove, and self-update steps use fixed
+  privacy-safe engine messages, release unused scenario-input reservations,
+  and leave successful current and legacy create forms unchanged.
 
 ## [0.9.19] - 2026-09-07
 


### PR DESCRIPTION
<!-- pip-control:v1 effect=repo:1055628515#1639@3:draft-pr sha256=596f4c829106716bb5220b7a893950f387f34aca52b4e38197d868d8e8995e95 -->
### Problem

The new refusal tests could still pass if one later named action ID disappeared or if a later campaign step failed while the first create succeeded.

### Solution

Later named successes are now asserted independently, process-level create refusals require a peeler failure on both report and campaign artifacts, and subject-level profile and self-update refusals recover on memory and file-backed SQLite.

[Implementation plan](https://github.com/marmot-protocol/mdk/issues/1639#issuecomment-5588387615)

Fixes #1639

<details>
<summary>Local checks and remediation details</summary>

Commit: `92d24387e72213f6ed0adc8559503e4aeabcc05f`

### Local checks

- cargo fmt --all --check: passed via just fast-ci
- cargo test -p cgka-conformance-simulator --locked --lib client::tests: 14 passed
- cargo test -p cgka-conformance-simulator --locked --lib subject::tests: 40 passed
- cargo test -p cgka-conformance-simulator --locked --lib scenario::tests: 17 passed
- cargo test -p cgka-conformance-simulator --locked --lib report::tests: 4 passed
- cargo test -p cgka-conformance-simulator --locked --bin cgka-conformance-campaign: 13 passed, 3 ignored
- cargo test -p cgka-conformance-simulator --locked --test canonical_scenarios refused_leave_releases_named_scenario_input_reservation: passed
- cargo test -p cgka-conformance-simulator --locked --test process_campaign_runner -- --skip large_group_pressure: 2 passed, 1 ignored
- cargo test -p cgka-conformance-simulator --locked --test report_runner: 27 passed
- cargo test -p cgka-conformance-simulator --locked --test large_group_family: 6 passed, 1 ignored
- cargo test -p cgka-conformance-simulator --locked --test tracing_audit: 4 passed
- cargo test -p cgka-conformance-simulator --locked --test vector_artifacts: 3 passed
- cargo test -p cgka-conformance-simulator --locked: failed only on untouched stateful_generator::report_runner_executes_and_preserves_both_journey_profiles (PermissionDenied opening /var/lib/pip); remaining crate tests that ran passed
- just fast-ci: passed

### Findings addressed

No findings required remediation.

### Review suggestions

- client.rs now loops over profile-after-remove and self-update-after-admin and requires each ID independently. Verified by client::tests::successful_create_forms_and_invite_refusal_preserve_action_ids.
- process_campaign_runner.rs now matches the first step as ScenarioStepStatus::Failed and requires kind peeler, and applies the same check to report-binary and campaign-worker artifacts. The 64-member test remains ignored and was not re-executed; the campaign-bin fixture already pinned peeler classification.
- Same independent ID assertions as the matching GitHub thread. Covered by the client unit test above.
- The ignored process-level boundary test now destructures Failed and requires kind peeler on both report and campaign outputs.
- Independent later action IDs plus shared create-refusal artifact checks for the report binary and campaign worker.
- Added subject::tests::profile_and_self_update_engine_refusals_recover_on_memory_and_file. It pins pre-join missing-group refusals, a non-admin profile refusal, fixed diagnostics, no refused outbound/pending work, and later named successes on memory and file-backed SQLite. The test passed.

Checks are builder-reported; CI and reviews are evaluated separately.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refused group operations now produce reported failed scenarios instead of panics.
  * Failure reports use consistent, privacy-safe error messages.
  * Failed operations preserve action identity and release unused scenario inputs.

* **Testing**
  * Added large-group Welcome-refusal coverage, including report, fixture, and portable failure-capsule validation.
  * Added end-to-end campaign checks using file-backed storage.

* **Documentation**
  * Documented how to run and interpret the 64-member Welcome-refusal boundary test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->