### PR TITLE
chore(release): prepare 0.9.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-connector"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "agent-control",
  "agent-stream-compose",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "agent-control"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "serde",
  "serde_json",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "agent-stream-compose"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -864,7 +864,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgka-conformance-simulator"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-engine"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-session"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-traits"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "async-trait",
  "criterion",
@@ -1196,7 +1196,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convergence-campaign-runner"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "async-trait",
  "cgka-conformance-simulator",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "fs-private"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "libc",
  "tempfile",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "incident-replay"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "cgka-conformance-simulator",
  "fs-private",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-account"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-app"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3385,7 +3385,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-c"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "libc",
  "marmot-uniffi",
@@ -3396,7 +3396,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-forensics"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "fs-private",
  "serde",
@@ -3407,7 +3407,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-markdown"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "serde",
  "serde_json",
@@ -3415,7 +3415,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-terminal-harness"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "agent-control",
  "async-trait",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-uniffi"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "cgka-engine",
  "cgka-traits",
@@ -5677,7 +5677,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-sqlite"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "cgka-traits",
  "fs-private",
@@ -6295,7 +6295,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-adapter"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6315,7 +6315,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-peeler"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6333,7 +6333,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-broker"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "cgka-traits",
  "clap",
@@ -6352,7 +6352,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-stream"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
@@ -7283,7 +7283,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wn-cli"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "agent-stream-compose",
  "cgka-traits",
