### PR TITLE
fix(search): stream shared-cache and Vertex results without graph delays

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -16,7 +16,8 @@ versioning through the workspace version in the root `Cargo.toml`.
   labels. Streaming consumers must apply `updated_results` as keyed replacements; CLI search merges them into one
   result per person. Radius windows filter known distances only; consumers must deduplicate off-graph identities
   across pages. Search-discovered public profiles are searchable across accounts but remain outside live directory
-  subscriptions. Local cache materialization and result batches are defensively capped at 10,000 rows.
+  subscriptions. Local cache materialization is capped at 10,000 distinct identities per account cache, and cache result
+  batches at 10,000 people.
 
 ## [0.9.20] - 2026-09-08
 

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -14,7 +14,9 @@ versioning through the workspace version in the root `Cargo.toml`.
 - User search includes cached public identities from every connected account and delivers Vertex matches without
   waiting for graph traversal. Swift/Kotlin and C expose a cache-only search and explicit selected-account follow
   labels. Streaming consumers must apply `updated_results` as keyed replacements; CLI search merges them into one
-  result per person. Search-discovered profiles remain outside live directory subscriptions.
+  result per person. Radius windows filter known distances only; consumers must deduplicate off-graph identities
+  across pages. Search-discovered public profiles are searchable across accounts but remain outside live directory
+  subscriptions. Local cache materialization and result batches are defensively capped at 10,000 rows.
 
 ## [0.9.20] - 2026-09-08
 

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,13 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+### Changed
+
+- User search includes cached public identities from every connected account and delivers Vertex matches without
+  waiting for graph traversal. Swift/Kotlin and C expose a cache-only search and explicit selected-account follow
+  labels. Streaming consumers must apply `updated_results` as keyed replacements; CLI search merges them into one
+  result per person. Search-discovered profiles remain outside live directory subscriptions.
+
 ## [0.9.20] - 2026-09-08
 
 ### Added

--- a/crates/cli/src/commands/users.rs
+++ b/crates/cli/src/commands/users.rs
@@ -184,15 +184,18 @@ async fn collect_user_search(
     params: UserSearchParams,
 ) -> Result<(Vec<UserDirectorySearchResult>, SearchCompleteness), WnError> {
     let mut subscription = app.search_users(params).await?;
-    let mut results = Vec::new();
+    let mut results = std::collections::BTreeMap::new();
     let mut completeness = SearchCompleteness::Complete;
     while let Some(update) = subscription.next_update().await {
         if let SearchUpdateTrigger::Error { message } = update.trigger {
             return Err(WnError::UserSearch(message));
         }
         completeness.observe(&update.trigger);
-        results.extend(update.new_results);
+        for result in update.new_results.into_iter().chain(update.updated_results) {
+            results.insert(result.account_id_hex.clone(), result);
+        }
     }
+    let mut results = results.into_values().collect::<Vec<_>>();
     sort_user_search_results(&mut results);
     Ok((results, completeness))
 }

--- a/crates/marmot-app/README.md
+++ b/crates/marmot-app/README.md
@@ -53,7 +53,8 @@ event, pre-cache direct follows, and cache profile metadata for those likely con
 directory subscriptions for local accounts and known users so profile, follow-list, relay-list, and KeyPackage updates
 keep warming the cache. `search_cached_users(searcher, query, limit)` searches public profiles learned through
 **any connected account**, including un-promoted profiles from previous searches, without relay access or group
-membership reads. Private labels/nicknames do not participate. `is_followed_by_searcher` is relative only to the
+membership reads. A profile learned during a search under one account is intentionally searchable under another account.
+Private labels/nicknames do not participate. `is_followed_by_searcher` is relative only to the
 selected account; another account's follows never confer that label. The older `search_user_directory` remains the
 explicit offline graph-radius query.
 
@@ -62,11 +63,16 @@ follow-graph traversal. The runtime resolves group co-members on the graph path,
 Consumers insert `new_results` and replace `updated_results` by `account_id_hex`, then re-sort; `total_result_count`
 counts unique people. Results with radius 255 have no established graph distance yet and may receive one later.
 Radius 1 also includes group co-members, so only the explicit follow flag means "You follow". Requested radius windows
-filter known distances; other cached/provider identities remain discoverable.
+filter known distances; other cached/provider identities remain discoverable and can recur on later pages.
+Deduplicate by account ID across searches/pages as well as within a stream. Cache materialization is capped at
+10,000 rows per account cache (in account-ID order), matching the shared directory's existing cap; the cache-only
+API and the stream's initial cache batch return at most 10,000 results. At that scale, local results can be partial;
+network enrichment remains available.
 
 Hosts should use the cache-only call off the UI thread on each query change, debounce network searches separately,
 and discard results when the query or selected account changes. Dropping the streaming subscription cancels both
-network sources, including blocked membership reads. Vertex's signed profiles are cached only in the un-promoted
+network sources, including blocked membership reads. A failed cache read or unavailable group membership is an optional-source
+failure: search continues without that input rather than emitting a terminal error. Vertex's signed profiles are cached only in the un-promoted
 search tier; discovering a stranger never creates a live per-author subscription. Traversal retains its radius,
 candidate, batch, and timeout bounds. Aggregate `search_stage` timings separate cache reads, membership, provider
 response, profile hydration, and network completion, without logging queries or identities.

--- a/crates/marmot-app/README.md
+++ b/crates/marmot-app/README.md
@@ -65,18 +65,18 @@ counts unique people. Results with radius 255 have no established graph distance
 Radius 1 also includes group co-members, so only the explicit follow flag means "You follow". Requested radius windows
 filter known distances; other cached/provider identities remain discoverable and can recur on later pages.
 Deduplicate by account ID across searches/pages as well as within a stream. Cache materialization is capped at
-10,000 rows per account cache (in account-ID order), matching the shared directory's existing cap; the cache-only
-API and the stream's initial cache batch return at most 10,000 results. At that scale, local results can be partial;
-network enrichment remains available.
+10,000 distinct identities per account cache (in account-ID order), matching the shared directory's existing cap;
+the cache-only API and the stream's initial cache batch return at most 10,000 results. At that scale, local results
+can be partial; network enrichment remains available.
 
 Hosts should use the cache-only call off the UI thread on each query change, debounce network searches separately,
 and discard results when the query or selected account changes. Dropping the streaming subscription cancels both
-network sources, including blocked membership reads. A failed cache read or unavailable group membership is an optional-source
-failure: search continues without that input rather than emitting a terminal error. Vertex's signed profiles are cached only in the un-promoted
-search tier; discovering a stranger never creates a live per-author subscription. Traversal retains its radius,
-candidate, batch, and timeout bounds. Aggregate `search_stage` timings separate cache reads, membership, provider
-response, profile hydration, and network completion, without logging queries or identities.
-
+network sources, including blocked membership reads. A failed cache read or unavailable group membership is an
+optional-source failure: search continues without that input rather than emitting a terminal error. Vertex's signed
+profiles are cached only in the un-promoted search tier; discovering a stranger never creates a live per-author
+subscription. Traversal retains its radius, candidate, batch, and timeout bounds. Aggregate `search_stage` timings
+separate cache reads, membership, provider response, profile hydration, and network completion, without logging
+queries or identities.
 
 Group creation and invites still take pubkeys at the action boundary. The app canonicalizes and deduplicates the
 requested roster, reuses current cached KeyPackages, and resolves cold members in bounded multi-author relay batches

--- a/crates/marmot-app/README.md
+++ b/crates/marmot-app/README.md
@@ -51,11 +51,26 @@ including their Media V1 state, but membership additions and re-additions are re
 The user directory is keyed by Nostr pubkey. Account setup and the daemon can refresh a local account's contact-list
 event, pre-cache direct follows, and cache profile metadata for those likely contacts. Runtime startup builds chunked
 directory subscriptions for local accounts and known users so profile, follow-list, relay-list, and KeyPackage updates
-keep warming the cache. The crate exposes two searches over that data for TUI/mobile pickers: `search_user_directory`
-answers offline from cached follow edges, and `search_users` streams matches while traversing the live follow graph,
-ranked by social distance. Live traversal is bounded by construction -- capped radius, batched author-scoped fetches
-under a per-radius timeout, and a per-search lifecycle that ends when its consumer drops the subscription -- and
-strangers it discovers are never promoted into the directory. It is not a crawler for the whole Nostr social graph.
+keep warming the cache. `search_cached_users(searcher, query, limit)` searches public profiles learned through
+**any connected account**, including un-promoted profiles from previous searches, without relay access or group
+membership reads. Private labels/nicknames do not participate. `is_followed_by_searcher` is relative only to the
+selected account; another account's follows never confer that label. The older `search_user_directory` remains the
+explicit offline graph-radius query.
+
+`search_users` emits a `CachedResultsFound` batch, then streams Vertex profile discovery independently of the bounded
+follow-graph traversal. The runtime resolves group co-members on the graph path, after the subscription is returned.
+Consumers insert `new_results` and replace `updated_results` by `account_id_hex`, then re-sort; `total_result_count`
+counts unique people. Results with radius 255 have no established graph distance yet and may receive one later.
+Radius 1 also includes group co-members, so only the explicit follow flag means "You follow". Requested radius windows
+filter known distances; other cached/provider identities remain discoverable.
+
+Hosts should use the cache-only call off the UI thread on each query change, debounce network searches separately,
+and discard results when the query or selected account changes. Dropping the streaming subscription cancels both
+network sources, including blocked membership reads. Vertex's signed profiles are cached only in the un-promoted
+search tier; discovering a stranger never creates a live per-author subscription. Traversal retains its radius,
+candidate, batch, and timeout bounds. Aggregate `search_stage` timings separate cache reads, membership, provider
+response, profile hydration, and network completion, without logging queries or identities.
+
 
 Group creation and invites still take pubkeys at the action boundary. The app canonicalizes and deduplicates the
 requested roster, reuses current cached KeyPackages, and resolves cold members in bounded multi-author relay batches

--- a/crates/marmot-app/src/directory/cache.rs
+++ b/crates/marmot-app/src/directory/cache.rs
@@ -134,6 +134,43 @@ impl DirectoryCache {
         Ok(entries)
     }
 
+    /// Public profile rows only: no per-user follow, key-package, or local-label reads.
+    /// Search includes un-promoted profiles without making them sync candidates.
+    pub(crate) fn public_search_records(
+        &self,
+        now: i64,
+    ) -> Result<Vec<UserDirectoryRecord>, AppError> {
+        let conn = self.lock()?;
+        let mut statement = conn.prepare(
+            "SELECT account_id_hex, npub, profile_json FROM directory_users
+             UNION ALL
+             SELECT account_id_hex, npub, profile_json FROM directory_search_graph_users
+             WHERE profile_json IS NOT NULL
+               AND (metadata_expires_at IS NULL OR metadata_expires_at > ?1)",
+        )?;
+        let rows = statement.query_map([now], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+            ))
+        })?;
+        rows.map(|row| {
+            let (account_id_hex, npub, profile_json) = row?;
+            Ok(UserDirectoryRecord {
+                account_id_hex,
+                npub,
+                profile: optional_value(profile_json)?,
+                local_account: None,
+                follows: Vec::new(),
+                follow_source_relays: Vec::new(),
+                relay_lists: AccountRelayListStatus::empty(),
+                key_package: None,
+            })
+        })
+        .collect()
+    }
+
     /// Look an account up for search: the promoted directory tier first, then
     /// the un-promoted search graph.
     ///

--- a/crates/marmot-app/src/directory/cache.rs
+++ b/crates/marmot-app/src/directory/cache.rs
@@ -134,7 +134,8 @@ impl DirectoryCache {
         Ok(entries)
     }
 
-    /// Public profile rows only: no per-user follow, key-package, or local-label reads.
+    /// Public identity/profile fields only: no follow, key-package, or local-label reads.
+    /// Profile-less promoted identities remain searchable by npub or pubkey.
     /// Search includes un-promoted profiles without making them sync candidates.
     pub(crate) fn public_search_records(
         &self,
@@ -150,13 +151,23 @@ impl DirectoryCache {
     ) -> Result<Vec<UserDirectoryRecord>, AppError> {
         let conn = self.lock()?;
         let mut statement = conn.prepare(
-            "SELECT account_id_hex, npub, profile_json FROM directory_users
-             UNION ALL
-             SELECT account_id_hex, npub, profile_json FROM directory_search_graph_users
-             WHERE profile_json IS NOT NULL
-               AND (metadata_expires_at IS NULL OR metadata_expires_at > ?1)
-             ORDER BY account_id_hex
-             LIMIT ?2",
+            "WITH candidates AS (
+                 SELECT account_id_hex, npub, profile_json, 0 AS tier FROM directory_users
+                 UNION ALL
+                 SELECT account_id_hex, npub, profile_json, 1 AS tier
+                 FROM directory_search_graph_users
+                 WHERE profile_json IS NOT NULL
+                   AND (metadata_expires_at IS NULL OR metadata_expires_at > ?1)
+             ), ranked AS (
+                 SELECT account_id_hex, npub, profile_json,
+                     ROW_NUMBER() OVER (
+                         PARTITION BY account_id_hex
+                         ORDER BY COALESCE(json_extract(profile_json, '$.created_at'), -1) DESC, tier
+                     ) AS choice
+                 FROM candidates
+             )
+             SELECT account_id_hex, npub, profile_json FROM ranked
+             WHERE choice = 1 ORDER BY account_id_hex LIMIT ?2",
         )?;
         let cap = i64::try_from(max).unwrap_or(i64::MAX);
         let rows = statement.query_map([now, cap], |row| {
@@ -828,15 +839,39 @@ mod tests {
                 .put(&directory_record(account_id(id), vec![]))
                 .unwrap();
         }
-        // Each put populates both tiers. The fourth identity must not be decoded beyond the row cap.
-        cache.lock().unwrap().execute(
-            "UPDATE directory_users SET profile_json = 'invalid json' WHERE account_id_hex = ?1",
-            [account_id(4)]).unwrap();
+        // Mirrored rows consume one identity slot, not two.
         let rows = cache.public_search_records_capped(i64::MAX, 3).unwrap();
         assert_eq!(rows.len(), 3);
         assert_eq!(rows[0].account_id_hex, account_id(1));
-        assert_eq!(rows[2].account_id_hex, account_id(2));
-        assert!(cache.public_search_records_capped(i64::MAX, 7).is_err());
+        assert_eq!(rows[2].account_id_hex, account_id(3));
+        assert_eq!(
+            cache
+                .public_search_records_capped(i64::MAX, 4)
+                .unwrap()
+                .len(),
+            4
+        );
+
+        // The fresher search-tier profile wins without emitting a duplicate.
+        let mut newer = directory_record(account_id(1), vec![]).profile.unwrap();
+        newer.created_at += 1;
+        newer.name = Some("new name".into());
+        cache
+            .put_search_graph_record(
+                &DirectorySearchGraphRecord {
+                    account_id_hex: account_id(1),
+                    npub: "npub-new".into(),
+                    profile: Some(newer.clone()),
+                    follows: None,
+                    metadata_updated_at: Some(newer.created_at),
+                    metadata_expires_at: None,
+                },
+                0,
+            )
+            .unwrap();
+        let rows = cache.public_search_records_capped(0, 1).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].profile.as_ref(), Some(&newer));
     }
 
     #[test]

