### PR TITLE
Parse structured Markdown details and summary disclosures

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -18,8 +18,9 @@ versioning through the workspace version in the root `Cargo.toml`.
 ### Fixed
 
 - Failed `<details>` candidates now keep a completed `<summary>` in the display
-  tree, multiline summaries can span more than two lines, and summary recognition
-  stays linear inside the documented scan window.
+  tree, restore ordinary block structure and source gaps on fallback, preserve
+  hard breaks and cross-line code spans in multiline summaries, and keep
+  summary recognition linear for many short continuation lines.
 
 ### Changed
 

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -15,6 +15,12 @@ versioning through the workspace version in the root `Cargo.toml`.
   `<details>` / `<summary>` lines, including UniFFI and C display trees. Hosts
   must regenerate bindings to render the new variant.
 
+### Fixed
+
+- Failed `<details>` candidates now keep a completed `<summary>` in the display
+  tree, multiline summaries can span more than two lines, and summary recognition
+  stays linear inside the documented scan window.
+
 ### Changed
 
 - User search includes cached public identities from every connected account and delivers Vertex matches without

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,12 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+### Added
+
+- App-message Markdown now emits a structured `Details` block for structural
+  `<details>` / `<summary>` lines, including UniFFI and C display trees. Hosts
+  must regenerate bindings to render the new variant.
+
 ### Changed
 
 - User search includes cached public identities from every connected account and delivers Vertex matches without

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -20,7 +20,9 @@ versioning through the workspace version in the root `Cargo.toml`.
 - Failed `<details>` candidates now keep a completed `<summary>` in the display
   tree, restore ordinary block structure and source gaps on fallback, preserve
   hard breaks and cross-line code spans in multiline summaries, and keep
-  summary recognition linear for many short continuation lines.
+  summary recognition linear for many short continuation lines. An open
+  summary code span now also keeps interior `</summary>` / `</details>` lines
+  literal until the matching backticks close.
 
 ### Changed
 

--- a/crates/marmot-app/src/messages/intents.rs
+++ b/crates/marmot-app/src/messages/intents.rs
@@ -109,6 +109,12 @@ fn collect_block_mention_hexes(block: &marmot_markdown::Block, out: &mut Vec<Str
         }
         // Code blocks, math blocks, and thematic breaks carry no inline
         // mentions.
+        Block::Details { summary, body, .. } => {
+            collect_inline_mention_hexes(summary, out);
+            for block in body {
+                collect_block_mention_hexes(block, out);
+            }
+        }
         Block::ThematicBreak | Block::CodeBlock { .. } | Block::MathBlock { .. } => {}
     }
 }
@@ -817,6 +823,36 @@ mod mention_tests {
         let capped = markdown_mention_scan_input(&input);
         assert_eq!(capped, "a".repeat(MAX_MARKDOWN_MENTION_SCAN_BYTES - 1));
         assert!(capped.is_char_boundary(capped.len()));
+    }
+
+    #[test]
+    fn mention_p_tags_walk_details_summary_and_body() {
+        let hex = valid_pubkey_hex();
+        let npub = npub_for_account_id(&hex).unwrap();
+        let closed = format!("<details>\n<summary>hi @{npub}</summary>\nalso @{npub}\n</details>");
+        let opened =
+            format!("<details open>\n<summary>hi @{npub}</summary>\nalso @{npub}\n</details>");
+        assert_eq!(
+            mention_p_tags(&closed),
+            vec![vec!["p".to_owned(), hex.clone()]]
+        );
+        assert_eq!(
+            mention_p_tags(&opened),
+            vec![vec!["p".to_owned(), hex.clone()]]
+        );
+        let nested = format!(
+            "<details>\n<summary>outer</summary>\n<details>\n<summary>@{npub}</summary>\n</details>\n</details>"
+        );
+        assert_eq!(
+            mention_p_tags(&nested),
+            vec![vec!["p".to_owned(), hex.clone()]]
+        );
+        let in_code =
+            format!("<details>\n<summary>`@{npub}`</summary>\n```\n@{npub}\n```\n</details>");
+        assert!(mention_p_tags(&in_code).is_empty());
+        let ignored_attr =
+            format!("<details title=\"@{npub}\">\n<summary>plain</summary>\nbody\n</details>");
+        assert!(mention_p_tags(&ignored_attr).is_empty());
     }
 
     #[test]

--- a/crates/marmot-app/src/messages/intents.rs
+++ b/crates/marmot-app/src/messages/intents.rs
@@ -871,6 +871,9 @@ mod mention_tests {
             "<details>\n    code\n<summary>@{summary_npub}</summary>\n@{body_npub}\n</details>"
         );
         assert_eq!(mention_p_tags(&later), expected);
+        let heading_fallback =
+            format!("<details>\n<summary>@{summary_npub}\n# heading\n\n@{body_npub}\n</details>");
+        assert_eq!(mention_p_tags(&heading_fallback), expected);
     }
 
     #[test]

