### PR TITLE
Fix nightly image catalogue dependency

### DIFF
--- a/Dockerfile.convergence-campaign
+++ b/Dockerfile.convergence-campaign
@@ -7,6 +7,7 @@ COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY .cargo ./.cargo
 COPY crates ./crates
 COPY integrations ./integrations
+COPY docs/marmot-architecture/product-event-catalogue.json ./docs/marmot-architecture/
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/workspace/target \


### PR DESCRIPTION
The simulator nightly image build fails because `marmot-app` embeds the
product event catalogue at compile time, but the builder never copies it.
Copy the catalogue into the expected path before compiling the campaign
binaries.

Closes #1770.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Included the product event catalogue in the convergence campaign container image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->