### PR TITLE
fix(incident-replay): raise the export input cap to 256 MiB and state why

### DIFF
--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -372,7 +372,7 @@ Gate designs evaluated against real exports and deliberately **rejected**:
   enter VCS.
 - Real exports are the manual pre-PR verification set:
   `cargo run -p incident-replay -- <export.json | export.ndjson>`.
-  The CLI rejects inputs larger than 64 MiB before JSON/NDJSON parsing.
+  The CLI rejects inputs larger than 256 MiB before JSON/NDJSON parsing.
 - Keep real inputs under ignored `incident-exports/` and generated local output under `target/` or ignored
   `incident-replay-output/`. Producer-attested artifacts may contain unredacted Scenario IR labels and payloads;
   treat them as confidential unless separately redacted and reviewed. Never add sensitive local replay capsules or

--- a/crates/incident-replay/src/main.rs
+++ b/crates/incident-replay/src/main.rs
@@ -29,9 +29,15 @@ use incident_replay::{
     IncidentSourceFormatV1, Outcome, is_stream, parse, parse_stream, route,
 };
 
-/// Match the workspace's audit-artifact ceiling and reject oversized forensic
-/// input before parsing can allocate from attacker-controlled JSON/NDJSON.
-const MAX_INCIDENT_EXPORT_BYTES: u64 = 64 * 1024 * 1024;
+/// Bound the in-memory `String` and the parsed event `Vec` for this
+/// operator-run CLI, and reject an oversized export before parsing can
+/// allocate from attacker-controlled JSON/NDJSON.
+///
+/// Sized from observed fleet exports — the largest was 72.9 MB as of
+/// 2026-09-03 — with room left for groups to age. Deliberately not tied to the
+/// audit upload ceiling: a Goggles group export is a server-side concatenation
+/// of many uploads, so nothing bounds it by what one upload may be.
+const MAX_INCIDENT_EXPORT_BYTES: u64 = 256 * 1024 * 1024;
 
 fn main() -> ExitCode {
     let mut args = std::env::args_os().skip(1);
@@ -225,6 +231,21 @@ mod tests {
             read_utf8_limited(io::Cursor::new("ciao".as_bytes()), 4).unwrap(),
             "ciao"
         );
+    }
+
+    /// A group export is a server-side concatenation of many uploads, so it
+    /// legitimately exceeds any single upload's ceiling. Sparse: `set_len`
+    /// reserves the size without writing, and the NUL bytes it reads back are
+    /// valid UTF-8.
+    #[test]
+    fn an_export_larger_than_one_upload_is_read() {
+        let over_one_upload = 64 * 1024 * 1024 + 1;
+        let file = tempfile::NamedTempFile::new().expect("temp file");
+        file.as_file().set_len(over_one_upload).expect("sparse len");
+
+        let export = read_incident_export(file.path()).expect("export is read");
+
+        assert_eq!(export.len() as u64, over_one_upload);
     }
 
     #[test]


### PR DESCRIPTION
The CLI refused the fleet's largest group export (72.9 MB on 2026-09-03) because `MAX_INCIDENT_EXPORT_BYTES` sat at 64 MiB with a comment claiming it matched the audit upload ceiling. A Goggles group export is a server-side concatenation of many uploads, so that coupling never held.

### Changes

- Raise the cap to 256 MiB. It bounds the in-memory `String` and the parsed event `Vec` for an operator-run tool, sized from observed exports with room for groups to age, and is deliberately not tied to the per-upload ceiling.
- Rewrite the doc comment to say that, and update the figure in the crate's AGENTS.md.
- `read_utf8_limited` is unchanged; its limit semantics stay pinned by the existing small-limit tests.

### Tests

One new behavior test reads a sparse 64 MiB + 1 file through `read_incident_export`. It failed with `incident export exceeds 67108864 bytes` before the change and passes after. No 256 MiB allocation test: the reader's enforcement of whatever limit it is given is already covered.

### Validation

`cargo test -p incident-replay` (114 passed), crate clippy clean, `just fast-ci` green. The branch build parses and classifies a live Goggles export end to end (exit 0). No streaming rewrite, no flag, no version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Increased the maximum incident export size from 64 MiB to 256 MiB.
  - Large group exports can now exceed the size limit for individual uploads.
- **Bug Fixes**
  - Added coverage to ensure exports larger than a single upload are accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->