--- a/crates/marmot-app/src/directory/cache.rs
+++ b/crates/marmot-app/src/directory/cache.rs
@@ -140,15 +140,26 @@ impl DirectoryCache {
         &self,
         now: i64,
     ) -> Result<Vec<UserDirectoryRecord>, AppError> {
+        self.public_search_records_capped(now, super::cached_search::CACHED_SEARCH_MAX_RECORDS)
+    }
+
+    fn public_search_records_capped(
+        &self,
+        now: i64,
+        max: usize,
+    ) -> Result<Vec<UserDirectoryRecord>, AppError> {
         let conn = self.lock()?;
         let mut statement = conn.prepare(
             "SELECT account_id_hex, npub, profile_json FROM directory_users
              UNION ALL
              SELECT account_id_hex, npub, profile_json FROM directory_search_graph_users
              WHERE profile_json IS NOT NULL
-               AND (metadata_expires_at IS NULL OR metadata_expires_at > ?1)",
+               AND (metadata_expires_at IS NULL OR metadata_expires_at > ?1)
+             ORDER BY account_id_hex
+             LIMIT ?2",
         )?;
-        let rows = statement.query_map([now], |row| {
+        let cap = i64::try_from(max).unwrap_or(i64::MAX);
+        let rows = statement.query_map([now, cap], |row| {
             Ok((
                 row.get::<_, String>(0)?,
                 row.get::<_, String>(1)?,
@@ -807,6 +818,25 @@ mod tests {
             .unwrap()
             .collect::<Result<_, _>>()
             .unwrap()
+    }
+
+    #[test]
+    fn public_search_materialization_stops_at_its_cap() {
+        let (_dir, cache) = test_cache();
+        for id in 1..=4 {
+            cache
+                .put(&directory_record(account_id(id), vec![]))
+                .unwrap();
+        }
+        // Each put populates both tiers. The fourth identity must not be decoded beyond the row cap.
+        cache.lock().unwrap().execute(
+            "UPDATE directory_users SET profile_json = 'invalid json' WHERE account_id_hex = ?1",
+            [account_id(4)]).unwrap();
+        let rows = cache.public_search_records_capped(i64::MAX, 3).unwrap();
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].account_id_hex, account_id(1));
+        assert_eq!(rows[2].account_id_hex, account_id(2));
+        assert!(cache.public_search_records_capped(i64::MAX, 7).is_err());
     }
 
     #[test]

--- a/crates/marmot-app/src/directory/cached_search.rs
+++ b/crates/marmot-app/src/directory/cached_search.rs
@@ -1,8 +1,8 @@
 //! Network-free public-profile search across every connected account's caches.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashSet, btree_map::Entry};
 
-use super::records::{user_directory_record_from_public, user_record_match};
+use super::records::user_record_match;
 use crate::{
     AppError, MarmotApp, OFF_GRAPH_SEARCH_RADIUS, UserDirectoryRecord, UserDirectorySearchResult,
     parse_account_id_hex, sort_user_search_results,
@@ -43,13 +43,17 @@ impl MarmotApp {
             if let Some(profile) = &mut record.profile {
                 profile.source_relays.clear();
             }
-            let current = records
-                .entry(record.account_id_hex.clone())
-                .or_insert_with(|| record.clone());
-            if record.profile.as_ref().map(|p| p.created_at)
-                > current.profile.as_ref().map(|p| p.created_at)
-            {
-                *current = record;
+            match records.entry(record.account_id_hex.clone()) {
+                Entry::Vacant(entry) => {
+                    entry.insert(record);
+                }
+                Entry::Occupied(mut entry) => {
+                    if record.profile.as_ref().map(|p| p.created_at)
+                        > entry.get().profile.as_ref().map(|p| p.created_at)
+                    {
+                        entry.insert(record);
+                    }
+                }
             }
         };
         let now = crate::unix_now_seconds() as i64;
@@ -58,8 +62,20 @@ impl MarmotApp {
                 insert(record);
             }
         }
-        for record in self.shared_storage()?.public_directory_users()? {
-            insert(user_directory_record_from_public(record)?);
+        for record in self.shared_storage()?.public_directory_profiles()? {
+            insert(UserDirectoryRecord {
+                account_id_hex: record.account_id_hex,
+                npub: record.npub,
+                profile: record
+                    .profile_json
+                    .map(|json| serde_json::from_str(&json))
+                    .transpose()?,
+                local_account: None,
+                follows: Vec::new(),
+                follow_source_relays: Vec::new(),
+                relay_lists: crate::AccountRelayListStatus::empty(),
+                key_package: None,
+            });
         }
         let mut results = records
             .into_values()
@@ -234,14 +250,15 @@ mod tests {
         assert!(!latest[&stale].is_followed_by_searcher);
         assert_eq!(latest[&stale].radius, OFF_GRAPH_SEARCH_RADIUS);
 
-        // A known-empty list remains authoritative even with another cache's stale edges.
-        own_cache
-            .remember_search_graph_follows(
-                &searcher.account_id_hex,
-                &crate::ids::npub_for_account_id_lossy(&searcher.account_id_hex),
-                &[],
-            )
-            .unwrap();
+        // The refresh path's explicit empty kind-3 clears stale graph edges too.
+        app.remember_directory_follow_list_for_test(
+            &searcher.account_id_hex,
+            &crate::directory::FetchedFollowList {
+                follows: Vec::new(),
+                source_relays: Vec::new(),
+            },
+        )
+        .unwrap();
         assert!(
             app.search_cached_users(&searcher.account_id_hex, "needle", 100)
                 .unwrap()

--- a/crates/marmot-app/src/directory/cached_search.rs
+++ b/crates/marmot-app/src/directory/cached_search.rs
@@ -8,6 +8,9 @@ use crate::{
     parse_account_id_hex, sort_user_search_results,
 };
 
+/// Defensive materialization cap, matching the shared public directory's bound.
+pub(crate) const CACHED_SEARCH_MAX_RECORDS: usize = 10_000;
+
 impl MarmotApp {
     /// Search all cached public identities, independent of social-graph reachability.
     /// This does no relay work or group-membership reads. Follow attribution is
@@ -83,7 +86,7 @@ impl MarmotApp {
             })
             .collect::<Vec<_>>();
         sort_user_search_results(&mut results);
-        results.truncate(limit);
+        results.truncate(limit.min(CACHED_SEARCH_MAX_RECORDS));
         Ok((follows, results))
     }
 
@@ -91,17 +94,44 @@ impl MarmotApp {
         &self,
         searcher: &str,
     ) -> Result<HashSet<String>, AppError> {
-        // A previous search may have learned the selected account's kind-3
-        // without promoting its profile into the directory.
-        for cache in self.directory_caches()? {
+        Ok(self
+            .cached_search_follow_list(searcher)?
+            .unwrap_or_default()
+            .into_iter()
+            .collect())
+    }
+
+    /// Prefer a connected searcher's own contact-list cache. Other accounts may
+    /// hold older copies of its public kind-3 and cannot override its follow badge.
+    /// `None` retains the distinction between unknown and explicitly empty lists.
+    pub(crate) fn cached_search_follow_list(
+        &self,
+        searcher: &str,
+    ) -> Result<Option<Vec<String>>, AppError> {
+        let account = self
+            .account_home()
+            .accounts()?
+            .into_iter()
+            .find(|account| account.account_id_hex == searcher && account.is_active_signing());
+        let caches = if let Some(account) = account {
+            vec![self.directory_cache_for_account(&account)?]
+        } else {
+            // The Rust API also supports a public, non-connected graph root.
+            self.directory_caches()?
+        };
+        for cache in &caches {
             if let Some(follows) = cache.search_graph_follows(searcher)? {
-                return Ok(follows.into_iter().collect());
+                return Ok(Some(follows));
             }
         }
-        Ok(self
-            .directory_entry_for_account_id(searcher)?
-            .map(|record| record.follows.into_iter().collect())
-            .unwrap_or_default())
+        for cache in &caches {
+            if let Some(record) = cache.entry(searcher)?
+                && !record.follows.is_empty()
+            {
+                return Ok(Some(record.follows));
+            }
+        }
+        Ok(None)
     }
 }
 
@@ -111,6 +141,114 @@ mod tests {
     use crate::directory::cache::DirectorySearchGraphRecord;
     use crate::directory::records::public_directory_user_record;
     use crate::{UserDirectoryLocalAccount, UserProfileMetadata};
+
+    #[tokio::test]
+    async fn connected_searcher_ignores_another_accounts_stale_follows() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = MarmotApp::with_relay_and_config(
+            dir.path(),
+            "wss://relay.invalid",
+            crate::MarmotAppConfig::default().with_open_ranking_provider(None, Vec::new()),
+        );
+        let other = app.account_home().create_account("a-other").unwrap();
+        let searcher = app.account_home().create_account("z-searcher").unwrap();
+        let own_cache = app.directory_cache_for_account(&searcher).unwrap();
+        let other_cache = app.directory_cache_for_account(&other).unwrap();
+        let followed = "11".repeat(32);
+        let stale = "22".repeat(32);
+        for id in [&searcher.account_id_hex, &followed, &stale] {
+            let mut record = app.empty_directory_record(id);
+            record.profile = Some(UserProfileMetadata {
+                name: Some("needle".into()),
+                created_at: 1,
+                ..Default::default()
+            });
+            own_cache.put(&record).unwrap();
+        }
+        own_cache
+            .remember_search_graph_follows(
+                &searcher.account_id_hex,
+                &crate::ids::npub_for_account_id_lossy(&searcher.account_id_hex),
+                std::slice::from_ref(&followed),
+            )
+            .unwrap();
+        other_cache
+            .remember_search_graph_follows(
+                &searcher.account_id_hex,
+                &crate::ids::npub_for_account_id_lossy(&searcher.account_id_hex),
+                std::slice::from_ref(&stale),
+            )
+            .unwrap();
+        let cached = app
+            .search_cached_users(&searcher.account_id_hex, "needle", 100)
+            .unwrap();
+        assert_eq!(
+            cached[0].account_id_hex, searcher.account_id_hex,
+            "self ranks first"
+        );
+        assert_eq!(
+            cached
+                .iter()
+                .filter(|r| r.is_followed_by_searcher)
+                .map(|r| r.account_id_hex.clone())
+                .collect::<Vec<_>>(),
+            vec![followed.clone()]
+        );
+        let offline = app
+            .search_user_directory(crate::UserDirectorySearch {
+                searcher_account_id_hex: searcher.account_id_hex.clone(),
+                query: "needle".into(),
+                radius_start: 1,
+                radius_end: 1,
+                limit: None,
+            })
+            .unwrap();
+        assert_eq!(offline.len(), 1);
+        assert_eq!(offline[0].account_id_hex, followed);
+        assert!(offline[0].is_followed_by_searcher);
+        let mut stream = app
+            .search_users(crate::UserSearchParams {
+                searcher_account_id_hex: searcher.account_id_hex.clone(),
+                query: "needle".into(),
+                radius_start: 0,
+                radius_end: 1,
+                radius_one_seeds: Vec::new(),
+            })
+            .await
+            .unwrap();
+        let mut latest = BTreeMap::new();
+        while let Some(update) =
+            tokio::time::timeout(std::time::Duration::from_secs(5), stream.next_update())
+                .await
+                .unwrap()
+        {
+            assert!(!matches!(
+                update.trigger,
+                crate::SearchUpdateTrigger::Error { .. }
+            ));
+            for row in update.new_results.into_iter().chain(update.updated_results) {
+                latest.insert(row.account_id_hex.clone(), row);
+            }
+        }
+        assert!(latest[&followed].is_followed_by_searcher);
+        assert!(!latest[&stale].is_followed_by_searcher);
+        assert_eq!(latest[&stale].radius, OFF_GRAPH_SEARCH_RADIUS);
+
+        // A known-empty list remains authoritative even with another cache's stale edges.
+        own_cache
+            .remember_search_graph_follows(
+                &searcher.account_id_hex,
+                &crate::ids::npub_for_account_id_lossy(&searcher.account_id_hex),
+                &[],
+            )
+            .unwrap();
+        assert!(
+            app.search_cached_users(&searcher.account_id_hex, "needle", 100)
+                .unwrap()
+                .iter()
+                .all(|row| !row.is_followed_by_searcher)
+        );
+    }
 
     #[test]
     fn public_cache_spans_accounts_but_follow_labels_do_not() {

--- a/crates/marmot-app/src/directory/cached_search.rs
+++ b/crates/marmot-app/src/directory/cached_search.rs
@@ -1,0 +1,231 @@
+//! Network-free public-profile search across every connected account's caches.
+
+use std::collections::{BTreeMap, HashSet};
+
+use super::records::{user_directory_record_from_public, user_record_match};
+use crate::{
+    AppError, MarmotApp, OFF_GRAPH_SEARCH_RADIUS, UserDirectoryRecord, UserDirectorySearchResult,
+    parse_account_id_hex, sort_user_search_results,
+};
+
+impl MarmotApp {
+    /// Search all cached public identities, independent of social-graph reachability.
+    /// This does no relay work or group-membership reads. Follow attribution is
+    /// relative to `searcher_account_id_hex`; local labels and private nicknames
+    /// never participate. A zero limit returns no results. Call off the UI thread.
+    pub fn search_cached_users(
+        &self,
+        searcher_account_id_hex: &str,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<UserDirectorySearchResult>, AppError> {
+        self.cached_search_snapshot(searcher_account_id_hex, query, limit)
+            .map(|(_, results)| results)
+    }
+
+    pub(crate) fn cached_search_snapshot(
+        &self,
+        searcher_account_id_hex: &str,
+        query: &str,
+        limit: usize,
+    ) -> Result<(HashSet<String>, Vec<UserDirectorySearchResult>), AppError> {
+        let searcher = parse_account_id_hex(searcher_account_id_hex)?;
+        let query = query.trim().to_lowercase();
+        if query.is_empty() || limit == 0 {
+            return Ok((HashSet::new(), Vec::new()));
+        }
+        let follows = self.cached_search_follows(&searcher)?;
+        let mut records = BTreeMap::<String, UserDirectoryRecord>::new();
+        let mut insert = |mut record: UserDirectoryRecord| {
+            if let Some(profile) = &mut record.profile {
+                profile.source_relays.clear();
+            }
+            let current = records
+                .entry(record.account_id_hex.clone())
+                .or_insert_with(|| record.clone());
+            if record.profile.as_ref().map(|p| p.created_at)
+                > current.profile.as_ref().map(|p| p.created_at)
+            {
+                *current = record;
+            }
+        };
+        let now = crate::unix_now_seconds() as i64;
+        for cache in self.directory_caches()? {
+            for record in cache.public_search_records(now)? {
+                insert(record);
+            }
+        }
+        for record in self.shared_storage()?.public_directory_users()? {
+            insert(user_directory_record_from_public(record)?);
+        }
+        let mut results = records
+            .into_values()
+            .filter_map(|record| {
+                let found = user_record_match(&record, &query)?;
+                let is_followed_by_searcher = follows.contains(&record.account_id_hex);
+                let radius = if record.account_id_hex == searcher {
+                    0
+                } else if is_followed_by_searcher {
+                    1
+                } else {
+                    OFF_GRAPH_SEARCH_RADIUS
+                };
+                Some(UserDirectorySearchResult {
+                    account_id_hex: record.account_id_hex,
+                    npub: record.npub,
+                    radius,
+                    is_followed_by_searcher,
+                    matched_field: found.field,
+                    match_quality: found.quality,
+                    provider_rank: None,
+                    profile: record.profile,
+                })
+            })
+            .collect::<Vec<_>>();
+        sort_user_search_results(&mut results);
+        results.truncate(limit);
+        Ok((follows, results))
+    }
+
+    pub(crate) fn cached_search_follows(
+        &self,
+        searcher: &str,
+    ) -> Result<HashSet<String>, AppError> {
+        // A previous search may have learned the selected account's kind-3
+        // without promoting its profile into the directory.
+        for cache in self.directory_caches()? {
+            if let Some(follows) = cache.search_graph_follows(searcher)? {
+                return Ok(follows.into_iter().collect());
+            }
+        }
+        Ok(self
+            .directory_entry_for_account_id(searcher)?
+            .map(|record| record.follows.into_iter().collect())
+            .unwrap_or_default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::directory::cache::DirectorySearchGraphRecord;
+    use crate::directory::records::public_directory_user_record;
+    use crate::{UserDirectoryLocalAccount, UserProfileMetadata};
+
+    #[test]
+    fn public_cache_spans_accounts_but_follow_labels_do_not() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.invalid");
+        let alice = app
+            .account_home()
+            .create_account("private-alice-label")
+            .unwrap();
+        let bob = app
+            .account_home()
+            .create_account("private-bob-label")
+            .unwrap();
+        let alice_cache = app.directory_cache_for_account(&alice).unwrap();
+        let bob_cache = app.directory_cache_for_account(&bob).unwrap();
+        let peer = "11".repeat(32);
+        let shared_peer = "22".repeat(32);
+        let search_peer = "33".repeat(32);
+        let expired_peer = "44".repeat(32);
+        let mut record = app.empty_directory_record(&peer);
+        record.profile = Some(UserProfileMetadata {
+            name: Some("Needle".into()),
+            created_at: 1,
+            ..Default::default()
+        });
+        record.local_account = Some(UserDirectoryLocalAccount {
+            label: "private-peer-label".into(),
+            local_signing: false,
+        });
+        alice_cache.put(&record).unwrap();
+        record.profile.as_mut().unwrap().created_at = 2;
+        record.profile.as_mut().unwrap().display_name = Some("Newer needle".into());
+        bob_cache.put(&record).unwrap();
+        // Alice's contact list was learned by search only; Bob's was promoted.
+        alice_cache
+            .remember_search_graph_follows(
+                &alice.account_id_hex,
+                &crate::ids::npub_for_account_id_lossy(&alice.account_id_hex),
+                std::slice::from_ref(&peer),
+            )
+            .unwrap();
+        let mut bob_record = app.empty_directory_record(&bob.account_id_hex);
+        bob_record.follows = vec![shared_peer.clone()];
+        bob_cache.put(&bob_record).unwrap();
+        record.account_id_hex = shared_peer.clone();
+        record.npub = crate::ids::npub_for_account_id_lossy(&shared_peer);
+        app.shared_storage()
+            .unwrap()
+            .put_public_directory_user(&public_directory_user_record(&record).unwrap())
+            .unwrap();
+        let now = crate::unix_now_seconds() as i64;
+        for (id, expires) in [(&search_peer, now + 100), (&expired_peer, now)] {
+            bob_cache
+                .put_search_graph_record(
+                    &DirectorySearchGraphRecord {
+                        account_id_hex: id.clone(),
+                        npub: crate::ids::npub_for_account_id_lossy(id),
+                        profile: record.profile.clone(),
+                        follows: None,
+                        metadata_updated_at: Some(2),
+                        metadata_expires_at: Some(expires as u64),
+                    },
+                    now,
+                )
+                .unwrap();
+        }
+        let results = app
+            .search_cached_users(&alice.account_id_hex, " needle ", 100)
+            .unwrap();
+        assert_eq!(results.len(), 3);
+        assert_eq!(results[0].account_id_hex, peer);
+        assert!(results[0].is_followed_by_searcher);
+        assert_eq!(results[0].profile.as_ref().unwrap().created_at, 2);
+        assert!(
+            results[1..]
+                .iter()
+                .all(|r| !r.is_followed_by_searcher && r.radius == OFF_GRAPH_SEARCH_RADIUS)
+        );
+        let other = app
+            .search_cached_users(&bob.account_id_hex, "needle", 100)
+            .unwrap();
+        assert_eq!(other[0].account_id_hex, shared_peer);
+        assert!(other[0].is_followed_by_searcher);
+        assert!(
+            !other
+                .iter()
+                .find(|r| r.account_id_hex == peer)
+                .unwrap()
+                .is_followed_by_searcher
+        );
+        assert!(
+            app.search_cached_users(&alice.account_id_hex, "private-", 100)
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            app.search_cached_users(&alice.account_id_hex, "needle", 1)
+                .unwrap()
+                .len(),
+            1
+        );
+        assert!(
+            app.search_cached_users(&alice.account_id_hex, "needle", 0)
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            app.search_cached_users(&alice.account_id_hex, "   ", 100)
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            bob_cache.entry(&search_peer).unwrap().is_none(),
+            "cache search must never promote strangers"
+        );
+        assert!(app.search_cached_users("invalid", "needle", 100).is_err());
+    }
+}

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -846,6 +846,7 @@ impl MarmotApp {
                 continue;
             };
             results.push(UserDirectorySearchResult {
+                is_followed_by_searcher: radius == 1,
                 account_id_hex: record.account_id_hex.clone(),
                 npub: record.npub.clone(),
                 radius,

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -1313,6 +1313,9 @@ impl MarmotApp {
         entry.follows = follow_list.follows.clone();
         entry.follow_source_relays = follow_list.source_relays.clone();
         self.save_directory_entry(&entry)?;
+        // A fetched empty kind-3 is authoritative, unlike a profile-only
+        // promotion whose empty follow vec means "not loaded".
+        self.remember_directory_follow_edges_for_search(account_id_hex, follow_list)?;
         for follow in &follow_list.follows {
             self.remember_directory_user(follow)?;
         }

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -837,6 +837,8 @@ impl MarmotApp {
             return Ok(Vec::new());
         }
 
+        let follows =
+            self.cached_search_follows(&parse_account_id_hex(&search.searcher_account_id_hex)?)?;
         let mut results = Vec::new();
         for (record, radius) in records {
             if radius < search.radius_start || radius > search.radius_end {
@@ -846,7 +848,7 @@ impl MarmotApp {
                 continue;
             };
             results.push(UserDirectorySearchResult {
-                is_followed_by_searcher: radius == 1,
+                is_followed_by_searcher: follows.contains(&record.account_id_hex),
                 account_id_hex: record.account_id_hex.clone(),
                 npub: record.npub.clone(),
                 radius,
@@ -1174,11 +1176,16 @@ impl MarmotApp {
                     continue;
                 }
 
-                let Some(record) =
+                let Some(mut record) =
                     Self::directory_search_record_from_caches(&caches, &account_id, now)?
                 else {
                     continue;
                 };
+                if radius == 0 {
+                    record.follows = self
+                        .cached_search_follow_list(&account_id)?
+                        .unwrap_or_default();
+                }
                 if radius < radius_end {
                     for follow in &record.follows {
                         if next.len() >= USER_DIRECTORY_SEARCH_MAX_FRONTIER {

--- a/crates/marmot-app/src/directory/mod.rs
+++ b/crates/marmot-app/src/directory/mod.rs
@@ -1,4 +1,5 @@
 mod cache;
+mod cached_search;
 mod member_key_packages;
 mod methods;
 mod open_ranking;

--- a/crates/marmot-app/src/directory/records.rs
+++ b/crates/marmot-app/src/directory/records.rs
@@ -139,6 +139,9 @@ pub struct UserDirectorySearch {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct UserDirectorySearchResult {
+    /// Direct follow of the selected searcher, never inferred from radius or another account.
+    #[serde(default)]
+    pub is_followed_by_searcher: bool,
     pub account_id_hex: String,
     pub npub: String,
     pub radius: u8,
@@ -703,6 +706,7 @@ mod tests {
     #[test]
     fn search_result_serializes_match_attribution_as_snake_case_strings() {
         let result = UserDirectorySearchResult {
+            is_followed_by_searcher: false,
             account_id_hex: "aa".repeat(32),
             npub: "npub1example".to_owned(),
             radius: 1,

--- a/crates/marmot-app/src/directory/search.rs
+++ b/crates/marmot-app/src/directory/search.rs
@@ -319,7 +319,11 @@ async fn run_search<F>(
         let cached_query = query.clone();
         let cached_started = Instant::now();
         let cached = blocking_app_task(move || {
-            cached_app.cached_search_snapshot(&cached_searcher, &cached_query, usize::MAX)
+            cached_app.cached_search_snapshot(
+                &cached_searcher,
+                &cached_query,
+                super::cached_search::CACHED_SEARCH_MAX_RECORDS,
+            )
         });
         let cached = tokio::select! {
             _ = emitter.updates_tx.closed() => return,
@@ -340,12 +344,7 @@ async fn run_search<F>(
                     .await;
             }
             Err(error) => {
-                failed = true;
-                emitter
-                    .emit(SearchUpdateTrigger::Error {
-                        message: error.to_string(),
-                    })
-                    .await;
+                tracing::debug!(target: "marmot_app::directory", method = "search_cache", error_kind = error.privacy_safe_kind(), "cached search unavailable; continuing network search");
             }
         }
         trace_search_stage("cache", cached_started);
@@ -361,16 +360,10 @@ async fn run_search<F>(
             match resolved_seeds {
                 Ok(Ok(seeds)) => graph_params.radius_one_seeds.extend(seeds),
                 Ok(Err(error)) => {
-                    graph_emitter
-                        .emit(SearchUpdateTrigger::Error {
-                            message: error.to_string(),
-                        })
-                        .await
+                    tracing::debug!(target: "marmot_app::directory", method = "search_group_seeds", error_kind = error.privacy_safe_kind(), "group search seeds unavailable; continuing without them");
                 }
                 Err(_) => {
-                    graph_emitter
-                        .emit(SearchUpdateTrigger::RadiusTimeout { radius: 1 })
-                        .await
+                    tracing::debug!(target: "marmot_app::directory", method = "search_group_seeds", outcome = "timeout", "group search seeds timed out; continuing without them");
                 }
             }
             let started = Instant::now();
@@ -987,7 +980,19 @@ async fn extend_with_follows(
     searcher_layer: bool,
     emitter: &mut SearchEmitter,
 ) -> Result<(), AppError> {
-    let (cached, unknown) = partition_cached_follows(app, frontier).await?;
+    let (cached, unknown) = if searcher_layer {
+        let app = app.clone();
+        let searcher = frontier[0].clone();
+        blocking_app_task(move || {
+            Ok(match app.cached_search_follow_list(&searcher)? {
+                Some(follows) => (vec![follows], Vec::new()),
+                None => (Vec::new(), vec![searcher]),
+            })
+        })
+        .await?
+    } else {
+        partition_cached_follows(app, frontier).await?
+    };
 
     // Pass 1: contact lists already on the device. No relay round trip, so the
     // next layer starts forming immediately.
@@ -1024,7 +1029,7 @@ async fn extend_with_follows(
 /// how that claim gets checked in the field instead of assumed. Counts only --
 /// never an account id, a relay, or the query, per the privacy invariant in
 /// `AGENTS.md`.
-#[derive(Clone, Default)]
+#[derive(Default)]
 struct SearchTally {
     /// Answered from the device: the promoted directory or the search graph.
     from_cache: usize,
@@ -1188,16 +1193,15 @@ async fn cache_resolved_follows(
 }
 
 /// Sends updates to the subscription and keeps the running result total.
-#[derive(Clone)]
 struct SearchEmitter {
     updates_tx: mpsc::Sender<UserSearchUpdate>,
+    started: Instant,
     state: Arc<Mutex<SearchState>>,
     tally: SearchTally,
 }
 
 #[derive(Default)]
 struct SearchState {
-    started: Option<Instant>,
     first_result_reported: bool,
     first_network_result_reported: bool,
     results: HashMap<String, UserDirectorySearchResult>,
@@ -1210,10 +1214,8 @@ impl SearchEmitter {
     fn new(updates_tx: mpsc::Sender<UserSearchUpdate>) -> Self {
         Self {
             updates_tx,
-            state: Arc::new(Mutex::new(SearchState {
-                started: Some(Instant::now()),
-                ..Default::default()
-            })),
+            started: Instant::now(),
+            state: Arc::new(Mutex::new(SearchState::default())),
             tally: SearchTally::default(),
         }
     }
@@ -1221,23 +1223,34 @@ impl SearchEmitter {
     fn fork(&self) -> Self {
         Self {
             updates_tx: self.updates_tx.clone(),
+            started: self.started,
             state: self.state.clone(),
             tally: SearchTally::default(),
         }
     }
 
     fn total_result_count(&self) -> usize {
-        self.state.lock().expect("search state").results.len()
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .results
+            .len()
     }
 
     fn set_searcher(&mut self, searcher: &str, follows: HashSet<String>) {
         self.remember_graph_accounts(0, &[searcher.to_owned()]);
         self.remember_graph_accounts(1, &follows.iter().cloned().collect::<Vec<_>>());
-        self.state.lock().expect("search state").follows = follows;
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .follows = follows;
     }
 
     fn remember_follows(&mut self, follows: &[String]) {
-        let mut state = self.state.lock().expect("search state");
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         for id in follows {
             state.follows.insert(id.clone());
             if let Some(result) = state.results.get_mut(id)
@@ -1255,7 +1268,10 @@ impl SearchEmitter {
     }
 
     fn remember_graph_accounts(&mut self, radius: u8, account_ids: &[String]) {
-        let mut state = self.state.lock().expect("search state");
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         for account_id in account_ids {
             let known = state
                 .graph_radii
@@ -1279,7 +1295,10 @@ impl SearchEmitter {
         ranked_pubkeys: Vec<RankedPubkey>,
         radius_start: u8,
     ) -> Vec<RankedPubkey> {
-        let state = self.state.lock().expect("search state");
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         ranked_pubkeys
             .into_iter()
             .filter(|ranked| {
@@ -1329,7 +1348,7 @@ impl SearchEmitter {
             let radius = self
                 .state
                 .lock()
-                .expect("search state")
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .graph_radii
                 .get(&ranked.record.account_id_hex)
                 .copied()
@@ -1393,7 +1412,10 @@ impl SearchEmitter {
         let Ok(permit) = self.updates_tx.reserve().await else {
             return;
         };
-        let mut state = self.state.lock().expect("search state");
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let mut added = Vec::new();
         for mut result in new_results {
             result.is_followed_by_searcher = state.follows.contains(&result.account_id_hex);
@@ -1443,17 +1465,13 @@ impl SearchEmitter {
         }
         if !added.is_empty() || !updated_results.is_empty() {
             if !state.first_result_reported {
-                if let Some(started) = state.started {
-                    trace_search_stage("first_result", started);
-                }
+                trace_search_stage("first_result", self.started);
                 state.first_result_reported = true;
             }
             if !state.first_network_result_reported
                 && !matches!(trigger, SearchUpdateTrigger::CachedResultsFound)
             {
-                if let Some(started) = state.started {
-                    trace_search_stage("first_enrichment", started);
-                }
+                trace_search_stage("first_enrichment", self.started);
                 state.first_network_result_reported = true;
             }
         }
@@ -1466,7 +1484,7 @@ impl SearchEmitter {
     }
 }
 
-/// Rank results best-first: direct follows, nearest radius, then provider rank for discovery
+/// Rank results best-first: self, direct follows, nearest radius, then provider rank for discovery
 /// results, then local match strength, matched field, and pubkey for stability.
 ///
 /// Public because a streaming consumer has to re-rank for itself. Updates
@@ -1475,8 +1493,9 @@ impl SearchEmitter {
 /// stream must sort the aggregate to recover this order.
 pub fn sort_user_search_results(results: &mut [UserDirectorySearchResult]) {
     results.sort_by(|a, b| {
-        b.is_followed_by_searcher
-            .cmp(&a.is_followed_by_searcher)
+        (b.radius == 0)
+            .cmp(&(a.radius == 0))
+            .then_with(|| b.is_followed_by_searcher.cmp(&a.is_followed_by_searcher))
             .then_with(|| a.radius.cmp(&b.radius))
             .then_with(|| match (a.provider_rank, b.provider_rank) {
                 (Some(left), Some(right)) => right.total_cmp(&left),
@@ -1590,6 +1609,46 @@ mod tests {
         );
         assert!(graph_dropped.await.is_err());
         assert!(provider_dropped.await.is_err());
+    }
+
+    #[tokio::test]
+    async fn failed_membership_keeps_cached_results_and_completes_graph() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = MarmotApp::with_relay_and_config(
+            dir.path(),
+            "wss://relay.invalid",
+            crate::MarmotAppConfig::default().with_open_ranking_provider(None, Vec::new()),
+        );
+        let account = app.account_home().create_account("alice").unwrap();
+        app.directory_cache_for_account(&account)
+            .unwrap()
+            .put(&record_named(&account.account_id_hex, "needle"))
+            .unwrap();
+        let subscription = app
+            .search_users_with_seeds(
+                params(&account.account_id_hex, "needle", (0, 0)),
+                std::future::ready(Err(AppError::RelayDirectory(
+                    "membership unavailable".into(),
+                ))),
+            )
+            .await
+            .unwrap();
+        let updates = drain(subscription).await;
+        assert_eq!(updates[0].trigger, SearchUpdateTrigger::CachedResultsFound);
+        assert_eq!(updates[0].new_results.len(), 1);
+        assert!(
+            updates
+                .iter()
+                .any(|u| u.trigger == SearchUpdateTrigger::RadiusCompleted { radius: 0 })
+        );
+        assert!(updates.iter().all(|u| !matches!(
+            u.trigger,
+            SearchUpdateTrigger::Error { .. } | SearchUpdateTrigger::RadiusTimeout { .. }
+        )));
+        assert_eq!(
+            updates.last().unwrap().trigger,
+            SearchUpdateTrigger::SearchCompleted
+        );
     }
 
     #[tokio::test]

--- a/crates/marmot-app/src/directory/search.rs
+++ b/crates/marmot-app/src/directory/search.rs
@@ -299,6 +299,7 @@ async fn run_search<F>(
     let mut failed = false;
     let mut emitter = SearchEmitter::new(updates_tx);
     emitter.remember_graph_accounts(0, std::slice::from_ref(&searcher_account_id_hex));
+    emitter.remember_graph_accounts(1, &params.radius_one_seeds);
     // An empty query would match every candidate through `contains`, so it
     // finds nobody by definition rather than everybody.
     let query = params.query.trim().to_lowercase();
@@ -332,7 +333,6 @@ async fn run_search<F>(
         match cached {
             Ok((follows, mut results)) => {
                 emitter.set_searcher(&searcher_account_id_hex, follows);
-                emitter.remember_graph_accounts(1, &params.radius_one_seeds);
                 // Radius windows constrain known social distances, not discovery.
                 results.retain(|result| {
                     result.radius == OFF_GRAPH_SEARCH_RADIUS
@@ -344,7 +344,12 @@ async fn run_search<F>(
                     .await;
             }
             Err(error) => {
-                tracing::debug!(target: "marmot_app::directory", method = "search_cache", error_kind = error.privacy_safe_kind(), "cached search unavailable; continuing network search");
+                tracing::debug!(
+                    target: "marmot_app::directory",
+                    method = "search_cache",
+                    error_kind = error.privacy_safe_kind(),
+                    "cached search unavailable; continuing network search"
+                );
             }
         }
         trace_search_stage("cache", cached_started);
@@ -360,10 +365,20 @@ async fn run_search<F>(
             match resolved_seeds {
                 Ok(Ok(seeds)) => graph_params.radius_one_seeds.extend(seeds),
                 Ok(Err(error)) => {
-                    tracing::debug!(target: "marmot_app::directory", method = "search_group_seeds", error_kind = error.privacy_safe_kind(), "group search seeds unavailable; continuing without them");
+                    tracing::debug!(
+                        target: "marmot_app::directory",
+                        method = "search_group_seeds",
+                        error_kind = error.privacy_safe_kind(),
+                        "group search seeds unavailable; continuing without them"
+                    );
                 }
                 Err(_) => {
-                    tracing::debug!(target: "marmot_app::directory", method = "search_group_seeds", outcome = "timeout", "group search seeds timed out; continuing without them");
+                    tracing::debug!(
+                        target: "marmot_app::directory",
+                        method = "search_group_seeds",
+                        outcome = "timeout",
+                        "group search seeds timed out; continuing without them"
+                    );
                 }
             }
             let started = Instant::now();
@@ -411,11 +426,21 @@ async fn run_search<F>(
                         .await
                         .is_err()
                         {
-                            tracing::debug!(target: "marmot_app::directory", method = "search_cache_provider", outcome = "failed", "search profile cache write failed");
+                            tracing::debug!(
+                                target: "marmot_app::directory",
+                                method = "search_cache_provider",
+                                outcome = "failed",
+                                "search profile cache write failed"
+                            );
                         }
                     }
                     Err(_) => {
-                        tracing::debug!(target: "marmot_app::directory", method = "search_users_open_ranking_hydrate", outcome = "fetch_failed", "Open Ranking profile hydration unavailable")
+                        tracing::debug!(
+                            target: "marmot_app::directory",
+                            method = "search_users_open_ranking_hydrate",
+                            outcome = "fetch_failed",
+                            "Open Ranking profile hydration unavailable"
+                        )
                     }
                 }
                 trace_search_stage("provider_profiles", started);
@@ -658,7 +683,12 @@ async fn advance_radius(
     if depth.hop == 0 {
         layer.admit(params.radius_one_seeds.clone(), seen);
     }
-    extend_with_follows(app, frontier, seen, &mut layer, depth.hop == 0, emitter).await?;
+    let searcher = if depth.hop == 0 {
+        frontier.first().map(String::as_str)
+    } else {
+        None
+    };
+    extend_with_follows(app, frontier, seen, &mut layer, searcher, emitter).await?;
     if layer.truncated {
         emitter
             .emit(SearchUpdateTrigger::RadiusTruncated {
@@ -977,12 +1007,12 @@ async fn extend_with_follows(
     frontier: &[String],
     seen: &mut HashSet<String>,
     layer: &mut NextLayer,
-    searcher_layer: bool,
+    searcher: Option<&str>,
     emitter: &mut SearchEmitter,
 ) -> Result<(), AppError> {
-    let (cached, unknown) = if searcher_layer {
+    let (cached, unknown) = if let Some(searcher) = searcher {
         let app = app.clone();
-        let searcher = frontier[0].clone();
+        let searcher = searcher.to_owned();
         blocking_app_task(move || {
             Ok(match app.cached_search_follow_list(&searcher)? {
                 Some(follows) => (vec![follows], Vec::new()),
@@ -997,7 +1027,7 @@ async fn extend_with_follows(
     // Pass 1: contact lists already on the device. No relay round trip, so the
     // next layer starts forming immediately.
     for follows in cached {
-        if searcher_layer {
+        if searcher.is_some() {
             emitter.remember_follows(&follows);
         }
         if !layer.admit(follows, seen) {
@@ -1012,7 +1042,7 @@ async fn extend_with_follows(
         let fetched = fetch_follow_lists(app, batch).await?;
         cache_resolved_follows(app, &fetched).await?;
         for (_, follows) in fetched {
-            if searcher_layer {
+            if searcher.is_some() {
                 emitter.remember_follows(&follows);
             }
             if !layer.admit(follows, seen) {
@@ -1302,7 +1332,10 @@ impl SearchEmitter {
         ranked_pubkeys
             .into_iter()
             .filter(|ranked| {
-                !state.results.contains_key(&ranked.account_id_hex)
+                state
+                    .results
+                    .get(&ranked.account_id_hex)
+                    .is_none_or(|result| result.radius == OFF_GRAPH_SEARCH_RADIUS)
                     && state
                         .graph_radii
                         .get(&ranked.account_id_hex)
@@ -2152,6 +2185,64 @@ mod tests {
         assert_eq!(tally.from_write_relays, 1);
         assert_eq!(tally.from_open_ranking, 5);
         assert_eq!(tally.unresolved, 4);
+    }
+
+    #[tokio::test]
+    async fn cached_discovery_receives_provider_rank_and_a_fresher_profile() {
+        let (tx, mut rx) = mpsc::channel(4);
+        let mut emitter = SearchEmitter::new(tx);
+        let id = "11".repeat(32);
+        let cached = record_named(&id, "needle");
+        let cached_time = cached.profile.as_ref().unwrap().created_at;
+        emitter
+            .emit_matches(OFF_GRAPH_SEARCH_RADIUS, vec![cached], "needle")
+            .await;
+        let first = rx.recv().await.unwrap();
+        assert_eq!(first.new_results[0].provider_rank, None);
+        let ranked = emitter.remaining_ranked_pubkeys(
+            vec![RankedPubkey {
+                account_id_hex: id.clone(),
+                rank: 0.9,
+            }],
+            1,
+        );
+        assert_eq!(
+            ranked.len(),
+            1,
+            "cached off-graph hits still receive provider enrichment"
+        );
+        let mut fresh = record_named(&id, "needle updated");
+        fresh.profile.as_mut().unwrap().created_at = cached_time + 1;
+        emitter
+            .emit_ranked_matches(
+                vec![RankedDirectoryRecord {
+                    record: fresh,
+                    rank: ranked[0].rank,
+                }],
+                "needle",
+            )
+            .await;
+        let enriched = rx.recv().await.unwrap();
+        assert!(enriched.new_results.is_empty());
+        assert_eq!(enriched.total_result_count, 1);
+        assert_eq!(enriched.updated_results.len(), 1);
+        assert_eq!(enriched.updated_results[0].provider_rank, Some(0.9));
+        assert_eq!(
+            enriched.updated_results[0]
+                .profile
+                .as_ref()
+                .unwrap()
+                .created_at,
+            cached_time + 1
+        );
+        let other = UserDirectorySearchResult {
+            provider_rank: Some(0.5),
+            account_id_hex: "22".repeat(32),
+            ..enriched.updated_results[0].clone()
+        };
+        let mut rows = vec![other, enriched.updated_results[0].clone()];
+        sort_user_search_results(&mut rows);
+        assert_eq!(rows[0].account_id_hex, id);
     }
 
     #[tokio::test]

--- a/crates/marmot-app/src/directory/search.rs
+++ b/crates/marmot-app/src/directory/search.rs
@@ -3,8 +3,8 @@
 //! [`MarmotApp::search_users`] answers "who do I know called *foo*" by walking
 //! the searcher's own social graph outward and streaming matches as each layer
 //! resolves, while a bounded Open Ranking request supplies off-graph discovery.
-//! Graph results retain priority and social provenance; only remaining ranked
-//! pubkeys are hydrated from signed Nostr profile events.
+//! Cached public identities arrive first. Provider and graph results then arrive
+//! independently, with keyed replacements when relationship or profile data improves.
 //!
 //! Traversal is bounded by construction, as `AGENTS.md` requires: the radius is
 //! capped, relay work per radius is batched author-scoped fetches under a
@@ -18,7 +18,9 @@
 
 use std::cmp::Reverse;
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::time::Duration;
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use cgka_traits::TransportEndpoint;
 
@@ -76,14 +78,13 @@ const SEARCH_PUBKEY_BATCH_SIZE: usize = 200;
 /// Ceiling on the relay work a single radius may spend.
 const SEARCH_RADIUS_TIMEOUT: Duration = Duration::from_secs(300);
 
-/// Reported distance for matches that are not on the searcher's graph at all.
+/// No social distance from the searcher has been established for this result.
 ///
-/// Every consumer renders `radius` as provenance -- "via someone you follow".
-/// When a search falls back to a configured seed, or a discovery provider finds
-/// someone outside the graph, that person is not a measurable distance from
-/// the searcher. Labelling them radius 1 would make that provenance a lie, so
-/// they are reported as off-graph. `u8::MAX` also sorts last, which is where an
-/// off-graph match belongs.
+/// Public cache and provider hits can arrive before graph traversal knows their
+/// relationship. Later updates may supply a distance. Fallback-seed matches
+/// remain unmeasured because those hops are from the seed, not the searcher.
+/// Never infer a follow from this sentinel or from radius 1 (which also includes
+/// group co-members); use `is_followed_by_searcher` for that label.
 pub const OFF_GRAPH_SEARCH_RADIUS: u8 = u8::MAX;
 
 /// How far a layer has walked, and how that distance is reported.
@@ -172,8 +173,9 @@ pub enum SearchUpdateTrigger {
     RadiusStarted { radius: u8 },
     /// A batch of matches resolved at this radius.
     ResultsFound { radius: u8 },
-    /// A batch produced by the optional off-graph discovery tier after graph
-    /// traversal. Individual results retain any graph radius already observed,
+    /// Cached public matches from every connected account.
+    CachedResultsFound,
+    /// A batch produced independently by the optional discovery tier. Individual results retain any graph radius already observed,
     /// but this trigger never reopens a completed radius bucket.
     DiscoveryResultsFound,
     /// This radius finished resolving.
@@ -194,13 +196,14 @@ pub enum SearchUpdateTrigger {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct UserSearchUpdate {
     pub trigger: SearchUpdateTrigger,
-    /// Matches discovered by this step, pre-sorted within the batch. Ordering
-    /// *across* graph updates is radius order; an optional discovery batch
-    /// follows graph traversal and may contain results retaining graph
-    /// provenance. Flat-list consumers should re-sort the aggregate.
+    /// New identities, sorted within this batch. Sources arrive independently.
+    /// Merge by account id and re-sort after applying both new and updated rows.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub new_results: Vec<UserDirectorySearchResult>,
-    /// Running total emitted by this search so far, including `new_results`.
+    /// Replacements for previously emitted identities, keyed by account id.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub updated_results: Vec<UserDirectorySearchResult>,
+    /// Number of unique identities, including this update; replacements do not increment it.
     pub total_result_count: usize,
 }
 
@@ -230,6 +233,18 @@ impl MarmotApp {
         &self,
         params: UserSearchParams,
     ) -> Result<UserSearchSubscription, AppError> {
+        self.search_users_with_seeds(params, std::future::ready(Ok(Vec::new())))
+            .await
+    }
+
+    pub(crate) async fn search_users_with_seeds<F>(
+        &self,
+        params: UserSearchParams,
+        seeds: F,
+    ) -> Result<UserSearchSubscription, AppError>
+    where
+        F: Future<Output = Result<Vec<String>, AppError>> + Send + 'static,
+    {
         let observation = self.product_analytics.begin(
             crate::ProductFamily::Directory,
             "search",
@@ -253,6 +268,7 @@ impl MarmotApp {
                 params,
                 updates_tx,
                 observation,
+                seeds,
             )
             .await;
         });
@@ -262,13 +278,16 @@ impl MarmotApp {
 
 /// Drive one search to completion, reporting a failure as an update rather
 /// than losing it: the caller holds a subscription, not a `Result`.
-async fn run_search(
+async fn run_search<F>(
     app: MarmotApp,
     searcher_account_id_hex: String,
     params: UserSearchParams,
     updates_tx: mpsc::Sender<UserSearchUpdate>,
     observation: Option<crate::ProductObservation>,
-) {
+    seeds: F,
+) where
+    F: Future<Output = Result<Vec<String>, AppError>> + Send,
+{
     let source_observation = app
         .product_analytics
         .begin(
@@ -279,6 +298,7 @@ async fn run_search(
         .map(crate::ProductObservation::counts_only);
     let mut failed = false;
     let mut emitter = SearchEmitter::new(updates_tx);
+    emitter.remember_graph_accounts(0, std::slice::from_ref(&searcher_account_id_hex));
     // An empty query would match every candidate through `contains`, so it
     // finds nobody by definition rather than everybody.
     let query = params.query.trim().to_lowercase();
@@ -294,26 +314,124 @@ async fn run_search(
             .collect::<Vec<_>>();
         let open_ranking_search_endpoint =
             open_ranking_search_endpoint.filter(|_| !open_ranking_profile_relays.is_empty());
-        // Start the independent discovery request with the graph walk, but
-        // merge its results afterwards. That gives a graph result precedence
-        // when both sources return the same identity, without holding a
-        // mutable emitter across concurrent tasks.
-        let discovery_updates_tx = emitter.updates_tx.clone();
-        let (graph_result, ranked_pubkeys) = tokio::join!(
-            traverse_graph(
+        let cached_app = app.clone();
+        let cached_searcher = searcher_account_id_hex.clone();
+        let cached_query = query.clone();
+        let cached_started = Instant::now();
+        let cached = blocking_app_task(move || {
+            cached_app.cached_search_snapshot(&cached_searcher, &cached_query, usize::MAX)
+        });
+        let cached = tokio::select! {
+            _ = emitter.updates_tx.closed() => return,
+            result = cached => result,
+        };
+        match cached {
+            Ok((follows, mut results)) => {
+                emitter.set_searcher(&searcher_account_id_hex, follows);
+                emitter.remember_graph_accounts(1, &params.radius_one_seeds);
+                // Radius windows constrain known social distances, not discovery.
+                results.retain(|result| {
+                    result.radius == OFF_GRAPH_SEARCH_RADIUS
+                        || (params.radius_start..=params.radius_end).contains(&result.radius)
+                });
+                emitter.tally.resolved_from_cache(results.len());
+                emitter
+                    .emit_results(SearchUpdateTrigger::CachedResultsFound, results)
+                    .await;
+            }
+            Err(error) => {
+                failed = true;
+                emitter
+                    .emit(SearchUpdateTrigger::Error {
+                        message: error.to_string(),
+                    })
+                    .await;
+            }
+        }
+        trace_search_stage("cache", cached_started);
+        let mut graph_emitter = emitter.fork();
+        let mut discovery_emitter = emitter.fork();
+        let graph = async {
+            let mut graph_params = params.clone();
+            // Membership reads belong only to graph enrichment. A stalled worker
+            // cannot hold cache or provider results hostage.
+            let seed_started = Instant::now();
+            let resolved_seeds = timeout(SEARCH_RADIUS_TIMEOUT, seeds).await;
+            trace_search_stage("group_seeds", seed_started);
+            match resolved_seeds {
+                Ok(Ok(seeds)) => graph_params.radius_one_seeds.extend(seeds),
+                Ok(Err(error)) => {
+                    graph_emitter
+                        .emit(SearchUpdateTrigger::Error {
+                            message: error.to_string(),
+                        })
+                        .await
+                }
+                Err(_) => {
+                    graph_emitter
+                        .emit(SearchUpdateTrigger::RadiusTimeout { radius: 1 })
+                        .await
+                }
+            }
+            let started = Instant::now();
+            let result = traverse_graph(
                 &app,
                 &searcher_account_id_hex,
                 &query,
-                &params,
-                &mut emitter,
-            ),
-            fetch_open_ranking_pubkeys(
+                &graph_params,
+                &mut graph_emitter,
+            )
+            .await;
+            trace_search_stage("graph", started);
+            result
+        };
+        let discovery = async {
+            let started = Instant::now();
+            let ranked = fetch_open_ranking_pubkeys(
                 &query,
                 open_ranking_search_endpoint.as_deref(),
-                discovery_updates_tx,
-            ),
-        );
-        if let Err(error) = graph_result {
+                discovery_emitter.updates_tx.clone(),
+            )
+            .await;
+            trace_search_stage("provider_response", started);
+            let remaining = discovery_emitter.remaining_ranked_pubkeys(ranked, params.radius_start);
+            if !remaining.is_empty() && !discovery_emitter.is_cancelled() {
+                let started = Instant::now();
+                match hydrate_open_ranking_profiles(&app, remaining, &open_ranking_profile_relays)
+                    .await
+                {
+                    Ok(records) => {
+                        discovery_emitter
+                            .tally
+                            .resolved_from_open_ranking(records.len());
+                        // Cache signed profiles in the un-promoted tier for repeat queries.
+                        let profiles = records
+                            .iter()
+                            .map(|ranked| ranked.record.clone())
+                            .collect::<Vec<_>>();
+                        discovery_emitter.emit_ranked_matches(records, &query).await;
+                        if cache_resolved_profiles(
+                            &app,
+                            &profiles,
+                            crate::unix_now_seconds() as i64,
+                        )
+                        .await
+                        .is_err()
+                        {
+                            tracing::debug!(target: "marmot_app::directory", method = "search_cache_provider", outcome = "failed", "search profile cache write failed");
+                        }
+                    }
+                    Err(_) => {
+                        tracing::debug!(target: "marmot_app::directory", method = "search_users_open_ranking_hydrate", outcome = "fetch_failed", "Open Ranking profile hydration unavailable")
+                    }
+                }
+                trace_search_stage("provider_profiles", started);
+            }
+        };
+        let started = Instant::now();
+        let graph_result = drive_search_sources(emitter.updates_tx.clone(), graph, discovery).await;
+        trace_search_stage("network", started);
+        if let Some(Err(error)) = graph_result {
             failed = true;
             emitter
                 .emit(SearchUpdateTrigger::Error {
@@ -321,33 +439,8 @@ async fn run_search(
                 })
                 .await;
         }
-        let remaining = emitter.remaining_ranked_pubkeys(ranked_pubkeys, params.radius_start);
-        if !remaining.is_empty() && !emitter.is_cancelled() {
-            let hydration_updates_tx = emitter.updates_tx.clone();
-            let hydration = tokio::select! {
-                _ = hydration_updates_tx.closed() => None,
-                result = hydrate_open_ranking_profiles(
-                    &app,
-                    remaining,
-                    &open_ranking_profile_relays,
-                ) => Some(result),
-            };
-            match hydration {
-                None => {}
-                Some(Ok(records)) => {
-                    emitter.tally.resolved_from_open_ranking(records.len());
-                    emitter.emit_ranked_matches(records, &query).await;
-                }
-                Some(Err(_)) => {
-                    tracing::debug!(
-                        target: "marmot_app::directory",
-                        method = "search_users_open_ranking_hydrate",
-                        outcome = "fetch_failed",
-                        "Open Ranking profile hydration unavailable"
-                    );
-                }
-            }
-        }
+        emitter.tally.add(&graph_emitter.tally);
+        emitter.tally.add(&discovery_emitter.tally);
     }
     let cancelled = emitter.is_cancelled();
     emitter.emit(SearchUpdateTrigger::SearchCompleted).await;
@@ -368,12 +461,33 @@ async fn run_search(
             "cancelled"
         } else if failed {
             "failure"
-        } else if emitter.total_result_count == 0 {
+        } else if emitter.total_result_count() == 0 {
             "empty"
         } else {
             "success"
         });
     }
+}
+
+/// Both sources are polled independently and dropped immediately with their consumer.
+async fn drive_search_sources<G, D>(
+    updates: mpsc::Sender<UserSearchUpdate>,
+    graph: G,
+    discovery: D,
+) -> Option<Result<(), AppError>>
+where
+    G: Future<Output = Result<(), AppError>>,
+    D: Future<Output = ()>,
+{
+    tokio::select! {
+        _ = updates.closed() => None,
+        (result, ()) = async { tokio::join!(graph, discovery) } => Some(result),
+    }
+}
+
+fn trace_search_stage(stage: &'static str, started: Instant) {
+    tracing::debug!(target: "marmot_app::directory", method = "search_stage",
+        stage, duration_ms = started.elapsed().as_millis() as u64, "user search stage finished");
 }
 
 /// Fetch ranked identities from Vertex without exposing failures to the graph
@@ -409,7 +523,7 @@ async fn fetch_open_ranking_pubkeys(
 ///
 /// The ranked response itself is derived data. Profiles still come from signed
 /// Nostr events and pass through the relay-plane safety, signature, kind, and
-/// freshness checks. Nothing in this path is persisted.
+/// freshness checks. Resolved profiles are cached in the un-promoted search tier.
 async fn hydrate_open_ranking_profiles(
     app: &MarmotApp,
     ranked_pubkeys: Vec<RankedPubkey>,
@@ -470,12 +584,12 @@ async fn traverse_graph(
                 radius
             },
         };
+        emitter.remember_graph_accounts(depth.reported, &frontier);
         emitter
             .emit(SearchUpdateTrigger::RadiusStarted {
                 radius: depth.reported,
             })
             .await;
-        emitter.remember_graph_accounts(depth.reported, &frontier);
 
         // One timeout per radius, covering every relay round trip the radius
         // makes: resolving its profiles and reading the follow lists that
@@ -551,7 +665,7 @@ async fn advance_radius(
     if depth.hop == 0 {
         layer.admit(params.radius_one_seeds.clone(), seen);
     }
-    extend_with_follows(app, frontier, seen, &mut layer).await?;
+    extend_with_follows(app, frontier, seen, &mut layer, depth.hop == 0, emitter).await?;
     if layer.truncated {
         emitter
             .emit(SearchUpdateTrigger::RadiusTruncated {
@@ -870,12 +984,17 @@ async fn extend_with_follows(
     frontier: &[String],
     seen: &mut HashSet<String>,
     layer: &mut NextLayer,
+    searcher_layer: bool,
+    emitter: &mut SearchEmitter,
 ) -> Result<(), AppError> {
     let (cached, unknown) = partition_cached_follows(app, frontier).await?;
 
     // Pass 1: contact lists already on the device. No relay round trip, so the
     // next layer starts forming immediately.
     for follows in cached {
+        if searcher_layer {
+            emitter.remember_follows(&follows);
+        }
         if !layer.admit(follows, seen) {
             return Ok(());
         }
@@ -888,6 +1007,9 @@ async fn extend_with_follows(
         let fetched = fetch_follow_lists(app, batch).await?;
         cache_resolved_follows(app, &fetched).await?;
         for (_, follows) in fetched {
+            if searcher_layer {
+                emitter.remember_follows(&follows);
+            }
             if !layer.admit(follows, seen) {
                 return Ok(());
             }
@@ -902,7 +1024,7 @@ async fn extend_with_follows(
 /// how that claim gets checked in the field instead of assumed. Counts only --
 /// never an account id, a relay, or the query, per the privacy invariant in
 /// `AGENTS.md`.
-#[derive(Default)]
+#[derive(Clone, Default)]
 struct SearchTally {
     /// Answered from the device: the promoted directory or the search graph.
     from_cache: usize,
@@ -917,6 +1039,14 @@ struct SearchTally {
 }
 
 impl SearchTally {
+    fn add(&mut self, other: &Self) {
+        self.from_cache += other.from_cache;
+        self.from_relays += other.from_relays;
+        self.from_write_relays += other.from_write_relays;
+        self.from_open_ranking += other.from_open_ranking;
+        self.unresolved += other.unresolved;
+    }
+
     fn resolved_from_cache(&mut self, count: usize) {
         self.from_cache += count;
     }
@@ -1058,34 +1188,89 @@ async fn cache_resolved_follows(
 }
 
 /// Sends updates to the subscription and keeps the running result total.
+#[derive(Clone)]
 struct SearchEmitter {
     updates_tx: mpsc::Sender<UserSearchUpdate>,
-    total_result_count: usize,
-    emitted_account_ids: HashSet<String>,
-    graph_radii: HashMap<String, u8>,
+    state: Arc<Mutex<SearchState>>,
     tally: SearchTally,
+}
+
+#[derive(Default)]
+struct SearchState {
+    started: Option<Instant>,
+    first_result_reported: bool,
+    first_network_result_reported: bool,
+    results: HashMap<String, UserDirectorySearchResult>,
+    graph_radii: HashMap<String, u8>,
+    follows: HashSet<String>,
+    pending_updates: BTreeMap<String, UserDirectorySearchResult>,
 }
 
 impl SearchEmitter {
     fn new(updates_tx: mpsc::Sender<UserSearchUpdate>) -> Self {
         Self {
             updates_tx,
-            total_result_count: 0,
-            emitted_account_ids: HashSet::new(),
-            graph_radii: HashMap::new(),
+            state: Arc::new(Mutex::new(SearchState {
+                started: Some(Instant::now()),
+                ..Default::default()
+            })),
             tally: SearchTally::default(),
         }
     }
 
-    /// Whether the consumer has dropped the subscription, which is how a
-    /// search is cancelled.
+    fn fork(&self) -> Self {
+        Self {
+            updates_tx: self.updates_tx.clone(),
+            state: self.state.clone(),
+            tally: SearchTally::default(),
+        }
+    }
+
+    fn total_result_count(&self) -> usize {
+        self.state.lock().expect("search state").results.len()
+    }
+
+    fn set_searcher(&mut self, searcher: &str, follows: HashSet<String>) {
+        self.remember_graph_accounts(0, &[searcher.to_owned()]);
+        self.remember_graph_accounts(1, &follows.iter().cloned().collect::<Vec<_>>());
+        self.state.lock().expect("search state").follows = follows;
+    }
+
+    fn remember_follows(&mut self, follows: &[String]) {
+        let mut state = self.state.lock().expect("search state");
+        for id in follows {
+            state.follows.insert(id.clone());
+            if let Some(result) = state.results.get_mut(id)
+                && !result.is_followed_by_searcher
+            {
+                result.is_followed_by_searcher = true;
+                let result = result.clone();
+                state.pending_updates.insert(id.clone(), result);
+            }
+        }
+    }
+
     fn is_cancelled(&self) -> bool {
         self.updates_tx.is_closed()
     }
 
     fn remember_graph_accounts(&mut self, radius: u8, account_ids: &[String]) {
+        let mut state = self.state.lock().expect("search state");
         for account_id in account_ids {
-            self.graph_radii.entry(account_id.clone()).or_insert(radius);
+            let known = state
+                .graph_radii
+                .entry(account_id.clone())
+                .or_insert(radius);
+            *known = (*known).min(radius);
+            let radius = *known;
+            if let Some(result) = state.results.get_mut(account_id)
+                && radius < result.radius
+            {
+                result.radius = radius;
+                result.provider_rank = None;
+                let result = result.clone();
+                state.pending_updates.insert(account_id.clone(), result);
+            }
         }
     }
 
@@ -1094,11 +1279,12 @@ impl SearchEmitter {
         ranked_pubkeys: Vec<RankedPubkey>,
         radius_start: u8,
     ) -> Vec<RankedPubkey> {
+        let state = self.state.lock().expect("search state");
         ranked_pubkeys
             .into_iter()
             .filter(|ranked| {
-                !self.emitted_account_ids.contains(&ranked.account_id_hex)
-                    && self
+                !state.results.contains_key(&ranked.account_id_hex)
+                    && state
                         .graph_radii
                         .get(&ranked.account_id_hex)
                         .is_none_or(|radius| *radius >= radius_start)
@@ -1113,6 +1299,7 @@ impl SearchEmitter {
             .filter_map(|record| {
                 let search_match = user_record_match(&record, query)?;
                 Some(UserDirectorySearchResult {
+                    is_followed_by_searcher: false,
                     account_id_hex: record.account_id_hex,
                     npub: record.npub,
                     radius,
@@ -1123,10 +1310,6 @@ impl SearchEmitter {
                 })
             })
             .collect::<Vec<_>>();
-        results.retain(|result| {
-            self.emitted_account_ids
-                .insert(result.account_id_hex.clone())
-        });
         if results.is_empty() {
             return;
         }
@@ -1144,12 +1327,16 @@ impl SearchEmitter {
                 continue;
             };
             let radius = self
+                .state
+                .lock()
+                .expect("search state")
                 .graph_radii
                 .get(&ranked.record.account_id_hex)
                 .copied()
                 .unwrap_or(OFF_GRAPH_SEARCH_RADIUS);
             let provider_rank = (radius == OFF_GRAPH_SEARCH_RADIUS).then_some(ranked.rank);
             let result = UserDirectorySearchResult {
+                is_followed_by_searcher: false,
                 account_id_hex: ranked.record.account_id_hex,
                 npub: ranked.record.npub,
                 radius,
@@ -1158,12 +1345,7 @@ impl SearchEmitter {
                 provider_rank,
                 profile: ranked.record.profile,
             };
-            if self
-                .emitted_account_ids
-                .insert(result.account_id_hex.clone())
-            {
-                results.push(result);
-            }
+            results.push(result);
         }
         if !results.is_empty() {
             sort_user_search_results(&mut results);
@@ -1189,7 +1371,7 @@ impl SearchEmitter {
             from_write_relays = self.tally.from_write_relays,
             from_open_ranking = self.tally.from_open_ranking,
             unresolved = self.tally.unresolved,
-            matches = self.total_result_count,
+            matches = self.total_result_count(),
             "user search finished"
         );
     }
@@ -1207,19 +1389,84 @@ impl SearchEmitter {
         trigger: SearchUpdateTrigger,
         new_results: Vec<UserDirectorySearchResult>,
     ) {
-        self.total_result_count += new_results.len();
-        let _ = self
-            .updates_tx
-            .send(UserSearchUpdate {
+        // Reserve before locking: backpressure must not block provenance updates.
+        let Ok(permit) = self.updates_tx.reserve().await else {
+            return;
+        };
+        let mut state = self.state.lock().expect("search state");
+        let mut added = Vec::new();
+        for mut result in new_results {
+            result.is_followed_by_searcher = state.follows.contains(&result.account_id_hex);
+            if let Some(radius) = state.graph_radii.get(&result.account_id_hex) {
+                result.radius = result.radius.min(*radius);
+            }
+            if result.radius != OFF_GRAPH_SEARCH_RADIUS {
+                result.provider_rank = None;
+            }
+            if let Some(old) = state.results.get(&result.account_id_hex) {
+                result.radius = result.radius.min(old.radius);
+                if old.profile.as_ref().map(|p| p.created_at)
+                    > result.profile.as_ref().map(|p| p.created_at)
+                {
+                    result.profile = old.profile.clone();
+                    result.matched_field = old.matched_field;
+                    result.match_quality = old.match_quality;
+                }
+                if result.radius == OFF_GRAPH_SEARCH_RADIUS && result.provider_rank.is_none() {
+                    result.provider_rank = old.provider_rank;
+                }
+                if result == *old {
+                    continue;
+                }
+                state
+                    .pending_updates
+                    .insert(result.account_id_hex.clone(), result.clone());
+            } else {
+                added.push(result.clone());
+            }
+            state.results.insert(result.account_id_hex.clone(), result);
+        }
+        let mut updated_results = std::mem::take(&mut state.pending_updates)
+            .into_values()
+            .collect::<Vec<_>>();
+        sort_user_search_results(&mut added);
+        sort_user_search_results(&mut updated_results);
+        if added.is_empty()
+            && updated_results.is_empty()
+            && matches!(
                 trigger,
-                new_results,
-                total_result_count: self.total_result_count,
-            })
-            .await;
+                SearchUpdateTrigger::ResultsFound { .. }
+                    | SearchUpdateTrigger::DiscoveryResultsFound
+            )
+        {
+            return;
+        }
+        if !added.is_empty() || !updated_results.is_empty() {
+            if !state.first_result_reported {
+                if let Some(started) = state.started {
+                    trace_search_stage("first_result", started);
+                }
+                state.first_result_reported = true;
+            }
+            if !state.first_network_result_reported
+                && !matches!(trigger, SearchUpdateTrigger::CachedResultsFound)
+            {
+                if let Some(started) = state.started {
+                    trace_search_stage("first_enrichment", started);
+                }
+                state.first_network_result_reported = true;
+            }
+        }
+        permit.send(UserSearchUpdate {
+            trigger,
+            new_results: added,
+            updated_results,
+            total_result_count: state.results.len(),
+        });
     }
 }
 
-/// Rank results best-first: nearest radius, then provider rank for discovery
+/// Rank results best-first: direct follows, nearest radius, then provider rank for discovery
 /// results, then local match strength, matched field, and pubkey for stability.
 ///
 /// Public because a streaming consumer has to re-rank for itself. Updates
@@ -1228,8 +1475,9 @@ impl SearchEmitter {
 /// stream must sort the aggregate to recover this order.
 pub fn sort_user_search_results(results: &mut [UserDirectorySearchResult]) {
     results.sort_by(|a, b| {
-        a.radius
-            .cmp(&b.radius)
+        b.is_followed_by_searcher
+            .cmp(&a.is_followed_by_searcher)
+            .then_with(|| a.radius.cmp(&b.radius))
             .then_with(|| match (a.provider_rank, b.provider_rank) {
                 (Some(left), Some(right)) => right.total_cmp(&left),
                 (Some(_), None) => std::cmp::Ordering::Less,
@@ -1302,6 +1550,166 @@ mod tests {
         })
         .await
         .expect("generated identity bootstrap must become network-ready");
+    }
+
+    #[tokio::test]
+    async fn dropping_a_search_stops_both_pending_sources() {
+        let (tx, rx) = mpsc::channel(1);
+        let (graph_started, graph_ready) = tokio::sync::oneshot::channel();
+        let (provider_started, provider_ready) = tokio::sync::oneshot::channel();
+        let (graph_lifetime, graph_dropped) = tokio::sync::oneshot::channel::<()>();
+        let (provider_lifetime, provider_dropped) = tokio::sync::oneshot::channel::<()>();
+        let task = tokio::spawn(drive_search_sources(
+            tx,
+            async move {
+                let _lifetime = graph_lifetime;
+                let _ = graph_started.send(());
+                std::future::pending::<Result<(), AppError>>().await
+            },
+            async move {
+                let _lifetime = provider_lifetime;
+                let _ = provider_started.send(());
+                std::future::pending::<()>().await
+            },
+        ));
+        timeout(Duration::from_secs(5), graph_ready)
+            .await
+            .unwrap()
+            .unwrap();
+        timeout(Duration::from_secs(5), provider_ready)
+            .await
+            .unwrap()
+            .unwrap();
+        drop(rx);
+        assert!(
+            timeout(Duration::from_secs(5), task)
+                .await
+                .unwrap()
+                .unwrap()
+                .is_none()
+        );
+        assert!(graph_dropped.await.is_err());
+        assert!(provider_dropped.await.is_err());
+    }
+
+    #[tokio::test]
+    async fn cached_matches_arrive_before_blocked_membership_and_cancel_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = MarmotApp::with_relay_and_config(
+            dir.path(),
+            "wss://relay.invalid",
+            crate::MarmotAppConfig::default().with_open_ranking_provider(None, Vec::new()),
+        );
+        let account = app.account_home().create_account("alice").unwrap();
+        let cache = app.directory_cache_for_account(&account).unwrap();
+        let peer = "11".repeat(32);
+        cache.put(&record_named(&peer, "needle")).unwrap();
+        let (seed_started_tx, seed_started_rx) = tokio::sync::oneshot::channel();
+        let (dropped_tx, dropped_rx) = tokio::sync::oneshot::channel();
+        struct DropSignal(Option<tokio::sync::oneshot::Sender<()>>);
+        impl Drop for DropSignal {
+            fn drop(&mut self) {
+                let _ = self.0.take().unwrap().send(());
+            }
+        }
+        let mut subscription = app
+            .search_users_with_seeds(
+                params(&account.account_id_hex, "needle", (1, 2)),
+                async move {
+                    let _guard = DropSignal(Some(dropped_tx));
+                    let _ = seed_started_tx.send(());
+                    std::future::pending::<Result<Vec<String>, AppError>>().await
+                },
+            )
+            .await
+            .unwrap();
+        let update = timeout(Duration::from_secs(5), subscription.next_update())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(update.trigger, SearchUpdateTrigger::CachedResultsFound);
+        assert_eq!(update.new_results[0].account_id_hex, peer);
+        assert!(!update.new_results[0].is_followed_by_searcher);
+        timeout(Duration::from_secs(5), seed_started_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        drop(subscription);
+        timeout(Duration::from_secs(5), dropped_rx)
+            .await
+            .unwrap()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn provider_results_stream_before_graph_and_later_provenance_replaces_them() {
+        let (tx, mut rx) = mpsc::channel(8);
+        let mut emitter = SearchEmitter::new(tx.clone());
+        let mut graph_emitter = emitter.fork();
+        let mut provider_emitter = emitter.fork();
+        let id = "11".repeat(32);
+        let graph_id = id.clone();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let task = tokio::spawn(async move {
+            drive_search_sources(
+                tx,
+                async move {
+                    release_rx.await.unwrap();
+                    graph_emitter.remember_graph_accounts(1, std::slice::from_ref(&graph_id));
+                    graph_emitter
+                        .emit_matches(1, vec![record_named(&graph_id, "needle")], "needle")
+                        .await;
+                    Ok(())
+                },
+                async move {
+                    provider_emitter
+                        .emit_ranked_matches(
+                            vec![RankedDirectoryRecord {
+                                record: record_named(&id, "needle"),
+                                rank: 0.75,
+                            }],
+                            "needle",
+                        )
+                        .await;
+                },
+            )
+            .await
+        });
+        let first = timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(first.trigger, SearchUpdateTrigger::DiscoveryResultsFound);
+        assert_eq!(first.new_results.len(), 1);
+        assert_eq!(first.new_results[0].radius, OFF_GRAPH_SEARCH_RADIUS);
+        assert_eq!(first.new_results[0].provider_rank, Some(0.75));
+        assert!(
+            !task.is_finished(),
+            "graph is still blocked while provider results are visible"
+        );
+        release_tx.send(()).unwrap();
+        let next = timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(next.new_results.is_empty());
+        assert_eq!(next.updated_results.len(), 1);
+        assert_eq!(next.updated_results[0].radius, 1);
+        assert_eq!(next.updated_results[0].provider_rank, None);
+        assert!(
+            !next.updated_results[0].is_followed_by_searcher,
+            "group proximity is not a follow"
+        );
+        assert_eq!(next.total_result_count, 1);
+        task.await.unwrap().unwrap().unwrap();
+        emitter.remember_follows(&[first.new_results[0].account_id_hex.clone()]);
+        emitter
+            .emit(SearchUpdateTrigger::RadiusCompleted { radius: 1 })
+            .await;
+        let followed = rx.recv().await.unwrap();
+        assert!(followed.new_results.is_empty());
+        assert!(followed.updated_results[0].is_followed_by_searcher);
+        assert_eq!(followed.total_result_count, 1);
     }
 
     #[tokio::test]
@@ -1396,8 +1804,8 @@ mod tests {
                 .map(|update| update.trigger.clone())
                 .collect::<Vec<_>>(),
             vec![
+                SearchUpdateTrigger::CachedResultsFound,
                 SearchUpdateTrigger::RadiusStarted { radius: 0 },
-                SearchUpdateTrigger::ResultsFound { radius: 0 },
                 SearchUpdateTrigger::RadiusCompleted { radius: 0 },
                 SearchUpdateTrigger::SearchCompleted,
             ]
@@ -1623,7 +2031,8 @@ mod tests {
 
         let matched = updates
             .iter()
-            .flat_map(|update| &update.new_results)
+            .rev()
+            .flat_map(|update| update.updated_results.iter().chain(&update.new_results))
             .find(|result| result.account_id_hex == stranger)
             .expect("a follow-of-a-follow must be reachable at radius 2");
         assert_eq!(matched.radius, 2);
@@ -2033,8 +2442,8 @@ mod tests {
         );
     }
 
-    /// The seed is a last resort, not a supplement. Someone with a real graph
-    /// must never have a stranger's network folded into their results.
+    /// Cached profiles remain searchable, but the fallback graph is traversed
+    /// only when the searcher's own graph is empty.
     #[tokio::test]
     async fn a_searcher_with_follows_never_reaches_the_fallback_seed() {
         let dir = tempfile::tempdir().unwrap();
@@ -2089,12 +2498,28 @@ mod tests {
             .unwrap();
         let updates = drain(subscription).await;
 
+        let cached = updates
+            .iter()
+            .find(|update| update.trigger == SearchUpdateTrigger::CachedResultsFound)
+            .unwrap();
+        let result = cached
+            .new_results
+            .iter()
+            .find(|result| result.account_id_hex == seeded_stranger)
+            .unwrap();
+        assert_eq!(
+            result.radius, OFF_GRAPH_SEARCH_RADIUS,
+            "public cache is searchable without adopting the seed's graph"
+        );
+        assert!(!result.is_followed_by_searcher);
         assert!(
-            !updates
-                .iter()
-                .flat_map(|update| &update.new_results)
-                .any(|result| result.account_id_hex == seeded_stranger),
-            "a searcher with their own graph must not be given a stranger's"
+            updates.iter().all(|update| !matches!(
+                update.trigger,
+                SearchUpdateTrigger::RadiusStarted {
+                    radius: OFF_GRAPH_SEARCH_RADIUS
+                }
+            )),
+            "a searcher with follows must not traverse the fallback seed"
         );
     }
 
@@ -2301,6 +2726,7 @@ mod tests {
     fn a_batch_ranks_match_quality_before_matched_field() {
         let mut results = vec![
             UserDirectorySearchResult {
+                is_followed_by_searcher: false,
                 account_id_hex: format!("{:064x}", 1),
                 npub: "npub-contains-name".into(),
                 radius: 1,
@@ -2310,6 +2736,7 @@ mod tests {
                 profile: None,
             },
             UserDirectorySearchResult {
+                is_followed_by_searcher: false,
                 account_id_hex: format!("{:064x}", 2),
                 npub: "npub-exact-about".into(),
                 radius: 1,
@@ -2319,6 +2746,7 @@ mod tests {
                 profile: None,
             },
             UserDirectorySearchResult {
+                is_followed_by_searcher: false,
                 account_id_hex: format!("{:064x}", 3),
                 npub: "npub-exact-name".into(),
                 radius: 1,
@@ -2344,6 +2772,7 @@ mod tests {
     fn discovery_results_preserve_provider_rank() {
         let mut results = vec![
             UserDirectorySearchResult {
+                is_followed_by_searcher: false,
                 account_id_hex: format!("{:064x}", 4),
                 npub: "npub-lower-provider-rank".into(),
                 radius: OFF_GRAPH_SEARCH_RADIUS,
@@ -2353,6 +2782,7 @@ mod tests {
                 profile: None,
             },
             UserDirectorySearchResult {
+                is_followed_by_searcher: false,
                 account_id_hex: format!("{:064x}", 5),
                 npub: "npub-higher-provider-rank".into(),
                 radius: OFF_GRAPH_SEARCH_RADIUS,

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -1784,6 +1784,27 @@ impl MarmotAppRuntime {
             .await
     }
 
+    /// Stream cached public matches and provider discovery immediately, resolving
+    /// group co-members only on the independent graph-enrichment path.
+    pub async fn search_users(
+        &self,
+        params: crate::UserSearchParams,
+    ) -> Result<crate::UserSearchSubscription, AppError> {
+        let runtime = self.clone();
+        let searcher = params.searcher_account_id_hex.clone();
+        let include_groups = params.radius_end >= 1;
+        self.accounts
+            .app
+            .search_users_with_seeds(params, async move {
+                if include_groups {
+                    runtime.group_co_members(&searcher).await
+                } else {
+                    Ok(Vec::new())
+                }
+            })
+            .await
+    }
+
     /// Accounts the searcher currently shares a group with.
     ///
     /// Feeds [`UserSearchParams::radius_one_seeds`]: sharing a group is social

--- a/crates/marmot-c/CHANGELOG.md
+++ b/crates/marmot-c/CHANGELOG.md
@@ -7,6 +7,18 @@ Versions track the workspace version; releases are tagged `marmotc-v<version>`.
 
 ## [Unreleased]
 
+### Added
+
+- `marmot_search_cached_users`, `MarmotUserDirectorySearchResultList`, and
+  `marmot_user_directory_search_result_list_free` for network-free public cache search across connected accounts.
+
+### Changed
+
+- Search results include `is_followed_by_searcher`; streaming updates include keyed `updated_results` replacements
+  and a `CachedResultsFound` trigger. Consumers must merge by account ID, including across radius pages, and use
+  the explicit follow flag instead of radius 1 for badges. C consumers must rebuild against the matching generated
+  header and library because both search-result and search-update struct layouts changed.
+
 ## [0.9.20] - 2026-09-08
 
 ### Added

--- a/crates/marmot-c/include/marmot.h
+++ b/crates/marmot-c/include/marmot.h
@@ -448,6 +448,27 @@ typedef enum MarmotAccountSetupReadiness {
 } MarmotAccountSetupReadiness;
 
 /**
+ * Which profile field the query matched.
+ */
+typedef enum MarmotMatchedField {
+  MARMOT_MATCHED_FIELD_NAME,
+  MARMOT_MATCHED_FIELD_NIP05,
+  MARMOT_MATCHED_FIELD_DISPLAY_NAME,
+  MARMOT_MATCHED_FIELD_ABOUT,
+  MARMOT_MATCHED_FIELD_NPUB,
+  MARMOT_MATCHED_FIELD_PUBKEY,
+} MarmotMatchedField;
+
+/**
+ * How closely a result matched the query.
+ */
+typedef enum MarmotMatchQuality {
+  MARMOT_MATCH_QUALITY_EXACT,
+  MARMOT_MATCH_QUALITY_PREFIX,
+  MARMOT_MATCH_QUALITY_CONTAINS,
+} MarmotMatchQuality;
+
+/**
  * Where a prepared group image sits in the upload lifecycle.
  */
 typedef enum MarmotPreparedGroupImageUploadState {
@@ -633,27 +654,6 @@ typedef enum MarmotChatListUpdateTrigger {
   MARMOT_CHAT_LIST_UPDATE_TRIGGER_SNAPSHOT_REFRESH,
   MARMOT_CHAT_LIST_UPDATE_TRIGGER_REMOVED,
 } MarmotChatListUpdateTrigger;
-
-/**
- * Which profile field the query matched.
- */
-typedef enum MarmotMatchedField {
-  MARMOT_MATCHED_FIELD_NAME,
-  MARMOT_MATCHED_FIELD_NIP05,
-  MARMOT_MATCHED_FIELD_DISPLAY_NAME,
-  MARMOT_MATCHED_FIELD_ABOUT,
-  MARMOT_MATCHED_FIELD_NPUB,
-  MARMOT_MATCHED_FIELD_PUBKEY,
-} MarmotMatchedField;
-
-/**
- * How closely a result matched the query.
- */
-typedef enum MarmotMatchQuality {
-  MARMOT_MATCH_QUALITY_EXACT,
-  MARMOT_MATCH_QUALITY_PREFIX,
-  MARMOT_MATCH_QUALITY_CONTAINS,
-} MarmotMatchQuality;
 
 /**
  * What woke the background collection.
@@ -2273,6 +2273,35 @@ typedef struct MarmotExistingDirectConversation {
   bool archived;
   uint64_t activity_sort_at;
 } MarmotExistingDirectConversation;
+
+/**
+ * One search hit, with typed attribution for why it matched.
+ */
+typedef struct MarmotUserDirectorySearchResult {
+  char *account_id_hex;
+  char *npub;
+  /**
+   * Social distance from the searching account.
+   */
+  uint8_t radius;
+  bool is_followed_by_searcher;
+  enum MarmotMatchedField matched_field;
+  enum MarmotMatchQuality match_quality;
+  bool has_provider_rank;
+  /**
+   *Only meaningful when the matching `has_` flag is set.
+   */
+  double provider_rank;
+  struct MarmotUserProfileMetadata *profile;
+} MarmotUserDirectorySearchResult;
+
+/**
+ *Owned list; free the root with its `_free` function only.
+ */
+typedef struct MarmotUserDirectorySearchResultList {
+  struct MarmotUserDirectorySearchResult *items;
+  uintptr_t len;
+} MarmotUserDirectorySearchResultList;
 
 /**
  * What the local directory cache knows about one requested id.
@@ -3906,6 +3935,7 @@ typedef enum MarmotSearchUpdateTrigger_Tag {
    */
   MARMOT_SEARCH_UPDATE_TRIGGER_SEARCH_COMPLETED,
   MARMOT_SEARCH_UPDATE_TRIGGER_ERROR,
+  MARMOT_SEARCH_UPDATE_TRIGGER_CACHED_RESULTS_FOUND,
 } MarmotSearchUpdateTrigger_Tag;
 
 typedef struct MarmotSearchUpdateTrigger_RadiusStarted_Body {
@@ -3945,26 +3975,6 @@ typedef struct MarmotSearchUpdateTrigger {
 } MarmotSearchUpdateTrigger;
 
 /**
- * One search hit, with typed attribution for why it matched.
- */
-typedef struct MarmotUserDirectorySearchResult {
-  char *account_id_hex;
-  char *npub;
-  /**
-   * Social distance from the searching account.
-   */
-  uint8_t radius;
-  enum MarmotMatchedField matched_field;
-  enum MarmotMatchQuality match_quality;
-  bool has_provider_rank;
-  /**
-   *Only meaningful when the matching `has_` flag is set.
-   */
-  double provider_rank;
-  struct MarmotUserProfileMetadata *profile;
-} MarmotUserDirectorySearchResult;
-
-/**
  * One step of a running user search. Free with
  * `marmot_user_search_update_free`.
  */
@@ -3975,6 +3985,8 @@ typedef struct MarmotUserSearchUpdate {
    */
   struct MarmotUserDirectorySearchResult *new_results;
   uintptr_t new_results_len;
+  struct MarmotUserDirectorySearchResult *updated_results;
+  uintptr_t updated_results_len;
   uint32_t total_result_count;
 } MarmotUserSearchUpdate;
 
@@ -5992,6 +6004,23 @@ MarmotStatus marmot_existing_direct_conversation(const struct MarmotClient *clie
                                                  const char *account_ref,
                                                  const char *peer_account_id,
                                                  struct MarmotExistingDirectConversation **out);
+
+/**
+ * Search public identities cached through any connected account. Follow
+ * flags refer to the selected account. Call off the UI thread and free with
+ * `marmot_user_directory_search_result_list_free`.
+ *
+ * # Safety
+ * `client` must be a live handle; string arguments must be valid
+ * NUL-terminated strings (nullable ones may be NULL); array
+ * arguments must hold their stated length (or be NULL with
+ * length 0); out-pointers must be valid.
+ */
+MarmotStatus marmot_search_cached_users(const struct MarmotClient *client,
+                                        const char *account_id_hex,
+                                        const char *query,
+                                        uint32_t limit,
+                                        struct MarmotUserDirectorySearchResultList **out);
 
 /**
  * What the local directory cache holds for each requested id, one
@@ -8061,6 +8090,15 @@ void marmot_cached_identity_projection_free(struct MarmotCachedIdentityProjectio
  * library.
  */
 void marmot_cached_identity_projection_list_free(struct MarmotCachedIdentityProjectionList *list);
+
+/**
+ * Free a list returned by this library. NULL is a no-op.
+ *
+ * # Safety
+ * `list` must be NULL or an unfreed pointer returned by this
+ * library.
+ */
+void marmot_user_directory_search_result_list_free(struct MarmotUserDirectorySearchResultList *list);
 
 /**
  * Free a value of this type returned by this library. NULL

--- a/crates/marmot-c/src/commands.rs
+++ b/crates/marmot-c/src/commands.rs
@@ -39,6 +39,7 @@ use crate::types::chat_list::{
 };
 use crate::types::common::{MarmotMessageTag, MarmotStringArray, MarmotStringList};
 use crate::types::directory::MarmotCachedIdentityProjectionList;
+use crate::types::directory::MarmotUserDirectorySearchResultList;
 use crate::types::draft::MarmotMessageDraftAttachmentInput;
 use crate::types::draft::{MarmotMessageDraft, MarmotMessageDraftSummaryList};
 use crate::types::group::{
@@ -1010,6 +1011,11 @@ c_cmd! {
     /// before opening it. Free with
     /// `marmot_existing_direct_conversation_free`.
     async fn marmot_existing_direct_conversation(account_ref: str, peer_account_id: str) -> opt_rec(MarmotExistingDirectConversation) = existing_direct_conversation;
+
+    /// Search public identities cached through any connected account. Follow
+    /// flags refer to the selected account. Call off the UI thread and free with
+    /// `marmot_user_directory_search_result_list_free`.
+    sync fn marmot_search_cached_users(account_id_hex: str, query: str, limit: val u32) -> rec(MarmotUserDirectorySearchResultList) = search_cached_users;
 
     /// What the local directory cache holds for each requested id, one
     /// row per request in order. Free with

--- a/crates/marmot-c/src/types/directory.rs
+++ b/crates/marmot-c/src/types/directory.rs
@@ -48,11 +48,13 @@ c_enum! {
 
 c_mirror! {
     /// One search hit, with typed attribution for why it matched.
-    MarmotUserDirectorySearchResult from UserDirectorySearchResultFfi {
+    MarmotUserDirectorySearchResult from UserDirectorySearchResultFfi,
+    list(MarmotUserDirectorySearchResultList, marmot_user_directory_search_result_list_free) {
         str account_id_hex,
         str npub,
         /// Social distance from the searching account.
         copy radius: u8,
+        copy is_followed_by_searcher: bool,
         copy matched_field: MarmotMatchedField,
         copy match_quality: MarmotMatchQuality,
         opt_copy has_provider_rank/provider_rank: f64,
@@ -84,6 +86,7 @@ pub enum MarmotSearchUpdateTrigger {
     Error {
         message: *mut ::std::ffi::c_char,
     },
+    CachedResultsFound,
 }
 
 impl From<SearchUpdateTriggerFfi> for MarmotSearchUpdateTrigger {
@@ -92,6 +95,7 @@ impl From<SearchUpdateTriggerFfi> for MarmotSearchUpdateTrigger {
             SearchUpdateTriggerFfi::RadiusStarted { radius } => Self::RadiusStarted { radius },
             SearchUpdateTriggerFfi::ResultsFound { radius } => Self::ResultsFound { radius },
             SearchUpdateTriggerFfi::DiscoveryResultsFound => Self::DiscoveryResultsFound,
+            SearchUpdateTriggerFfi::CachedResultsFound => Self::CachedResultsFound,
             SearchUpdateTriggerFfi::RadiusCompleted { radius } => Self::RadiusCompleted { radius },
             SearchUpdateTriggerFfi::RadiusTimeout { radius } => Self::RadiusTimeout { radius },
             SearchUpdateTriggerFfi::RadiusTruncated { radius } => Self::RadiusTruncated { radius },
@@ -119,6 +123,46 @@ c_mirror! {
         rec trigger: MarmotSearchUpdateTrigger,
         /// Hits discovered since the previous update, not the full set.
         vec new_results/new_results_len: MarmotUserDirectorySearchResult,
+        vec updated_results/updated_results_len: MarmotUserDirectorySearchResult,
         copy total_result_count: u32,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn search_replacements_preserve_follow_attribution_and_free_all_rows() {
+        let _guard = crate::memory::audit::test_lock();
+        #[cfg(feature = "alloc-audit")]
+        let before = crate::memory::audit::live_allocations();
+        let result = UserDirectorySearchResultFfi {
+            account_id_hex: "11".repeat(32),
+            npub: "npub1test".into(),
+            radius: 1,
+            is_followed_by_searcher: true,
+            matched_field: MatchedFieldFfi::Name,
+            match_quality: MatchQualityFfi::Exact,
+            provider_rank: None,
+            profile: Some(marmot_uniffi::conversions::UserProfileMetadataFfi {
+                name: Some("needle".into()),
+                ..Default::default()
+            }),
+        };
+        let mut update = MarmotUserSearchUpdate::from(UserSearchUpdateFfi {
+            trigger: SearchUpdateTriggerFfi::CachedResultsFound,
+            new_results: vec![result.clone()],
+            updated_results: vec![result],
+            total_result_count: 1,
+        });
+        assert_eq!(update.new_results_len, 1);
+        assert_eq!(update.updated_results_len, 1);
+        unsafe {
+            assert!((*update.updated_results).is_followed_by_searcher);
+            update.free_in_place();
+        }
+        #[cfg(feature = "alloc-audit")]
+        assert_eq!(crate::memory::audit::live_allocations(), before);
     }
 }

--- a/crates/marmot-uniffi/src/commands/directory.rs
+++ b/crates/marmot-uniffi/src/commands/directory.rs
@@ -144,29 +144,33 @@ impl Marmot {
             .into())
     }
 
-    /// Search the searcher's web of trust, streaming matches as each radius
-    /// resolves.
+    /// Search public identities cached through any connected account, without
+    /// network or group-membership work. Follow flags refer only to the selected
+    /// searcher. Call off the UI thread; zero limit returns no rows.
+    pub fn search_cached_users(
+        &self,
+        account_id_hex: String,
+        query: String,
+        limit: u32,
+    ) -> Result<Vec<conversions::UserDirectorySearchResultFfi>, MarmotKitError> {
+        Ok(self
+            .app
+            .search_cached_users(&account_id_hex, &query, limit as usize)?
+            .into_iter()
+            .map(Into::into)
+            .collect())
+    }
+
+    /// Stream cached public identities across accounts, then independent provider
+    /// and graph results. The radius window bounds known social distances;
+    /// cached/provider identities without a known distance remain discoverable.
     ///
-    /// `radius_start`/`radius_end` are inclusive social distances: 0 is the
-    /// searcher, 1 their direct follows. Lower radii are still traversed to
-    /// reach the window, they just do not emit — which is what makes
-    /// `radius_start` usable for paging further out without re-delivering
-    /// results the host already has.
-    ///
-    /// Returns as soon as the traversal is spawned; drive
-    /// [`UserSearchSubscription::next_update`] in a loop until it yields
-    /// `None`. Dropping the subscription cancels the traversal, so a host that
-    /// abandons a search should release it rather than draining it.
-    ///
-    /// Radius 1 covers more than the follow list: people sharing a group with
-    /// the searcher are seeded into it, because sharing a group is social
-    /// proximity even when neither has followed the other. That membership is
-    /// gathered here, where both the app and the runtime are in scope, rather
-    /// than inside the search — hosts pass nothing extra for it.
-    ///
-    /// People found this way are deliberately *not* added to the local
-    /// directory: a search result is not a relationship. `user_profile` keeps
-    /// answering only for accounts the user has actually interacted with.
+    /// Returns without waiting for group membership. Consume until completion,
+    /// inserting `new_results` and replacing `updated_results` by account id.
+    /// Release the subscription on query/account changes to cancel its work.
+    /// Direct-follow labels use `is_followed_by_searcher`, not radius 1 (which
+    /// also includes group co-members). Search never promotes strangers into
+    /// the directory's live subscription set.
     pub async fn search_users(
         &self,
         account_id_hex: String,
@@ -174,22 +178,14 @@ impl Marmot {
         radius_start: u8,
         radius_end: u8,
     ) -> Result<Arc<UserSearchSubscription>, MarmotKitError> {
-        // Seeds are radius 1 by definition, so a window that stops at radius 0
-        // cannot use them -- and gathering them costs a membership read per
-        // group. Ask only when the answer can matter.
-        let radius_one_seeds = if radius_end >= 1 {
-            self.runtime.group_co_members(&account_id_hex).await?
-        } else {
-            Vec::new()
-        };
         let inner = self
-            .app
+            .runtime
             .search_users(UserSearchParams {
                 searcher_account_id_hex: account_id_hex,
                 query,
                 radius_start,
                 radius_end,
-                radius_one_seeds,
+                radius_one_seeds: Vec::new(),
             })
             .await?;
         Ok(UserSearchSubscription::new(inner))
@@ -480,6 +476,13 @@ mod tests {
         )
         .await
         .expect("publish profile");
+
+        let cached = kit
+            .search_cached_users(account_id_hex.clone(), "needle".into(), 20)
+            .unwrap();
+        assert_eq!(cached.len(), 1);
+        assert_eq!(cached[0].account_id_hex, account_id_hex);
+        assert!(!cached[0].is_followed_by_searcher);
 
         let subscription = kit
             .search_users(account_id_hex.clone(), "needle".to_owned(), 0, 0)

--- a/crates/marmot-uniffi/src/commands/directory.rs
+++ b/crates/marmot-uniffi/src/commands/directory.rs
@@ -164,6 +164,8 @@ impl Marmot {
     /// Stream cached public identities across accounts, then independent provider
     /// and graph results. The radius window bounds known social distances;
     /// cached/provider identities without a known distance remain discoverable.
+    /// Those identities can recur when paging radii: deduplicate by account id
+    /// across pages as well as within each subscription.
     ///
     /// Returns without waiting for group membership. Consume until completion,
     /// inserting `new_results` and replacing `updated_results` by account id.

--- a/crates/marmot-uniffi/src/conversions/directory_search.rs
+++ b/crates/marmot-uniffi/src/conversions/directory_search.rs
@@ -55,18 +55,18 @@ impl From<MatchedField> for MatchedFieldFfi {
 
 /// One person the search found.
 ///
-/// `radius` is social distance from the searcher: 0 is the searcher, 1 a
-/// direct follow. Render it as provenance ("via someone you follow").
-///
-/// `255` is the exception and means *off-graph*: this person came from a
-/// configured fallback or a discovery provider rather than through anyone the user
-/// knows. Present those as discovery, never as a connection -- they are not a
-/// distance from the user at all.
+/// `is_followed_by_searcher` is the direct-follow label for the selected account.
+/// Radius 1 can also mean a shared group; it must not be used as a follow flag.
+/// Radius 255 means no relationship has been established for this result yet;
+/// a later update may supply a graph radius. Cached public profiles can come
+/// from any connected account without inheriting that account's relationships.
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct UserDirectorySearchResultFfi {
     pub account_id_hex: String,
     pub npub: String,
     pub radius: u8,
+    /// Direct follow of the selected searcher; radius 1 alone is insufficient.
+    pub is_followed_by_searcher: bool,
     pub matched_field: MatchedFieldFfi,
     pub match_quality: MatchQualityFfi,
     /// Rank supplied by an off-graph discovery provider.
@@ -80,6 +80,7 @@ impl From<UserDirectorySearchResult> for UserDirectorySearchResultFfi {
             account_id_hex: value.account_id_hex,
             npub: value.npub,
             radius: value.radius,
+            is_followed_by_searcher: value.is_followed_by_searcher,
             matched_field: value.matched_field.into(),
             match_quality: value.match_quality.into(),
             provider_rank: value.provider_rank,
@@ -101,6 +102,7 @@ pub enum SearchUpdateTriggerFfi {
     /// Results from the optional off-graph discovery tier. Each result still
     /// carries its own graph or discovery provenance.
     DiscoveryResultsFound,
+    CachedResultsFound,
     RadiusCompleted {
         radius: u8,
     },
@@ -129,6 +131,7 @@ impl From<SearchUpdateTrigger> for SearchUpdateTriggerFfi {
             SearchUpdateTrigger::RadiusStarted { radius } => Self::RadiusStarted { radius },
             SearchUpdateTrigger::ResultsFound { radius } => Self::ResultsFound { radius },
             SearchUpdateTrigger::DiscoveryResultsFound => Self::DiscoveryResultsFound,
+            SearchUpdateTrigger::CachedResultsFound => Self::CachedResultsFound,
             SearchUpdateTrigger::RadiusCompleted { radius } => Self::RadiusCompleted { radius },
             SearchUpdateTrigger::RadiusTimeout { radius } => Self::RadiusTimeout { radius },
             SearchUpdateTrigger::RadiusTruncated { radius } => Self::RadiusTruncated { radius },
@@ -142,12 +145,13 @@ impl From<SearchUpdateTrigger> for SearchUpdateTriggerFfi {
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct UserSearchUpdateFfi {
     pub trigger: SearchUpdateTriggerFfi,
-    /// Matches found by this step, pre-sorted within the batch. Ordering
-    /// *across* graph updates is radius order; an optional discovery batch
-    /// follows graph traversal and may contain results retaining graph
-    /// provenance. A host rendering one flat list should re-sort the aggregate.
+    /// New identities, sorted within this batch. Cache, provider, and graph
+    /// sources arrive independently. Merge by account id and re-sort after
+    /// applying `updated_results` as replacements.
     pub new_results: Vec<UserDirectorySearchResultFfi>,
-    /// Running total this search has emitted so far, including `new_results`.
+    /// Replace existing rows with these values, matching by account id.
+    pub updated_results: Vec<UserDirectorySearchResultFfi>,
+    /// Unique person count; replacements do not increment it.
     pub total_result_count: u32,
 }
 
@@ -156,6 +160,7 @@ impl From<UserSearchUpdate> for UserSearchUpdateFfi {
         Self {
             trigger: value.trigger.into(),
             new_results: value.new_results.into_iter().map(Into::into).collect(),
+            updated_results: value.updated_results.into_iter().map(Into::into).collect(),
             total_result_count: saturating_u32(value.total_result_count),
         }
     }
@@ -174,6 +179,7 @@ mod tests {
         let update = UserSearchUpdate {
             trigger: SearchUpdateTrigger::ResultsFound { radius: 1 },
             new_results: vec![UserDirectorySearchResult {
+                is_followed_by_searcher: false,
                 account_id_hex: "aa".repeat(32),
                 npub: "npub1example".to_owned(),
                 radius: 1,
@@ -182,9 +188,15 @@ mod tests {
                 provider_rank: Some(0.75),
                 profile: None,
             }],
+            updated_results: Vec::new(),
             total_result_count: 1,
         };
 
+        let mut replacement = update.new_results[0].clone();
+        replacement.is_followed_by_searcher = true;
+        replacement.provider_rank = None;
+        let mut update = update;
+        update.updated_results.push(replacement);
         let ffi = UserSearchUpdateFfi::from(update);
 
         assert!(matches!(
@@ -193,6 +205,10 @@ mod tests {
         ));
         assert_eq!(ffi.total_result_count, 1);
         assert_eq!(ffi.new_results.len(), 1);
+        assert_eq!(ffi.updated_results.len(), 1);
+        assert!(ffi.updated_results[0].is_followed_by_searcher);
+        assert_eq!(ffi.updated_results[0].provider_rank, None);
+
         assert_eq!(ffi.new_results[0].provider_rank, Some(0.75));
         assert!(matches!(
             ffi.new_results[0].matched_field,
@@ -209,6 +225,7 @@ mod tests {
         let ffi = UserSearchUpdateFfi::from(UserSearchUpdate {
             trigger: SearchUpdateTrigger::SearchCompleted,
             new_results: Vec::new(),
+            updated_results: Vec::new(),
             total_result_count: 3,
         });
 

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -62,9 +62,9 @@ pub use prepared_group_image_upload::{
     PreparedGroupImageUploadState,
 };
 pub use shared::{
-    DirectoryPresentation, DirectoryPresentationChanges, PublicDirectoryUserRecord,
-    SqliteSharedStorage, StoredAuditLogSettings, StoredRelayTelemetrySettings,
-    StoredUsageDiagnosticsSettings,
+    DirectoryPresentation, DirectoryPresentationChanges, PublicDirectoryProfileRecord,
+    PublicDirectoryUserRecord, SqliteSharedStorage, StoredAuditLogSettings,
+    StoredRelayTelemetrySettings, StoredUsageDiagnosticsSettings,
 };
 pub use storage::messages::MessageFormatPromotionProgress;
 #[cfg(feature = "storage-format-benchmarks")]

--- a/crates/storage-sqlite/src/shared.rs
+++ b/crates/storage-sqlite/src/shared.rs
@@ -53,6 +53,15 @@ pub struct PublicDirectoryUserRecord {
     pub follows: Vec<String>,
 }
 
+/// Public identity/profile projection for search; excludes follows, relay lists,
+/// key packages, and event provenance that search does not consume.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PublicDirectoryProfileRecord {
+    pub account_id_hex: String,
+    pub npub: String,
+    pub profile_json: Option<String>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StoredRelayTelemetrySettings {
     pub export_enabled: bool,
@@ -298,6 +307,29 @@ impl SqliteSharedStorage {
 
     pub fn public_directory_users(&self) -> StorageResult<Vec<PublicDirectoryUserRecord>> {
         self.public_directory_users_capped(PUBLIC_DIRECTORY_USERS_MAX)
+    }
+
+    /// Read only searchable public identity/profile fields, with the same
+    /// defensive identity cap as `public_directory_users`. No follow-edge join.
+    pub fn public_directory_profiles(&self) -> StorageResult<Vec<PublicDirectoryProfileRecord>> {
+        let conn = self.lock()?;
+        let mut statement = conn
+            .prepare_cached(
+                "SELECT account_id_hex, npub, profile_json FROM directory_users
+                 ORDER BY account_id_hex LIMIT ?1",
+            )
+            .storage()?;
+        statement
+            .query_map([PUBLIC_DIRECTORY_USERS_MAX as i64], |row| {
+                Ok(PublicDirectoryProfileRecord {
+                    account_id_hex: row.get(0)?,
+                    npub: row.get(1)?,
+                    profile_json: row.get(2)?,
+                })
+            })
+            .storage()?
+            .map(|row| row.storage())
+            .collect()
     }
 
     fn public_directory_users_capped(
@@ -680,6 +712,36 @@ mod tests {
             .unwrap();
         assert_eq!(stored.npub, record.npub);
         assert_eq!(stored.follows, vec![follow]);
+    }
+
+    #[test]
+    fn public_directory_profiles_do_not_read_follow_edges_or_unrelated_json() {
+        let storage = SqliteSharedStorage::in_memory().unwrap();
+        let record = PublicDirectoryUserRecord {
+            account_id_hex: "aa".repeat(32),
+            npub: "npub1test".into(),
+            profile_json: Some(r#"{"name":"Alice"}"#.into()),
+            relay_lists_json: "not parsed by profile projection".into(),
+            key_package_json: Some("also not parsed".into()),
+            event_id_hex: None,
+            event_kind: None,
+            event_created_at: None,
+            follows: vec!["bb".repeat(32)],
+        };
+        storage.put_public_directory_user(&record).unwrap();
+        storage
+            .lock()
+            .unwrap()
+            .execute_batch("DROP TABLE directory_user_follows")
+            .unwrap();
+        assert_eq!(
+            storage.public_directory_profiles().unwrap(),
+            vec![PublicDirectoryProfileRecord {
+                account_id_hex: record.account_id_hex,
+                npub: record.npub,
+                profile_json: record.profile_json,
+            }]
+        );
     }
 
     // #761: the batched listing is defensively bounded. The uncapped path still


### PR DESCRIPTION
Cached people could wait behind group-membership reads, and fast Vertex results were held until the follow-graph traversal finished. This change returns matching public profiles from all connected accounts first, then streams Vertex discovery and graph enrichment independently.

- Add a cache-only search API across account caches and the shared public directory, including unpromoted search profiles intentionally shared across accounts. Local materialization is capped at 10,000 distinct identities per account cache and 10,000 returned cache results; above those bounds, local results can be partial. Private labels do not participate; `is_followed_by_searcher` refers only to the selected account.
- Deliver cached results before membership reads, hydrate Vertex results without waiting for the graph, and cancel both network sources when the consumer drops the subscription.
- Emit `updated_results` as replacements keyed by account ID when provenance or profile data improves. Counts remain unique, and the CLI merges replacements.
- Expose the contract through UniFFI and C, regenerate the C header, and add aggregate stage timings without query or identity logging. Search profiles remain outside live directory subscriptions.

### Client integration

This PR contains the MDK work. iOS still needs refreshed bindings, a cache-only call off the UI thread on each query change, separately debounced network searches, and keyed replacement handling with query/account stale-result guards. Follow badges must use the explicit flag because radius 1 also includes group co-members. The FFI record changes require matching regenerated bindings; no version bump or release is included.

### Validation

- `just fast-ci`
- App directory tests: 125 passed, including cross-account cache coverage, stale cross-account follow isolation, bounded materialization, self-first ordering, cached Vertex enrichment, explicit empty-follow refresh, recoverable membership failure, blocked-membership independence, provider-before-graph delivery, replacements, and cancellation.
- Shared-storage tests (45), UniFFI directory tests (9), and CLI user-command tests (6) passed. Shared cache search uses a profile-only projection, excluding follow edges and unrelated JSON.
- Full C tests with `alloc-audit` passed; generated header and C smoke passed for shared and static linkage.
- Generated Swift bindings compiled and passed a native host round-trip for the new search fields. Generated Android Kotlin bindings compiled. No iOS or Android device validation is claimed.

One parallel app-directory run encountered two SQLCipher initialization failures in migration tests. Both a serial rerun and a subsequent parallel rerun passed; the intermittent failure was not diagnosed or changed in this PR.