@@ -7316,7 +7316,7 @@ dependencies = [
 
 [[package]]
 name = "wn-codex"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "async-trait",
  "clap",
@@ -7330,7 +7330,7 @@ dependencies = [
 
 [[package]]
 name = "wn-opencode"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "async-trait",
  "clap",
@@ -7345,7 +7345,7 @@ dependencies = [
 
 [[package]]
 name = "wn-pi"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.9.19"
+version = "0.9.20"
 license = "MIT"
 publish = false
 

--- a/crates/cgka-conformance-simulator/vectors/admin-handover.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-handover.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-handover/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "admin-handover/v1",

--- a/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-policy-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "admin-policy-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "concurrent-invite-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "concurrent-invite-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-committer-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "convergence-committer-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-witness-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "convergence-witness-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/conversation.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/conversation.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "conversation/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "conversation/v1",

--- a/crates/cgka-conformance-simulator/vectors/cross-route-own-commit-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/cross-route-own-commit-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "cross-route-own-commit-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "cross-route-own-commit-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "current-profile-required-set/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "application_profile": {
     "name": "current",

--- a/crates/cgka-conformance-simulator/vectors/deferred-tick-catchup.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/deferred-tick-catchup.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "deferred-tick-catchup/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "deferred-tick-catchup/v1",

--- a/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "delayed-past-epoch-app-message/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "delayed-past-epoch-app-message/v1",

--- a/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "drop-queued/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "drop-queued/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "group-data-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "group-data-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-profile-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-profile-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-profile-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "group-profile-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "convergence-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "membership-fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "membership-fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incremental-growth.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incremental-growth.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "incremental-growth/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "incremental-growth/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-member/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "invite-member/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "invite-publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/late-welcome-backfill.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/late-welcome-backfill.v1.json
@@ -1,7 +1,7 @@
 {
  "scenario_name": "late-welcome-backfill/v1",
  "vector_version": "1",
- "conformance_version": "0.9.19",
+ "conformance_version": "0.9.20",
  "seed": null,
  "scenario": {
   "name": "late-welcome-backfill/v1",

--- a/crates/cgka-conformance-simulator/vectors/latecomer-forward-secrecy.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/latecomer-forward-secrecy.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "latecomer-forward-secrecy/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "latecomer-forward-secrecy/v1",

--- a/crates/cgka-conformance-simulator/vectors/leaver-removal-secrecy.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/leaver-removal-secrecy.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "leaver-removal-secrecy/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "leaver-removal-secrecy/v1",

--- a/crates/cgka-conformance-simulator/vectors/multigroup-isolation.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/multigroup-isolation.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "multigroup-isolation/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "multigroup-isolation/v1",

--- a/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "partition-clear-leave/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "partition-clear-leave/v1",

--- a/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "queue-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "queue-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/readd-after-eviction.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/readd-after-eviction.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "readd-after-eviction/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "readd-after-eviction/v1",

--- a/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "restart-delivery-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "restart-delivery-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/route-equivalence.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/route-equivalence.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "route-equivalence/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "route-equivalence/v1",

--- a/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "three-client-message-exchange/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.19",
+  "conformance_version": "0.9.20",
   "seed": null,
   "scenario": {
     "name": "three-client-message-exchange/v1",

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,8 +9,14 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+## [0.9.20] - 2026-09-08
+
 ### Added
 
+- Durable chat names and avatars, background presentation maintenance, and
+  complete presented chat-list reads and subscriptions across the runtime,
+  Swift/Kotlin, and C bindings.
+- First-class Hermes plugin packaging and media dispatch.
 - Added `usage-diagnostics show|enable|disable` with JSON output and live daemon
   routing. One explicit local consent controls OTLP and stock Aptabase exports;
   prior telemetry users reconfirm. Standalone commands and TUI children are silent
@@ -18,6 +24,18 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ### Changed
 
+- Account databases advance through migrations 65–67 for durable chat
+  presentation, background maintenance checkpoints, and invitation recovery.
+  Shared storage advances through versions 2–3 for diagnostics consent and
+  profile-change tracking. Back up before upgrading; downgrade is unsupported.
+  Re-upgrade or restore a pre-upgrade database/export instead of removing
+  migration rows. See the
+  [storage-format contract](../../docs/marmot-architecture/storage-format-v2.md).
+  Upgrades from before `0.9.15` also cross migration 47: keep at least 3.25
+  times the account database size free for its history-table rebuild and
+  gradual post-readiness promotion. The 2,048-row release check measured a
+  4.01-times peak footprint (3.01 times additional space), a 6,159 ms migration,
+  4,916 ms promotion, and 146 ms slowest 32-row batch.
 - Interactive onboarding cancellation now ends approved, interrupted, or ready
   sign-in attempts, keeps the account signed out, and retains uncertain
   publication evidence for a later explicit restart. Late publication or signer
@@ -29,6 +47,15 @@ versioning through the workspace version in the root `Cargo.toml`.
   uncertain publications. Explicit recovery retains opaque historical bytes
   and starts a fresh approval epoch; Swift/Kotlin/C hosts use the epoch-aware
   approval APIs for recovered attempts.
+
+### Fixed
+
+- Invitations superseded by convergence recover through durable reinvite and
+  rejoin state, including after restart.
+- Transport receipt synchronization uses one account-owned boundary, and
+  message-latency measurements cover recovery gating.
+- Audit uploads stop retrying files rejected with a bare HTTP 413 response.
+- Directory caches bound retained unknown profile metadata.
 
 ## [0.9.19] - 2026-09-07
 
@@ -2095,7 +2122,8 @@ Initial release of the `dm` command-line app, the `dmd` background daemon, and t
 - Local installation docs for `cargo install --path crates/cli --locked --bins`.
 - Homebrew release checklist and namespaced tap packaging path for `marmot-protocol/tap/darkmatter`.
 
-[Unreleased]: https://github.com/marmot-protocol/mdk/compare/v0.9.19...HEAD
+[Unreleased]: https://github.com/marmot-protocol/mdk/compare/v0.9.20...HEAD
+[0.9.20]: https://github.com/marmot-protocol/mdk/compare/v0.9.19...v0.9.20
 [0.9.19]: https://github.com/marmot-protocol/mdk/compare/v0.9.18...v0.9.19
 [0.9.18]: https://github.com/marmot-protocol/mdk/compare/v0.9.17...v0.9.18
 [0.9.17]: https://github.com/marmot-protocol/mdk/compare/v0.9.16...v0.9.17

--- a/crates/marmot-c/CHANGELOG.md
+++ b/crates/marmot-c/CHANGELOG.md
@@ -7,8 +7,12 @@ Versions track the workspace version; releases are tagged `marmotc-v<version>`.
 
 ## [Unreleased]
 
+## [0.9.20] - 2026-09-08
+
 ### Added
 
+- Presented chat-list reads and subscriptions, chat presentation records, and
+  unified usage-diagnostics consent and settings APIs.
 - Explicit onboarding recovery/query and epoch-aware approval/acknowledgment
   commands. `MarmotOnboardingSnapshot` includes `recovery_epoch`; C consumers
   must rebuild against the matching generated header and library.
@@ -49,5 +53,6 @@ Versions track the workspace version; releases are tagged `marmotc-v<version>`.
   just a local account's. Both return `MarmotAccountRelayLists`.
   ([#1605](https://github.com/marmot-protocol/mdk/pull/1605))
 
-[Unreleased]: https://github.com/marmot-protocol/mdk/compare/marmotc-v0.9.16...HEAD
+[Unreleased]: https://github.com/marmot-protocol/mdk/compare/marmotc-v0.9.20...HEAD
+[0.9.20]: https://github.com/marmot-protocol/mdk/compare/marmotc-v0.9.19...marmotc-v0.9.20
 [0.9.16]: https://github.com/marmot-protocol/mdk/releases/tag/marmotc-v0.9.16

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -23,7 +23,7 @@ Choose the runtime you already use:
 | Pi | Terminal harness | Repository and coding tasks through Pi |
 
 The guided installers prompt on the terminal for the White Noise account that
-may invite and message the agent. They install release `wn-agent-v0.9.19`, create
+may invite and message the agent. They install release `wn-agent-v0.9.20`, create
 an isolated White Noise identity for the selected connector, and start same-user
 services where supported. Download each installer with its adjacent checksum,
 verify it, and only then execute the local file:
@@ -50,7 +50,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
 ```
 
 ### Hermes
@@ -110,7 +110,7 @@ install_verified "$base_url/install-pi-marmot.sh" \
 
 ### Finish In White Noise
 
-Release 0.9.19 records the new agent's `npub` and `nprofile` in the
+Release 0.9.20 records the new agent's `npub` and `nprofile` in the
 `bootstrap.json` path printed at completion. Display them with:
 
 ```sh

--- a/integrations/codex/marmot/README.md
+++ b/integrations/codex/marmot/README.md
@@ -54,7 +54,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
 install_verified "$base_url/install-codex-marmot.sh" \
   "$base_url/install-codex-marmot.sh.sha256" \
   --yes --allow-welcomer npub1...

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -138,7 +138,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256"
 ```
@@ -155,7 +155,7 @@ repeated or given a comma-separated list to authorize multiple senders:
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256" \
   --yes \
@@ -171,7 +171,7 @@ with `--generate-identity`). To preserve an existing Nostr identity, place its
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256" \
   --yes \
@@ -201,7 +201,7 @@ To accept Marmot messages from any sender (explicit opt-in):
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256" \
   --yes --allow-all-users

--- a/integrations/openclaw/marmot/README.md
+++ b/integrations/openclaw/marmot/README.md
@@ -82,7 +82,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
 install_verified "$base_url/install-openclaw-marmot.sh" \
   "$base_url/install-openclaw-marmot.sh.sha256"
 ```
@@ -102,7 +102,7 @@ an `npub` or raw hex public key:
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
 install_verified "$base_url/install-openclaw-marmot.sh" \
   "$base_url/install-openclaw-marmot.sh.sha256" \
   --yes --allow-welcomer npub1...
@@ -116,7 +116,7 @@ with `--generate-identity`). To preserve an existing Nostr identity, place its
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
 install_verified "$base_url/install-openclaw-marmot.sh" \
   "$base_url/install-openclaw-marmot.sh.sha256" \
   --yes \

--- a/integrations/opencode/marmot/README.md
+++ b/integrations/opencode/marmot/README.md
@@ -56,7 +56,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
 install_verified "$base_url/install-opencode-marmot.sh" \
   "$base_url/install-opencode-marmot.sh.sha256"
 ```
@@ -67,7 +67,7 @@ as either an `npub` or raw hex public key:
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
 install_verified "$base_url/install-opencode-marmot.sh" \
   "$base_url/install-opencode-marmot.sh.sha256" \
   --yes --allow-welcomer npub1...

--- a/integrations/pi/marmot/README.md
+++ b/integrations/pi/marmot/README.md
@@ -48,7 +48,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
 install_verified "$base_url/install-pi-marmot.sh" \
   "$base_url/install-pi-marmot.sh.sha256"
 ```
@@ -58,7 +58,7 @@ For noninteractive setup, provide the allowed inviter and prompt sender:
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
 install_verified "$base_url/install-pi-marmot.sh" \
   "$base_url/install-pi-marmot.sh.sha256" \
   --yes --allow-welcomer npub1...

--- a/release.md
+++ b/release.md
@@ -354,7 +354,7 @@ workspace release looks like:
 ```sh
 (
 set -eu
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
 
 install_verified() (
   set -eu

--- a/scripts/install-hermes-marmot.sh
+++ b/scripts/install-hermes-marmot.sh
@@ -118,7 +118,7 @@ Hermes accepts after gateway restart via $HERMES_HOME/.env.
 
 Verified download (then choose one invocation below):
   set -eu
-  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19
+  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20
   tmpdir="$(mktemp -d)"
   trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
   installer_script=install-hermes-marmot.sh

--- a/scripts/install-openclaw-marmot.sh
+++ b/scripts/install-openclaw-marmot.sh
@@ -110,7 +110,7 @@ Environment:
 
 Verified download (then choose one invocation below):
   set -eu
-  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.19
+  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20
   tmpdir="$(mktemp -d)"
   trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
   installer_script=install-openclaw-marmot.sh


### PR DESCRIPTION
Prepare compatibility cohort 0.9.20 for MDK, wn-agent, MarmotKit, and Marmot C. Synchronize all 26 workspace packages, 31 conformance fixtures, installer documentation pins, and the cohort and C binding changelogs.

The release includes durable chat presentation and native APIs, diagnostics consent and stock Aptabase support, safer onboarding cancellation, invitation recovery, and Hermes plugin packaging/media dispatch. Release notes document account migrations 65–67, shared-store versions 2–3, unsupported downgrade, backup restoration, and refreshed migration-47 resource measurements.

Validation:
- `just fast-ci` passed.
- All five installer dry runs passed.
- `just tamarin`: all 78 lemmas verified.
- `MDK_STORAGE_OPS_ROWS=2048 just bench-storage-upgrade`: passed; 4.01x peak footprint, 6,159 ms migration, 4,916 ms promotion, 146 ms slowest batch.
- A probe linked against exact v0.9.19 storage source and pinned dependencies upgraded the legacy fixture to schema 64. The candidate upgraded it to 67 and preserved the fixture group and message. Reopening with 0.9.20 did not rewrite database bytes. The 0.9.19 probe refused schema 67 with `UnsupportedSchemaVersion` without changing database bytes; restoring the backup reopened successfully with 0.9.19.
- Verified that the lockfile changes only the 26 workspace package versions and all 31 conformance fixture versions match 0.9.20.

- Focused storage, UniFFI, agent connector, and terminal-harness tests: 1,057 passed, 12 ignored, under umask 022. The first attempt under umask 077 exposed an existing test assumption about initial attacker-directory permissions; no product code was changed.
- Canonical vector fixtures match generated traces.
- Local iOS device/simulator, macOS, and all four Android ABI binding builds passed. iOS and macOS generated identical Swift.

- Final-head GitHub CI passed at `33aee0ef6ad0efd65a974afbf4a357fc90949fe7`, including simulator and independent-model checks, all four Rust test shards, relay/CLI end-to-end tests, C smoke tests, and the WN Agent platform and integration matrix.