--- a/crates/marmot-app/src/messages/intents.rs
+++ b/crates/marmot-app/src/messages/intents.rs
@@ -827,32 +827,50 @@ mod mention_tests {
 
     #[test]
     fn mention_p_tags_walk_details_summary_and_body() {
-        let hex = valid_pubkey_hex();
-        let npub = npub_for_account_id(&hex).unwrap();
-        let closed = format!("<details>\n<summary>hi @{npub}</summary>\nalso @{npub}\n</details>");
-        let opened =
-            format!("<details open>\n<summary>hi @{npub}</summary>\nalso @{npub}\n</details>");
-        assert_eq!(
-            mention_p_tags(&closed),
-            vec![vec!["p".to_owned(), hex.clone()]]
+        let summary_hex = valid_pubkey_hex();
+        let body_hex = valid_pubkey_hex();
+        let summary_npub = npub_for_account_id(&summary_hex).unwrap();
+        let body_npub = npub_for_account_id(&body_hex).unwrap();
+        let closed = format!(
+            "<details>\n<summary>hi @{summary_npub}</summary>\nalso @{body_npub}\n</details>"
         );
-        assert_eq!(
-            mention_p_tags(&opened),
-            vec![vec!["p".to_owned(), hex.clone()]]
+        let opened = format!(
+            "<details open>\n<summary>hi @{summary_npub}</summary>\nalso @{body_npub}\n</details>"
         );
+        let expected = vec![
+            vec!["p".to_owned(), summary_hex.clone()],
+            vec!["p".to_owned(), body_hex.clone()],
+        ];
+        assert_eq!(mention_p_tags(&closed), expected);
+        assert_eq!(mention_p_tags(&opened), expected);
         let nested = format!(
-            "<details>\n<summary>outer</summary>\n<details>\n<summary>@{npub}</summary>\n</details>\n</details>"
+            "<details>\n<summary>outer</summary>\n<details>\n<summary>@{summary_npub}</summary>\n@{body_npub}\n</details>\n</details>"
+        );
+        assert_eq!(mention_p_tags(&nested), expected);
+        let in_code = format!(
+            "<details>\n<summary>`@{summary_npub}`</summary>\n```\n@{body_npub}\n```\n</details>"
+        );
+        assert!(mention_p_tags(&in_code).is_empty());
+        let ignored_attr = format!(
+            "<details title=\"@{summary_npub}\">\n<summary>plain</summary>\nbody\n</details>"
+        );
+        assert!(mention_p_tags(&ignored_attr).is_empty());
+        let duplicate = format!(
+            "<details>\n<summary>@{summary_npub}</summary>\nagain @{summary_npub}\n</details>"
         );
         assert_eq!(
-            mention_p_tags(&nested),
-            vec![vec!["p".to_owned(), hex.clone()]]
+            mention_p_tags(&duplicate),
+            vec![vec!["p".to_owned(), summary_hex.clone()]]
         );
-        let in_code =
-            format!("<details>\n<summary>`@{npub}`</summary>\n```\n@{npub}\n```\n</details>");
-        assert!(mention_p_tags(&in_code).is_empty());
-        let ignored_attr =
-            format!("<details title=\"@{npub}\">\n<summary>plain</summary>\nbody\n</details>");
-        assert!(mention_p_tags(&ignored_attr).is_empty());
+        let fallback = format!("<details>\n<summary>hi @{summary_npub}</summary>\nbody");
+        assert_eq!(
+            mention_p_tags(&fallback),
+            vec![vec!["p".to_owned(), summary_hex.clone()]]
+        );
+        let later = format!(
+            "<details>\n    code\n<summary>@{summary_npub}</summary>\n@{body_npub}\n</details>"
+        );
+        assert_eq!(mention_p_tags(&later), expected);
     }
 
     #[test]

--- a/crates/marmot-c/CHANGELOG.md
+++ b/crates/marmot-c/CHANGELOG.md
@@ -9,6 +9,10 @@ Versions track the workspace version; releases are tagged `marmotc-v<version>`.
 
 ### Added
 
+- Additive `MarmotMarkdownBlock::Details` with an indirect `MarmotMarkdownDetails`
+  payload for bounded `<details>` / `<summary>` display blocks. Existing block
+  discriminants and union stride are unchanged; C consumers must regenerate
+  compatible bindings to render the new tag.
 - `marmot_search_cached_users`, `MarmotUserDirectorySearchResultList`, and
   `marmot_user_directory_search_result_list_free` for network-free public cache search across connected accounts.
 

--- a/crates/marmot-c/README.md
+++ b/crates/marmot-c/README.md
@@ -54,6 +54,11 @@ int main(void) {
 }
 ```
 
+`MarmotMarkdownBlock` appends an additive `Details` tag whose fields live
+behind `MarmotMarkdownDetails`. Existing discriminants and union stride stay
+the same; regenerate `marmot.h` and consumer bindings to handle the new tag.
+Older clients cannot render it.
+
 `examples/smoke.c` is a worked example covering lifecycle, Markdown
 tagged-union walking, offline reads, the error taxonomy, and best-effort
 identity creation. `./crates/marmot-c/c-smoke.sh` builds and runs it

--- a/crates/marmot-c/examples/smoke.c
+++ b/crates/marmot-c/examples/smoke.c
@@ -84,6 +84,11 @@ static int walk_markdown(const struct MarmotMarkdownDocument *doc) {
             printf("smoke:   block %zu: list with %zu items\n", i,
                    b->LIST_BLOCK.items_len);
             break;
+        case MARMOT_MARKDOWN_BLOCK_DETAILS:
+            printf("smoke:   block %zu: details (open=%d body=%zu)\n", i,
+                   b->DETAILS.details ? (int)b->DETAILS.details->open : -1,
+                   b->DETAILS.details ? b->DETAILS.details->body_len : 0);
+            break;
         default:
             printf("smoke:   block %zu: other (tag %d)\n", i, (int)b->tag);
             break;
@@ -169,6 +174,22 @@ int main(int argc, char **argv) {
     check(doc->blocks_len >= 4, "markdown has heading + paragraph + list + code");
     int headings = walk_markdown(doc);
     check(headings == 1, "walked tree found the heading");
+    marmot_markdown_document_free(doc);
+
+    doc = NULL;
+    st = marmot_parse_markdown(client,
+                               "<details>\n<summary>More</summary>\nHidden **bold**\n</details>",
+                               &doc);
+    check(st == MARMOT_STATUS_OK && doc != NULL, "details markdown parsed");
+    if (doc == NULL) {
+        return 1;
+    }
+    check(doc->blocks_len == 1, "details is a single top-level block");
+    check(doc->blocks[0].tag == MARMOT_MARKDOWN_BLOCK_DETAILS, "details tag");
+    check(doc->blocks[0].DETAILS.details != NULL, "details payload");
+    check(!doc->blocks[0].DETAILS.details->open, "details default closed");
+    check(doc->blocks[0].DETAILS.details->summary_len == 1, "details summary");
+    check(doc->blocks[0].DETAILS.details->body_len == 1, "details body");
     marmot_markdown_document_free(doc);
 
     /* ---- offline reads ------------------------------------------------ */

--- a/crates/marmot-c/include/marmot.h
+++ b/crates/marmot-c/include/marmot.h
@@ -1821,6 +1821,20 @@ typedef struct MarmotMarkdownTableRow {
 } MarmotMarkdownTableRow;
 
 /**
+ * Owned payload for [`MarmotMarkdownBlock::Details`]. Indirection keeps the
+ * existing tagged-union size and discriminants unchanged.
+ */
+typedef struct MarmotMarkdownDetails {
+  struct MarmotMarkdownInline *summary;
+  uintptr_t summary_len;
+  bool open;
+  struct MarmotMarkdownBlock *body;
+  uintptr_t body_len;
+  uint8_t *blank_lines_before;
+  uintptr_t blank_lines_before_len;
+} MarmotMarkdownDetails;
+
+/**
  * One block-level Markdown node.
  */
 typedef enum MarmotMarkdownBlock_Tag {
@@ -1832,6 +1846,7 @@ typedef enum MarmotMarkdownBlock_Tag {
   MARMOT_MARKDOWN_BLOCK_LIST_BLOCK,
   MARMOT_MARKDOWN_BLOCK_TABLE,
   MARMOT_MARKDOWN_BLOCK_MATH_BLOCK,
+  MARMOT_MARKDOWN_BLOCK_DETAILS,
 } MarmotMarkdownBlock_Tag;
 
 typedef struct MarmotMarkdownBlock_Paragraph_Body {
@@ -1881,6 +1896,10 @@ typedef struct MarmotMarkdownBlock_MathBlock_Body {
   char *content;
 } MarmotMarkdownBlock_MathBlock_Body;
 
+typedef struct MarmotMarkdownBlock_Details_Body {
+  struct MarmotMarkdownDetails *details;
+} MarmotMarkdownBlock_Details_Body;
+
 typedef struct MarmotMarkdownBlock {
   MarmotMarkdownBlock_Tag tag;
   union {
@@ -1891,6 +1910,7 @@ typedef struct MarmotMarkdownBlock {
     MarmotMarkdownBlock_ListBlock_Body LIST_BLOCK;
     MarmotMarkdownBlock_Table_Body TABLE;
     MarmotMarkdownBlock_MathBlock_Body MATH_BLOCK;
+    MarmotMarkdownBlock_Details_Body DETAILS;
   };
 } MarmotMarkdownBlock;
 

--- a/crates/marmot-c/src/types/markdown.rs
+++ b/crates/marmot-c/src/types/markdown.rs
@@ -16,7 +16,8 @@ use marmot_uniffi::{
 
 use crate::macros::{c_enum, c_mirror};
 use crate::memory::{
-    CFree, free_c_string, free_vec, owned_c_string, owned_opt_c_string, owned_vec,
+    CFree, boxed, free_boxed, free_c_string, free_vec, owned_c_string, owned_opt_c_string,
+    owned_vec,
 };
 
 c_enum! {
@@ -414,6 +415,22 @@ pub enum MarmotMarkdownBlock {
     MathBlock {
         content: *mut c_char,
     },
+    Details {
+        details: *mut MarmotMarkdownDetails,
+    },
+}
+
+/// Owned payload for [`MarmotMarkdownBlock::Details`]. Indirection keeps the
+/// existing tagged-union size and discriminants unchanged.
+#[repr(C)]
+pub struct MarmotMarkdownDetails {
+    pub summary: *mut MarmotMarkdownInline,
+    pub summary_len: usize,
+    pub open: bool,
+    pub body: *mut MarmotMarkdownBlock,
+    pub body_len: usize,
+    pub blank_lines_before: *mut u8,
+    pub blank_lines_before_len: usize,
 }
 
 fn block_vec(blocks: Vec<MarkdownBlockFfi>) -> (*mut MarmotMarkdownBlock, usize) {
@@ -491,6 +508,27 @@ impl From<MarkdownBlockFfi> for MarmotMarkdownBlock {
             MarkdownBlockFfi::MathBlock { content } => Self::MathBlock {
                 content: owned_c_string(content),
             },
+            MarkdownBlockFfi::Details {
+                summary,
+                open,
+                body,
+                blank_lines_before,
+            } => {
+                let (summary, summary_len) = inline_vec(summary);
+                let (body, body_len) = block_vec(body);
+                let (blank_lines_before, blank_lines_before_len) = owned_vec(blank_lines_before);
+                Self::Details {
+                    details: boxed(MarmotMarkdownDetails {
+                        summary,
+                        summary_len,
+                        open,
+                        body,
+                        body_len,
+                        blank_lines_before,
+                        blank_lines_before_len,
+                    }),
+                }
+            }
         }
     }
 }
@@ -544,7 +582,18 @@ impl CFree for MarmotMarkdownBlock {
                     free_vec(*rows, *rows_len);
                 }
                 Self::MathBlock { content } => free_c_string(*content),
+                Self::Details { details } => free_boxed(*details),
             }
+        }
+    }
+}
+
+impl CFree for MarmotMarkdownDetails {
+    unsafe fn free_in_place(&mut self) {
+        unsafe {
+            free_vec(self.summary, self.summary_len);
+            free_vec(self.body, self.body_len);
+            free_vec(self.blank_lines_before, self.blank_lines_before_len);
         }
     }
 }
@@ -632,6 +681,82 @@ mod tests {
 
         let mirror: MarmotMarkdownDocument = doc.into();
         assert_eq!(mirror.blocks_len, 3);
+        let root = boxed(mirror);
+        unsafe { marmot_markdown_document_free(root) };
+
+        #[cfg(feature = "alloc-audit")]
+        assert_eq!(crate::memory::audit::live_allocations(), start);
+    }
+
+    #[test]
+    fn details_payload_is_indirect_and_existing_tags_stay_stable() {
+        assert_eq!(std::mem::size_of::<MarmotMarkdownBlock>(), 56);
+        assert_eq!(std::mem::align_of::<MarmotMarkdownBlock>(), 8);
+        let paragraph = MarmotMarkdownBlock::Paragraph {
+            inlines: std::ptr::null_mut(),
+            inlines_len: 0,
+        };
+        let heading = MarmotMarkdownBlock::Heading {
+            level: 1,
+            inlines: std::ptr::null_mut(),
+            inlines_len: 0,
+        };
+        let math = MarmotMarkdownBlock::MathBlock {
+            content: std::ptr::null_mut(),
+        };
+        assert_eq!(block_tag(&paragraph), 0);
+        assert_eq!(block_tag(&heading), 1);
+        assert_eq!(block_tag(&MarmotMarkdownBlock::ThematicBreak), 2);
+        assert_eq!(block_tag(&math), 7);
+        let details = MarmotMarkdownBlock::Details {
+            details: std::ptr::null_mut(),
+        };
+        assert_eq!(block_tag(&details), 8);
+        assert_eq!(
+            std::mem::size_of_val(&[paragraph, heading, math, details]),
+            56 * 4
+        );
+    }
+
+    fn block_tag(block: &MarmotMarkdownBlock) -> u32 {
+        unsafe { *(block as *const MarmotMarkdownBlock as *const u32) }
+    }
+
+    #[test]
+    fn details_nested_empty_roundtrip_returns_to_baseline() {
+        let _guard = crate::memory::audit::test_lock();
+        #[cfg(feature = "alloc-audit")]
+        let start = crate::memory::audit::live_allocations();
+
+        let doc = MarkdownDocumentFfi {
+            blocks: vec![MarkdownBlockFfi::Details {
+                summary: vec![],
+                open: true,
+                body: vec![MarkdownBlockFfi::Details {
+                    summary: vec![MarkdownInlineFfi::Text {
+                        content: "inner".into(),
+                    }],
+                    open: false,
+                    body: vec![],
+                    blank_lines_before: vec![],
+                }],
+                blank_lines_before: vec![0],
+            }],
+            truncated: false,
+            blank_lines_before: vec![0],
+        };
+        let mirror: MarmotMarkdownDocument = doc.into();
+        assert_eq!(mirror.blocks_len, 1);
+        unsafe {
+            match &*mirror.blocks {
+                MarmotMarkdownBlock::Details { details } => {
+                    assert!(!details.is_null());
+                    assert!((**details).open);
+                    assert_eq!((**details).body_len, 1);
+                }
+                other => panic!("expected details, got tag {}", block_tag(other)),
+            }
+        }
         let root = boxed(mirror);
         unsafe { marmot_markdown_document_free(root) };
 

--- a/crates/marmot-markdown/README.md
+++ b/crates/marmot-markdown/README.md
@@ -58,7 +58,9 @@ This is a block-oriented extension, not a general HTML parser:
   Markdown and do not swallow following siblings.
 - Recognition is limited to a 65536-byte original-source prefix and a 4096-byte
   structural tag cap (inclusive of `<` through `>`). Each details block consumes
-  one existing container-depth slot.
+  one existing container-depth slot. Recognition work is linear in that capped
+  prefix: backtick runs are indexed once per candidate so unmatched openers do
+  not rescan the same suffix.
 - Body blank-line counts align with `body` and saturate at
   `MAX_SOURCE_BLANK_LINES`. Delimiter-only lines are not blocks. Blanks before
   the closer stay inside the disclosure.

--- a/crates/marmot-markdown/README.md
+++ b/crates/marmot-markdown/README.md
@@ -60,9 +60,10 @@ This is a block-oriented extension, not a general HTML parser:
   structural tag cap (inclusive of `<` through `>`). Each details block consumes
   one existing container-depth slot. Recognition work is linear in that capped
   prefix: each continuation line is scanned once with carried code-span state,
-  and unmatched backtick runs are never rescanned. Failed candidates restore
-  ordinary block structure and source gaps instead of collapsing to one
-  paragraph.
+  and unmatched backtick runs are never rescanned. An open summary code span
+  keeps interior `</summary>` and `</details>` lines as content until a
+  matching run closes it. Failed candidates restore ordinary block structure
+  and source gaps instead of collapsing to one paragraph.
 - Body blank-line counts align with `body` and saturate at
   `MAX_SOURCE_BLANK_LINES`. Delimiter-only lines are not blocks. Blanks before
   the closer stay inside the disclosure.

--- a/crates/marmot-markdown/README.md
+++ b/crates/marmot-markdown/README.md
@@ -59,8 +59,10 @@ This is a block-oriented extension, not a general HTML parser:
 - Recognition is limited to a 65536-byte original-source prefix and a 4096-byte
   structural tag cap (inclusive of `<` through `>`). Each details block consumes
   one existing container-depth slot. Recognition work is linear in that capped
-  prefix: backtick runs are indexed once per candidate so unmatched openers do
-  not rescan the same suffix.
+  prefix: each continuation line is scanned once with carried code-span state,
+  and unmatched backtick runs are never rescanned. Failed candidates restore
+  ordinary block structure and source gaps instead of collapsing to one
+  paragraph.
 - Body blank-line counts align with `body` and saturate at
   `MAX_SOURCE_BLANK_LINES`. Delimiter-only lines are not blocks. Blanks before
   the closer stay inside the disclosure.

--- a/crates/marmot-markdown/README.md
+++ b/crates/marmot-markdown/README.md
@@ -35,6 +35,34 @@ destination or link text when policy keeps it inert.
 - No CGKA engine, storage, transport, or runtime state.
 - No UniFFI surface of its own (bindings expose parsed output through `marmot-app` / `marmot-uniffi` as needed).
 
+## Bounded details/summary disclosures
+
+The parser recognizes structural `<details>` / `<summary>` lines as `Block::Details`.
+This is a block-oriented extension, not a general HTML parser:
+
+- The opening `<details ...>` and closing `</details>` each occupy their own
+  logical line after quote/list prefixes and at most three columns of local
+  indent. Surrounding horizontal whitespace is allowed. Compact one-line HTML
+  such as `<details><summary>x</summary>y</details>` stays literal text.
+- An optional first nonblank `<summary ...>...</summary>` child is inline-parsed
+  (formatting, entities, links, and Nostr mentions). Missing or empty summaries
+  yield `summary: []`; clients may supply a localized fallback label. A later
+  summary is ordinary body text. A malformed initial summary falls back to
+  ordinary Markdown instead of dropping text.
+- The `open` attribute means expanded even when written `open="false"`. Other
+  attributes are ignored and never tokenized as destinations. Styles, scripts,
+  event handlers, and URLs are not rendering instructions.
+- Recognition uses original source before entity decoding. Escaped
+  (`\<details>`, `&lt;details&gt;`), inline-code, fenced/indented code, and math
+  forms stay literal. Failed or unclosed candidates keep their tags as ordinary
+  Markdown and do not swallow following siblings.
+- Recognition is limited to a 65536-byte original-source prefix and a 4096-byte
+  structural tag cap (inclusive of `<` through `>`). Each details block consumes
+  one existing container-depth slot.
+- Body blank-line counts align with `body` and saturate at
+  `MAX_SOURCE_BLANK_LINES`. Delimiter-only lines are not blocks. Blanks before
+  the closer stay inside the disclosure.
+
 Golden fixtures under `tests/golden/` lock parser output for regression coverage.
 
 ## Run the tests

--- a/crates/marmot-markdown/src/ast.rs
+++ b/crates/marmot-markdown/src/ast.rs
@@ -48,6 +48,14 @@ pub enum Block {
     MathBlock {
         content: String,
     },
+    Details {
+        summary: Vec<Inline>,
+        open: bool,
+        body: Vec<Block>,
+        /// Blank source lines before each corresponding body block.
+        #[serde(default)]
+        blank_lines_before: Vec<u8>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/marmot-markdown/src/block.rs
+++ b/crates/marmot-markdown/src/block.rs
@@ -12,7 +12,7 @@
 use std::collections::HashMap;
 
 use crate::ast::{Alignment, Block, CodeBlockKind, Inline, ListItem, ListKind, TableCell};
-use crate::details::{self, SummaryLine};
+use crate::details::{self, SummaryContinue, SummaryLine};
 use crate::scanner;
 
 pub(crate) const MAX_CONTAINER_DEPTH: usize = 96;
@@ -69,6 +69,9 @@ enum Container {
         blank_lines_before: Vec<u8>,
         leading_blank_lines: u8,
         summary_inner: Option<String>,
+        /// Original summary source lines with tags, retained until commit so
+        /// fallback can restore them in source order.
+        summary_raw: Option<String>,
         summary_state: SummaryState,
         failed: bool,
     },
@@ -77,22 +80,28 @@ enum Container {
 #[derive(Debug)]
 enum SummaryState {
     AwaitingFirstNonblank,
-    AwaitingClose {
+    Collecting {
         after_open: String,
-        held_line: String,
+        raw_lines: Vec<String>,
     },
     Done,
 }
 
 enum SummaryAction {
     MarkDone,
-    Complete(String),
+    Complete {
+        inner: String,
+        raw: String,
+    },
     Hold {
         after_open: String,
-        held_line: String,
+        raw_lines: Vec<String>,
     },
     FailAndContinue,
-    FailReplay(String),
+    FailReplay {
+        raw_lines: Vec<String>,
+        consume: bool,
+    },
 }
 
 #[derive(Debug)]
@@ -291,7 +300,7 @@ impl BlockParser {
                     if self.try_close_details(rest_str, probe_off) {
                         return;
                     }
-                    if self.try_accept_summary_line(rest_str) {
+                    if self.try_accept_summary_line(rest_str, probe_off) {
                         return;
                     }
                     if self.try_open_details(rest_str, probe_off) {
@@ -436,6 +445,11 @@ impl BlockParser {
             // continuation. If a paragraph is open, this is lazy paragraph
             // continuation (handled below as a paragraph append).
             if sub_col >= 4 && !matches!(self.leaf, Some(Leaf::Paragraph(_))) {
+                let rest = std::str::from_utf8(&bytes[off..]).unwrap_or("");
+                if self.details_is_collecting_summary() && self.try_accept_summary_line(rest, off) {
+                    return;
+                }
+                self.end_summary_eligibility();
                 // Append to existing indented code or open a new one.
                 let stripped = indented_strip(line, off);
                 if let Some(Leaf::IndentedCode {
@@ -1028,10 +1042,14 @@ impl BlockParser {
     }
 
     fn try_open_details(&mut self, rest: &str, probe_off: usize) -> bool {
+        let tag_start_abs = self.line_start + probe_off;
+        if tag_start_abs >= self.details_window {
+            return false;
+        }
         let Some(open) = details::parse_details_opener_line(rest) else {
             return false;
         };
-        let tag_end_abs = self.line_start + probe_off + open.tag_end;
+        let tag_end_abs = tag_start_abs + open.tag_end;
         if tag_end_abs > self.details_window {
             return false;
         }
@@ -1048,46 +1066,146 @@ impl BlockParser {
             blank_lines_before: Vec::new(),
             leading_blank_lines,
             summary_inner: None,
+            summary_raw: None,
             summary_state: SummaryState::AwaitingFirstNonblank,
             failed: false,
         });
         true
     }
 
-    fn try_accept_summary_line(&mut self, rest: &str) -> bool {
+    fn details_is_collecting_summary(&self) -> bool {
+        matches!(
+            self.containers.last(),
+            Some(Container::Details {
+                summary_state: SummaryState::Collecting { .. },
+                ..
+            })
+        )
+    }
+
+    fn end_summary_eligibility(&mut self) {
+        if let Some(Container::Details {
+            summary_state: state @ SummaryState::AwaitingFirstNonblank,
+            ..
+        }) = self.containers.last_mut()
+        {
+            *state = SummaryState::Done;
+        }
+    }
+
+    fn summary_scan_budget(&self, probe_off: usize) -> usize {
+        self.details_window
+            .saturating_sub(self.line_start.saturating_add(probe_off))
+    }
+
+    fn line_extends_past_window(&self, probe_off: usize, rest: &str) -> bool {
+        self.line_start
+            .saturating_add(probe_off)
+            .saturating_add(rest.len())
+            > self.details_window
+    }
+
+    fn try_accept_summary_line(&mut self, rest: &str, probe_off: usize) -> bool {
+        let budget = self.summary_scan_budget(probe_off);
+        let extends_past = self.line_extends_past_window(probe_off, rest);
+        if budget == 0 {
+            return match self.containers.last() {
+                Some(Container::Details {
+                    summary_state: SummaryState::AwaitingFirstNonblank,
+                    ..
+                }) => {
+                    self.end_summary_eligibility();
+                    false
+                }
+                Some(Container::Details {
+                    summary_state: SummaryState::Collecting { raw_lines, .. },
+                    ..
+                }) => {
+                    let raw = raw_lines.clone();
+                    self.apply_summary_action(SummaryAction::FailReplay {
+                        raw_lines: raw,
+                        consume: false,
+                    })
+                }
+                _ => false,
+            };
+        }
         let action = match self.containers.last() {
             Some(Container::Details { summary_state, .. }) => match summary_state {
                 SummaryState::Done => return false,
-                SummaryState::AwaitingFirstNonblank => match details::parse_summary_line(rest) {
-                    SummaryLine::NotSummary => SummaryAction::MarkDone,
-                    SummaryLine::Complete { inner } => SummaryAction::Complete(inner),
-                    SummaryLine::OpenOnly { after_open } => SummaryAction::Hold {
-                        after_open,
-                        held_line: rest.trim_matches([' ', '\t']).to_string(),
-                    },
-                    SummaryLine::CloseOnly { .. } | SummaryLine::Malformed => {
-                        SummaryAction::FailAndContinue
-                    }
-                },
-                SummaryState::AwaitingClose {
-                    after_open,
-                    held_line,
-                } => match details::parse_summary_close_only(rest) {
-                    Some(before_close) => {
-                        let mut inner = after_open.clone();
-                        if !before_close.is_empty() {
-                            if !inner.is_empty() {
-                                inner.push('\n');
-                            }
-                            inner.push_str(&before_close);
+                SummaryState::AwaitingFirstNonblank => {
+                    match details::parse_summary_line_bounded(rest, budget) {
+                        SummaryLine::NotSummary => SummaryAction::MarkDone,
+                        SummaryLine::Complete { inner } => {
+                            let raw = rest.trim_matches([' ', '\t']).to_string();
+                            SummaryAction::Complete { inner, raw }
                         }
-                        SummaryAction::Complete(inner)
+                        SummaryLine::OpenOnly { after_open } => {
+                            if extends_past {
+                                SummaryAction::FailAndContinue
+                            } else {
+                                SummaryAction::Hold {
+                                    after_open,
+                                    raw_lines: vec![rest.trim_matches([' ', '\t']).to_string()],
+                                }
+                            }
+                        }
+                        SummaryLine::Malformed => SummaryAction::FailAndContinue,
                     }
-                    None => SummaryAction::FailReplay(held_line.clone()),
-                },
+                }
+                SummaryState::Collecting {
+                    after_open,
+                    raw_lines,
+                } => {
+                    let prefix = if after_open.is_empty() {
+                        0
+                    } else {
+                        after_open.len() + 1
+                    };
+                    let max_search = prefix.saturating_add(budget);
+                    match details::continue_summary_bounded(after_open, rest, max_search) {
+                        SummaryContinue::Complete { inner } => {
+                            let mut raw = raw_lines.clone();
+                            raw.push(rest.trim_matches([' ', '\t']).to_string());
+                            SummaryAction::Complete {
+                                inner,
+                                raw: raw.join("\n"),
+                            }
+                        }
+                        SummaryContinue::StillOpen { accumulated } => {
+                            if extends_past {
+                                let mut raw = raw_lines.clone();
+                                raw.push(rest.trim_matches([' ', '\t']).to_string());
+                                SummaryAction::FailReplay {
+                                    raw_lines: raw,
+                                    consume: true,
+                                }
+                            } else {
+                                let mut raw = raw_lines.clone();
+                                raw.push(rest.trim_matches([' ', '\t']).to_string());
+                                SummaryAction::Hold {
+                                    after_open: accumulated,
+                                    raw_lines: raw,
+                                }
+                            }
+                        }
+                        SummaryContinue::Malformed => {
+                            let mut raw = raw_lines.clone();
+                            raw.push(rest.trim_matches([' ', '\t']).to_string());
+                            SummaryAction::FailReplay {
+                                raw_lines: raw,
+                                consume: true,
+                            }
+                        }
+                    }
+                }
             },
             _ => return false,
         };
+        self.apply_summary_action(action)
+    }
+
+    fn apply_summary_action(&mut self, action: SummaryAction) -> bool {
         match action {
             SummaryAction::MarkDone => {
                 if let Some(Container::Details { summary_state, .. }) = self.containers.last_mut() {
@@ -1095,10 +1213,11 @@ impl BlockParser {
                 }
                 false
             }
-            SummaryAction::Complete(inner) => {
+            SummaryAction::Complete { inner, raw } => {
                 if let Some(Container::Details {
                     summary_state,
                     summary_inner,
+                    summary_raw,
                     ..
                 }) = self.containers.last_mut()
                 {
@@ -1107,6 +1226,7 @@ impl BlockParser {
                     } else {
                         Some(inner)
                     };
+                    *summary_raw = Some(raw);
                     *summary_state = SummaryState::Done;
                 }
                 self.clear_current_details_gap();
@@ -1114,12 +1234,12 @@ impl BlockParser {
             }
             SummaryAction::Hold {
                 after_open,
-                held_line,
+                raw_lines,
             } => {
                 if let Some(Container::Details { summary_state, .. }) = self.containers.last_mut() {
-                    *summary_state = SummaryState::AwaitingClose {
+                    *summary_state = SummaryState::Collecting {
                         after_open,
-                        held_line,
+                        raw_lines,
                     };
                 }
                 true
@@ -1136,7 +1256,7 @@ impl BlockParser {
                 }
                 false
             }
-            SummaryAction::FailReplay(held) => {
+            SummaryAction::FailReplay { raw_lines, consume } => {
                 if let Some(Container::Details {
                     summary_state,
                     failed,
@@ -1146,10 +1266,12 @@ impl BlockParser {
                     *failed = true;
                     *summary_state = SummaryState::Done;
                 }
-                self.push_new_block(Block::Paragraph {
-                    inlines: vec![Inline::Text(held)],
-                });
-                false
+                if !raw_lines.is_empty() {
+                    self.push_new_block(Block::Paragraph {
+                        inlines: vec![Inline::Text(raw_lines.join("\n"))],
+                    });
+                }
+                consume
             }
         }
     }
@@ -1157,9 +1279,9 @@ impl BlockParser {
     fn flush_held_summary_on_blank(&mut self) {
         let held = match self.containers.last() {
             Some(Container::Details {
-                summary_state: SummaryState::AwaitingClose { held_line, .. },
+                summary_state: SummaryState::Collecting { raw_lines, .. },
                 ..
-            }) => held_line.clone(),
+            }) => raw_lines.clone(),
             _ => return,
         };
         if let Some(Container::Details {
@@ -1171,9 +1293,11 @@ impl BlockParser {
             *failed = true;
             *summary_state = SummaryState::Done;
         }
-        self.push_new_block(Block::Paragraph {
-            inlines: vec![Inline::Text(held)],
-        });
+        if !held.is_empty() {
+            self.push_new_block(Block::Paragraph {
+                inlines: vec![Inline::Text(held.join("\n"))],
+            });
+        }
     }
 
     fn clear_current_details_gap(&mut self) {
@@ -1190,6 +1314,7 @@ impl BlockParser {
             mut blank_lines_before,
             leading_blank_lines,
             summary_inner,
+            mut summary_raw,
             summary_state,
             failed,
         } = c
@@ -1197,28 +1322,26 @@ impl BlockParser {
             unreachable!("finish_details requires Details");
         };
 
-        if let SummaryState::AwaitingClose { held_line, .. } = summary_state {
-            children.insert(
-                0,
-                Block::Paragraph {
-                    inlines: vec![Inline::Text(held_line)],
-                },
-            );
-            blank_lines_before.insert(0, 0);
-            return self.fallback_details(
-                opener_raw,
-                children,
-                blank_lines_before,
-                leading_blank_lines,
-                closer.map(|(raw, _)| raw),
-            );
+        let still_collecting = matches!(summary_state, SummaryState::Collecting { .. });
+        if let SummaryState::Collecting { raw_lines, .. } = summary_state {
+            summary_raw = Some(raw_lines.join("\n"));
         }
 
         let matched = !failed
+            && !still_collecting
             && closer
                 .as_ref()
                 .is_some_and(|(_, end)| *end <= self.details_window);
         if !matched {
+            if let Some(raw) = summary_raw.filter(|raw| !raw.is_empty()) {
+                children.insert(
+                    0,
+                    Block::Paragraph {
+                        inlines: vec![Inline::Text(raw)],
+                    },
+                );
+                blank_lines_before.insert(0, 0);
+            }
             return self.fallback_details(
                 opener_raw,
                 children,

--- a/crates/marmot-markdown/src/block.rs
+++ b/crates/marmot-markdown/src/block.rs
@@ -1061,7 +1061,7 @@ impl BlockParser {
             Some(Container::Details {
                 summary_state: SummaryState::Collecting { collector, .. },
                 ..
-            }) if collector.has_unmatched_openers() && !collector.has_deferred_closer()
+            }) if collector.has_unmatched_openers()
         )
     }
 

--- a/crates/marmot-markdown/src/block.rs
+++ b/crates/marmot-markdown/src/block.rs
@@ -70,8 +70,10 @@ enum Container {
         leading_blank_lines: u8,
         summary_inner: Option<String>,
         /// Original summary source lines with tags, retained until commit so
-        /// fallback can restore them in source order.
-        summary_raw: Option<String>,
+        /// fallback can restore ordinary block semantics.
+        summary_raw_lines: Vec<String>,
+        summary_replayed: bool,
+        pre_summary_gap: u8,
         summary_state: SummaryState,
         failed: bool,
     },
@@ -81,7 +83,7 @@ enum Container {
 enum SummaryState {
     AwaitingFirstNonblank,
     Collecting {
-        after_open: String,
+        collector: details::SummaryCollector,
         raw_lines: Vec<String>,
     },
     Done,
@@ -91,10 +93,11 @@ enum SummaryAction {
     MarkDone,
     Complete {
         inner: String,
-        raw: String,
+        raw_lines: Vec<String>,
+        leftover: Vec<String>,
     },
     Hold {
-        after_open: String,
+        collector: details::SummaryCollector,
         raw_lines: Vec<String>,
     },
     FailAndContinue,
@@ -1029,6 +1032,17 @@ impl BlockParser {
         if !self.details_is_current_parent() {
             return false;
         }
+        if self.summary_blocks_details_close() {
+            return false;
+        }
+        if let Some((inner, leftover)) = self.finalize_collecting_summary() {
+            let raw_lines = self.take_collecting_raw_lines();
+            self.apply_summary_action(SummaryAction::Complete {
+                inner,
+                raw_lines,
+                leftover,
+            });
+        }
         self.close_leaf();
         self.close_dangling_lists();
         let closer_end = self.line_start + probe_off + close.tag_end;
@@ -1039,6 +1053,36 @@ impl BlockParser {
             return true;
         }
         false
+    }
+
+    fn summary_blocks_details_close(&self) -> bool {
+        matches!(
+            self.containers.last(),
+            Some(Container::Details {
+                summary_state: SummaryState::Collecting { collector, .. },
+                ..
+            }) if collector.has_unmatched_openers() && !collector.has_deferred_closer()
+        )
+    }
+
+    fn finalize_collecting_summary(&self) -> Option<(String, Vec<String>)> {
+        match self.containers.last() {
+            Some(Container::Details {
+                summary_state: SummaryState::Collecting { collector, .. },
+                ..
+            }) => collector.finalize(),
+            _ => None,
+        }
+    }
+
+    fn take_collecting_raw_lines(&mut self) -> Vec<String> {
+        match self.containers.last_mut() {
+            Some(Container::Details {
+                summary_state: SummaryState::Collecting { raw_lines, .. },
+                ..
+            }) => std::mem::take(raw_lines),
+            _ => Vec::new(),
+        }
     }
 
     fn try_open_details(&mut self, rest: &str, probe_off: usize) -> bool {
@@ -1066,7 +1110,9 @@ impl BlockParser {
             blank_lines_before: Vec::new(),
             leading_blank_lines,
             summary_inner: None,
-            summary_raw: None,
+            summary_raw_lines: Vec::new(),
+            summary_replayed: false,
+            pre_summary_gap: 0,
             summary_state: SummaryState::AwaitingFirstNonblank,
             failed: false,
         });
@@ -1118,10 +1164,10 @@ impl BlockParser {
                     false
                 }
                 Some(Container::Details {
-                    summary_state: SummaryState::Collecting { raw_lines, .. },
+                    summary_state: SummaryState::Collecting { .. },
                     ..
                 }) => {
-                    let raw = raw_lines.clone();
+                    let raw = self.take_collecting_raw_lines();
                     self.apply_summary_action(SummaryAction::FailReplay {
                         raw_lines: raw,
                         consume: false,
@@ -1131,78 +1177,89 @@ impl BlockParser {
             };
         }
         let action = match self.containers.last() {
-            Some(Container::Details { summary_state, .. }) => match summary_state {
-                SummaryState::Done => return false,
-                SummaryState::AwaitingFirstNonblank => {
-                    match details::parse_summary_line_bounded(rest, budget) {
-                        SummaryLine::NotSummary => SummaryAction::MarkDone,
-                        SummaryLine::Complete { inner } => {
-                            let raw = rest.trim_matches([' ', '\t']).to_string();
-                            SummaryAction::Complete { inner, raw }
-                        }
-                        SummaryLine::OpenOnly { after_open } => {
-                            if extends_past {
-                                SummaryAction::FailAndContinue
-                            } else {
-                                SummaryAction::Hold {
-                                    after_open,
-                                    raw_lines: vec![rest.trim_matches([' ', '\t']).to_string()],
-                                }
-                            }
-                        }
-                        SummaryLine::Malformed => SummaryAction::FailAndContinue,
-                    }
-                }
-                SummaryState::Collecting {
-                    after_open,
-                    raw_lines,
-                } => {
-                    let prefix = if after_open.is_empty() {
-                        0
+            Some(Container::Details {
+                summary_state: SummaryState::Done,
+                ..
+            }) => return false,
+            Some(Container::Details {
+                summary_state: SummaryState::AwaitingFirstNonblank,
+                ..
+            }) => match details::parse_summary_line_bounded(rest, budget) {
+                SummaryLine::NotSummary => SummaryAction::MarkDone,
+                SummaryLine::Complete { inner } => SummaryAction::Complete {
+                    inner,
+                    raw_lines: vec![rest.to_string()],
+                    leftover: Vec::new(),
+                },
+                SummaryLine::OpenOnly { after_open } => {
+                    if extends_past {
+                        SummaryAction::FailAndContinue
                     } else {
-                        after_open.len() + 1
-                    };
-                    let max_search = prefix.saturating_add(budget);
-                    match details::continue_summary_bounded(after_open, rest, max_search) {
-                        SummaryContinue::Complete { inner } => {
-                            let mut raw = raw_lines.clone();
-                            raw.push(rest.trim_matches([' ', '\t']).to_string());
-                            SummaryAction::Complete {
-                                inner,
-                                raw: raw.join("\n"),
-                            }
-                        }
-                        SummaryContinue::StillOpen { accumulated } => {
-                            if extends_past {
-                                let mut raw = raw_lines.clone();
-                                raw.push(rest.trim_matches([' ', '\t']).to_string());
-                                SummaryAction::FailReplay {
-                                    raw_lines: raw,
-                                    consume: true,
-                                }
-                            } else {
-                                let mut raw = raw_lines.clone();
-                                raw.push(rest.trim_matches([' ', '\t']).to_string());
-                                SummaryAction::Hold {
-                                    after_open: accumulated,
-                                    raw_lines: raw,
-                                }
-                            }
-                        }
-                        SummaryContinue::Malformed => {
-                            let mut raw = raw_lines.clone();
-                            raw.push(rest.trim_matches([' ', '\t']).to_string());
-                            SummaryAction::FailReplay {
-                                raw_lines: raw,
-                                consume: true,
-                            }
+                        SummaryAction::Hold {
+                            collector: details::SummaryCollector::from_after_open(&after_open),
+                            raw_lines: vec![rest.to_string()],
                         }
                     }
                 }
+                SummaryLine::Malformed => SummaryAction::FailAndContinue,
             },
+            Some(Container::Details {
+                summary_state: SummaryState::Collecting { .. },
+                ..
+            }) => {
+                if extends_past {
+                    let raw = self.take_collecting_raw_lines();
+                    return self.apply_summary_action(SummaryAction::FailReplay {
+                        raw_lines: raw,
+                        consume: false,
+                    });
+                }
+                return self.continue_collecting_summary(rest, budget);
+            }
             _ => return false,
         };
         self.apply_summary_action(action)
+    }
+
+    fn continue_collecting_summary(&mut self, rest: &str, budget: usize) -> bool {
+        let outcome = match self.containers.last_mut() {
+            Some(Container::Details {
+                summary_state:
+                    SummaryState::Collecting {
+                        collector,
+                        raw_lines,
+                    },
+                ..
+            }) => {
+                let continue_result = collector.push_line(rest, budget);
+                match continue_result {
+                    SummaryContinue::Complete { inner } => {
+                        raw_lines.push(rest.to_string());
+                        Some(SummaryAction::Complete {
+                            inner,
+                            raw_lines: std::mem::take(raw_lines),
+                            leftover: Vec::new(),
+                        })
+                    }
+                    SummaryContinue::StillOpen => {
+                        raw_lines.push(rest.to_string());
+                        None
+                    }
+                    SummaryContinue::Malformed => {
+                        raw_lines.push(rest.to_string());
+                        Some(SummaryAction::FailReplay {
+                            raw_lines: std::mem::take(raw_lines),
+                            consume: true,
+                        })
+                    }
+                }
+            }
+            _ => return false,
+        };
+        match outcome {
+            Some(action) => self.apply_summary_action(action),
+            None => true,
+        }
     }
 
     fn apply_summary_action(&mut self, action: SummaryAction) -> bool {
@@ -1213,11 +1270,26 @@ impl BlockParser {
                 }
                 false
             }
-            SummaryAction::Complete { inner, raw } => {
+            SummaryAction::Complete {
+                inner,
+                raw_lines,
+                leftover,
+            } => {
+                let leftover_n = leftover.len();
+                let (summary_lines, leftover_raw) =
+                    if leftover_n > 0 && leftover_n <= raw_lines.len() {
+                        let split_at = raw_lines.len() - leftover_n;
+                        let leftover_raw = raw_lines[split_at..].to_vec();
+                        (raw_lines[..split_at].to_vec(), leftover_raw)
+                    } else {
+                        (raw_lines, leftover)
+                    };
+                let gap = self.current_details_gap();
                 if let Some(Container::Details {
                     summary_state,
                     summary_inner,
-                    summary_raw,
+                    summary_raw_lines,
+                    pre_summary_gap,
                     ..
                 }) = self.containers.last_mut()
                 {
@@ -1226,22 +1298,34 @@ impl BlockParser {
                     } else {
                         Some(inner)
                     };
-                    *summary_raw = Some(raw);
+                    *summary_raw_lines = summary_lines;
+                    *pre_summary_gap = gap;
                     *summary_state = SummaryState::Done;
                 }
                 self.clear_current_details_gap();
+                if !leftover_raw.is_empty() {
+                    self.replay_ordinary_lines(leftover_raw, 0);
+                }
                 true
             }
             SummaryAction::Hold {
-                after_open,
+                collector,
                 raw_lines,
             } => {
-                if let Some(Container::Details { summary_state, .. }) = self.containers.last_mut() {
+                let gap = self.current_details_gap();
+                if let Some(Container::Details {
+                    summary_state,
+                    pre_summary_gap,
+                    ..
+                }) = self.containers.last_mut()
+                {
+                    *pre_summary_gap = gap;
                     *summary_state = SummaryState::Collecting {
-                        after_open,
+                        collector,
                         raw_lines,
                     };
                 }
+                self.clear_current_details_gap();
                 true
             }
             SummaryAction::FailAndContinue => {
@@ -1257,26 +1341,52 @@ impl BlockParser {
                 false
             }
             SummaryAction::FailReplay { raw_lines, consume } => {
+                let gap = self.current_details_pre_gap();
                 if let Some(Container::Details {
                     summary_state,
                     failed,
+                    summary_replayed,
                     ..
                 }) = self.containers.last_mut()
                 {
                     *failed = true;
                     *summary_state = SummaryState::Done;
+                    *summary_replayed = true;
                 }
-                if !raw_lines.is_empty() {
-                    self.push_new_block(Block::Paragraph {
-                        inlines: vec![Inline::Text(raw_lines.join("\n"))],
-                    });
-                }
+                self.replay_ordinary_lines(raw_lines, gap);
                 consume
             }
         }
     }
 
+    fn current_details_gap(&self) -> u8 {
+        if matches!(self.containers.last(), Some(Container::Details { .. })) {
+            self.pending_source_gaps[self.containers.len()]
+        } else {
+            0
+        }
+    }
+
+    fn current_details_pre_gap(&self) -> u8 {
+        match self.containers.last() {
+            Some(Container::Details {
+                pre_summary_gap, ..
+            }) if *pre_summary_gap > 0 => *pre_summary_gap,
+            Some(Container::Details { .. }) => self.current_details_gap(),
+            _ => 0,
+        }
+    }
+
     fn flush_held_summary_on_blank(&mut self) {
+        if let Some((inner, leftover)) = self.finalize_collecting_summary() {
+            let raw_lines = self.take_collecting_raw_lines();
+            self.apply_summary_action(SummaryAction::Complete {
+                inner,
+                raw_lines,
+                leftover,
+            });
+            return;
+        }
         let held = match self.containers.last() {
             Some(Container::Details {
                 summary_state: SummaryState::Collecting { raw_lines, .. },
@@ -1284,20 +1394,10 @@ impl BlockParser {
             }) => raw_lines.clone(),
             _ => return,
         };
-        if let Some(Container::Details {
-            summary_state,
-            failed,
-            ..
-        }) = self.containers.last_mut()
-        {
-            *failed = true;
-            *summary_state = SummaryState::Done;
-        }
-        if !held.is_empty() {
-            self.push_new_block(Block::Paragraph {
-                inlines: vec![Inline::Text(held.join("\n"))],
-            });
-        }
+        self.apply_summary_action(SummaryAction::FailReplay {
+            raw_lines: held,
+            consume: true,
+        });
     }
 
     fn clear_current_details_gap(&mut self) {
@@ -1314,7 +1414,9 @@ impl BlockParser {
             mut blank_lines_before,
             leading_blank_lines,
             summary_inner,
-            mut summary_raw,
+            summary_raw_lines,
+            summary_replayed,
+            pre_summary_gap,
             summary_state,
             failed,
         } = c
@@ -1322,25 +1424,28 @@ impl BlockParser {
             unreachable!("finish_details requires Details");
         };
 
-        let still_collecting = matches!(summary_state, SummaryState::Collecting { .. });
-        if let SummaryState::Collecting { raw_lines, .. } = summary_state {
-            summary_raw = Some(raw_lines.join("\n"));
-        }
+        let (still_collecting, collecting_raw, finalized) = match summary_state {
+            SummaryState::Collecting {
+                collector,
+                raw_lines,
+            } => (true, raw_lines, collector.finalize()),
+            _ => (false, summary_raw_lines, None),
+        };
 
         let matched = !failed
             && !still_collecting
             && closer
                 .as_ref()
                 .is_some_and(|(_, end)| *end <= self.details_window);
+        let _ = finalized;
         if !matched {
-            if let Some(raw) = summary_raw.filter(|raw| !raw.is_empty()) {
-                children.insert(
-                    0,
-                    Block::Paragraph {
-                        inlines: vec![Inline::Text(raw)],
-                    },
-                );
-                blank_lines_before.insert(0, 0);
+            if !summary_replayed && !collecting_raw.is_empty() {
+                let (mut restored, mut restored_gaps) =
+                    self.parse_ordinary_line_blocks(collecting_raw, pre_summary_gap);
+                restored.append(&mut children);
+                restored_gaps.append(&mut blank_lines_before);
+                children = restored;
+                blank_lines_before = restored_gaps;
             }
             return self.fallback_details(
                 opener_raw,
@@ -1364,6 +1469,165 @@ impl BlockParser {
             },
             leading_blank_lines,
         );
+    }
+
+    fn parse_ordinary_line_blocks(
+        &mut self,
+        lines: Vec<String>,
+        first_gap: u8,
+    ) -> (Vec<Block>, Vec<u8>) {
+        let saved_leaf = self.leaf.take();
+        let saved_leaf_gap = self.leaf_blank_lines_before;
+        self.containers.push(Container::Details {
+            open: false,
+            opener_raw: String::new(),
+            children: Vec::new(),
+            blank_lines_before: Vec::new(),
+            leading_blank_lines: 0,
+            summary_inner: None,
+            summary_raw_lines: Vec::new(),
+            summary_replayed: true,
+            pre_summary_gap: 0,
+            summary_state: SummaryState::Done,
+            failed: true,
+        });
+        self.replay_ordinary_lines(lines, first_gap);
+        let popped = self.containers.pop();
+        self.leaf = saved_leaf;
+        self.leaf_blank_lines_before = saved_leaf_gap;
+        match popped {
+            Some(Container::Details {
+                children,
+                blank_lines_before,
+                ..
+            }) => (children, blank_lines_before),
+            _ => (Vec::new(), Vec::new()),
+        }
+    }
+
+    fn replay_ordinary_lines(&mut self, lines: Vec<String>, first_gap: u8) {
+        if lines.is_empty() {
+            return;
+        }
+        if matches!(self.containers.last(), Some(Container::Details { .. })) {
+            self.pending_source_gaps[self.containers.len()] = first_gap;
+        }
+        for line in lines {
+            self.classify_ordinary_rest(&line);
+        }
+        self.close_leaf();
+    }
+
+    fn classify_ordinary_rest(&mut self, rest: &str) {
+        let bytes = rest.as_bytes();
+        let (sub_col, sub_off) = scanner::measure_indent(bytes);
+        if sub_col < 4 {
+            let rest_bytes = &bytes[sub_off..];
+            if !rest_bytes.is_empty() {
+                if let Some((level, text)) = parse_atx_heading(rest_bytes) {
+                    self.close_leaf();
+                    self.push_new_block(Block::Heading {
+                        level,
+                        inlines: vec![Inline::Text(text)],
+                    });
+                    return;
+                }
+                if let Some((fence, fence_len, info)) = parse_fence_open(rest_bytes) {
+                    self.close_leaf();
+                    self.begin_leaf();
+                    self.leaf = Some(Leaf::FencedCode {
+                        fence,
+                        fence_len,
+                        indent: sub_col,
+                        info,
+                        content: String::new(),
+                    });
+                    return;
+                }
+                if is_math_fence(rest_bytes) {
+                    self.close_leaf();
+                    self.begin_leaf();
+                    self.leaf = Some(Leaf::MathBlock {
+                        indent: sub_col,
+                        content: String::new(),
+                    });
+                    return;
+                }
+                if is_thematic_break(rest_bytes) {
+                    self.close_leaf();
+                    self.push_new_block(Block::ThematicBreak);
+                    return;
+                }
+                if rest_bytes[0] == b'>'
+                    && let Some((_, no)) = try_open_blockquote(bytes, 0, 0)
+                    && self.containers.len() < MAX_CONTAINER_DEPTH
+                {
+                    self.close_leaf();
+                    let leading_blank_lines = self.take_pending_source_gap();
+                    self.containers.push(Container::BlockQuote {
+                        children: Vec::new(),
+                        blank_lines_before: Vec::new(),
+                        leading_blank_lines,
+                    });
+                    if no < rest.len() {
+                        self.classify_ordinary_rest(&rest[no..]);
+                    }
+                    if let Some(Container::BlockQuote { .. }) = self.containers.last() {
+                        let quote = self.containers.pop().unwrap();
+                        self.close_container(quote);
+                    }
+                    return;
+                }
+                if let Some(open) =
+                    try_open_list_marker(bytes, 0, 0, matches!(self.leaf, Some(Leaf::Paragraph(_))))
+                    && self.containers.len() + 2 <= MAX_CONTAINER_DEPTH
+                {
+                    self.close_leaf();
+                    self.ensure_list_open(open.kind);
+                    self.containers.push(Container::ListItem {
+                        children: Vec::new(),
+                        blank_lines_before: Vec::new(),
+                        indent: open.indent,
+                    });
+                    if open.off_after < rest.len() {
+                        self.classify_ordinary_rest(&rest[open.off_after..]);
+                    } else {
+                        self.append_paragraph("");
+                    }
+                    self.close_leaf();
+                    if let Some(Container::ListItem { .. }) = self.containers.last() {
+                        let item = self.containers.pop().unwrap();
+                        self.close_container(item);
+                    }
+                    if let Some(Container::List { .. }) = self.containers.last() {
+                        let list = self.containers.pop().unwrap();
+                        self.close_container(list);
+                    }
+                    return;
+                }
+            }
+        }
+        if sub_col >= 4 && !matches!(self.leaf, Some(Leaf::Paragraph(_))) {
+            let stripped = indented_strip(rest, 0);
+            if let Some(Leaf::IndentedCode { content, .. }) = &mut self.leaf {
+                content.push_str(stripped);
+                content.push('\n');
+            } else {
+                self.close_leaf();
+                self.begin_leaf();
+                let mut content = String::new();
+                content.push_str(stripped);
+                content.push('\n');
+                self.leaf = Some(Leaf::IndentedCode {
+                    content,
+                    pending_blanks: 0,
+                    pending_source_gaps: Box::new([0; MAX_CONTAINER_DEPTH + 1]),
+                    pending_list_blanks: Box::new([false; MAX_CONTAINER_DEPTH]),
+                });
+            }
+            return;
+        }
+        self.append_paragraph_from(rest, 0);
     }
 
     fn fallback_details(

--- a/crates/marmot-markdown/src/block.rs
+++ b/crates/marmot-markdown/src/block.rs
@@ -12,6 +12,7 @@
 use std::collections::HashMap;
 
 use crate::ast::{Alignment, Block, CodeBlockKind, Inline, ListItem, ListKind, TableCell};
+use crate::details::{self, SummaryLine};
 use crate::scanner;
 
 pub(crate) const MAX_CONTAINER_DEPTH: usize = 96;
@@ -29,9 +30,10 @@ pub(crate) struct LinkRef {
 }
 
 pub(crate) fn parse_blocks(input: &str) -> (Vec<Block>, Vec<u8>, HashMap<String, LinkRef>) {
-    let mut p = BlockParser::new();
-    for line in scanner::lines(input) {
-        p.feed(line);
+    details::Work::reset();
+    let mut p = BlockParser::new(details::recognition_window(input));
+    for (line, start) in scanner::lines_with_offsets(input) {
+        p.feed(line, start);
     }
     p.finish();
     (p.root, p.root_blank_lines_before, p.refs)
@@ -60,6 +62,37 @@ enum Container {
         blank_lines_before: Vec<u8>,
         indent: usize,
     },
+    Details {
+        open: bool,
+        opener_raw: String,
+        children: Vec<Block>,
+        blank_lines_before: Vec<u8>,
+        leading_blank_lines: u8,
+        summary_inner: Option<String>,
+        summary_state: SummaryState,
+        failed: bool,
+    },
+}
+
+#[derive(Debug)]
+enum SummaryState {
+    AwaitingFirstNonblank,
+    AwaitingClose {
+        after_open: String,
+        held_line: String,
+    },
+    Done,
+}
+
+enum SummaryAction {
+    MarkDone,
+    Complete(String),
+    Hold {
+        after_open: String,
+        held_line: String,
+    },
+    FailAndContinue,
+    FailReplay(String),
 }
 
 #[derive(Debug)]
@@ -110,6 +143,9 @@ struct BlockParser {
     /// (slot `index + 1`). Each slot saturates independently so blank markers
     /// belonging to a nested quote cannot consume an ancestor's count budget.
     pending_source_gaps: [u8; MAX_CONTAINER_DEPTH + 1],
+    /// UTF-8-safe source prefix in which complete details candidates may match.
+    details_window: usize,
+    line_start: usize,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -125,7 +161,7 @@ struct ContainerMatch {
 }
 
 impl BlockParser {
-    fn new() -> Self {
+    fn new(details_window: usize) -> Self {
         Self {
             refs: HashMap::new(),
             root: Vec::new(),
@@ -134,12 +170,15 @@ impl BlockParser {
             leaf: None,
             leaf_blank_lines_before: 0,
             pending_source_gaps: [0; MAX_CONTAINER_DEPTH + 1],
+            details_window,
+            line_start: 0,
         }
     }
 
     // -------- top-level line dispatch --------
 
-    fn feed(&mut self, line: &str) {
+    fn feed(&mut self, line: &str, line_start: usize) {
+        self.line_start = line_start;
         let bytes = line.as_bytes();
         let ContainerMatch {
             cursor,
@@ -190,6 +229,7 @@ impl BlockParser {
                 _ => self.close_leaf(),
             }
             if mark_blank {
+                self.flush_held_summary_on_blank();
                 self.record_source_blank(scanner::is_blank(bytes), &blank_owners);
                 self.mark_list_blank_at_depth(matched_depth);
             }
@@ -247,6 +287,16 @@ impl BlockParser {
 
                 // Leaf-block starters that beat container openers.
                 if !rest.is_empty() {
+                    let rest_str = std::str::from_utf8(rest).unwrap_or("");
+                    if self.try_close_details(rest_str, probe_off) {
+                        return;
+                    }
+                    if self.try_accept_summary_line(rest_str) {
+                        return;
+                    }
+                    if self.try_open_details(rest_str, probe_off) {
+                        return;
+                    }
                     if let Some((level, text)) = parse_atx_heading(rest) {
                         self.close_leaf();
                         self.push_new_block(Block::Heading {
@@ -500,9 +550,9 @@ impl BlockParser {
                     }
                     blank_owners[i + 1] = scanner::is_blank(&bytes[off..]);
                 }
-                Container::List { .. } => {
-                    // Lists themselves consume nothing; their open ListItem
-                    // (if any) handles indent matching.
+                Container::List { .. } | Container::Details { .. } => {
+                    // Lists and details consume nothing; list items handle
+                    // indent matching, and details close on an explicit tag.
                 }
                 Container::ListItem { indent, .. } => {
                     let needed = *indent;
@@ -723,11 +773,28 @@ impl BlockParser {
         blank_owners: &[bool; MAX_CONTAINER_DEPTH + 1],
     ) {
         if physically_blank {
-            Self::increment_gap(&mut pending_source_gaps[0]);
+            // Blanks inside an open details stay in that disclosure; they must
+            // not become a sibling gap on an ancestor after the closer.
+            let inner_from = containers
+                .iter()
+                .enumerate()
+                .rev()
+                .find_map(|(index, container)| {
+                    matches!(container, Container::Details { .. }).then_some(index + 1)
+                })
+                .unwrap_or(0);
+            if inner_from == 0 {
+                Self::increment_gap(&mut pending_source_gaps[0]);
+            }
             for (index, container) in containers.iter().enumerate() {
+                if index + 1 < inner_from {
+                    continue;
+                }
                 if matches!(
                     container,
-                    Container::BlockQuote { .. } | Container::ListItem { .. }
+                    Container::BlockQuote { .. }
+                        | Container::ListItem { .. }
+                        | Container::Details { .. }
                 ) {
                     Self::increment_gap(&mut pending_source_gaps[index + 1]);
                 }
@@ -768,9 +835,11 @@ impl BlockParser {
         self.close_dangling_lists();
         let slot = match self.containers.last() {
             None => 0,
-            Some(Container::BlockQuote { .. } | Container::ListItem { .. }) => {
-                self.containers.len()
-            }
+            Some(
+                Container::BlockQuote { .. }
+                | Container::ListItem { .. }
+                | Container::Details { .. },
+            ) => self.containers.len(),
             Some(Container::List { .. }) => unreachable!("dangling lists were just closed"),
         };
         let count = self.pending_source_gaps[slot];
@@ -805,6 +874,11 @@ impl BlockParser {
                 ..
             })
             | Some(Container::ListItem {
+                children,
+                blank_lines_before: child_gaps,
+                ..
+            })
+            | Some(Container::Details {
                 children,
                 blank_lines_before: child_gaps,
                 ..
@@ -863,6 +937,7 @@ impl BlockParser {
                 let block = Block::List { kind, tight, items };
                 self.push_block(block, leading_blank_lines);
             }
+            Container::Details { .. } => self.finish_details(c, None),
         }
     }
 
@@ -917,6 +992,281 @@ impl BlockParser {
                 *tight = false;
                 *last_blank = false;
             }
+        }
+    }
+
+    fn details_is_current_parent(&self) -> bool {
+        match self.containers.last() {
+            Some(Container::Details { .. }) => true,
+            Some(Container::List { .. }) => self
+                .containers
+                .iter()
+                .rev()
+                .nth(1)
+                .is_some_and(|c| matches!(c, Container::Details { .. })),
+            _ => false,
+        }
+    }
+
+    fn try_close_details(&mut self, rest: &str, probe_off: usize) -> bool {
+        let Some(close) = details::parse_details_closer_line(rest) else {
+            return false;
+        };
+        if !self.details_is_current_parent() {
+            return false;
+        }
+        self.close_leaf();
+        self.close_dangling_lists();
+        let closer_end = self.line_start + probe_off + close.tag_end;
+        let closer_raw = rest.trim_matches([' ', '\t']).to_string();
+        if let Some(Container::Details { .. }) = self.containers.last() {
+            let c = self.containers.pop().unwrap();
+            self.finish_details(c, Some((closer_raw, closer_end)));
+            return true;
+        }
+        false
+    }
+
+    fn try_open_details(&mut self, rest: &str, probe_off: usize) -> bool {
+        let Some(open) = details::parse_details_opener_line(rest) else {
+            return false;
+        };
+        let tag_end_abs = self.line_start + probe_off + open.tag_end;
+        if tag_end_abs > self.details_window {
+            return false;
+        }
+        if self.containers.len() >= MAX_CONTAINER_DEPTH {
+            return false;
+        }
+        self.close_leaf();
+        let opener_raw = rest.trim_matches([' ', '\t']).to_string();
+        let leading_blank_lines = self.take_pending_source_gap();
+        self.containers.push(Container::Details {
+            open: open.open,
+            opener_raw,
+            children: Vec::new(),
+            blank_lines_before: Vec::new(),
+            leading_blank_lines,
+            summary_inner: None,
+            summary_state: SummaryState::AwaitingFirstNonblank,
+            failed: false,
+        });
+        true
+    }
+
+    fn try_accept_summary_line(&mut self, rest: &str) -> bool {
+        let action = match self.containers.last() {
+            Some(Container::Details { summary_state, .. }) => match summary_state {
+                SummaryState::Done => return false,
+                SummaryState::AwaitingFirstNonblank => match details::parse_summary_line(rest) {
+                    SummaryLine::NotSummary => SummaryAction::MarkDone,
+                    SummaryLine::Complete { inner } => SummaryAction::Complete(inner),
+                    SummaryLine::OpenOnly { after_open } => SummaryAction::Hold {
+                        after_open,
+                        held_line: rest.trim_matches([' ', '\t']).to_string(),
+                    },
+                    SummaryLine::CloseOnly { .. } | SummaryLine::Malformed => {
+                        SummaryAction::FailAndContinue
+                    }
+                },
+                SummaryState::AwaitingClose {
+                    after_open,
+                    held_line,
+                } => match details::parse_summary_close_only(rest) {
+                    Some(before_close) => {
+                        let mut inner = after_open.clone();
+                        if !before_close.is_empty() {
+                            if !inner.is_empty() {
+                                inner.push('\n');
+                            }
+                            inner.push_str(&before_close);
+                        }
+                        SummaryAction::Complete(inner)
+                    }
+                    None => SummaryAction::FailReplay(held_line.clone()),
+                },
+            },
+            _ => return false,
+        };
+        match action {
+            SummaryAction::MarkDone => {
+                if let Some(Container::Details { summary_state, .. }) = self.containers.last_mut() {
+                    *summary_state = SummaryState::Done;
+                }
+                false
+            }
+            SummaryAction::Complete(inner) => {
+                if let Some(Container::Details {
+                    summary_state,
+                    summary_inner,
+                    ..
+                }) = self.containers.last_mut()
+                {
+                    *summary_inner = if details::summary_inner_is_empty(&inner) {
+                        None
+                    } else {
+                        Some(inner)
+                    };
+                    *summary_state = SummaryState::Done;
+                }
+                self.clear_current_details_gap();
+                true
+            }
+            SummaryAction::Hold {
+                after_open,
+                held_line,
+            } => {
+                if let Some(Container::Details { summary_state, .. }) = self.containers.last_mut() {
+                    *summary_state = SummaryState::AwaitingClose {
+                        after_open,
+                        held_line,
+                    };
+                }
+                true
+            }
+            SummaryAction::FailAndContinue => {
+                if let Some(Container::Details {
+                    summary_state,
+                    failed,
+                    ..
+                }) = self.containers.last_mut()
+                {
+                    *failed = true;
+                    *summary_state = SummaryState::Done;
+                }
+                false
+            }
+            SummaryAction::FailReplay(held) => {
+                if let Some(Container::Details {
+                    summary_state,
+                    failed,
+                    ..
+                }) = self.containers.last_mut()
+                {
+                    *failed = true;
+                    *summary_state = SummaryState::Done;
+                }
+                self.push_new_block(Block::Paragraph {
+                    inlines: vec![Inline::Text(held)],
+                });
+                false
+            }
+        }
+    }
+
+    fn flush_held_summary_on_blank(&mut self) {
+        let held = match self.containers.last() {
+            Some(Container::Details {
+                summary_state: SummaryState::AwaitingClose { held_line, .. },
+                ..
+            }) => held_line.clone(),
+            _ => return,
+        };
+        if let Some(Container::Details {
+            summary_state,
+            failed,
+            ..
+        }) = self.containers.last_mut()
+        {
+            *failed = true;
+            *summary_state = SummaryState::Done;
+        }
+        self.push_new_block(Block::Paragraph {
+            inlines: vec![Inline::Text(held)],
+        });
+    }
+
+    fn clear_current_details_gap(&mut self) {
+        if let Some(Container::Details { .. }) = self.containers.last() {
+            self.pending_source_gaps[self.containers.len()] = 0;
+        }
+    }
+
+    fn finish_details(&mut self, c: Container, closer: Option<(String, usize)>) {
+        let Container::Details {
+            open,
+            opener_raw,
+            mut children,
+            mut blank_lines_before,
+            leading_blank_lines,
+            summary_inner,
+            summary_state,
+            failed,
+        } = c
+        else {
+            unreachable!("finish_details requires Details");
+        };
+
+        if let SummaryState::AwaitingClose { held_line, .. } = summary_state {
+            children.insert(
+                0,
+                Block::Paragraph {
+                    inlines: vec![Inline::Text(held_line)],
+                },
+            );
+            blank_lines_before.insert(0, 0);
+            return self.fallback_details(
+                opener_raw,
+                children,
+                blank_lines_before,
+                leading_blank_lines,
+                closer.map(|(raw, _)| raw),
+            );
+        }
+
+        let matched = !failed
+            && closer
+                .as_ref()
+                .is_some_and(|(_, end)| *end <= self.details_window);
+        if !matched {
+            return self.fallback_details(
+                opener_raw,
+                children,
+                blank_lines_before,
+                leading_blank_lines,
+                closer.map(|(raw, _)| raw),
+            );
+        }
+
+        let summary = match summary_inner {
+            Some(raw) => vec![Inline::Text(raw)],
+            None => Vec::new(),
+        };
+        self.push_block(
+            Block::Details {
+                summary,
+                open,
+                body: children,
+                blank_lines_before,
+            },
+            leading_blank_lines,
+        );
+    }
+
+    fn fallback_details(
+        &mut self,
+        opener_raw: String,
+        children: Vec<Block>,
+        child_gaps: Vec<u8>,
+        leading_blank_lines: u8,
+        closer_raw: Option<String>,
+    ) {
+        self.push_block(
+            Block::Paragraph {
+                inlines: vec![Inline::Text(opener_raw)],
+            },
+            leading_blank_lines,
+        );
+        for (block, gap) in children.into_iter().zip(child_gaps) {
+            self.push_block(block, gap);
+        }
+        if let Some(closer_raw) = closer_raw {
+            self.push_block(
+                Block::Paragraph {
+                    inlines: vec![Inline::Text(closer_raw)],
+                },
+                0,
+            );
         }
     }
 }
@@ -1343,6 +1693,12 @@ impl BlockParser {
             return false;
         }
         if try_open_list_marker(bytes, cursor.col, cursor.off, true).is_some() {
+            return false;
+        }
+        let rest_str = std::str::from_utf8(rest).unwrap_or("");
+        if details::parse_details_opener_line(rest_str).is_some()
+            || details::parse_details_closer_line(rest_str).is_some()
+        {
             return false;
         }
         if let Some(open) = try_open_list_marker(bytes, probe_col, probe_off, false)

--- a/crates/marmot-markdown/src/block.rs
+++ b/crates/marmot-markdown/src/block.rs
@@ -83,7 +83,7 @@ enum Container {
 enum SummaryState {
     AwaitingFirstNonblank,
     Collecting {
-        collector: details::SummaryCollector,
+        collector: Box<details::SummaryCollector>,
         raw_lines: Vec<String>,
     },
     Done,
@@ -157,6 +157,7 @@ struct BlockParser {
     pending_source_gaps: [u8; MAX_CONTAINER_DEPTH + 1],
     /// UTF-8-safe source prefix in which complete details candidates may match.
     details_window: usize,
+    container_depth_limit: usize,
     line_start: usize,
 }
 
@@ -183,6 +184,7 @@ impl BlockParser {
             leaf_blank_lines_before: 0,
             pending_source_gaps: [0; MAX_CONTAINER_DEPTH + 1],
             details_window,
+            container_depth_limit: MAX_CONTAINER_DEPTH,
             line_start: 0,
         }
     }
@@ -393,7 +395,7 @@ impl BlockParser {
                     if rest[0] == b'>'
                         && let Some((nc, no)) = try_open_blockquote(bytes, probe_col, probe_off)
                     {
-                        if self.containers.len() >= MAX_CONTAINER_DEPTH {
+                        if self.containers.len() >= self.container_depth_limit {
                             self.append_paragraph_from(line, probe_off);
                             return;
                         }
@@ -420,7 +422,7 @@ impl BlockParser {
                         probe_off,
                         matches!(self.leaf, Some(Leaf::Paragraph(_))),
                     ) {
-                        if self.containers.len() + 2 > MAX_CONTAINER_DEPTH {
+                        if self.containers.len() + 2 > self.container_depth_limit {
                             self.append_paragraph_from(line, probe_off);
                             return;
                         }
@@ -1097,7 +1099,7 @@ impl BlockParser {
         if tag_end_abs > self.details_window {
             return false;
         }
-        if self.containers.len() >= MAX_CONTAINER_DEPTH {
+        if self.containers.len() >= self.container_depth_limit {
             return false;
         }
         self.close_leaf();
@@ -1321,7 +1323,7 @@ impl BlockParser {
                 {
                     *pre_summary_gap = gap;
                     *summary_state = SummaryState::Collecting {
-                        collector,
+                        collector: Box::new(collector),
                         raw_lines,
                     };
                 }
@@ -1424,12 +1426,9 @@ impl BlockParser {
             unreachable!("finish_details requires Details");
         };
 
-        let (still_collecting, collecting_raw, finalized) = match summary_state {
-            SummaryState::Collecting {
-                collector,
-                raw_lines,
-            } => (true, raw_lines, collector.finalize()),
-            _ => (false, summary_raw_lines, None),
+        let (still_collecting, collecting_raw) = match summary_state {
+            SummaryState::Collecting { raw_lines, .. } => (true, raw_lines),
+            _ => (false, summary_raw_lines),
         };
 
         let matched = !failed
@@ -1437,7 +1436,6 @@ impl BlockParser {
             && closer
                 .as_ref()
                 .is_some_and(|(_, end)| *end <= self.details_window);
-        let _ = finalized;
         if !matched {
             if !summary_replayed && !collecting_raw.is_empty() {
                 let (mut restored, mut restored_gaps) =
@@ -1476,158 +1474,29 @@ impl BlockParser {
         lines: Vec<String>,
         first_gap: u8,
     ) -> (Vec<Block>, Vec<u8>) {
-        let saved_leaf = self.leaf.take();
-        let saved_leaf_gap = self.leaf_blank_lines_before;
-        self.containers.push(Container::Details {
-            open: false,
-            opener_raw: String::new(),
-            children: Vec::new(),
-            blank_lines_before: Vec::new(),
-            leading_blank_lines: 0,
-            summary_inner: None,
-            summary_raw_lines: Vec::new(),
-            summary_replayed: true,
-            pre_summary_gap: 0,
-            summary_state: SummaryState::Done,
-            failed: true,
-        });
-        self.replay_ordinary_lines(lines, first_gap);
-        let popped = self.containers.pop();
-        self.leaf = saved_leaf;
-        self.leaf_blank_lines_before = saved_leaf_gap;
-        match popped {
-            Some(Container::Details {
-                children,
-                blank_lines_before,
-                ..
-            }) => (children, blank_lines_before),
-            _ => (Vec::new(), Vec::new()),
+        // Replay the bounded held source through the ordinary block parser so
+        // setext headings, verbatim leaves, tables, and container continuations
+        // have the same semantics as non-disclosure Markdown. A zero window
+        // prevents disclosure recognition (and recursive fallback) on replay.
+        let mut replay = Self::new(0);
+        replay.container_depth_limit = self
+            .container_depth_limit
+            .saturating_sub(self.containers.len());
+        replay.refs = std::mem::take(&mut self.refs);
+        replay.pending_source_gaps[0] = first_gap;
+        for line in lines {
+            replay.feed(&line, 0);
         }
+        replay.finish();
+        self.refs = replay.refs;
+        (replay.root, replay.root_blank_lines_before)
     }
 
     fn replay_ordinary_lines(&mut self, lines: Vec<String>, first_gap: u8) {
-        if lines.is_empty() {
-            return;
+        let (blocks, gaps) = self.parse_ordinary_line_blocks(lines, first_gap);
+        for (block, gap) in blocks.into_iter().zip(gaps) {
+            self.push_block(block, gap);
         }
-        if matches!(self.containers.last(), Some(Container::Details { .. })) {
-            self.pending_source_gaps[self.containers.len()] = first_gap;
-        }
-        for line in lines {
-            self.classify_ordinary_rest(&line);
-        }
-        self.close_leaf();
-    }
-
-    fn classify_ordinary_rest(&mut self, rest: &str) {
-        let bytes = rest.as_bytes();
-        let (sub_col, sub_off) = scanner::measure_indent(bytes);
-        if sub_col < 4 {
-            let rest_bytes = &bytes[sub_off..];
-            if !rest_bytes.is_empty() {
-                if let Some((level, text)) = parse_atx_heading(rest_bytes) {
-                    self.close_leaf();
-                    self.push_new_block(Block::Heading {
-                        level,
-                        inlines: vec![Inline::Text(text)],
-                    });
-                    return;
-                }
-                if let Some((fence, fence_len, info)) = parse_fence_open(rest_bytes) {
-                    self.close_leaf();
-                    self.begin_leaf();
-                    self.leaf = Some(Leaf::FencedCode {
-                        fence,
-                        fence_len,
-                        indent: sub_col,
-                        info,
-                        content: String::new(),
-                    });
-                    return;
-                }
-                if is_math_fence(rest_bytes) {
-                    self.close_leaf();
-                    self.begin_leaf();
-                    self.leaf = Some(Leaf::MathBlock {
-                        indent: sub_col,
-                        content: String::new(),
-                    });
-                    return;
-                }
-                if is_thematic_break(rest_bytes) {
-                    self.close_leaf();
-                    self.push_new_block(Block::ThematicBreak);
-                    return;
-                }
-                if rest_bytes[0] == b'>'
-                    && let Some((_, no)) = try_open_blockquote(bytes, 0, 0)
-                    && self.containers.len() < MAX_CONTAINER_DEPTH
-                {
-                    self.close_leaf();
-                    let leading_blank_lines = self.take_pending_source_gap();
-                    self.containers.push(Container::BlockQuote {
-                        children: Vec::new(),
-                        blank_lines_before: Vec::new(),
-                        leading_blank_lines,
-                    });
-                    if no < rest.len() {
-                        self.classify_ordinary_rest(&rest[no..]);
-                    }
-                    if let Some(Container::BlockQuote { .. }) = self.containers.last() {
-                        let quote = self.containers.pop().unwrap();
-                        self.close_container(quote);
-                    }
-                    return;
-                }
-                if let Some(open) =
-                    try_open_list_marker(bytes, 0, 0, matches!(self.leaf, Some(Leaf::Paragraph(_))))
-                    && self.containers.len() + 2 <= MAX_CONTAINER_DEPTH
-                {
-                    self.close_leaf();
-                    self.ensure_list_open(open.kind);
-                    self.containers.push(Container::ListItem {
-                        children: Vec::new(),
-                        blank_lines_before: Vec::new(),
-                        indent: open.indent,
-                    });
-                    if open.off_after < rest.len() {
-                        self.classify_ordinary_rest(&rest[open.off_after..]);
-                    } else {
-                        self.append_paragraph("");
-                    }
-                    self.close_leaf();
-                    if let Some(Container::ListItem { .. }) = self.containers.last() {
-                        let item = self.containers.pop().unwrap();
-                        self.close_container(item);
-                    }
-                    if let Some(Container::List { .. }) = self.containers.last() {
-                        let list = self.containers.pop().unwrap();
-                        self.close_container(list);
-                    }
-                    return;
-                }
-            }
-        }
-        if sub_col >= 4 && !matches!(self.leaf, Some(Leaf::Paragraph(_))) {
-            let stripped = indented_strip(rest, 0);
-            if let Some(Leaf::IndentedCode { content, .. }) = &mut self.leaf {
-                content.push_str(stripped);
-                content.push('\n');
-            } else {
-                self.close_leaf();
-                self.begin_leaf();
-                let mut content = String::new();
-                content.push_str(stripped);
-                content.push('\n');
-                self.leaf = Some(Leaf::IndentedCode {
-                    content,
-                    pending_blanks: 0,
-                    pending_source_gaps: Box::new([0; MAX_CONTAINER_DEPTH + 1]),
-                    pending_list_blanks: Box::new([false; MAX_CONTAINER_DEPTH]),
-                });
-            }
-            return;
-        }
-        self.append_paragraph_from(rest, 0);
     }
 
     fn fallback_details(

--- a/crates/marmot-markdown/src/details.rs
+++ b/crates/marmot-markdown/src/details.rs
@@ -5,7 +5,6 @@
 //! linear scan bound.
 
 use std::cell::Cell;
-use std::collections::HashMap;
 
 /// Inclusive byte length from `<` through `>` for a structural tag.
 pub(crate) const MAX_DETAILS_TAG_BYTES: usize = 4096;
@@ -82,8 +81,200 @@ pub(crate) enum SummaryLine {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum SummaryContinue {
     Complete { inner: String },
-    StillOpen { accumulated: String },
+    StillOpen,
     Malformed,
+}
+
+#[derive(Debug, Clone)]
+struct DeferredCloser {
+    rel_start: usize,
+    tag_end: usize,
+    trailing_ws_only: bool,
+}
+
+/// Incremental summary closer / code-span state. Each new line is scanned
+/// once; unmatched backtick runs stay pending until a later match or the
+/// candidate ends, so a closer is not committed before a later matching run.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct SummaryCollector {
+    inner: String,
+    unmatched: Vec<(usize, usize)>,
+    deferred_closers: Vec<DeferredCloser>,
+}
+
+impl SummaryCollector {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn from_after_open(after_open: &str) -> Self {
+        let mut collector = Self::new();
+        let _ = collector.push_segment(after_open, usize::MAX, true);
+        collector
+    }
+
+    pub(crate) fn inner(&self) -> &str {
+        &self.inner
+    }
+
+    pub(crate) fn has_unmatched_openers(&self) -> bool {
+        !self.unmatched.is_empty()
+    }
+
+    pub(crate) fn has_deferred_closer(&self) -> bool {
+        self.deferred_closers
+            .iter()
+            .any(|closer| closer.trailing_ws_only)
+    }
+
+    pub(crate) fn push_line(&mut self, next_line: &str, max_bytes: usize) -> SummaryContinue {
+        Work::charge(1);
+        let (next, _) = trim_leading_ws(next_line);
+        if starts_with_open_angle(next) && look_like_summary_open(next) {
+            return SummaryContinue::Malformed;
+        }
+        self.push_segment(next, max_bytes, false)
+    }
+
+    /// Resolve unmatched backtick runs as literal and take the first
+    /// unprotected closer, returning leftover lines after that closer.
+    pub(crate) fn finalize(&self) -> Option<(String, Vec<String>)> {
+        let closer = self
+            .deferred_closers
+            .iter()
+            .find(|closer| closer.trailing_ws_only)?;
+        if closer.rel_start > self.inner.len() || closer.tag_end > self.inner.len() {
+            return None;
+        }
+        let inner = self.inner[..inner_end(closer.rel_start, &self.inner)].to_string();
+        Some((inner, leftover_lines(&self.inner, closer.tag_end)))
+    }
+
+    fn push_segment(&mut self, text: &str, max_bytes: usize, first: bool) -> SummaryContinue {
+        let take = floor_char_boundary(text, text.len().min(max_bytes));
+        let sliced = &text[..take];
+        let join = !first && !self.inner.is_empty();
+        let from = if join {
+            self.inner.len() + 1
+        } else {
+            self.inner.len()
+        };
+        Work::charge_bytes(sliced.len() + usize::from(join));
+        if join {
+            self.inner.push('\n');
+        }
+        self.inner.push_str(sliced);
+        match self.scan_from(from) {
+            CloseSeek::Found { rel_start, tag_end } => {
+                if !trailing_ws_only(&self.inner, tag_end) {
+                    return SummaryContinue::Malformed;
+                }
+                SummaryContinue::Complete {
+                    inner: self.inner[..inner_end(rel_start, &self.inner)].to_string(),
+                }
+            }
+            CloseSeek::ProtectedOrAbsent => SummaryContinue::StillOpen,
+            CloseSeek::Malformed => SummaryContinue::Malformed,
+        }
+    }
+
+    fn scan_from(&mut self, from: usize) -> CloseSeek {
+        let bytes = self.inner.as_bytes();
+        let limit = bytes.len();
+        let mut i = from;
+        while i < limit {
+            Work::charge(1);
+            if bytes[i] == b'`' {
+                let run_end = skip_backtick_run(bytes, i, limit);
+                let run_len = run_end - i;
+                if let Some(opener_start) = take_unmatched(&mut self.unmatched, run_len) {
+                    self.unmatched
+                        .retain(|(pos, _)| *pos <= opener_start || *pos >= i);
+                    self.deferred_closers
+                        .retain(|closer| closer.rel_start <= opener_start || closer.rel_start >= i);
+                    i = run_end;
+                } else {
+                    self.unmatched.push((i, run_len));
+                    i = run_end;
+                }
+                continue;
+            }
+            if bytes[i] == b'<'
+                && bytes.get(i + 1) == Some(&b'/')
+                && let Some(name_end) = match_name(&bytes[i + 2..], b"summary")
+            {
+                let mut j = i + 2 + name_end;
+                if tag_name_boundary(bytes.get(j).copied()) {
+                    j = skip_ascii_ws(bytes, j);
+                    if bytes.get(j) == Some(&b'>') {
+                        let tag_end = j + 1;
+                        if tag_end - i > MAX_DETAILS_TAG_BYTES {
+                            return CloseSeek::Malformed;
+                        }
+                        let unmatched_before = self.unmatched.iter().any(|(pos, _)| *pos < i);
+                        if unmatched_before {
+                            self.deferred_closers.push(DeferredCloser {
+                                rel_start: i,
+                                tag_end,
+                                trailing_ws_only: trailing_ws_only_until_eol(bytes, tag_end),
+                            });
+                            i = tag_end;
+                            continue;
+                        }
+                        return CloseSeek::Found {
+                            rel_start: i,
+                            tag_end,
+                        };
+                    }
+                    return CloseSeek::Malformed;
+                }
+            }
+            i += 1;
+        }
+        CloseSeek::ProtectedOrAbsent
+    }
+}
+
+fn take_unmatched(unmatched: &mut Vec<(usize, usize)>, run_len: usize) -> Option<usize> {
+    let idx = unmatched.iter().position(|(_, len)| *len == run_len)?;
+    Some(unmatched.remove(idx).0)
+}
+
+fn inner_end(rel_start: usize, inner: &str) -> usize {
+    if rel_start > 0 && inner.as_bytes()[rel_start - 1] == b'\n' {
+        rel_start - 1
+    } else {
+        rel_start
+    }
+}
+
+fn leftover_lines(inner: &str, tag_end: usize) -> Vec<String> {
+    if tag_end >= inner.len() {
+        return Vec::new();
+    }
+    let after = &inner[tag_end..];
+    let mut lines = Vec::new();
+    for (idx, line) in after.split('\n').enumerate() {
+        if idx == 0 {
+            continue;
+        }
+        lines.push(line.to_string());
+    }
+    lines
+}
+
+fn trailing_ws_only(text: &str, tag_end: usize) -> bool {
+    trailing_ws_only_until_eol(text.as_bytes(), tag_end)
+}
+
+fn trailing_ws_only_until_eol(bytes: &[u8], mut i: usize) -> bool {
+    while i < bytes.len() && bytes[i] != b'\n' && bytes[i] != b'\r' {
+        if bytes[i] != b' ' && bytes[i] != b'\t' {
+            return false;
+        }
+        i += 1;
+    }
+    true
 }
 
 /// After container prefixes have been stripped, try to read a details opener
@@ -137,7 +328,7 @@ pub(crate) fn parse_summary_line(line: &str) -> SummaryLine {
 
 pub(crate) fn parse_summary_line_bounded(line: &str, max_bytes: usize) -> SummaryLine {
     Work::charge(1);
-    let (body, _) = trim_line_ws(line);
+    let (body, _) = trim_leading_ws(line);
     if !starts_with_open_angle(body) {
         return SummaryLine::NotSummary;
     }
@@ -154,19 +345,14 @@ pub(crate) fn parse_summary_line_bounded(line: &str, max_bytes: usize) -> Summar
     }
 
     let after = &body[open.tag_end..];
-    match find_summary_close_bounded(after, max_bytes.saturating_sub(open.tag_end)) {
-        CloseSeek::Found { rel_start, tag_end } => {
-            if !is_only_ws(&after.as_bytes()[tag_end..]) {
-                return SummaryLine::Malformed;
-            }
-            SummaryLine::Complete {
-                inner: after[..rel_start].to_string(),
-            }
-        }
-        CloseSeek::ProtectedOrAbsent => SummaryLine::OpenOnly {
-            after_open: after.to_string(),
+    let budget = max_bytes.saturating_sub(open.tag_end);
+    let mut collector = SummaryCollector::new();
+    match collector.push_segment(after, budget, true) {
+        SummaryContinue::Complete { inner } => SummaryLine::Complete { inner },
+        SummaryContinue::StillOpen => SummaryLine::OpenOnly {
+            after_open: collector.inner().to_string(),
         },
-        CloseSeek::Malformed => SummaryLine::Malformed,
+        SummaryContinue::Malformed => SummaryLine::Malformed,
     }
 }
 
@@ -182,45 +368,8 @@ pub(crate) fn continue_summary_bounded(
     next_line: &str,
     max_bytes: usize,
 ) -> SummaryContinue {
-    Work::charge(1);
-    let (next, _) = trim_line_ws(next_line);
-    if starts_with_open_angle(next) && look_like_summary_open(next) {
-        return SummaryContinue::Malformed;
-    }
-    let search = join_summary_inner(accumulated, next);
-    match find_summary_close_bounded(&search, max_bytes) {
-        CloseSeek::Found { rel_start, tag_end } => {
-            if !is_only_ws(&search.as_bytes()[tag_end..]) {
-                return SummaryContinue::Malformed;
-            }
-            let prefix_len = if accumulated.is_empty() {
-                0
-            } else {
-                accumulated.len() + 1
-            };
-            let before_close = if rel_start >= prefix_len {
-                &search[prefix_len..rel_start]
-            } else {
-                &search[..rel_start]
-            };
-            SummaryContinue::Complete {
-                inner: join_summary_inner(accumulated, before_close),
-            }
-        }
-        CloseSeek::ProtectedOrAbsent => SummaryContinue::StillOpen {
-            accumulated: search,
-        },
-        CloseSeek::Malformed => SummaryContinue::Malformed,
-    }
-}
-
-pub(crate) fn join_summary_inner(left: &str, right: &str) -> String {
-    match (left.is_empty(), right.is_empty()) {
-        (true, true) => String::new(),
-        (true, false) => right.to_string(),
-        (false, true) => left.to_string(),
-        (false, false) => format!("{left}\n{right}"),
-    }
+    let mut collector = SummaryCollector::from_after_open(accumulated);
+    collector.push_line(next_line, max_bytes)
 }
 
 fn look_like_summary_open(body: &str) -> bool {
@@ -387,82 +536,6 @@ enum CloseSeek {
     Malformed,
 }
 
-/// Find `</summary>` in `after`, skipping markdown code spans. A closer
-/// inside a code span is content, not a terminator. Backtick runs are
-/// indexed once so unmatched openers never rescan the same suffix.
-fn find_summary_close_bounded(after: &str, max_bytes: usize) -> CloseSeek {
-    let limit = after.len().min(max_bytes);
-    let limit = floor_char_boundary(after, limit);
-    let bytes = after.as_bytes();
-    let index = CodeSpanIndex::new(&bytes[..limit]);
-    let mut i = 0;
-    while i < limit {
-        Work::charge(1);
-        if bytes[i] == b'`' {
-            let run_end = skip_backtick_run(bytes, i, limit);
-            let run_len = run_end - i;
-            if let Some((_, close_end)) = index.next_run(run_len, i) {
-                i = close_end.min(limit);
-            } else {
-                i = run_end;
-            }
-            continue;
-        }
-        if bytes[i] == b'<'
-            && bytes.get(i + 1) == Some(&b'/')
-            && let Some(name_end) = match_name(&bytes[i + 2..], b"summary")
-        {
-            let mut j = i + 2 + name_end;
-            if tag_name_boundary(bytes.get(j).copied()) {
-                j = skip_ascii_ws(bytes, j);
-                if bytes.get(j) == Some(&b'>') {
-                    let tag_end = j + 1 - i;
-                    if tag_end > MAX_DETAILS_TAG_BYTES {
-                        return CloseSeek::Malformed;
-                    }
-                    return CloseSeek::Found {
-                        rel_start: i,
-                        tag_end: j + 1,
-                    };
-                }
-                return CloseSeek::Malformed;
-            }
-        }
-        i += 1;
-    }
-    CloseSeek::ProtectedOrAbsent
-}
-
-/// Backtick runs indexed once by length. A failed match skips the whole
-/// opener run instead of retrying at every remaining tick.
-struct CodeSpanIndex {
-    by_len: HashMap<usize, Vec<(usize, usize)>>,
-}
-
-impl CodeSpanIndex {
-    fn new(bytes: &[u8]) -> Self {
-        let mut by_len: HashMap<usize, Vec<(usize, usize)>> = HashMap::new();
-        let mut i = 0;
-        while i < bytes.len() {
-            Work::charge_bytes(1);
-            if bytes[i] != b'`' {
-                i += 1;
-                continue;
-            }
-            let end = skip_backtick_run(bytes, i, bytes.len());
-            by_len.entry(end - i).or_default().push((i, end));
-            i = end;
-        }
-        Self { by_len }
-    }
-
-    fn next_run(&self, run_len: usize, after_start: usize) -> Option<(usize, usize)> {
-        let runs = self.by_len.get(&run_len)?;
-        let next = runs.partition_point(|(start, _)| *start <= after_start);
-        runs.get(next).copied()
-    }
-}
-
 fn skip_backtick_run(bytes: &[u8], start: usize, limit: usize) -> usize {
     let mut end = start;
     while end < limit && bytes[end] == b'`' {
@@ -534,6 +607,15 @@ fn trim_line_ws(line: &str) -> (&str, usize) {
         end -= 1;
     }
     (&line[start..end], start)
+}
+
+fn trim_leading_ws(line: &str) -> (&str, usize) {
+    let bytes = line.as_bytes();
+    let mut start = 0;
+    while start < bytes.len() && (bytes[start] == b' ' || bytes[start] == b'\t') {
+        start += 1;
+    }
+    (&line[start..], start)
 }
 
 /// True when `inner` is empty or only whitespace (including newlines).
@@ -617,9 +699,7 @@ mod tests {
     fn continue_summary_spans_lines_and_code() {
         assert_eq!(
             continue_summary("", "More **information**"),
-            SummaryContinue::StillOpen {
-                accumulated: "More **information**".into()
-            }
+            SummaryContinue::StillOpen
         );
         assert_eq!(
             continue_summary("More **information**", "</summary>"),
@@ -632,6 +712,19 @@ mod tests {
             SummaryContinue::Complete {
                 inner: "use `literal\n</summary>` here".into()
             }
+        );
+    }
+
+    #[test]
+    fn bounded_summary_never_copies_unbounded_suffix() {
+        Work::reset();
+        let huge = format!("<summary>{}", "z".repeat(1_000_000));
+        let classified = parse_summary_line_bounded(&huge, 16);
+        assert!(matches!(classified, SummaryLine::OpenOnly { .. }));
+        let work = Work::get();
+        assert!(
+            work < 8_192,
+            "a 16-byte budget must not copy a 1MB suffix, work={work}"
         );
     }
 

--- a/crates/marmot-markdown/src/details.rs
+++ b/crates/marmot-markdown/src/details.rs
@@ -1,0 +1,565 @@
+//! Bounded `<details>` / `<summary>` tag grammar.
+//!
+//! Recognition is a block-oriented extension over original source, not HTML
+//! recovery. Callers charge work through [`Work`] so tests can assert a
+//! linear scan bound.
+
+use std::cell::Cell;
+
+/// Inclusive byte length from `<` through `>` for a structural tag.
+pub(crate) const MAX_DETAILS_TAG_BYTES: usize = 4096;
+/// Original-source prefix eligible for disclosure recognition per parse.
+pub(crate) const MAX_DETAILS_SCAN_BYTES: usize = 65536;
+
+thread_local! {
+    static WORK: Cell<usize> = const { Cell::new(0) };
+}
+
+/// Monotonic recognition-work counter for tests.
+pub(crate) struct Work;
+
+impl Work {
+    pub(crate) fn reset() {
+        WORK.with(|c| c.set(0));
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get() -> usize {
+        WORK.with(Cell::get)
+    }
+
+    fn charge(n: usize) {
+        WORK.with(|c| c.set(c.get().saturating_add(n)));
+    }
+}
+
+/// UTF-8-safe prefix of `input` in which complete details candidates may be
+/// recognized. The bound is inclusive of index `window - 1`.
+pub(crate) fn recognition_window(input: &str) -> usize {
+    if input.len() <= MAX_DETAILS_SCAN_BYTES {
+        return input.len();
+    }
+    let mut end = MAX_DETAILS_SCAN_BYTES;
+    while end > 0 && !input.is_char_boundary(end) {
+        end -= 1;
+    }
+    end
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DetailsOpen {
+    pub open: bool,
+    /// Byte index after `>` in the supplied line.
+    pub tag_end: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DetailsClose {
+    /// Byte index after `>` in the supplied line.
+    pub tag_end: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SummaryLine {
+    NotSummary,
+    /// `<summary ...>inner</summary>` on one logical line.
+    Complete {
+        inner: String,
+    },
+    /// Opening tag present; closer is not on this line.
+    OpenOnly {
+        after_open: String,
+    },
+    /// Closing tag present; opener is not on this line.
+    CloseOnly {
+        before_close: String,
+    },
+    Malformed,
+}
+
+/// After container prefixes have been stripped, try to read a details opener
+/// that occupies the rest of the logical line.
+pub(crate) fn parse_details_opener_line(line: &str) -> Option<DetailsOpen> {
+    Work::charge(1);
+    let (body, start) = trim_line_ws(line);
+    if !starts_with_open_angle(body) {
+        return None;
+    }
+    let parsed = parse_open_tag(body.as_bytes(), b"details")?;
+    if parsed.self_closing {
+        return None;
+    }
+    if !is_only_ws(&body.as_bytes()[parsed.tag_end..]) {
+        return None;
+    }
+    Some(DetailsOpen {
+        open: parsed.has_open_attr,
+        tag_end: start + parsed.tag_end,
+    })
+}
+
+/// After container prefixes have been stripped, try to read a details closer
+/// that occupies the rest of the logical line.
+pub(crate) fn parse_details_closer_line(line: &str) -> Option<DetailsClose> {
+    Work::charge(1);
+    let (body, start) = trim_line_ws(line);
+    if !starts_with_open_angle(body) {
+        return None;
+    }
+    let tag_end = parse_close_tag(body.as_bytes(), b"details")?;
+    if !is_only_ws(&body.as_bytes()[tag_end..]) {
+        return None;
+    }
+    Some(DetailsClose {
+        tag_end: start + tag_end,
+    })
+}
+
+/// Classify a candidate first-child summary line (container prefixes already
+/// stripped). Leading/trailing horizontal whitespace around the whole line is
+/// allowed; anything else before the opener or after the closer is malformed.
+pub(crate) fn parse_summary_line(line: &str) -> SummaryLine {
+    Work::charge(1);
+    let (body, _) = trim_line_ws(line);
+    if !starts_with_open_angle(body) {
+        if let Some(inner) = parse_summary_close_only(line) {
+            return SummaryLine::CloseOnly {
+                before_close: inner,
+            };
+        }
+        if looks_like_summary_close(body) {
+            return SummaryLine::Malformed;
+        }
+        return SummaryLine::NotSummary;
+    }
+
+    let Some(open) = parse_open_tag(body.as_bytes(), b"summary") else {
+        return if look_like_summary_open(body) {
+            SummaryLine::Malformed
+        } else {
+            SummaryLine::NotSummary
+        };
+    };
+    if open.self_closing {
+        return SummaryLine::Malformed;
+    }
+
+    let after = &body[open.tag_end..];
+    match find_summary_close(after) {
+        CloseSeek::Found { rel_start, tag_end } => {
+            if !is_only_ws(&after.as_bytes()[tag_end..]) {
+                return SummaryLine::Malformed;
+            }
+            SummaryLine::Complete {
+                inner: after[..rel_start].to_string(),
+            }
+        }
+        CloseSeek::ProtectedOrAbsent => SummaryLine::OpenOnly {
+            after_open: after.to_string(),
+        },
+        CloseSeek::Malformed => SummaryLine::Malformed,
+    }
+}
+
+fn look_like_summary_open(body: &str) -> bool {
+    let bytes = body.as_bytes();
+    bytes.first() == Some(&b'<') && match_name(&bytes[1..], b"summary").is_some()
+}
+
+fn looks_like_summary_close(body: &str) -> bool {
+    let bytes = body.as_bytes();
+    bytes.len() >= 2
+        && bytes[0] == b'<'
+        && bytes[1] == b'/'
+        && match_name(&bytes[2..], b"summary").is_some()
+}
+
+#[derive(Debug)]
+struct ParsedOpenTag {
+    tag_end: usize,
+    has_open_attr: bool,
+    self_closing: bool,
+}
+
+fn parse_open_tag(bytes: &[u8], name: &[u8]) -> Option<ParsedOpenTag> {
+    if bytes.first() != Some(&b'<') {
+        return None;
+    }
+    let after_lt = 1;
+    if bytes.get(after_lt) == Some(&b'/') {
+        return None;
+    }
+    let name_end = match_name(&bytes[after_lt..], name)?;
+    let mut i = after_lt + name_end;
+    if !tag_name_boundary(bytes.get(i).copied()) {
+        return None;
+    }
+
+    let mut has_open_attr = false;
+    let mut self_closing = false;
+    loop {
+        if i > MAX_DETAILS_TAG_BYTES {
+            return None;
+        }
+        Work::charge(1);
+        i = skip_ascii_ws(bytes, i);
+        if i >= bytes.len() {
+            return None;
+        }
+        if i + 1 > MAX_DETAILS_TAG_BYTES {
+            return None;
+        }
+        match bytes[i] {
+            b'>' => {
+                let tag_end = i + 1;
+                if tag_end > MAX_DETAILS_TAG_BYTES {
+                    return None;
+                }
+                return Some(ParsedOpenTag {
+                    tag_end,
+                    has_open_attr,
+                    self_closing,
+                });
+            }
+            b'/' => {
+                self_closing = true;
+                i += 1;
+                i = skip_ascii_ws(bytes, i);
+                if bytes.get(i) != Some(&b'>') {
+                    return None;
+                }
+                let tag_end = i + 1;
+                if tag_end > MAX_DETAILS_TAG_BYTES {
+                    return None;
+                }
+                return Some(ParsedOpenTag {
+                    tag_end,
+                    has_open_attr,
+                    self_closing,
+                });
+            }
+            _ => {
+                let (attr_end, is_open) = parse_attribute(bytes, i)?;
+                if attr_end > MAX_DETAILS_TAG_BYTES {
+                    return None;
+                }
+                if is_open {
+                    has_open_attr = true;
+                }
+                i = attr_end;
+            }
+        }
+    }
+}
+
+fn parse_close_tag(bytes: &[u8], name: &[u8]) -> Option<usize> {
+    if bytes.len() < 2 || bytes[0] != b'<' || bytes[1] != b'/' {
+        return None;
+    }
+    let name_end = match_name(&bytes[2..], name)?;
+    let mut i = 2 + name_end;
+    if !tag_name_boundary(bytes.get(i).copied()) {
+        return None;
+    }
+    i = skip_ascii_ws(bytes, i);
+    if bytes.get(i) != Some(&b'>') {
+        return None;
+    }
+    let tag_end = i + 1;
+    if tag_end > MAX_DETAILS_TAG_BYTES {
+        return None;
+    }
+    Work::charge(tag_end);
+    Some(tag_end)
+}
+
+fn parse_attribute(bytes: &[u8], start: usize) -> Option<(usize, bool)> {
+    if start >= bytes.len() || !is_attr_name_start(bytes[start]) {
+        return None;
+    }
+    let mut i = start + 1;
+    while i < bytes.len() && is_attr_name_continue(bytes[i]) {
+        i += 1;
+    }
+    let name = &bytes[start..i];
+    let is_open = name.eq_ignore_ascii_case(b"open");
+    i = skip_ascii_ws(bytes, i);
+    if bytes.get(i) != Some(&b'=') {
+        return Some((i, is_open));
+    }
+    i += 1;
+    i = skip_ascii_ws(bytes, i);
+    if i >= bytes.len() {
+        return None;
+    }
+    match bytes[i] {
+        b'"' | b'\'' => {
+            let quote = bytes[i];
+            i += 1;
+            while i < bytes.len() && bytes[i] != quote {
+                Work::charge(1);
+                i += 1;
+                if i - start + 1 > MAX_DETAILS_TAG_BYTES {
+                    return None;
+                }
+            }
+            if i >= bytes.len() {
+                return None;
+            }
+            i += 1;
+            Some((i, is_open))
+        }
+        b'>' | b'/' => None,
+        _ => {
+            let val_start = i;
+            while i < bytes.len() && !matches!(bytes[i], b' ' | b'\t' | b'>' | b'/') {
+                Work::charge(1);
+                i += 1;
+                if i - start + 1 > MAX_DETAILS_TAG_BYTES {
+                    return None;
+                }
+            }
+            if i == val_start {
+                return None;
+            }
+            Some((i, is_open))
+        }
+    }
+}
+
+enum CloseSeek {
+    Found { rel_start: usize, tag_end: usize },
+    ProtectedOrAbsent,
+    Malformed,
+}
+
+/// Find `</summary>` in `after`, skipping markdown code spans. A closer
+/// inside a code span is content, not a terminator.
+fn find_summary_close(after: &str) -> CloseSeek {
+    let bytes = after.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        Work::charge(1);
+        if bytes[i] == b'`' {
+            match skip_code_span(bytes, i) {
+                Some(end) => i = end,
+                None => i += 1,
+            }
+            continue;
+        }
+        if bytes[i] == b'<'
+            && bytes.get(i + 1) == Some(&b'/')
+            && let Some(name_end) = match_name(&bytes[i + 2..], b"summary")
+        {
+            let mut j = i + 2 + name_end;
+            if tag_name_boundary(bytes.get(j).copied()) {
+                j = skip_ascii_ws(bytes, j);
+                if bytes.get(j) == Some(&b'>') {
+                    let tag_end = j + 1 - i;
+                    if tag_end > MAX_DETAILS_TAG_BYTES {
+                        return CloseSeek::Malformed;
+                    }
+                    return CloseSeek::Found {
+                        rel_start: i,
+                        tag_end: j + 1,
+                    };
+                }
+                return CloseSeek::Malformed;
+            }
+        }
+        i += 1;
+    }
+    CloseSeek::ProtectedOrAbsent
+}
+
+fn skip_code_span(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut ticks = 0;
+    while start + ticks < bytes.len() && bytes[start + ticks] == b'`' {
+        ticks += 1;
+    }
+    if ticks == 0 {
+        return None;
+    }
+    let mut i = start + ticks;
+    while i < bytes.len() {
+        if bytes[i] == b'`' {
+            let mut run = 0;
+            while i + run < bytes.len() && bytes[i + run] == b'`' {
+                run += 1;
+            }
+            if run == ticks {
+                return Some(i + run);
+            }
+            i += run;
+        } else {
+            i += 1;
+        }
+    }
+    None
+}
+
+fn match_name(bytes: &[u8], name: &[u8]) -> Option<usize> {
+    if bytes.len() < name.len() {
+        return None;
+    }
+    if !bytes[..name.len()].eq_ignore_ascii_case(name) {
+        return None;
+    }
+    Some(name.len())
+}
+
+fn tag_name_boundary(b: Option<u8>) -> bool {
+    match b {
+        None => true,
+        Some(b) => !b.is_ascii_alphanumeric(),
+    }
+}
+
+fn is_attr_name_start(b: u8) -> bool {
+    b.is_ascii_alphabetic()
+}
+
+fn is_attr_name_continue(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b':'
+}
+
+fn skip_ascii_ws(bytes: &[u8], mut i: usize) -> usize {
+    while i < bytes.len() && (bytes[i] == b' ' || bytes[i] == b'\t') {
+        i += 1;
+    }
+    i
+}
+
+fn is_only_ws(bytes: &[u8]) -> bool {
+    bytes.iter().all(|&b| b == b' ' || b == b'\t')
+}
+
+fn starts_with_open_angle(s: &str) -> bool {
+    s.as_bytes().first() == Some(&b'<')
+}
+
+fn trim_line_ws(line: &str) -> (&str, usize) {
+    let bytes = line.as_bytes();
+    let mut start = 0;
+    let mut end = bytes.len();
+    while start < end && (bytes[start] == b' ' || bytes[start] == b'\t') {
+        start += 1;
+    }
+    while end > start && (bytes[end - 1] == b' ' || bytes[end - 1] == b'\t') {
+        end -= 1;
+    }
+    (&line[start..end], start)
+}
+
+/// True when `inner` is empty or only horizontal whitespace.
+pub(crate) fn summary_inner_is_empty(inner: &str) -> bool {
+    inner.bytes().all(|b| b == b' ' || b == b'\t')
+}
+
+/// Second line of a two-line summary: optional content then `</summary>`.
+pub(crate) fn parse_summary_close_only(line: &str) -> Option<String> {
+    Work::charge(1);
+    let (body, _) = trim_line_ws(line);
+    if starts_with_open_angle(body) && look_like_summary_open(body) {
+        return None;
+    }
+    match find_summary_close(body) {
+        CloseSeek::Found { rel_start, tag_end } if is_only_ws(&body.as_bytes()[tag_end..]) => {
+            Some(body[..rel_start].to_string())
+        }
+        CloseSeek::Malformed => None,
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opener_basic_and_open_attr() {
+        Work::reset();
+        let a = parse_details_opener_line("  <details>  ").unwrap();
+        assert!(!a.open);
+        let b = parse_details_opener_line("<DETAILS open>").unwrap();
+        assert!(b.open);
+        let c = parse_details_opener_line(r#"<details open="false">"#).unwrap();
+        assert!(c.open);
+        let d = parse_details_opener_line("<details opened>").unwrap();
+        assert!(!d.open);
+        let e = parse_details_opener_line(r#"<details data-open="1" class="open">"#).unwrap();
+        assert!(!e.open);
+        assert!(parse_details_opener_line("<detailsx>").is_none());
+        assert!(parse_details_opener_line("<details/>").is_none());
+        assert!(parse_details_opener_line("<details> trailing").is_none());
+        assert!(parse_details_opener_line("<details><summary>x</summary></details>").is_none());
+    }
+
+    #[test]
+    fn opener_quoted_gt_and_false_prefix() {
+        assert!(parse_details_opener_line(r#"<details title="a>b">"#).is_some());
+        assert!(!parse_details_opener_line("<details openx>").unwrap().open);
+        assert!(
+            !parse_details_opener_line(r#"<details foo='open'>"#)
+                .unwrap()
+                .open
+        );
+    }
+
+    #[test]
+    fn closer_rejects_attributes() {
+        assert!(parse_details_closer_line("  </details>  ").is_some());
+        assert!(parse_details_closer_line("</DETAILS>").is_some());
+        assert!(parse_details_closer_line("</details foo>").is_none());
+        assert!(parse_details_closer_line("</detailsx>").is_none());
+    }
+
+    #[test]
+    fn summary_oneline_and_code_span() {
+        assert_eq!(
+            parse_summary_line("<summary>Tap</summary>"),
+            SummaryLine::Complete {
+                inner: "Tap".into()
+            }
+        );
+        assert_eq!(
+            parse_summary_line("<summary>`</summary>` more</summary>"),
+            SummaryLine::Complete {
+                inner: "`</summary>` more".into()
+            }
+        );
+        assert_eq!(
+            parse_summary_line("<summary>"),
+            SummaryLine::OpenOnly {
+                after_open: String::new()
+            }
+        );
+        assert!(matches!(
+            parse_summary_line("<summary foo=>"),
+            SummaryLine::Malformed
+        ));
+        assert_eq!(parse_summary_line("hello"), SummaryLine::NotSummary);
+    }
+
+    #[test]
+    fn tag_cap_is_inclusive() {
+        let pad = "x".repeat(MAX_DETAILS_TAG_BYTES - "<details class=''>".len());
+        let exact = format!("<details class='{pad}'>");
+        assert_eq!(exact.len(), MAX_DETAILS_TAG_BYTES);
+        assert!(parse_details_opener_line(&exact).is_some());
+        let over = format!("<details class='{pad}y'>");
+        assert!(over.len() > MAX_DETAILS_TAG_BYTES);
+        assert!(parse_details_opener_line(&over).is_none());
+    }
+
+    #[test]
+    fn window_stops_on_utf8_boundary() {
+        let mut s = "a".repeat(MAX_DETAILS_SCAN_BYTES - 1);
+        s.push('é');
+        s.push_str("more");
+        let w = recognition_window(&s);
+        assert!(w <= MAX_DETAILS_SCAN_BYTES);
+        assert!(s.is_char_boundary(w));
+        assert_eq!(w, MAX_DETAILS_SCAN_BYTES - 1);
+    }
+}

--- a/crates/marmot-markdown/src/details.rs
+++ b/crates/marmot-markdown/src/details.rs
@@ -5,6 +5,7 @@
 //! linear scan bound.
 
 use std::cell::Cell;
+use std::collections::HashMap;
 
 /// Inclusive byte length from `<` through `>` for a structural tag.
 pub(crate) const MAX_DETAILS_TAG_BYTES: usize = 4096;
@@ -99,6 +100,7 @@ struct DeferredCloser {
 pub(crate) struct SummaryCollector {
     inner: String,
     unmatched: Vec<(usize, usize)>,
+    unmatched_by_length: HashMap<usize, usize>,
     deferred_closers: Vec<DeferredCloser>,
 }
 
@@ -181,16 +183,31 @@ impl SummaryCollector {
             if bytes[i] == b'`' {
                 let run_end = skip_backtick_run(bytes, i, limit);
                 let run_len = run_end - i;
-                if let Some(opener_start) = take_unmatched(&mut self.unmatched, run_len) {
-                    self.unmatched
-                        .retain(|(pos, _)| *pos <= opener_start || *pos >= i);
-                    self.deferred_closers
-                        .retain(|closer| closer.rel_start <= opener_start || closer.rel_start >= i);
-                    i = run_end;
+                Work::charge(1);
+                if let Some(&opener_index) = self.unmatched_by_length.get(&run_len) {
+                    let opener_start = self.unmatched[opener_index].0;
+                    // Matching a run protects everything after its opener.
+                    // Each pending run/closer is pushed and removed at most
+                    // once; do not rescan the unaffected prefix for each span.
+                    while self.unmatched.len() > opener_index {
+                        Work::charge(1);
+                        let (_, len) = self.unmatched.pop().unwrap();
+                        self.unmatched_by_length.remove(&len);
+                    }
+                    while self
+                        .deferred_closers
+                        .last()
+                        .is_some_and(|closer| closer.rel_start > opener_start)
+                    {
+                        Work::charge(1);
+                        self.deferred_closers.pop();
+                    }
                 } else {
+                    self.unmatched_by_length
+                        .insert(run_len, self.unmatched.len());
                     self.unmatched.push((i, run_len));
-                    i = run_end;
                 }
+                i = run_end;
                 continue;
             }
             if bytes[i] == b'<'
@@ -205,7 +222,7 @@ impl SummaryCollector {
                         if tag_end - i > MAX_DETAILS_TAG_BYTES {
                             return CloseSeek::Malformed;
                         }
-                        let unmatched_before = self.unmatched.iter().any(|(pos, _)| *pos < i);
+                        let unmatched_before = !self.unmatched.is_empty();
                         if unmatched_before {
                             self.deferred_closers.push(DeferredCloser {
                                 rel_start: i,
@@ -227,11 +244,6 @@ impl SummaryCollector {
         }
         CloseSeek::ProtectedOrAbsent
     }
-}
-
-fn take_unmatched(unmatched: &mut Vec<(usize, usize)>, run_len: usize) -> Option<usize> {
-    let idx = unmatched.iter().position(|(_, len)| *len == run_len)?;
-    Some(unmatched.remove(idx).0)
 }
 
 fn inner_end(rel_start: usize, inner: &str) -> usize {
@@ -762,6 +774,24 @@ mod tests {
                 );
             }
             prev = work;
+        }
+    }
+
+    #[test]
+    fn deferred_closers_and_later_code_spans_stay_linear() {
+        for n in [500, 1_000, 2_000] {
+            Work::reset();
+            let mut collector = SummaryCollector::from_after_open("`");
+            for _ in 0..n {
+                let _ = collector.push_line("</summary>", usize::MAX);
+            }
+            for _ in 0..n {
+                let _ = collector.push_line("``code``", usize::MAX);
+            }
+            let bytes = collector.inner().len();
+            let work = Work::get();
+            assert!(work <= bytes * 16, "bytes={bytes}, work={work}");
+            assert!(collector.finalize().is_some());
         }
     }
 

--- a/crates/marmot-markdown/src/details.rs
+++ b/crates/marmot-markdown/src/details.rs
@@ -121,12 +121,6 @@ impl SummaryCollector {
         !self.unmatched.is_empty()
     }
 
-    pub(crate) fn has_deferred_closer(&self) -> bool {
-        self.deferred_closers
-            .iter()
-            .any(|closer| closer.trailing_ws_only)
-    }
-
     pub(crate) fn push_line(&mut self, next_line: &str, max_bytes: usize) -> SummaryContinue {
         Work::charge(1);
         let (next, _) = trim_leading_ws(next_line);
@@ -711,6 +705,27 @@ mod tests {
             continue_summary("use `literal", "</summary>` here</summary>"),
             SummaryContinue::Complete {
                 inner: "use `literal\n</summary>` here".into()
+            }
+        );
+        let mut collector = SummaryCollector::from_after_open("`one");
+        assert!(matches!(
+            collector.push_line("</summary>", usize::MAX),
+            SummaryContinue::StillOpen
+        ));
+        assert!(collector.has_unmatched_openers());
+        assert!(matches!(
+            collector.push_line("</details>", usize::MAX),
+            SummaryContinue::StillOpen
+        ));
+        assert!(matches!(
+            collector.push_line("two`", usize::MAX),
+            SummaryContinue::StillOpen
+        ));
+        assert!(!collector.has_unmatched_openers());
+        assert_eq!(
+            collector.push_line("</summary>", usize::MAX),
+            SummaryContinue::Complete {
+                inner: "`one\n</summary>\n</details>\ntwo`".into()
             }
         );
     }

--- a/crates/marmot-markdown/src/details.rs
+++ b/crates/marmot-markdown/src/details.rs
@@ -5,6 +5,7 @@
 //! linear scan bound.
 
 use std::cell::Cell;
+use std::collections::HashMap;
 
 /// Inclusive byte length from `<` through `>` for a structural tag.
 pub(crate) const MAX_DETAILS_TAG_BYTES: usize = 4096;
@@ -30,6 +31,10 @@ impl Work {
 
     fn charge(n: usize) {
         WORK.with(|c| c.set(c.get().saturating_add(n)));
+    }
+
+    fn charge_bytes(n: usize) {
+        Self::charge(n);
     }
 }
 
@@ -70,10 +75,14 @@ pub(crate) enum SummaryLine {
     OpenOnly {
         after_open: String,
     },
-    /// Closing tag present; opener is not on this line.
-    CloseOnly {
-        before_close: String,
-    },
+    Malformed,
+}
+
+/// Result of scanning one additional nonblank line of an already-open summary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SummaryContinue {
+    Complete { inner: String },
+    StillOpen { accumulated: String },
     Malformed,
 }
 
@@ -118,18 +127,18 @@ pub(crate) fn parse_details_closer_line(line: &str) -> Option<DetailsClose> {
 /// Classify a candidate first-child summary line (container prefixes already
 /// stripped). Leading/trailing horizontal whitespace around the whole line is
 /// allowed; anything else before the opener or after the closer is malformed.
+///
+/// First-nonblank classification does not search for a closer-only line: a
+/// body line of backticks must not pay summary-close work.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn parse_summary_line(line: &str) -> SummaryLine {
+    parse_summary_line_bounded(line, usize::MAX)
+}
+
+pub(crate) fn parse_summary_line_bounded(line: &str, max_bytes: usize) -> SummaryLine {
     Work::charge(1);
     let (body, _) = trim_line_ws(line);
     if !starts_with_open_angle(body) {
-        if let Some(inner) = parse_summary_close_only(line) {
-            return SummaryLine::CloseOnly {
-                before_close: inner,
-            };
-        }
-        if looks_like_summary_close(body) {
-            return SummaryLine::Malformed;
-        }
         return SummaryLine::NotSummary;
     }
 
@@ -145,7 +154,7 @@ pub(crate) fn parse_summary_line(line: &str) -> SummaryLine {
     }
 
     let after = &body[open.tag_end..];
-    match find_summary_close(after) {
+    match find_summary_close_bounded(after, max_bytes.saturating_sub(open.tag_end)) {
         CloseSeek::Found { rel_start, tag_end } => {
             if !is_only_ws(&after.as_bytes()[tag_end..]) {
                 return SummaryLine::Malformed;
@@ -161,17 +170,62 @@ pub(crate) fn parse_summary_line(line: &str) -> SummaryLine {
     }
 }
 
+/// Continue an open `<summary>` across the next consecutive nonblank line,
+/// keeping code-span matching in the accumulated inner source.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn continue_summary(accumulated: &str, next_line: &str) -> SummaryContinue {
+    continue_summary_bounded(accumulated, next_line, usize::MAX)
+}
+
+pub(crate) fn continue_summary_bounded(
+    accumulated: &str,
+    next_line: &str,
+    max_bytes: usize,
+) -> SummaryContinue {
+    Work::charge(1);
+    let (next, _) = trim_line_ws(next_line);
+    if starts_with_open_angle(next) && look_like_summary_open(next) {
+        return SummaryContinue::Malformed;
+    }
+    let search = join_summary_inner(accumulated, next);
+    match find_summary_close_bounded(&search, max_bytes) {
+        CloseSeek::Found { rel_start, tag_end } => {
+            if !is_only_ws(&search.as_bytes()[tag_end..]) {
+                return SummaryContinue::Malformed;
+            }
+            let prefix_len = if accumulated.is_empty() {
+                0
+            } else {
+                accumulated.len() + 1
+            };
+            let before_close = if rel_start >= prefix_len {
+                &search[prefix_len..rel_start]
+            } else {
+                &search[..rel_start]
+            };
+            SummaryContinue::Complete {
+                inner: join_summary_inner(accumulated, before_close),
+            }
+        }
+        CloseSeek::ProtectedOrAbsent => SummaryContinue::StillOpen {
+            accumulated: search,
+        },
+        CloseSeek::Malformed => SummaryContinue::Malformed,
+    }
+}
+
+pub(crate) fn join_summary_inner(left: &str, right: &str) -> String {
+    match (left.is_empty(), right.is_empty()) {
+        (true, true) => String::new(),
+        (true, false) => right.to_string(),
+        (false, true) => left.to_string(),
+        (false, false) => format!("{left}\n{right}"),
+    }
+}
+
 fn look_like_summary_open(body: &str) -> bool {
     let bytes = body.as_bytes();
     bytes.first() == Some(&b'<') && match_name(&bytes[1..], b"summary").is_some()
-}
-
-fn looks_like_summary_close(body: &str) -> bool {
-    let bytes = body.as_bytes();
-    bytes.len() >= 2
-        && bytes[0] == b'<'
-        && bytes[1] == b'/'
-        && match_name(&bytes[2..], b"summary").is_some()
 }
 
 #[derive(Debug)]
@@ -334,16 +388,23 @@ enum CloseSeek {
 }
 
 /// Find `</summary>` in `after`, skipping markdown code spans. A closer
-/// inside a code span is content, not a terminator.
-fn find_summary_close(after: &str) -> CloseSeek {
+/// inside a code span is content, not a terminator. Backtick runs are
+/// indexed once so unmatched openers never rescan the same suffix.
+fn find_summary_close_bounded(after: &str, max_bytes: usize) -> CloseSeek {
+    let limit = after.len().min(max_bytes);
+    let limit = floor_char_boundary(after, limit);
     let bytes = after.as_bytes();
+    let index = CodeSpanIndex::new(&bytes[..limit]);
     let mut i = 0;
-    while i < bytes.len() {
+    while i < limit {
         Work::charge(1);
         if bytes[i] == b'`' {
-            match skip_code_span(bytes, i) {
-                Some(end) => i = end,
-                None => i += 1,
+            let run_end = skip_backtick_run(bytes, i, limit);
+            let run_len = run_end - i;
+            if let Some((_, close_end)) = index.next_run(run_len, i) {
+                i = close_end.min(limit);
+            } else {
+                i = run_end;
             }
             continue;
         }
@@ -372,30 +433,53 @@ fn find_summary_close(after: &str) -> CloseSeek {
     CloseSeek::ProtectedOrAbsent
 }
 
-fn skip_code_span(bytes: &[u8], start: usize) -> Option<usize> {
-    let mut ticks = 0;
-    while start + ticks < bytes.len() && bytes[start + ticks] == b'`' {
-        ticks += 1;
-    }
-    if ticks == 0 {
-        return None;
-    }
-    let mut i = start + ticks;
-    while i < bytes.len() {
-        if bytes[i] == b'`' {
-            let mut run = 0;
-            while i + run < bytes.len() && bytes[i + run] == b'`' {
-                run += 1;
+/// Backtick runs indexed once by length. A failed match skips the whole
+/// opener run instead of retrying at every remaining tick.
+struct CodeSpanIndex {
+    by_len: HashMap<usize, Vec<(usize, usize)>>,
+}
+
+impl CodeSpanIndex {
+    fn new(bytes: &[u8]) -> Self {
+        let mut by_len: HashMap<usize, Vec<(usize, usize)>> = HashMap::new();
+        let mut i = 0;
+        while i < bytes.len() {
+            Work::charge_bytes(1);
+            if bytes[i] != b'`' {
+                i += 1;
+                continue;
             }
-            if run == ticks {
-                return Some(i + run);
-            }
-            i += run;
-        } else {
-            i += 1;
+            let end = skip_backtick_run(bytes, i, bytes.len());
+            by_len.entry(end - i).or_default().push((i, end));
+            i = end;
         }
+        Self { by_len }
     }
-    None
+
+    fn next_run(&self, run_len: usize, after_start: usize) -> Option<(usize, usize)> {
+        let runs = self.by_len.get(&run_len)?;
+        let next = runs.partition_point(|(start, _)| *start <= after_start);
+        runs.get(next).copied()
+    }
+}
+
+fn skip_backtick_run(bytes: &[u8], start: usize, limit: usize) -> usize {
+    let mut end = start;
+    while end < limit && bytes[end] == b'`' {
+        Work::charge_bytes(1);
+        end += 1;
+    }
+    end
+}
+
+fn floor_char_boundary(s: &str, mut end: usize) -> usize {
+    if end >= s.len() {
+        return s.len();
+    }
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    end
 }
 
 fn match_name(bytes: &[u8], name: &[u8]) -> Option<usize> {
@@ -425,6 +509,7 @@ fn is_attr_name_continue(b: u8) -> bool {
 
 fn skip_ascii_ws(bytes: &[u8], mut i: usize) -> usize {
     while i < bytes.len() && (bytes[i] == b' ' || bytes[i] == b'\t') {
+        Work::charge_bytes(1);
         i += 1;
     }
     i
@@ -451,25 +536,11 @@ fn trim_line_ws(line: &str) -> (&str, usize) {
     (&line[start..end], start)
 }
 
-/// True when `inner` is empty or only horizontal whitespace.
+/// True when `inner` is empty or only whitespace (including newlines).
 pub(crate) fn summary_inner_is_empty(inner: &str) -> bool {
-    inner.bytes().all(|b| b == b' ' || b == b'\t')
-}
-
-/// Second line of a two-line summary: optional content then `</summary>`.
-pub(crate) fn parse_summary_close_only(line: &str) -> Option<String> {
-    Work::charge(1);
-    let (body, _) = trim_line_ws(line);
-    if starts_with_open_angle(body) && look_like_summary_open(body) {
-        return None;
-    }
-    match find_summary_close(body) {
-        CloseSeek::Found { rel_start, tag_end } if is_only_ws(&body.as_bytes()[tag_end..]) => {
-            Some(body[..rel_start].to_string())
-        }
-        CloseSeek::Malformed => None,
-        _ => None,
-    }
+    inner
+        .bytes()
+        .all(|b| b == b' ' || b == b'\t' || b == b'\n' || b == b'\r')
 }
 
 #[cfg(test)]
@@ -539,6 +610,51 @@ mod tests {
             SummaryLine::Malformed
         ));
         assert_eq!(parse_summary_line("hello"), SummaryLine::NotSummary);
+        assert_eq!(parse_summary_line(&"`".repeat(64)), SummaryLine::NotSummary);
+    }
+
+    #[test]
+    fn continue_summary_spans_lines_and_code() {
+        assert_eq!(
+            continue_summary("", "More **information**"),
+            SummaryContinue::StillOpen {
+                accumulated: "More **information**".into()
+            }
+        );
+        assert_eq!(
+            continue_summary("More **information**", "</summary>"),
+            SummaryContinue::Complete {
+                inner: "More **information**".into()
+            }
+        );
+        assert_eq!(
+            continue_summary("use `literal", "</summary>` here</summary>"),
+            SummaryContinue::Complete {
+                inner: "use `literal\n</summary>` here".into()
+            }
+        );
+    }
+
+    #[test]
+    fn unmatched_backtick_close_search_is_linear() {
+        let mut prev = 0usize;
+        for n in [2_000usize, 4_000, 8_000, 16_000] {
+            Work::reset();
+            let line = "`".repeat(n);
+            let _ = continue_summary("after", &line);
+            let work = Work::get();
+            assert!(
+                work <= n * 8 + 256,
+                "close search must stay linear, n={n} work={work}"
+            );
+            if prev > 0 {
+                assert!(
+                    work <= prev.saturating_mul(3),
+                    "work must not jump quadratically, prev={prev} work={work}"
+                );
+            }
+            prev = work;
+        }
     }
 
     #[test]

--- a/crates/marmot-markdown/src/inline.rs
+++ b/crates/marmot-markdown/src/inline.rs
@@ -142,6 +142,21 @@ fn walk(block: Block, refs: &HashMap<String, LinkRef>) -> Block {
                 })
                 .collect(),
         },
+        Block::Details {
+            summary,
+            open,
+            body,
+            blank_lines_before,
+        } => Block::Details {
+            summary: if summary.is_empty() {
+                Vec::new()
+            } else {
+                tokenize(&extract_raw(summary), refs)
+            },
+            open,
+            body: walk_blocks(body, refs),
+            blank_lines_before,
+        },
         Block::Table {
             alignments,
             header,

--- a/crates/marmot-markdown/src/lib.rs
+++ b/crates/marmot-markdown/src/lib.rs
@@ -28,11 +28,12 @@
 //!
 //! ## HTML is not parsed
 //!
-//! Unlike CommonMark proper, this parser **does not** recognize HTML
+//! Unlike CommonMark proper, this parser **does not** recognize general HTML
 //! blocks or raw HTML inlines. Tag-like sequences (`<div>`, `<!-- ... -->`,
 //! etc.) are passed through as literal text and HTML-escaped at render
 //! time. Only autolinks — `<scheme:body>` and `<email@host>` — get
-//! structured treatment.
+//! structured treatment, plus a bounded [`Block::Details`] extension for
+//! structural `<details>` / `<summary>` lines (see the crate README).
 //!
 //! ## Untrusted destinations
 //!
@@ -60,6 +61,7 @@
 pub mod ast;
 mod block;
 mod destination;
+mod details;
 mod entity;
 mod inline;
 mod nostr;
@@ -95,6 +97,13 @@ pub use destination::classify_link_destination;
 ///   literal.
 /// - Math: inline `$…$` and block `$$ … $$` (content is opaque — recognized
 ///   but never parsed as LaTeX).
+/// - Bounded `<details>` / `<summary>` disclosure blocks. The opener and
+///   closer each occupy their own logical line after quote/list prefixes and
+///   at most three columns of local indent. Compact one-line HTML stays
+///   literal. Recognition is limited to a 65536-byte original-source prefix
+///   and a 4096-byte structural tag cap. Missing or empty summaries yield an
+///   empty `summary` list; clients may localize a fallback label. Failed
+///   candidates remain ordinary Markdown with their tags literal.
 /// - Nostr bare mentions (`@npub1…`) and URIs (`nostr:<hrp>1…`) for the
 ///   whitelisted HRPs `npub`, `note`, `nevent`, `nprofile`, `naddr`,
 ///   `nrelay`. `nsec` is deliberately rejected from the ergonomic
@@ -109,4 +118,30 @@ pub use destination::classify_link_destination;
 pub fn parse(input: &str) -> Document {
     let (blocks, blank_lines_before, refs) = block::parse_blocks(input);
     inline::parse_inlines(blocks, blank_lines_before, &refs)
+}
+
+#[cfg(test)]
+mod details_work_tests {
+    use super::*;
+    use crate::details::Work;
+
+    #[test]
+    fn many_failed_openers_stay_linear() {
+        let mut md = String::new();
+        for _ in 0..200 {
+            md.push_str("<details>\n");
+        }
+        md.push_str("tail\n");
+        let doc = parse(&md);
+        assert!(
+            !doc.blocks
+                .iter()
+                .any(|b| matches!(b, Block::Details { .. }))
+        );
+        let work = Work::get();
+        assert!(
+            work < 200 * 64,
+            "failed openers must not rescan quadratically, work={work}"
+        );
+    }
 }

--- a/crates/marmot-markdown/src/lib.rs
+++ b/crates/marmot-markdown/src/lib.rs
@@ -215,4 +215,93 @@ mod details_work_tests {
             "unequal run lengths must not rescan suffixes, work={work}"
         );
     }
+
+    #[test]
+    fn multiline_scanner_actual_work_is_linear() {
+        let mut prev = 0usize;
+        for n in [1_000usize, 2_000, 4_000, 8_000] {
+            Work::reset();
+            let mut md = String::from("<details>\n<summary>\n");
+            for _ in 0..n {
+                md.push_str("x\n");
+            }
+            md.push_str("</details>");
+            let _ = parse(&md);
+            let work = Work::get();
+            let bytes = md.len();
+            assert!(
+                work <= bytes * 16 + 4_096,
+                "multiline continuation must stay linear, n={n} bytes={bytes} work={work}"
+            );
+            if prev > 0 {
+                assert!(
+                    work <= prev.saturating_mul(3),
+                    "work must not jump quadratically, n={n} prev={prev} work={work}"
+                );
+            }
+            prev = work;
+        }
+        Work::reset();
+        let near_cap = 32_000usize;
+        let mut md = String::from("<details>\n<summary>\n");
+        for _ in 0..near_cap {
+            md.push_str("x\n");
+        }
+        let bytes = md.len();
+        let _ = parse(&md);
+        let work = Work::get();
+        assert!(
+            work <= bytes * 16 + 4_096,
+            "many-line open summary near the FFI cap must stay linear, bytes={bytes} work={work}"
+        );
+    }
+
+    #[test]
+    fn many_line_open_summary_release_probe_compares_to_control() {
+        use std::time::Instant;
+        let n = 32_749usize;
+        let mut hostile = String::from("<details>\n<summary>\n");
+        for _ in 0..n {
+            hostile.push_str("x\n");
+        }
+        let mut control = String::from("<details>\n");
+        for _ in 0..n {
+            control.push_str("x\n");
+        }
+        let _ = parse(&hostile);
+        let _ = parse(&control);
+        let started = Instant::now();
+        let _ = parse(&hostile);
+        let hostile_us = started.elapsed().as_micros();
+        let started = Instant::now();
+        let _ = parse(&control);
+        let control_us = started.elapsed().as_micros();
+        eprintln!(
+            "many-line open-summary probe bytes={} hostile_us={} control_us={} ratio={:.2}",
+            hostile.len(),
+            hostile_us,
+            control_us,
+            hostile_us as f64 / control_us.max(1) as f64
+        );
+        assert!(
+            hostile_us < 5_000_000,
+            "hostile many-line summary must stay well under the previous multi-second stall, us={hostile_us}"
+        );
+    }
+
+    #[test]
+    fn bounded_summary_never_copies_unbounded_suffix() {
+        Work::reset();
+        let huge = format!("<summary>{}", "z".repeat(1_000_000));
+        let classified = crate::details::parse_summary_line_bounded(&huge, 16);
+        assert!(matches!(
+            classified,
+            crate::details::SummaryLine::OpenOnly { .. }
+        ));
+        let work = Work::get();
+        assert!(
+            work < 8_192,
+            "a 16-byte budget must not copy a 1MB suffix, work={work}"
+        );
+    }
 }

--- a/crates/marmot-markdown/src/lib.rs
+++ b/crates/marmot-markdown/src/lib.rs
@@ -257,36 +257,17 @@ mod details_work_tests {
     }
 
     #[test]
-    fn many_line_open_summary_release_probe_compares_to_control() {
-        use std::time::Instant;
-        let n = 32_749usize;
-        let mut hostile = String::from("<details>\n<summary>\n");
-        for _ in 0..n {
-            hostile.push_str("x\n");
+    fn deferred_summary_closers_with_later_code_spans_stay_linear() {
+        for n in [500, 1_000, 2_000] {
+            let md = format!(
+                "<details>\n<summary>`\n{}{}",
+                "</summary>\n".repeat(n),
+                "``code``\n".repeat(n),
+            );
+            let _ = parse(&md);
+            let work = Work::get();
+            assert!(work <= md.len() * 16 + 4_096, "work={work}");
         }
-        let mut control = String::from("<details>\n");
-        for _ in 0..n {
-            control.push_str("x\n");
-        }
-        let _ = parse(&hostile);
-        let _ = parse(&control);
-        let started = Instant::now();
-        let _ = parse(&hostile);
-        let hostile_us = started.elapsed().as_micros();
-        let started = Instant::now();
-        let _ = parse(&control);
-        let control_us = started.elapsed().as_micros();
-        eprintln!(
-            "many-line open-summary probe bytes={} hostile_us={} control_us={} ratio={:.2}",
-            hostile.len(),
-            hostile_us,
-            control_us,
-            hostile_us as f64 / control_us.max(1) as f64
-        );
-        assert!(
-            hostile_us < 5_000_000,
-            "hostile many-line summary must stay well under the previous multi-second stall, us={hostile_us}"
-        );
     }
 
     #[test]

--- a/crates/marmot-markdown/src/lib.rs
+++ b/crates/marmot-markdown/src/lib.rs
@@ -144,4 +144,75 @@ mod details_work_tests {
             "failed openers must not rescan quadratically, work={work}"
         );
     }
+
+    #[test]
+    fn unmatched_backtick_first_line_stays_linear() {
+        use crate::details::MAX_DETAILS_SCAN_BYTES;
+        let mut prev = 0usize;
+        for n in [4_000usize, 8_000, 16_000, 32_000] {
+            Work::reset();
+            let md = format!("<details>\n{}\n</details>", "`".repeat(n));
+            let _ = parse(&md);
+            let work = Work::get();
+            assert!(
+                work <= n * 16 + 4_096,
+                "backtick close-search must stay linear, n={n} work={work}"
+            );
+            if prev > 0 {
+                assert!(
+                    work <= prev.saturating_mul(3),
+                    "work must not jump quadratically, n={n} prev={prev} work={work}"
+                );
+            }
+            prev = work;
+        }
+        Work::reset();
+        let near_cap = 65_519.min(MAX_DETAILS_SCAN_BYTES.saturating_sub(16));
+        let md = format!("<details>\n{}\n</details>", "`".repeat(near_cap));
+        let _ = parse(&md);
+        let work = Work::get();
+        assert!(
+            work <= near_cap * 16 + 4_096,
+            "FFI-cap backtick line must stay linear, work={work}"
+        );
+    }
+
+    #[test]
+    fn summary_opener_plus_backticks_stays_linear() {
+        let mut prev = 0usize;
+        for n in [4_000usize, 8_000, 16_000, 32_000] {
+            Work::reset();
+            let md = format!("<details>\n<summary>{}\n</details>", "`".repeat(n));
+            let _ = parse(&md);
+            let work = Work::get();
+            assert!(
+                work <= n * 16 + 4_096,
+                "summary+backtick search must stay linear, n={n} work={work}"
+            );
+            if prev > 0 {
+                assert!(
+                    work <= prev.saturating_mul(3),
+                    "work must not jump quadratically, n={n} prev={prev} work={work}"
+                );
+            }
+            prev = work;
+        }
+    }
+
+    #[test]
+    fn unequal_backtick_runs_stay_linear() {
+        Work::reset();
+        let mut md = String::from("<details>\n<summary>");
+        for len in 1..=64 {
+            md.push_str(&"`".repeat(len));
+            md.push('x');
+        }
+        md.push_str("\n</details>");
+        let _ = parse(&md);
+        let work = Work::get();
+        assert!(
+            work < 64 * 64 * 8,
+            "unequal run lengths must not rescan suffixes, work={work}"
+        );
+    }
 }

--- a/crates/marmot-markdown/src/scanner.rs
+++ b/crates/marmot-markdown/src/scanner.rs
@@ -8,45 +8,53 @@
 ///
 /// The iterator yields one item per line; if the input ends without a
 /// trailing newline, the final partial line is still yielded.
-pub(crate) fn lines(input: &str) -> Lines<'_> {
-    Lines { rest: input }
+#[allow(dead_code)]
+pub(crate) fn lines(input: &str) -> impl Iterator<Item = &str> {
+    lines_with_offsets(input).map(|(line, _)| line)
 }
 
-pub(crate) struct Lines<'a> {
-    rest: &'a str,
+/// Yield `(line, start_byte_offset)` over original source, matching [`lines`].
+pub(crate) fn lines_with_offsets(input: &str) -> LinesWithOffsets<'_> {
+    LinesWithOffsets { input, pos: 0 }
 }
 
-impl<'a> Iterator for Lines<'a> {
-    type Item = &'a str;
+pub(crate) struct LinesWithOffsets<'a> {
+    input: &'a str,
+    pos: usize,
+}
 
-    fn next(&mut self) -> Option<&'a str> {
-        if self.rest.is_empty() {
+impl<'a> Iterator for LinesWithOffsets<'a> {
+    type Item = (&'a str, usize);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.pos >= self.input.len() {
             return None;
         }
-        let bytes = self.rest.as_bytes();
-        let mut i = 0;
+        let start = self.pos;
+        let bytes = self.input.as_bytes();
+        let mut i = start;
         while i < bytes.len() {
             match bytes[i] {
                 b'\n' => {
-                    let line = &self.rest[..i];
-                    self.rest = &self.rest[i + 1..];
-                    return Some(line);
+                    let line = &self.input[start..i];
+                    self.pos = i + 1;
+                    return Some((line, start));
                 }
                 b'\r' => {
-                    let line = &self.rest[..i];
+                    let line = &self.input[start..i];
                     let mut step = 1;
                     if i + 1 < bytes.len() && bytes[i + 1] == b'\n' {
                         step = 2;
                     }
-                    self.rest = &self.rest[i + step..];
-                    return Some(line);
+                    self.pos = i + step;
+                    return Some((line, start));
                 }
                 _ => i += 1,
             }
         }
-        let line = self.rest;
-        self.rest = "";
-        Some(line)
+        let line = &self.input[start..];
+        self.pos = self.input.len();
+        Some((line, start))
     }
 }
 

--- a/crates/marmot-markdown/tests/common/render.rs
+++ b/crates/marmot-markdown/tests/common/render.rs
@@ -122,6 +122,23 @@ fn render_block(b: &Block, out: &mut String) {
             out.push_str(&escape(content));
             out.push_str("</div>\n");
         }
+        Block::Details {
+            summary,
+            open,
+            body,
+            ..
+        } => {
+            if *open {
+                out.push_str("<details open>\n");
+            } else {
+                out.push_str("<details>\n");
+            }
+            out.push_str("<summary>");
+            render_inlines(summary, out);
+            out.push_str("</summary>\n");
+            render_blocks(body, out);
+            out.push_str("</details>\n");
+        }
     }
 }
 

--- a/crates/marmot-markdown/tests/details_regressions.rs
+++ b/crates/marmot-markdown/tests/details_regressions.rs
@@ -240,6 +240,156 @@ fn blank_interrupted_summary_falls_back() {
 }
 
 #[test]
+fn fallback_restores_markdown_heading() {
+    let doc = parse("<details>\n<summary>one\n# heading\n\nbody\n</details>");
+    assert!(!has_details(&doc));
+    assert_eq!(doc.blocks[0], paragraph("<details>"));
+    assert!(
+        doc.blocks
+            .iter()
+            .any(|block| matches!(block, Block::Heading { level: 1, .. })),
+        "fallback must restore heading structure: {doc:?}"
+    );
+    assert_eq!(doc.blocks.last(), Some(&paragraph("</details>")));
+    assert!(texts(&doc).contains("one"));
+    assert!(texts(&doc).contains("heading"));
+    assert!(texts(&doc).contains("body"));
+}
+
+#[test]
+fn fallback_retains_blank_before_summary() {
+    let doc = parse("<details>\n\n<summary>sum</summary>\n\nbody");
+    assert!(!has_details(&doc));
+    assert_eq!(
+        doc.blank_lines_before,
+        vec![0, 1, 1],
+        "gap before a completed summary must survive fallback: {doc:?}"
+    );
+    assert_eq!(doc.blocks[0], paragraph("<details>"));
+    assert!(texts(&doc).contains("sum"));
+    assert_eq!(doc.blocks.last(), Some(&paragraph("body")));
+}
+
+#[test]
+fn fallback_multiline_keeps_lists_code_refs_and_siblings() {
+    let doc = parse(
+        "<details>\n<summary>one\n- item\n    code\n[lab]: /url\n\nsee [lab]\n# After\n</details>\n\nsibling",
+    );
+    assert!(!has_details(&doc));
+    assert!(
+        doc.blocks
+            .iter()
+            .any(|block| matches!(block, Block::List { .. })),
+        "list structure must survive fallback: {doc:?}"
+    );
+    assert!(
+        doc.blocks
+            .iter()
+            .any(|block| matches!(block, Block::CodeBlock { .. })),
+        "indented code must survive fallback: {doc:?}"
+    );
+    assert!(
+        doc.blocks
+            .iter()
+            .any(|block| matches!(block, Block::Heading { .. })),
+        "following heading must survive: {doc:?}"
+    );
+    assert_eq!(doc.blocks.last(), Some(&paragraph("sibling")));
+}
+
+#[test]
+fn fallback_blank_before_summary_on_container_loss_and_scan_refusal() {
+    let listed = parse("- <details>\n\n  <summary>sum</summary>\n  body\n# After");
+    assert!(!has_details(&listed));
+    let Block::List { items, .. } = &listed.blocks[0] else {
+        panic!("list: {listed:?}");
+    };
+    assert!(
+        items[0].blank_lines_before.get(1) == Some(&1),
+        "container-loss fallback must keep the blank before summary: {listed:?}"
+    );
+    assert_eq!(listed.blocks.last(), Some(&common::heading(1, "After")));
+
+    let header = "<details>\n\n<summary>sum</summary>\n";
+    let pad = 65_536_usize.saturating_sub(header.len());
+    let md = format!("{header}{}</details>", "y".repeat(pad));
+    let doc = parse(&md);
+    assert!(!has_details(&doc));
+    assert_eq!(doc.blank_lines_before[0], 0);
+    assert!(
+        doc.blank_lines_before.get(1) == Some(&1),
+        "scan-refused fallback must keep the blank before summary: {doc:?}"
+    );
+}
+
+#[test]
+fn summary_code_protects_details_delimiter() {
+    let doc = parse("<details>\n<summary>`one\n</details>\ntwo`\n</summary>\nbody\n</details>");
+    let Block::Details { summary, body, .. } = &doc.blocks[0] else {
+        panic!("expected Details, got {doc:?}");
+    };
+    assert!(
+        summary
+            .iter()
+            .any(|inline| matches!(inline, Inline::Code(s) if s.contains("</details>"))),
+        "code span must protect the details delimiter: {summary:?}"
+    );
+    assert_eq!(body, &vec![paragraph("body")]);
+}
+
+#[test]
+fn code_span_can_protect_earlier_line_summary_closer() {
+    let doc = parse("<details>\n<summary>`one\n</summary>\ntwo`</summary>\nbody\n</details>");
+    let Block::Details { summary, .. } = &doc.blocks[0] else {
+        panic!("expected Details, got {doc:?}");
+    };
+    assert_eq!(
+        summary,
+        &[code("one </summary> two")],
+        "later matching ticks must protect the earlier closer: {summary:?}"
+    );
+}
+
+#[test]
+fn summary_retains_hard_break() {
+    let doc = parse("<details>\n<summary>one  \ntwo</summary>\nbody\n</details>");
+    let Block::Details { summary, .. } = &doc.blocks[0] else {
+        panic!("expected Details, got {doc:?}");
+    };
+    assert!(
+        summary
+            .iter()
+            .any(|inline| matches!(inline, Inline::HardBreak)),
+        "two trailing spaces must remain a hard break: {summary:?}"
+    );
+}
+
+#[test]
+fn summary_code_span_can_span_three_lines_and_crlf() {
+    let doc = parse("<details>\n<summary>`one\n</summary>\ntwo`</summary>\nbody\n</details>");
+    let Block::Details { summary, .. } = &doc.blocks[0] else {
+        panic!("expected Details, got {doc:?}");
+    };
+    assert!(
+        summary
+            .iter()
+            .any(|inline| matches!(inline, Inline::Code(_)))
+    );
+
+    let crlf = parse(
+        "<details>\r\n<summary>`one\r\n</summary>\r\ntwo`</summary>\r\nbody\r\n</details>\r\n",
+    );
+    let Block::Details { summary, .. } = &crlf.blocks[0] else {
+        panic!("expected CRLF Details, got {crlf:?}");
+    };
+    assert!(
+        summary
+            .iter()
+            .any(|inline| matches!(inline, Inline::Code(_)))
+    );
+}
+
+#[test]
 fn indented_code_then_summary_in_quote() {
     let doc = parse("> <details>\n>     code\n>\n> <summary>later</summary>\n> body\n> </details>");
     let Block::BlockQuote { blocks, .. } = &doc.blocks[0] else {

--- a/crates/marmot-markdown/tests/details_regressions.rs
+++ b/crates/marmot-markdown/tests/details_regressions.rs
@@ -273,7 +273,7 @@ fn fallback_retains_blank_before_summary() {
 #[test]
 fn fallback_multiline_keeps_lists_code_refs_and_siblings() {
     let doc = parse(
-        "<details>\n<summary>one\n- item\n    code\n[lab]: /url\n\nsee [lab]\n# After\n</details>\n\nsibling",
+        "<details>\n<summary>one\n- item\n\n    code\n\n[lab]: /url\n\nsee [lab]\n# After\n</details>\n\nsibling",
     );
     assert!(!has_details(&doc));
     assert!(
@@ -444,4 +444,88 @@ fn indented_code_then_summary_in_quote() {
         )),
         _ => false,
     }));
+}
+
+#[test]
+fn failed_summary_replays_ordinary_block_semantics() {
+    for summary in [
+        "<summary>\nTitle\n---",
+        "<summary>\nTitle\n===",
+        "<summary>\n~~~rust\n# literal heading\n~~~",
+        "<summary>\n$$\nx + y\n$$",
+        "<summary>\n- first\n- second",
+        "<summary>\n> first\n> second",
+        "<summary>\nheader | value\n--- | ---\na | b",
+    ] {
+        let expected = parse(summary);
+        for ending in ["", "\n\n# After", "\n</details>\n# After"] {
+            let doc = parse(&format!("<details>\n{summary}{ending}"));
+            assert_eq!(doc.blocks[0], paragraph("<details>"));
+            assert_eq!(
+                &doc.blocks[1..1 + expected.blocks.len()],
+                expected.blocks.as_slice(),
+                "fallback changed ordinary Markdown: {summary:?}, ending={ending:?}: {doc:?}"
+            );
+            if !ending.is_empty() {
+                assert_eq!(doc.blocks.last(), Some(&common::heading(1, "After")));
+            }
+        }
+    }
+}
+
+#[test]
+fn failed_summary_replay_respects_remaining_container_depth() {
+    let prefix = "> ".repeat(90);
+    let held = format!("<summary>\n{}content", "> ".repeat(200));
+    let input = held
+        .lines()
+        .map(|line| format!("{prefix}{line}\n"))
+        .collect::<String>();
+    let doc = parse(&format!("{prefix}<details>\n{input}"));
+    let mut blocks = doc.blocks.as_slice();
+    let mut depth = 0;
+    loop {
+        let quote = blocks.iter().find_map(|block| match block {
+            Block::BlockQuote { blocks, .. } => Some(blocks.as_slice()),
+            _ => None,
+        });
+        let Some(children) = quote else { break };
+        depth += 1;
+        assert!(depth <= 96, "fallback exceeded container depth: {depth}");
+        blocks = children;
+    }
+    assert!(texts(&doc).contains("content"));
+}
+
+#[test]
+fn many_line_open_summary_release_probe_compares_to_control() {
+    use std::time::Instant;
+    let n = 32_749usize;
+    let mut hostile = String::from("<details>\n<summary>\n");
+    for _ in 0..n {
+        hostile.push_str("x\n");
+    }
+    let mut control = String::from("<details>\n");
+    for _ in 0..n {
+        control.push_str("x\n");
+    }
+    let _ = parse(&hostile);
+    let _ = parse(&control);
+    let started = Instant::now();
+    let _ = parse(&hostile);
+    let hostile_us = started.elapsed().as_micros();
+    let started = Instant::now();
+    let _ = parse(&control);
+    let control_us = started.elapsed().as_micros();
+    eprintln!(
+        "many-line open-summary probe bytes={} hostile_us={} control_us={} ratio={:.2}",
+        hostile.len(),
+        hostile_us,
+        control_us,
+        hostile_us as f64 / control_us.max(1) as f64
+    );
+    assert!(
+        hostile_us < 5_000_000,
+        "hostile many-line summary must stay well under the previous multi-second stall, us={hostile_us}"
+    );
 }

--- a/crates/marmot-markdown/tests/details_regressions.rs
+++ b/crates/marmot-markdown/tests/details_regressions.rs
@@ -1,0 +1,263 @@
+//! Reviewer-required disclosure regressions (fallback, multiline, bounds).
+
+use marmot_markdown::{Block, Inline, parse};
+
+mod common;
+use common::{code, paragraph, t};
+
+fn texts(doc: &marmot_markdown::Document) -> String {
+    fn walk_blocks(blocks: &[Block], out: &mut String) {
+        for block in blocks {
+            match block {
+                Block::Paragraph { inlines } | Block::Heading { inlines, .. } => {
+                    walk_inlines(inlines, out);
+                }
+                Block::BlockQuote { blocks, .. } => walk_blocks(blocks, out),
+                Block::List { items, .. } => {
+                    for item in items {
+                        walk_blocks(&item.blocks, out);
+                    }
+                }
+                Block::Details { summary, body, .. } => {
+                    walk_inlines(summary, out);
+                    walk_blocks(body, out);
+                }
+                Block::CodeBlock { content, .. } | Block::MathBlock { content } => {
+                    out.push_str(content);
+                }
+                Block::Table { header, rows, .. } => {
+                    for cell in header.iter().chain(rows.iter().flatten()) {
+                        walk_inlines(&cell.inlines, out);
+                    }
+                }
+                Block::ThematicBreak => {}
+            }
+            out.push('\n');
+        }
+    }
+    fn walk_inlines(inlines: &[Inline], out: &mut String) {
+        for inline in inlines {
+            match inline {
+                Inline::Text(s) | Inline::Code(s) => out.push_str(s),
+                Inline::Emph(c) | Inline::Strong(c) | Inline::Strikethrough(c) => {
+                    walk_inlines(c, out);
+                }
+                Inline::Link { children, .. } => walk_inlines(children, out),
+                Inline::SoftBreak | Inline::HardBreak => out.push('\n'),
+                Inline::Image { alt, .. } => walk_inlines(alt, out),
+                Inline::Autolink { url, .. } => out.push_str(url),
+                Inline::Math(s) => out.push_str(s),
+                Inline::NostrMention(entity) | Inline::NostrUri(entity) => {
+                    out.push_str(&entity.bech32);
+                }
+            }
+        }
+    }
+    let mut out = String::new();
+    walk_blocks(&doc.blocks, &mut out);
+    out
+}
+
+fn has_details(doc: &marmot_markdown::Document) -> bool {
+    fn walk(blocks: &[Block]) -> bool {
+        blocks.iter().any(|block| match block {
+            Block::Details { .. } => true,
+            Block::BlockQuote { blocks, .. } => walk(blocks),
+            Block::List { items, .. } => items.iter().any(|item| walk(&item.blocks)),
+            _ => false,
+        })
+    }
+    walk(&doc.blocks)
+}
+
+#[test]
+fn eof_fallback_preserves_completed_summary() {
+    let doc = parse("<details>\n<summary>KEEP_THIS_SUMMARY</summary>\nbody");
+    assert!(!has_details(&doc));
+    assert_eq!(doc.blocks[0], paragraph("<details>"));
+    assert!(
+        texts(&doc).contains("KEEP_THIS_SUMMARY"),
+        "completed summary must survive EOF fallback: {doc:?}"
+    );
+    assert!(texts(&doc).contains("<summary>"));
+    assert!(texts(&doc).contains("</summary>"));
+    assert_eq!(doc.blocks.last(), Some(&paragraph("body")));
+}
+
+#[test]
+fn container_loss_preserves_completed_summary() {
+    let doc = parse("> <details>\n> <summary>KEEP **THIS**</summary>\n> body\n</details>\n# After");
+    assert!(!has_details(&doc));
+    let Block::BlockQuote { blocks, .. } = &doc.blocks[0] else {
+        panic!("quote");
+    };
+    assert!(
+        texts(&doc).contains("KEEP"),
+        "quoted fallback must keep the completed summary: {doc:?}"
+    );
+    assert!(
+        blocks.iter().any(|block| match block {
+            Block::Paragraph { inlines } => inlines.iter().any(|inline| matches!(
+                inline,
+                Inline::Text(s) if s.contains("<summary>")
+            )),
+            _ => false,
+        }),
+        "summary delimiters must remain literal: {blocks:?}"
+    );
+    assert!(blocks.iter().any(|block| {
+        match block {
+            Block::Paragraph { inlines } => inlines
+                .iter()
+                .any(|inline| matches!(inline, Inline::Strong(_))),
+            _ => false,
+        }
+    }));
+    assert_eq!(doc.blocks.last(), Some(&common::heading(1, "After")));
+}
+
+#[test]
+fn scan_refusal_preserves_completed_summary() {
+    let header = "<details>\n<summary>KEEP_THIS_SUMMARY</summary>\n";
+    let pad = 65_536_usize.saturating_sub(header.len());
+    let md = format!("{header}{}</details>\n# After", "y".repeat(pad));
+    let doc = parse(&md);
+    assert!(!has_details(&doc), "closer past the window must not commit");
+    assert!(
+        texts(&doc).contains("KEEP_THIS_SUMMARY"),
+        "scan-refused fallback must keep the completed summary"
+    );
+    assert!(texts(&doc).contains("<summary>"));
+    assert_eq!(doc.blocks.last(), Some(&common::heading(1, "After")));
+}
+
+#[test]
+fn summary_accepts_three_consecutive_lines() {
+    let (_, summary, body, _) = {
+        let doc = parse("<details>\n<summary>\nMore **information**\n</summary>\nbody\n</details>");
+        match &doc.blocks[0] {
+            Block::Details { summary, body, .. } => (true, summary.clone(), body.clone(), ()),
+            other => panic!("expected Details, got {other:?}"),
+        }
+    };
+    assert!(
+        summary
+            .iter()
+            .any(|inline| matches!(inline, Inline::Strong(_)))
+    );
+    assert!(
+        texts(&marmot_markdown::Document {
+            blocks: vec![Block::Paragraph {
+                inlines: summary.clone()
+            }],
+            blank_lines_before: vec![0],
+        })
+        .contains("More")
+    );
+    assert_eq!(body, vec![paragraph("body")]);
+}
+
+#[test]
+fn summary_code_spans_can_cross_a_line() {
+    let doc =
+        parse("<details>\n<summary>use `literal\n</summary>` here</summary>\nbody\n</details>");
+    let Block::Details { summary, .. } = &doc.blocks[0] else {
+        panic!("expected Details, got {doc:?}");
+    };
+    assert_eq!(
+        summary,
+        &[t("use "), code("literal </summary>"), t(" here"),]
+    );
+}
+
+#[test]
+fn indented_code_before_summary_prevents_extraction() {
+    let doc =
+        parse("<details>\n    code\n<summary>ordinary later text</summary>\nbody\n</details>");
+    let Block::Details { summary, body, .. } = &doc.blocks[0] else {
+        panic!("expected Details, got {doc:?}");
+    };
+    assert!(
+        summary.is_empty(),
+        "later summary must not be promoted: {summary:?}"
+    );
+    assert!(
+        body.iter().any(|block| match block {
+            Block::CodeBlock { content, .. } => content.contains("code"),
+            _ => false,
+        }),
+        "indented code must start the body: {body:?}"
+    );
+    assert!(
+        body.iter().any(|block| match block {
+            Block::Paragraph { inlines } => inlines.iter().any(|inline| matches!(
+                inline,
+                Inline::Text(s) if s.contains("<summary>ordinary later text</summary>")
+            )),
+            _ => false,
+        }),
+        "later summary stays literal body text: {body:?}"
+    );
+}
+
+#[test]
+fn fallback_preserves_summary_mention_and_gaps() {
+    let npub = format!("npub1{}", "q".repeat(52));
+    let doc = parse(&format!(
+        "<details>\n<summary>see @{npub} **now**</summary>\n\nbody\n"
+    ));
+    assert!(!has_details(&doc));
+    assert_eq!(doc.blank_lines_before[0], 0);
+    assert!(
+        texts(&doc).contains(&npub),
+        "summary mention must survive fallback: {doc:?}"
+    );
+    assert!(texts(&doc).contains("now"));
+    assert_eq!(doc.blocks.last(), Some(&paragraph("body")));
+}
+
+#[test]
+fn summary_crossing_scan_boundary_stays_literal() {
+    let header = "<details>\n<summary>";
+    let pad = 65_536_usize.saturating_sub(header.len()) + 8;
+    let md = format!(
+        "{header}{}KEEP</summary>\nbody\n</details>",
+        "z".repeat(pad)
+    );
+    let doc = parse(&md);
+    assert!(!has_details(&doc));
+    assert!(texts(&doc).contains("KEEP"));
+    assert!(texts(&doc).contains("<summary>"));
+    assert!(texts(&doc).contains("body"));
+}
+
+#[test]
+fn blank_interrupted_summary_falls_back() {
+    let doc = parse("<details>\n<summary>\n\nMore\n</summary>\nbody\n</details>");
+    assert!(!has_details(&doc));
+    assert!(texts(&doc).contains("<summary>"));
+    assert!(texts(&doc).contains("More"));
+}
+
+#[test]
+fn indented_code_then_summary_in_quote() {
+    let doc = parse("> <details>\n>     code\n>\n> <summary>later</summary>\n> body\n> </details>");
+    let Block::BlockQuote { blocks, .. } = &doc.blocks[0] else {
+        panic!("quote");
+    };
+    let Block::Details { summary, body, .. } = &blocks[0] else {
+        panic!("details in quote: {blocks:?}");
+    };
+    assert!(summary.is_empty());
+    assert!(
+        body.iter()
+            .any(|block| matches!(block, Block::CodeBlock { .. }))
+    );
+    assert!(body.iter().any(|block| match block {
+        Block::Paragraph { inlines } => inlines.iter().any(|inline| matches!(
+            inline,
+            Inline::Text(s) if s.contains("<summary>later</summary>")
+        )),
+        _ => false,
+    }));
+}

--- a/crates/marmot-markdown/tests/details_regressions.rs
+++ b/crates/marmot-markdown/tests/details_regressions.rs
@@ -524,8 +524,6 @@ fn many_line_open_summary_release_probe_compares_to_control() {
         control_us,
         hostile_us as f64 / control_us.max(1) as f64
     );
-    assert!(
-        hostile_us < 5_000_000,
-        "hostile many-line summary must stay well under the previous multi-second stall, us={hostile_us}"
-    );
+    // Timing is diagnostic only: CPU contention must not fail this probe.
+    // The library's counted-work tests enforce the linear complexity bound.
 }

--- a/crates/marmot-markdown/tests/details_regressions.rs
+++ b/crates/marmot-markdown/tests/details_regressions.rs
@@ -365,6 +365,40 @@ fn summary_retains_hard_break() {
 }
 
 #[test]
+fn summary_code_span_protects_delimiter_only_interior_lines() {
+    let doc = parse(
+        "<details>\n<summary>`one\n</summary>\n</details>\ntwo`\n</summary>\nbody\n</details>",
+    );
+    let Block::Details { summary, body, .. } = &doc.blocks[0] else {
+        panic!("expected Details, got {doc:?}");
+    };
+    assert!(
+        summary.iter().any(|inline| matches!(
+            inline,
+            Inline::Code(s) if s.contains("</summary>") && s.contains("</details>")
+        )),
+        "delimiter-only interior lines must stay inside the code span: {summary:?}"
+    );
+    assert_eq!(body, &vec![paragraph("body")]);
+    assert_eq!(doc.blocks.len(), 1);
+
+    let crlf = parse(
+        "<details>\r\n<summary>`one\r\n</summary>\r\n</details>\r\ntwo`\r\n</summary>\r\nbody\r\n</details>\r\n",
+    );
+    let Block::Details { summary, body, .. } = &crlf.blocks[0] else {
+        panic!("expected CRLF Details, got {crlf:?}");
+    };
+    assert!(
+        summary.iter().any(|inline| matches!(
+            inline,
+            Inline::Code(s) if s.contains("</summary>") && s.contains("</details>")
+        )),
+        "CRLF delimiter-only lines must stay inside the code span: {summary:?}"
+    );
+    assert_eq!(body, &vec![paragraph("body")]);
+}
+
+#[test]
 fn summary_code_span_can_span_three_lines_and_crlf() {
     let doc = parse("<details>\n<summary>`one\n</summary>\ntwo`</summary>\nbody\n</details>");
     let Block::Details { summary, .. } = &doc.blocks[0] else {

--- a/crates/marmot-markdown/tests/golden.rs
+++ b/crates/marmot-markdown/tests/golden.rs
@@ -113,3 +113,8 @@ fn nested_containers() {
 fn bare_urls() {
     assert_golden("bare_urls");
 }
+
+#[test]
+fn details() {
+    assert_golden("details");
+}

--- a/crates/marmot-markdown/tests/golden/details.json
+++ b/crates/marmot-markdown/tests/golden/details.json
@@ -1,0 +1,63 @@
+{
+  "blocks": [
+    {
+      "Details": {
+        "summary": [
+          {
+            "Text": "Tap to expand"
+          }
+        ],
+        "open": false,
+        "body": [
+          {
+            "Paragraph": {
+              "inlines": [
+                {
+                  "Text": "Hidden body "
+                },
+                {
+                  "Strong": [
+                    {
+                      "Text": "bold"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "blank_lines_before": [
+          0
+        ]
+      }
+    },
+    {
+      "Details": {
+        "summary": [
+          {
+            "Text": "More"
+          }
+        ],
+        "open": true,
+        "body": [
+          {
+            "Paragraph": {
+              "inlines": [
+                {
+                  "Code": "code"
+                }
+              ]
+            }
+          }
+        ],
+        "blank_lines_before": [
+          1
+        ]
+      }
+    }
+  ],
+  "blank_lines_before": [
+    0,
+    1
+  ]
+}

--- a/crates/marmot-markdown/tests/golden/details.md
+++ b/crates/marmot-markdown/tests/golden/details.md
@@ -1,0 +1,11 @@
+<details>
+<summary>Tap to expand</summary>
+Hidden body **bold**
+</details>
+
+<details open>
+<summary>More</summary>
+
+`code`
+
+</details>

--- a/crates/marmot-markdown/tests/serde_roundtrip.rs
+++ b/crates/marmot-markdown/tests/serde_roundtrip.rs
@@ -80,6 +80,28 @@ fn roundtrip_math_and_html() {
 }
 
 #[test]
+fn roundtrip_details() {
+    roundtrip("<details open>\n<summary>*More*</summary>\n\ninner **bold**\n\n</details>");
+}
+
+#[test]
+fn legacy_details_without_gaps_deserializes() {
+    let json = r#"{
+        "blocks": [
+            {"Details": {"summary": [], "open": false, "body": []}}
+        ]
+    }"#;
+    let document: Document = serde_json::from_str(json).expect("deserialize");
+    let marmot_markdown::Block::Details {
+        blank_lines_before, ..
+    } = &document.blocks[0]
+    else {
+        panic!("expected details");
+    };
+    assert!(blank_lines_before.is_empty());
+}
+
+#[test]
 fn roundtrip_nostr_mention_and_uri() {
     let body = "xyq6ag2g4cd2y6h4r4ag2y3xeak0v6gxq46v9";
     let md = format!("Hello @npub1{body} via nostr:npub1{body}.");

--- a/crates/marmot-markdown/tests/source_gaps.rs
+++ b/crates/marmot-markdown/tests/source_gaps.rs
@@ -259,16 +259,37 @@ fn inline_parsing_is_unchanged_by_source_gap_metadata() {
 fn details_and_code_spans_keep_their_existing_ast_shape() {
     let document = parse("<details>\n<summary>More</summary>\n\n`code`\n\n</details>");
 
-    assert_eq!(document.blank_lines_before, vec![0, 1, 1]);
-    let marmot_markdown::Block::Paragraph { inlines } = &document.blocks[1] else {
+    assert_eq!(document.blank_lines_before, vec![0]);
+    let marmot_markdown::Block::Details {
+        summary,
+        open,
+        body,
+        blank_lines_before,
+    } = &document.blocks[0]
+    else {
+        panic!("recognized disclosure");
+    };
+    assert!(!open);
+    assert_eq!(summary, &[marmot_markdown::Inline::Text("More".to_owned())]);
+    assert_eq!(blank_lines_before, &vec![1]);
+    assert_eq!(body.len(), 1);
+    let marmot_markdown::Block::Paragraph { inlines } = &body[0] else {
         panic!("code span should remain in a paragraph");
     };
     assert_eq!(inlines, &[marmot_markdown::Inline::Code("code".to_owned())]);
-    let marmot_markdown::Block::Paragraph { inlines } = &document.blocks[2] else {
-        panic!("closing details tag should remain paragraph text");
-    };
-    assert_eq!(
-        inlines,
-        &[marmot_markdown::Inline::Text("</details>".to_owned())]
+}
+
+#[test]
+fn literal_details_tags_remain_when_unclosed() {
+    let document = parse("<details>\n<summary>More</summary>\n\n`code`");
+    assert!(
+        !document
+            .blocks
+            .iter()
+            .any(|block| matches!(block, marmot_markdown::Block::Details { .. }))
     );
+    let marmot_markdown::Block::Paragraph { inlines } = document.blocks.last().unwrap() else {
+        panic!("code span should remain in a paragraph");
+    };
+    assert_eq!(inlines, &[marmot_markdown::Inline::Code("code".to_owned())]);
 }

--- a/crates/marmot-markdown/tests/source_gaps.rs
+++ b/crates/marmot-markdown/tests/source_gaps.rs
@@ -288,6 +288,16 @@ fn literal_details_tags_remain_when_unclosed() {
             .iter()
             .any(|block| matches!(block, marmot_markdown::Block::Details { .. }))
     );
+    assert!(
+        document.blocks.iter().any(|block| match block {
+            marmot_markdown::Block::Paragraph { inlines } => inlines.iter().any(|inline| matches!(
+                inline,
+                marmot_markdown::Inline::Text(text) if text.contains("<summary>More</summary>")
+            )),
+            _ => false,
+        }),
+        "completed summary must be restored on unclosed fallback: {document:?}"
+    );
     let marmot_markdown::Block::Paragraph { inlines } = document.blocks.last().unwrap() else {
         panic!("code span should remain in a paragraph");
     };

--- a/crates/marmot-markdown/tests/unit_complex.rs
+++ b/crates/marmot-markdown/tests/unit_complex.rs
@@ -595,6 +595,7 @@ fn mixed_document_block_kinds() {
             Block::List { .. } => "L",
             Block::Table { .. } => "T",
             Block::MathBlock { .. } => "M",
+            Block::Details { .. } => "D",
         })
         .collect();
     assert_eq!(kinds, vec!["H1", "P", "H2", "BQ", "H2", "Code", "H2", "L"]);

--- a/crates/marmot-markdown/tests/unit_containers.rs
+++ b/crates/marmot-markdown/tests/unit_containers.rs
@@ -665,7 +665,9 @@ fn max_container_depth(blocks: &[Block]) -> usize {
 
 fn max_single_block_container_depth(block: &Block) -> usize {
     match block {
-        Block::BlockQuote { blocks, .. } => 1 + max_container_depth(blocks),
+        Block::BlockQuote { blocks, .. } | Block::Details { body: blocks, .. } => {
+            1 + max_container_depth(blocks)
+        }
         Block::List { items, .. } => {
             1 + items
                 .iter()

--- a/crates/marmot-markdown/tests/unit_details.rs
+++ b/crates/marmot-markdown/tests/unit_details.rs
@@ -110,6 +110,15 @@ fn multiline_summary() {
         details_only("<details>\n<summary>More\ninfo</summary>\nbody\n</details>");
     assert_eq!(summary, vec![t("More"), Inline::SoftBreak, t("info")]);
     assert_eq!(body, vec![paragraph("body")]);
+    let (_, summary, body, _) = details_only(
+        "<details>\r\n<summary>\r\nMore **information**\r\n</summary>\r\nbody\r\n</details>\r\n",
+    );
+    assert!(
+        summary
+            .iter()
+            .any(|inline| matches!(inline, Inline::Strong(_)))
+    );
+    assert_eq!(body, vec![paragraph("body")]);
 }
 
 #[test]

--- a/crates/marmot-markdown/tests/unit_details.rs
+++ b/crates/marmot-markdown/tests/unit_details.rs
@@ -1,0 +1,322 @@
+//! Structured `<details>` / `<summary>` block recognition.
+
+use marmot_markdown::{Block, Inline, parse};
+
+mod common;
+use common::{em, paragraph, strong, t};
+
+fn details_only(md: &str) -> (bool, Vec<Inline>, Vec<Block>, Vec<u8>) {
+    let doc = parse(md);
+    assert_eq!(
+        doc.blocks.len(),
+        1,
+        "expected a single top-level block: {doc:?}"
+    );
+    match &doc.blocks[0] {
+        Block::Details {
+            summary,
+            open,
+            body,
+            blank_lines_before,
+        } => (
+            *open,
+            summary.clone(),
+            body.clone(),
+            blank_lines_before.clone(),
+        ),
+        other => panic!("expected Details, got {other:?}"),
+    }
+}
+
+fn no_delimiter_text(inlines: &[Inline]) -> bool {
+    !inlines.iter().any(|inline| match inline {
+        Inline::Text(s) => {
+            s.to_ascii_lowercase().contains("<details")
+                || s.to_ascii_lowercase().contains("</details")
+                || s.to_ascii_lowercase().contains("<summary")
+                || s.to_ascii_lowercase().contains("</summary")
+        }
+        Inline::Emph(c) | Inline::Strong(c) | Inline::Strikethrough(c) => !no_delimiter_text(c),
+        Inline::Link { children, .. } => !no_delimiter_text(children),
+        _ => false,
+    })
+}
+
+#[test]
+fn issue_input_without_blank_lines() {
+    let md = "<details>\n<summary>Tap to expand</summary>\nHidden body **bold**\n</details>";
+    let (open, summary, body, gaps) = details_only(md);
+    assert!(!open);
+    assert_eq!(summary, vec![t("Tap to expand")]);
+    assert_eq!(body.len(), 1);
+    assert_eq!(gaps, vec![0]);
+    let Block::Paragraph { inlines } = &body[0] else {
+        panic!("expected body paragraph");
+    };
+    assert_eq!(inlines[0], t("Hidden body "));
+    assert!(matches!(inlines[1], Inline::Strong(_)));
+    assert!(no_delimiter_text(inlines));
+    assert!(no_delimiter_text(&summary));
+}
+
+#[test]
+fn issue_input_with_blank_lines() {
+    let md = "<details>\n<summary>Sum</summary>\n\nBody para\n\n</details>";
+    let (open, summary, body, gaps) = details_only(md);
+    assert!(!open);
+    assert_eq!(summary, vec![t("Sum")]);
+    assert_eq!(body, vec![paragraph("Body para")]);
+    assert_eq!(gaps, vec![1]);
+}
+
+#[test]
+fn open_attribute_and_case() {
+    let (open, ..) = details_only("<DETAILS OPEN>\n<body>\n</DETAILS>");
+    assert!(open);
+    let (open, ..) = details_only("<details open=\"false\">\nbody\n</details>");
+    assert!(open);
+    let (open, ..) = details_only("<details opened>\nbody\n</details>");
+    assert!(!open);
+    let (open, ..) = details_only("<details data-open=\"1\" title=\"open\">\nbody\n</details>");
+    assert!(!open);
+}
+
+#[test]
+fn ignored_quoted_gt_and_false_prefixes() {
+    let (open, summary, body, _) =
+        details_only("<details title=\"a>b\" foo='open'>\n<summary>Hi</summary>\nX\n</details>");
+    assert!(!open);
+    assert_eq!(summary, vec![t("Hi")]);
+    assert_eq!(body, vec![paragraph("X")]);
+}
+
+#[test]
+fn empty_and_missing_summary() {
+    let (_, summary, body, _) = details_only("<details>\n<summary></summary>\nbody\n</details>");
+    assert!(summary.is_empty());
+    assert_eq!(body, vec![paragraph("body")]);
+    let (_, summary, body, _) = details_only("<details>\n\nbody\n</details>");
+    assert!(summary.is_empty());
+    assert_eq!(body, vec![paragraph("body")]);
+    let (_, summary, body, gaps) = details_only("<details>\n</details>");
+    assert!(summary.is_empty());
+    assert!(body.is_empty());
+    assert!(gaps.is_empty());
+}
+
+#[test]
+fn multiline_summary() {
+    let (_, summary, body, _) =
+        details_only("<details>\n<summary>More\ninfo</summary>\nbody\n</details>");
+    assert_eq!(summary, vec![t("More"), Inline::SoftBreak, t("info")]);
+    assert_eq!(body, vec![paragraph("body")]);
+}
+
+#[test]
+fn formatted_and_nostr_summary() {
+    let body = "qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq";
+    let md = format!("<details>\n<summary>See *{body}* @npub1{body}</summary>\ninside\n</details>");
+    let (_, summary, ..) = details_only(&md);
+    assert!(matches!(summary[0], Inline::Text(_)));
+    assert!(summary.iter().any(|i| matches!(i, Inline::Emph(_))));
+    assert!(summary.iter().any(|i| matches!(i, Inline::NostrMention(_))));
+}
+
+#[test]
+fn later_summary_is_body_text() {
+    let (_, summary, body, _) =
+        details_only("<details>\n<summary>First</summary>\n<summary>Later</summary>\n</details>");
+    assert_eq!(summary, vec![t("First")]);
+    assert_eq!(body, vec![paragraph("<summary>Later</summary>")]);
+}
+
+#[test]
+fn nested_and_adjacent() {
+    let doc = parse(
+        "<details>\n<summary>Outer</summary>\n<details>\n<summary>Inner</summary>\nin\n</details>\n</details>\n\n<details>\nnext\n</details>",
+    );
+    assert_eq!(doc.blocks.len(), 2);
+    let Block::Details { body, .. } = &doc.blocks[0] else {
+        panic!("outer");
+    };
+    assert!(matches!(body[0], Block::Details { .. }));
+    assert!(matches!(doc.blocks[1], Block::Details { .. }));
+}
+
+#[test]
+fn quoted_and_list_nesting() {
+    let doc = parse(
+        "> <details>\n> <summary>Q</summary>\n> quoted\n> </details>\n\n- <details>\n  listed\n  </details>",
+    );
+    assert_eq!(doc.blocks.len(), 2);
+    let Block::BlockQuote { blocks, .. } = &doc.blocks[0] else {
+        panic!("quote");
+    };
+    assert!(matches!(blocks[0], Block::Details { .. }));
+    let Block::List { items, .. } = &doc.blocks[1] else {
+        panic!("list");
+    };
+    assert!(matches!(items[0].blocks[0], Block::Details { .. }));
+}
+
+#[test]
+fn body_holds_blocks_and_code() {
+    let md = "<details>\n<summary>S</summary>\n\n# Head\n\n- item\n\n```\n</details>\n```\n\nstill\n</details>";
+    let (_, _, body, _) = details_only(md);
+    assert!(matches!(body[0], Block::Heading { .. }));
+    assert!(matches!(body[1], Block::List { .. }));
+    assert!(matches!(body[2], Block::CodeBlock { .. }));
+    assert_eq!(body[3], paragraph("still"));
+}
+
+#[test]
+fn compact_inline_stays_literal() {
+    let doc = parse("<details><summary>x</summary>y</details>");
+    assert_eq!(
+        doc.blocks,
+        vec![paragraph("<details><summary>x</summary>y</details>")]
+    );
+}
+
+#[test]
+fn escaped_and_entity_and_code_stay_literal() {
+    let doc = parse("\\<details>\n");
+    assert!(!matches!(doc.blocks[0], Block::Details { .. }));
+    let doc = parse("&lt;details&gt;\nsummary\n&lt;/details&gt;");
+    assert!(
+        !doc.blocks
+            .iter()
+            .any(|b| matches!(b, Block::Details { .. }))
+    );
+    let doc = parse("`<details>`\n");
+    let Block::Paragraph { inlines } = &doc.blocks[0] else {
+        panic!("para");
+    };
+    assert!(matches!(inlines[0], Inline::Code(_)));
+}
+
+#[test]
+fn unmatched_and_malformed_fallback() {
+    let doc = parse("<details>\nhello\n");
+    assert_eq!(doc.blocks[0], paragraph("<details>"));
+    assert_eq!(doc.blocks[1], paragraph("hello"));
+    let doc = parse("<details>\nhello\n</details foo>");
+    assert!(
+        !doc.blocks
+            .iter()
+            .any(|b| matches!(b, Block::Details { .. }))
+    );
+    let doc = parse("<detailsx>\nhello\n</details>");
+    assert!(!matches!(doc.blocks[0], Block::Details { .. }));
+    let doc = parse("<details>\n<summary\nhello\n</details>");
+    assert!(
+        !doc.blocks
+            .iter()
+            .any(|b| matches!(b, Block::Details { .. }))
+    );
+}
+
+#[test]
+fn closer_outside_quote_does_not_steal() {
+    let doc = parse("> <details>\n> hello\n</details>");
+    let Block::BlockQuote { blocks, .. } = &doc.blocks[0] else {
+        panic!("quote");
+    };
+    assert!(!blocks.iter().any(|b| matches!(b, Block::Details { .. })));
+    assert_eq!(doc.blocks[1], paragraph("</details>"));
+}
+
+#[test]
+fn sibling_after_fallback_is_preserved() {
+    let doc = parse("<details>\nhello\n\n# After");
+    assert_eq!(doc.blocks.last(), Some(&common::heading(1, "After")));
+}
+
+#[test]
+fn source_gaps_after_summary_and_not_after_close() {
+    let doc = parse("before\n\n<details>\n<summary>S</summary>\n\ninner\n\n</details>\n\nafter");
+    assert_eq!(doc.blank_lines_before, vec![0, 1, 1]);
+    let Block::Details {
+        blank_lines_before, ..
+    } = &doc.blocks[1]
+    else {
+        panic!("details");
+    };
+    assert_eq!(blank_lines_before, &vec![1]);
+}
+
+#[test]
+fn shared_and_forward_references() {
+    let doc = parse("[lab]: /url\n\n<details>\n<summary>[lab]</summary>\nsee [lab]\n</details>");
+    let Block::Details { summary, body, .. } = &doc.blocks[0] else {
+        panic!("details");
+    };
+    let (summary, body) = (summary.clone(), body.clone());
+    assert!(matches!(
+        summary[0],
+        Inline::Link { ref dest, .. } if dest == "/url"
+    ));
+    let Block::Paragraph { inlines } = &body[0] else {
+        panic!("body");
+    };
+    assert!(matches!(
+        inlines[1],
+        Inline::Link { ref dest, .. } if dest == "/url"
+    ));
+}
+
+#[test]
+fn crlf_and_unicode_summary() {
+    let md = "<details>\r\n<summary>café 🦫</summary>\r\nbody\r\n</details>\r\n";
+    let (_, summary, body, _) = details_only(md);
+    assert_eq!(summary, vec![t("café 🦫")]);
+    assert_eq!(body, vec![paragraph("body")]);
+}
+
+#[test]
+fn scan_and_tag_caps() {
+    let over_tag = format!("<details class='{}'>", "x".repeat(4096));
+    let md = format!("{over_tag}\nbody\n</details>");
+    let doc = parse(&md);
+    assert!(!matches!(doc.blocks[0], Block::Details { .. }));
+
+    let mut inside = "pre\n".to_string();
+    inside.push_str("<details>\nbody\n</details>");
+    let doc = parse(&inside);
+    assert!(
+        doc.blocks
+            .iter()
+            .any(|b| matches!(b, Block::Details { .. })),
+        "opener inside the 65536-byte window should match"
+    );
+
+    let mut outside = "x".repeat(65536);
+    outside.push_str("\n<details>\nbody\n</details>");
+    let doc = parse(&outside);
+    assert!(
+        !doc.blocks
+            .iter()
+            .any(|b| matches!(b, Block::Details { .. })),
+        "opener after the recognition window must stay literal"
+    );
+}
+
+#[test]
+fn code_span_protects_summary_close() {
+    let (_, summary, ..) =
+        details_only("<details>\n<summary>use `</summary>` here</summary>\nbody\n</details>");
+    assert_eq!(
+        summary,
+        vec![t("use "), common::code("</summary>"), t(" here")]
+    );
+}
+
+#[test]
+fn strong_in_body() {
+    let (_, _, body, _) = details_only("<details>\nHidden body **bold**\n</details>");
+    let Block::Paragraph { inlines } = &body[0] else {
+        panic!("para");
+    };
+    assert!(inlines.iter().any(|i| matches!(i, Inline::Strong(_))));
+    let _ = (em(vec![]), strong(vec![]));
+}

--- a/crates/marmot-markdown/tests/unit_nesting_depth.rs
+++ b/crates/marmot-markdown/tests/unit_nesting_depth.rs
@@ -43,7 +43,13 @@ fn max_inline_depth(doc: &marmot_markdown::Document) -> usize {
                 inline_stack.push((inlines.as_slice(), 0, 1));
                 walk_inlines(&mut inline_stack, &mut max);
             }
-            Block::BlockQuote { blocks, .. } => block_stack.push((blocks.as_slice(), 0)),
+            Block::BlockQuote { blocks, .. } | Block::Details { body: blocks, .. } => {
+                if let Block::Details { summary, .. } = block {
+                    inline_stack.push((summary.as_slice(), 0, 1));
+                    walk_inlines(&mut inline_stack, &mut max);
+                }
+                block_stack.push((blocks.as_slice(), 0));
+            }
             Block::List { items, .. } => {
                 for item in items {
                     block_stack.push((item.blocks.as_slice(), 0));

--- a/crates/marmot-uniffi/README.md
+++ b/crates/marmot-uniffi/README.md
@@ -15,6 +15,11 @@ package that shared surface:
 The generated Swift file is platform-independent: `output/MarmotKit.swift` and `output/macos/MarmotKit.swift` are the
 same UniFFI surface, and releases publish it once.
 
+`MarkdownBlockFfi` now includes an additive `Details` variant for bounded
+`<details>` / `<summary>` display blocks. Hosts must regenerate Swift/Kotlin
+bindings to handle the new tag; older generated sources cannot render it.
+No generated Swift or Kotlin files are committed here.
+
 See [`DISTRIBUTION.md`](DISTRIBUTION.md) for immutable Apple and Android artifacts, exact release and snapshot URLs,
 checksums, provenance, and generated-source synchronization rules.
 

--- a/crates/marmot-uniffi/details-markdown-smoke.sh
+++ b/crates/marmot-uniffi/details-markdown-smoke.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Native Details DTO lift/lower round trips. This does not package Apple/Android artifacts.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+smoke_language="${1:-swift}"
+case "$smoke_language" in
+  swift) command -v swiftc >/dev/null ;;
+  kotlin)
+    command -v kotlinc >/dev/null
+    : "${MDK_KOTLIN_CLASSPATH:?Supply JNA with native libraries, Android platform, annotations, and coroutines jars}"
+    ;;
+  *) echo 'Usage: details-markdown-smoke.sh swift|kotlin' >&2; exit 2 ;;
+esac
+cargo build -p marmot-uniffi --features cli --locked
+smoke_target="$(cargo metadata --no-deps --format-version 1 | python3 -c 'import json,sys; print(json.load(sys.stdin)["target_directory"])')/debug"
+case "$(uname -s)" in
+  Darwin) smoke_library="$smoke_target/libmarmot_uniffi.dylib" ;;
+  Linux) smoke_library="$smoke_target/libmarmot_uniffi.so" ;;
+  *) echo 'Native smoke runner supports macOS and Linux' >&2; exit 2 ;;
+esac
+smoke_dir="$(mktemp -d)"
+trap 'rm -rf "$smoke_dir"' EXIT
+"$smoke_target/uniffi-bindgen" generate --library "$smoke_library" --language "$smoke_language" --out-dir "$smoke_dir"
+if [[ "$smoke_language" == swift ]]; then
+  cat "$smoke_dir/marmot_uniffi.swift" crates/marmot-uniffi/tests/details_markdown_smoke.swift > "$smoke_dir/CombinedSmoke.swift"
+  swiftc -parse-as-library -I "$smoke_dir" -Xcc "-fmodule-map-file=$smoke_dir/marmot_uniffiFFI.modulemap" \
+    -L "$smoke_target" -lmarmot_uniffi "$smoke_dir/CombinedSmoke.swift" -o "$smoke_dir/smoke"
+  DYLD_LIBRARY_PATH="$smoke_target" LD_LIBRARY_PATH="$smoke_target" "$smoke_dir/smoke"
+else
+  kotlinc "$smoke_dir/dev/ipf/marmotkit/marmot_uniffi.kt" crates/marmot-uniffi/tests/details_markdown_smoke.kt \
+    -cp "$MDK_KOTLIN_CLASSPATH" -include-runtime -d "$smoke_dir/smoke.jar"
+  java -Djna.library.path="$smoke_target" -cp "$smoke_dir/smoke.jar:$MDK_KOTLIN_CLASSPATH" \
+    dev.ipf.marmotkit.Details_markdown_smokeKt
+fi

--- a/crates/marmot-uniffi/src/conversions/common.rs
+++ b/crates/marmot-uniffi/src/conversions/common.rs
@@ -76,7 +76,7 @@ pub fn group_id_from_hex(group_id_hex: &str) -> Result<GroupId, crate::errors::M
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::markdown::MarkdownBlockFfi;
+    use crate::markdown::{MarkdownBlockFfi, MarkdownInlineFfi};
 
     #[test]
     fn chat_tokens_include_details_blocks() {
@@ -88,5 +88,38 @@ mod tests {
         let other =
             markdown_content_tokens(1, "<details>\n<summary>More</summary>\nbody\n</details>");
         assert!(other.blocks.is_empty());
+        let fallback = markdown_content_tokens(
+            MARMOT_APP_EVENT_KIND_CHAT,
+            "<details>\n<summary>KEEP_THIS_SUMMARY</summary>\nbody",
+        );
+        assert!(
+            !fallback
+                .blocks
+                .iter()
+                .any(|block| matches!(block, MarkdownBlockFfi::Details { .. }))
+        );
+        assert!(fallback.blocks.iter().any(|block| match block {
+            MarkdownBlockFfi::Paragraph { inlines } => inlines.iter().any(|inline| matches!(
+                inline,
+                MarkdownInlineFfi::Text { content } if content.contains("KEEP_THIS_SUMMARY")
+            )),
+            _ => false,
+        }));
+        let later = markdown_content_tokens(
+            MARMOT_APP_EVENT_KIND_CHAT,
+            "<details>\n    code\n<summary>ordinary later text</summary>\nbody\n</details>",
+        );
+        let MarkdownBlockFfi::Details { summary, body, .. } = &later.blocks[0] else {
+            panic!("expected details");
+        };
+        assert!(summary.is_empty());
+        assert!(body.iter().any(|block| match block {
+            MarkdownBlockFfi::Paragraph { inlines } => inlines.iter().any(|inline| matches!(
+                inline,
+                MarkdownInlineFfi::Text { content }
+                    if content.contains("<summary>ordinary later text</summary>")
+            )),
+            _ => false,
+        }));
     }
 }

--- a/crates/marmot-uniffi/src/conversions/common.rs
+++ b/crates/marmot-uniffi/src/conversions/common.rs
@@ -121,6 +121,19 @@ mod tests {
             )),
             _ => false,
         }));
+        let protected = markdown_content_tokens(
+            MARMOT_APP_EVENT_KIND_CHAT,
+            "<details>\n<summary>`one\n</summary>\n</details>\ntwo`\n</summary>\nbody\n</details>",
+        );
+        let MarkdownBlockFfi::Details { summary, .. } = &protected.blocks[0] else {
+            panic!("expected protected delimiter tokens");
+        };
+        assert!(
+            summary
+                .iter()
+                .any(|inline| matches!(inline, MarkdownInlineFfi::Code { content } if content.contains("</details>")))
+        );
+        assert_eq!(protected.blocks.len(), 1);
         let tokens = markdown_content_tokens(
             MARMOT_APP_EVENT_KIND_CHAT,
             "<details>\n<summary>`one\n</summary>\ntwo`</summary>\nbody\n</details>",

--- a/crates/marmot-uniffi/src/conversions/common.rs
+++ b/crates/marmot-uniffi/src/conversions/common.rs
@@ -121,5 +121,29 @@ mod tests {
             )),
             _ => false,
         }));
+        let tokens = markdown_content_tokens(
+            MARMOT_APP_EVENT_KIND_CHAT,
+            "<details>\n<summary>`one\n</summary>\ntwo`</summary>\nbody\n</details>",
+        );
+        let MarkdownBlockFfi::Details { summary, .. } = &tokens.blocks[0] else {
+            panic!("expected details tokens");
+        };
+        assert!(
+            summary
+                .iter()
+                .any(|inline| matches!(inline, MarkdownInlineFfi::Code { .. }))
+        );
+        let hard = markdown_content_tokens(
+            MARMOT_APP_EVENT_KIND_CHAT,
+            "<details>\n<summary>one  \ntwo</summary>\nbody\n</details>",
+        );
+        let MarkdownBlockFfi::Details { summary, .. } = &hard.blocks[0] else {
+            panic!("expected hard-break tokens");
+        };
+        assert!(
+            summary
+                .iter()
+                .any(|inline| matches!(inline, MarkdownInlineFfi::HardBreak))
+        );
     }
 }

--- a/crates/marmot-uniffi/src/conversions/common.rs
+++ b/crates/marmot-uniffi/src/conversions/common.rs
@@ -72,3 +72,21 @@ pub fn group_id_from_hex(group_id_hex: &str) -> Result<GroupId, crate::errors::M
     }
     Ok(GroupId::new(bytes))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::markdown::MarkdownBlockFfi;
+
+    #[test]
+    fn chat_tokens_include_details_blocks() {
+        let tokens = markdown_content_tokens(
+            MARMOT_APP_EVENT_KIND_CHAT,
+            "<details>\n<summary>More</summary>\nbody\n</details>",
+        );
+        assert!(matches!(tokens.blocks[0], MarkdownBlockFfi::Details { .. }));
+        let other =
+            markdown_content_tokens(1, "<details>\n<summary>More</summary>\nbody\n</details>");
+        assert!(other.blocks.is_empty());
+    }
+}

--- a/crates/marmot-uniffi/src/markdown.rs
+++ b/crates/marmot-uniffi/src/markdown.rs
@@ -728,6 +728,64 @@ mod tests {
     }
 
     #[test]
+    fn bridges_multiline_summary_and_fallback_preserves_text() {
+        let document = parse_markdown_document(
+            "<details>\n<summary>\nMore **information**\n</summary>\nbody\n</details>",
+        );
+        let MarkdownBlockFfi::Details { summary, body, .. } = &document.blocks[0] else {
+            panic!("expected details");
+        };
+        assert!(
+            summary
+                .iter()
+                .any(|inline| matches!(inline, MarkdownInlineFfi::Strong { .. }))
+        );
+        assert!(matches!(body[0], MarkdownBlockFfi::Paragraph { .. }));
+
+        let fallback =
+            parse_markdown_document("<details>\n<summary>KEEP_THIS_SUMMARY</summary>\nbody");
+        assert!(
+            !fallback
+                .blocks
+                .iter()
+                .any(|block| matches!(block, MarkdownBlockFfi::Details { .. }))
+        );
+        assert!(fallback.blocks.iter().any(|block| match block {
+            MarkdownBlockFfi::Paragraph { inlines } => inlines.iter().any(|inline| matches!(
+                inline,
+                MarkdownInlineFfi::Text { content } if content.contains("KEEP_THIS_SUMMARY")
+            )),
+            _ => false,
+        }));
+
+        let later = parse_markdown_document(
+            "<details>\n    code\n<summary>ordinary later text</summary>\nbody\n</details>",
+        );
+        let MarkdownBlockFfi::Details { summary, body, .. } = &later.blocks[0] else {
+            panic!("expected details after indented code");
+        };
+        assert!(summary.is_empty());
+        assert!(body.iter().any(|block| match block {
+            MarkdownBlockFfi::Paragraph { inlines } => inlines.iter().any(|inline| matches!(
+                inline,
+                MarkdownInlineFfi::Text { content } if content.contains("<summary>ordinary later text</summary>")
+            )),
+            _ => false,
+        }));
+    }
+
+    #[test]
+    fn hostile_backtick_details_input_stays_bounded() {
+        let ticks = "`".repeat(65_519 - "<details>\n\n</details>".len());
+        let document = parse_markdown_document(&format!("<details>\n{ticks}\n</details>"));
+        assert!(!document.truncated);
+        let summary_ticks = "`".repeat(8_192);
+        let document =
+            parse_markdown_document(&format!("<details>\n<summary>{summary_ticks}\n</details>"));
+        assert!(!document.blocks.is_empty());
+    }
+
+    #[test]
     fn bridges_pathological_nesting_without_unbounded_recursion() {
         let document = parse_markdown_document(&">".repeat(2_000));
         assert!(max_block_depth(&document.blocks) <= MAX_FFI_MARKDOWN_DEPTH);

--- a/crates/marmot-uniffi/src/markdown.rs
+++ b/crates/marmot-uniffi/src/markdown.rs
@@ -772,6 +772,29 @@ mod tests {
             )),
             _ => false,
         }));
+
+        let code_span = parse_markdown_document(
+            "<details>\n<summary>`one\n</summary>\ntwo`</summary>\nbody\n</details>",
+        );
+        let MarkdownBlockFfi::Details { summary, .. } = &code_span.blocks[0] else {
+            panic!("expected multiline code-span details");
+        };
+        assert!(
+            summary
+                .iter()
+                .any(|inline| matches!(inline, MarkdownInlineFfi::Code { .. }))
+        );
+
+        let hard =
+            parse_markdown_document("<details>\n<summary>one  \ntwo</summary>\nbody\n</details>");
+        let MarkdownBlockFfi::Details { summary, .. } = &hard.blocks[0] else {
+            panic!("expected hard-break details");
+        };
+        assert!(
+            summary
+                .iter()
+                .any(|inline| matches!(inline, MarkdownInlineFfi::HardBreak))
+        );
     }
 
     #[test]
@@ -782,6 +805,12 @@ mod tests {
         let summary_ticks = "`".repeat(8_192);
         let document =
             parse_markdown_document(&format!("<details>\n<summary>{summary_ticks}\n</details>"));
+        assert!(!document.blocks.is_empty());
+        let mut many_lines = String::from("<details>\n<summary>\n");
+        for _ in 0..4_096 {
+            many_lines.push_str("x\n");
+        }
+        let document = parse_markdown_document(&many_lines);
         assert!(!document.blocks.is_empty());
     }
 

--- a/crates/marmot-uniffi/src/markdown.rs
+++ b/crates/marmot-uniffi/src/markdown.rs
@@ -65,6 +65,13 @@ pub enum MarkdownBlockFfi {
     MathBlock {
         content: String,
     },
+    Details {
+        summary: Vec<MarkdownInlineFfi>,
+        open: bool,
+        body: Vec<MarkdownBlockFfi>,
+        /// Blank source lines before each corresponding body block.
+        blank_lines_before: Vec<u8>,
+    },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
@@ -294,6 +301,20 @@ fn markdown_block_from_md(value: MdBlock, depth: usize) -> MarkdownBlockFfi {
                 .collect(),
         },
         MdBlock::MathBlock { content } => MarkdownBlockFfi::MathBlock { content },
+        MdBlock::Details {
+            summary,
+            open,
+            body,
+            blank_lines_before,
+        } => MarkdownBlockFfi::Details {
+            summary: markdown_inlines_from_md(summary, 0),
+            open,
+            body: body
+                .into_iter()
+                .map(|block| markdown_block_from_md(block, depth + 1))
+                .collect(),
+            blank_lines_before,
+        },
     }
 }
 
@@ -681,6 +702,32 @@ mod tests {
     }
 
     #[test]
+    fn bridges_details_block() {
+        let document = parse_markdown_document(
+            "<details>\n<summary>Tap to expand</summary>\nHidden body **bold**\n</details>",
+        );
+        let MarkdownBlockFfi::Details {
+            summary,
+            open,
+            body,
+            blank_lines_before,
+        } = &document.blocks[0]
+        else {
+            panic!("expected details");
+        };
+        assert!(!open);
+        assert!(matches!(
+            &summary[0],
+            MarkdownInlineFfi::Text { content } if content == "Tap to expand"
+        ));
+        assert_eq!(blank_lines_before, &[0]);
+        let MarkdownBlockFfi::Paragraph { inlines } = &body[0] else {
+            panic!("expected body paragraph");
+        };
+        assert!(matches!(inlines[1], MarkdownInlineFfi::Strong { .. }));
+    }
+
+    #[test]
     fn bridges_pathological_nesting_without_unbounded_recursion() {
         let document = parse_markdown_document(&">".repeat(2_000));
         assert!(max_block_depth(&document.blocks) <= MAX_FFI_MARKDOWN_DEPTH);
@@ -692,7 +739,8 @@ mod tests {
 
     fn max_single_block_depth(block: &MarkdownBlockFfi) -> usize {
         match block {
-            MarkdownBlockFfi::BlockQuote { blocks, .. } => 1 + max_block_depth(blocks),
+            MarkdownBlockFfi::BlockQuote { blocks, .. }
+            | MarkdownBlockFfi::Details { body: blocks, .. } => 1 + max_block_depth(blocks),
             MarkdownBlockFfi::ListBlock { items, .. } => {
                 1 + items
                     .iter()

--- a/crates/marmot-uniffi/src/markdown.rs
+++ b/crates/marmot-uniffi/src/markdown.rs
@@ -773,6 +773,20 @@ mod tests {
             _ => false,
         }));
 
+        let protected = parse_markdown_document(
+            "<details>\n<summary>`one\n</summary>\n</details>\ntwo`\n</summary>\nbody\n</details>",
+        );
+        let MarkdownBlockFfi::Details { summary, body, .. } = &protected.blocks[0] else {
+            panic!("expected protected delimiter details");
+        };
+        assert!(
+            summary
+                .iter()
+                .any(|inline| matches!(inline, MarkdownInlineFfi::Code { content } if content.contains("</details>")))
+        );
+        assert!(matches!(body[0], MarkdownBlockFfi::Paragraph { .. }));
+        assert_eq!(protected.blocks.len(), 1);
+
         let code_span = parse_markdown_document(
             "<details>\n<summary>`one\n</summary>\ntwo`</summary>\nbody\n</details>",
         );

--- a/crates/marmot-uniffi/tests/details_markdown_smoke.kt
+++ b/crates/marmot-uniffi/tests/details_markdown_smoke.kt
@@ -5,9 +5,11 @@ fun main() {
         summary = listOf(MarkdownInlineFfi.Text("More")),
         open = false,
         body = listOf(MarkdownBlockFfi.Paragraph(listOf(MarkdownInlineFfi.Text("body")))),
-        blankLinesBefore = listOf(1.toUByte()),
+        blankLinesBefore = byteArrayOf(1),
     )
     val copy = FfiConverterTypeMarkdownBlockFfi.lift(FfiConverterTypeMarkdownBlockFfi.lower(block))
-    check(copy == block)
+    check(copy is MarkdownBlockFfi.Details)
+    check(copy.summary == block.summary && copy.open == block.open && copy.body == block.body)
+    check(copy.blankLinesBefore.contentEquals(block.blankLinesBefore))
     println("Kotlin Markdown Details DTO round trip passed")
 }

--- a/crates/marmot-uniffi/tests/details_markdown_smoke.kt
+++ b/crates/marmot-uniffi/tests/details_markdown_smoke.kt
@@ -1,0 +1,13 @@
+package dev.ipf.marmotkit
+
+fun main() {
+    val block = MarkdownBlockFfi.Details(
+        summary = listOf(MarkdownInlineFfi.Text("More")),
+        open = false,
+        body = listOf(MarkdownBlockFfi.Paragraph(listOf(MarkdownInlineFfi.Text("body")))),
+        blankLinesBefore = listOf(1.toUByte()),
+    )
+    val copy = FfiConverterTypeMarkdownBlockFfi.lift(FfiConverterTypeMarkdownBlockFfi.lower(block))
+    check(copy == block)
+    println("Kotlin Markdown Details DTO round trip passed")
+}

--- a/crates/marmot-uniffi/tests/details_markdown_smoke.swift
+++ b/crates/marmot-uniffi/tests/details_markdown_smoke.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+@main
+struct DetailsMarkdownSmoke {
+    static func main() throws {
+        let block = MarkdownBlockFfi.details(
+            summary: [MarkdownInlineFfi.text(content: "More")],
+            open: false,
+            body: [MarkdownBlockFfi.paragraph(inlines: [MarkdownInlineFfi.text(content: "body")])],
+            blankLinesBefore: [1]
+        )
+        let copy = try FfiConverterTypeMarkdownBlockFfi.lift(FfiConverterTypeMarkdownBlockFfi.lower(block))
+        precondition(copy == block)
+        print("Swift Markdown Details DTO round trip passed")
+    }
+}

--- a/crates/marmot-uniffi/tests/details_markdown_smoke.swift
+++ b/crates/marmot-uniffi/tests/details_markdown_smoke.swift
@@ -7,7 +7,7 @@ struct DetailsMarkdownSmoke {
             summary: [MarkdownInlineFfi.text(content: "More")],
             open: false,
             body: [MarkdownBlockFfi.paragraph(inlines: [MarkdownInlineFfi.text(content: "body")])],
-            blankLinesBefore: [1]
+            blankLinesBefore: Data([1])
         )
         let copy = try FfiConverterTypeMarkdownBlockFfi.lift(FfiConverterTypeMarkdownBlockFfi.lower(block))
         precondition(copy == block)


### PR DESCRIPTION
Messages containing structural `<details>` and `<summary>` lines now produce a typed disclosure block with an inline summary, initial open state, block body, and source gaps. The structure is exposed through UniFFI and the C ABI, and mention extraction visits both summary and body.

Recognition stays within the source, tag-length, and container-depth limits. Multiline summary code spans protect interior closing tags. Failed candidates retain their literal tags and replay held summary content through the ordinary Markdown parser, preserving headings, code, lists, quotes, and tables. Pending code-span runs and deferred closers are processed incrementally without repeatedly scanning earlier entries.

The timing probe lives in integration tests so it can report measurements without violating the library direct-output audit. Regression coverage includes fallback structure and nesting limits, multiline/CRLF code spans, hard breaks, mentions, allocation cleanup, and adversarial counted-work bounds.

Validation:
- `just fast-ci`
- `cargo test --locked -p marmot-markdown`
- `cargo test --locked -p cgka-conformance-simulator --test tracing_audit`
- `cargo test --locked -p marmot-uniffi`
- `cargo test --locked -p marmot-app --lib mention_p_tags`
- `cargo test --locked -p marmot-c --features alloc-audit --lib`
- Release-mode multiline summary timing probe
- Generated Swift and Kotlin Details DTO smoke round trips

[Implementation plan](https://github.com/marmot-protocol/mdk/issues/891#issuecomment-5605474674)

Fixes #891
