### PR TITLE
Bind direct QUIC clients to the destination address family

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -18,6 +18,15 @@ versioning through the workspace version in the root `Cargo.toml`.
   across pages. Search-discovered public profiles are searchable across accounts but remain outside live directory
   subscriptions. Local cache materialization is capped at 10,000 distinct identities per account cache, and cache result
   batches at 10,000 people.
+- `wn stream send` (direct and `--broker`) now applies the shared public-address gate to explicit `--connect`
+  destinations. Unflagged loopback, private, link-local, CGNAT, and other non-public targets return
+  `unsafe_quic_endpoint`. `--insecure-local` still opens loopback only; a pinned certificate is TLS trust, not address
+  authorization.
+
+### Fixed
+
+- Direct QUIC stream clients bind the unspecified address of the destination family so IPv6 and normally routed
+  off-host receivers are reachable. The wildcard source bind does not authorize the remote destination.
 
 ## [0.9.20] - 2026-09-08
 

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -409,7 +409,11 @@ wn --account <npub-or-hex> stream verify <group-hex> \
 starts include concrete `quic://host:port` candidates for that stream. `stream watch` reads the durable start payload,
 subscribes to the broker candidate, and prints the provisional text preview plus transcript hash. `stream send --broker`
 publishes ordered `TextDelta` records through the memory-only broker. Without `--broker`, `stream send` still connects
-directly to a peer receiver, which is useful with `wn stream receive --bind 127.0.0.1:4450` for local transport probes.
+directly to a peer receiver. Explicit `--connect` destinations on both send routes must be public unicast addresses;
+`--insecure-local` is the only exception, and it opens loopback only. A pinned `--server-cert-der-hex` is TLS trust, not
+address authorization, so unflagged loopback, private, link-local, and CGNAT targets are rejected. Local transport
+probes therefore need `wn stream receive --bind 127.0.0.1:4450` plus `--insecure-local` on send. The client source bind
+is a family-matched wildcard (`0.0.0.0:0` / `[::]:0`) and does not itself authorize the remote destination.
 `stream verify` compares a received QUIC transcript hash and chunk count against the latest durable final payload for the
 same stream id. QUIC chunks are transient preview data; normal Marmot messages remain the durable group history. Use
 `quic://quic-broker.ipf.dev:4450` with platform trust for the shared production broker, and use `--insecure-local` only

--- a/crates/cli/src/commands/stream.rs
+++ b/crates/cli/src/commands/stream.rs
@@ -808,6 +808,7 @@ pub(crate) fn broker_trust(
         ensure_insecure_local_endpoint(server_addr)?;
         return Ok(BrokerServerTrust::InsecureLocal);
     }
+    ensure_public_quic_endpoint(server_addr)?;
     server_cert_der_hex
         .map(|value| hex::decode(value).map(BrokerServerTrust::CertificateDer))
         .transpose()
@@ -850,11 +851,16 @@ fn stream_trust(
         ensure_insecure_local_endpoint(server_addr)?;
         return Ok(ServerTrust::InsecureLocal);
     }
+    ensure_public_quic_endpoint(server_addr)?;
     server_cert_der_hex
         .map(|value| hex::decode(value).map(ServerTrust::CertificateDer))
         .transpose()
         .map(|trust| trust.unwrap_or(ServerTrust::Platform))
         .map_err(Into::into)
+}
+
+fn ensure_public_quic_endpoint(server_addr: SocketAddr) -> Result<(), WnError> {
+    reject_non_public_socket_addr(server_addr, false).map_err(|_| WnError::UnsafeQuicEndpoint)
 }
 
 fn ensure_insecure_local_endpoint(server_addr: SocketAddr) -> Result<(), WnError> {
@@ -883,4 +889,131 @@ fn resolve_selected_account(
         return Ok(None);
     };
     Ok(Some(resolve_account_ref(account_home, &account)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn addr(raw: &str) -> SocketAddr {
+        raw.parse().expect("test socket address parses")
+    }
+
+    #[test]
+    fn explicit_send_trust_helpers_preserve_verified_modes_for_public_endpoints() {
+        // Local `stream send` and app-backed `stream send` both call these
+        // helpers before dialing, including the `--broker` sibling.
+        let cert_hex = hex::encode([0x11_u8; 8]);
+        for raw in ["93.184.216.34:4450", "[2606:4700::1]:4450"] {
+            let server = addr(raw);
+            assert!(matches!(
+                stream_trust(server, None, false),
+                Ok(ServerTrust::Platform)
+            ));
+            assert!(matches!(
+                broker_trust(server, None, false),
+                Ok(BrokerServerTrust::Platform)
+            ));
+            assert!(matches!(
+                stream_trust(server, Some(cert_hex.clone()), false),
+                Ok(ServerTrust::CertificateDer(_))
+            ));
+            assert!(matches!(
+                broker_trust(server, Some(cert_hex.clone()), false),
+                Ok(BrokerServerTrust::CertificateDer(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn explicit_send_trust_helpers_use_shared_classifier_for_unsafe_classes() {
+        for raw in [
+            "127.0.0.1:4450",
+            "[::1]:4450",
+            "10.0.0.1:4450",
+            "192.168.1.1:4450",
+            "100.64.0.1:4450",
+            "169.254.169.254:4450",
+            "0.0.0.0:4450",
+            "[::]:4450",
+            "[fc00::1]:4450",
+            "[fe80::1]:4450",
+            "[::ffff:10.0.0.1]:4450",
+            "[::ffff:127.0.0.1]:4450",
+        ] {
+            let server = addr(raw);
+            assert!(
+                reject_non_public_socket_addr(server, false).is_err(),
+                "{raw} must stay classified unsafe"
+            );
+            assert!(
+                matches!(
+                    stream_trust(server, None, false),
+                    Err(WnError::UnsafeQuicEndpoint)
+                ),
+                "{raw}"
+            );
+            assert!(
+                matches!(
+                    broker_trust(server, None, false),
+                    Err(WnError::UnsafeQuicEndpoint)
+                ),
+                "{raw}"
+            );
+            assert!(
+                matches!(
+                    stream_trust(server, Some(hex::encode([0x22_u8; 8])), false),
+                    Err(WnError::UnsafeQuicEndpoint)
+                ),
+                "certificate must not authorize {raw}"
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_send_insecure_local_allows_only_literal_loopback() {
+        for raw in ["127.0.0.1:4450", "[::1]:4450"] {
+            let server = addr(raw);
+            assert!(matches!(
+                stream_trust(server, None, true),
+                Ok(ServerTrust::InsecureLocal)
+            ));
+            assert!(matches!(
+                broker_trust(server, None, true),
+                Ok(BrokerServerTrust::InsecureLocal)
+            ));
+        }
+        for raw in [
+            "10.0.0.1:4450",
+            "93.184.216.34:4450",
+            "[fc00::1]:4450",
+            "[2606:4700::1]:4450",
+        ] {
+            let server = addr(raw);
+            assert!(matches!(
+                stream_trust(server, None, true),
+                Err(WnError::InsecureLocalRequiresLoopback(_))
+            ));
+            assert!(matches!(
+                broker_trust(server, None, true),
+                Err(WnError::InsecureLocalRequiresLoopback(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn explicit_send_conflicting_trust_options_keep_existing_precedence() {
+        let cert_hex = hex::encode([0x33_u8; 8]);
+        for raw in ["127.0.0.1:4450", "93.184.216.34:4450"] {
+            let server = addr(raw);
+            assert!(matches!(
+                stream_trust(server, Some(cert_hex.clone()), true),
+                Err(WnError::ConflictingStreamTrust)
+            ));
+            assert!(matches!(
+                broker_trust(server, Some(cert_hex.clone()), true),
+                Err(WnError::ConflictingStreamTrust)
+            ));
+        }
+    }
 }

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -105,6 +105,10 @@ pub(crate) enum WnError {
     InvalidTranscriptHashLength(usize),
     #[error("choose either --server-cert-der-hex or --insecure-local")]
     ConflictingStreamTrust,
+    #[error(
+        "QUIC endpoint must be a public address; --insecure-local permits loopback endpoints only"
+    )]
+    UnsafeQuicEndpoint,
     #[error("--insecure-local is only allowed for loopback QUIC endpoints, got {0}")]
     InsecureLocalRequiresLoopback(SocketAddr),
     #[error("messages subscribe requires the daemon; start it with `wn daemon start`")]
@@ -326,6 +330,10 @@ pub(crate) fn wn_error_json(err: &WnError) -> Value {
         }),
         WnError::ConflictingStreamTrust => json!({
             "code": "conflicting_stream_trust",
+            "message": err.to_string(),
+        }),
+        WnError::UnsafeQuicEndpoint => json!({
+            "code": "unsafe_quic_endpoint",
             "message": err.to_string(),
         }),
         WnError::InsecureLocalRequiresLoopback(addr) => json!({
@@ -748,6 +756,26 @@ mod tests {
     use marmot_account::AccountError;
 
     use super::*;
+
+    #[test]
+    fn unsafe_quic_endpoint_json_omits_addresses_and_certificates() {
+        let err = WnError::UnsafeQuicEndpoint;
+        let message = err.to_string();
+        assert!(message.contains("public address"));
+        assert!(message.contains("--insecure-local"));
+        assert!(!message.contains("127.0.0.1"));
+        assert!(!message.contains("::1"));
+        assert!(!message.contains("cert"));
+
+        let json = wn_error_json(&err);
+        assert_eq!(json["code"], "unsafe_quic_endpoint");
+        assert_eq!(json["message"], message);
+        assert!(json.get("addr").is_none());
+        assert!(json.get("candidate").is_none());
+        let rendered = json.to_string();
+        assert!(!rendered.contains("127.0.0.1"));
+        assert!(!rendered.contains("cert"));
+    }
 
     #[test]
     fn missing_key_package_errors_include_repair_guidance() {

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -3171,6 +3171,70 @@ fn stream_send_insecure_local_rejects_remote_endpoints() {
 }
 
 #[test]
+fn stream_send_rejects_non_public_endpoints_without_insecure_local() {
+    let home = tempfile::tempdir().expect("tempdir");
+
+    for args in [
+        ["stream", "send", "--connect", "127.0.0.1:4450", "hello"].as_slice(),
+        [
+            "stream",
+            "send",
+            "--broker",
+            "--connect",
+            "127.0.0.1:4450",
+            "hello",
+        ]
+        .as_slice(),
+        ["stream", "send", "--connect", "10.0.0.1:4450", "hello"].as_slice(),
+        [
+            "stream",
+            "send",
+            "--broker",
+            "--connect",
+            "[fc00::1]:4450",
+            "hello",
+        ]
+        .as_slice(),
+        [
+            "stream",
+            "send",
+            "--connect",
+            "127.0.0.1:4450",
+            "--server-cert-der-hex",
+            "00",
+            "hello",
+        ]
+        .as_slice(),
+        [
+            "stream",
+            "send",
+            "--broker",
+            "--connect",
+            "[::1]:4450",
+            "--server-cert-der-hex",
+            "00",
+            "hello",
+        ]
+        .as_slice(),
+    ] {
+        let error = run_json_error(home.path(), args);
+        assert_eq!(
+            error["code"], "unsafe_quic_endpoint",
+            "args={args:?} error={error}"
+        );
+        let rendered = error.to_string();
+        assert!(
+            !rendered.contains("127.0.0.1")
+                && !rendered.contains("10.0.0.1")
+                && !rendered.contains("fc00")
+                && !rendered.contains("::1"),
+            "endpoint-free diagnostic leaked an address: {rendered}"
+        );
+        assert!(error.get("addr").is_none(), "{error}");
+    }
+}
+
+#[test]
 fn stream_start_quic_chunks_and_final_payload_verify_through_mls_messages() {
     let home = tempfile::tempdir().expect("tempdir");
     let broker = spawn_quic_broker();

--- a/crates/transport-quic-stream/README.md
+++ b/crates/transport-quic-stream/README.md
@@ -9,7 +9,11 @@ orchestration stay in higher layers.
 ## What this crate does
 
 - Sets up QUIC client/server endpoints with ALPN pinning and shared hardening defaults (connect deadline, frame caps,
-  early-data policy) also consumed by `transport-quic-broker`.
+  early-data policy) also consumed by `transport-quic-broker`. Direct clients bind the unspecified address of the
+  destination family (`0.0.0.0:0` / `[::]:0`) so IPv6 and normally routed off-host destinations are reachable. That
+  wildcard source bind is not authorization of the remote address: `SendTextStream` callers must supply an already
+  validated and pinned `SocketAddr` plus configuration-derived trust/`server_name`. The API has no resolver or
+  dev-flag context and does not infer permission from the destination IP.
 - Seals and opens length-delimited preview records with HKDF-derived keys and AAD.
 - Sends and receives text-stream preview chunks over ordered QUIC streams.
 - Requires encrypted publishers to reserve sequences through an account-device

--- a/crates/transport-quic-stream/src/protocol.rs
+++ b/crates/transport-quic-stream/src/protocol.rs
@@ -1,7 +1,6 @@
 //! Direct-path QUIC protocol/ALPN identifiers, frame-size constants, and the
 //! plaintext/frame-length cap helpers shared across the transport.
 
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
 
 use cgka_traits::agent_text_stream::{
@@ -9,7 +8,6 @@ use cgka_traits::agent_text_stream::{
 };
 
 pub(crate) const FRAME_LEN_BYTES: usize = 4;
-pub(crate) const LOCAL_BIND: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
 
 /// Direct-path QUIC ALPN, pinned by spec/transports/quic.md. Both peers MUST
 /// negotiate exactly this protocol; it is the direct-path counterpart to the

--- a/crates/transport-quic-stream/src/send.rs
+++ b/crates/transport-quic-stream/src/send.rs
@@ -20,6 +20,11 @@ use crate::publisher_sequence::reserve_publisher_records;
 use crate::receive::ServerTrust;
 use crate::tls::client_endpoint;
 
+/// Direct-path sender request. Callers supply an already validated and pinned
+/// `server_addr` plus configuration-derived `trust` and `server_name`. This
+/// API has no resolver or dev-flag context and does not infer permission from
+/// the destination IP. A family-matched unspecified client bind is not
+/// authorization of the remote destination.
 #[derive(Clone, Debug)]
 pub struct SendTextStream {
     pub server_addr: SocketAddr,

--- a/crates/transport-quic-stream/src/tests.rs
+++ b/crates/transport-quic-stream/src/tests.rs
@@ -1,7 +1,7 @@
 //! Cross-cutting unit and end-to-end tests exercising the protocol caps,
 //! splitter, framing, crypto round-trip, limits, and the send/receive loop.
 
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::str;
 use std::time::Duration;
 
@@ -25,13 +25,29 @@ use crate::limits::{
     AgentTextStreamReceiveLimits,
 };
 use crate::protocol::{
-    AGENT_TEXT_STREAM_FRAME_ALLOWANCE, LOCAL_BIND, QUIC_STREAM_ALPN_V1, QUIC_STREAM_PROTOCOL_V1,
+    AGENT_TEXT_STREAM_FRAME_ALLOWANCE, QUIC_STREAM_ALPN_V1, QUIC_STREAM_PROTOCOL_V1,
     SEND_CLOSE_WAIT, frame_len_cap,
 };
 use crate::receive::{QuicTextStreamReceiver, ServerTrust, stream_record_text};
 use crate::send::{SendTextStream, send_text_stream, split_text_deltas};
-use crate::tls::{client_endpoint, configure_server};
+use crate::tls::{client_bind_addr_for_server, client_endpoint, configure_server};
 use tokio::time::{sleep, timeout};
+
+const LOCAL_BIND: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
+
+fn is_io_address_family_unavailable(err: &std::io::Error) -> bool {
+    matches!(
+        err.kind(),
+        std::io::ErrorKind::AddrNotAvailable | std::io::ErrorKind::Unsupported
+    ) || matches!(err.raw_os_error(), Some(47 | 49 | 97 | 99))
+}
+
+fn is_address_family_unavailable(err: &QuicTextStreamError) -> bool {
+    match err {
+        QuicTextStreamError::Io(io_err) => is_io_address_family_unavailable(io_err),
+        _ => false,
+    }
+}
 
 #[test]
 fn direct_path_alpn_is_the_pinned_wire_value() {
@@ -312,9 +328,152 @@ async fn insecure_local_rejects_remote_server_addr() {
 }
 
 #[tokio::test]
+async fn insecure_local_rejects_remote_ipv6_server_addr() {
+    let err = send_text_stream(SendTextStream {
+        server_addr: SocketAddr::new(IpAddr::V6("2001:db8::1".parse().unwrap()), 4450),
+        server_name: "example.com".to_owned(),
+        trust: ServerTrust::InsecureLocal,
+        stream_id: vec![0x42; 32],
+        start_event_id: MessageId::new(vec![0x24; 32]),
+        text: "hello".to_owned(),
+        max_chunk_bytes: 5,
+        chunk_delay: Duration::ZERO,
+        crypto: None,
+        max_plaintext_frame_len: None,
+    })
+    .await
+    .unwrap_err();
+
+    assert!(matches!(
+        err,
+        QuicTextStreamError::InsecureLocalRequiresLoopback(_)
+    ));
+}
+
+#[test]
+fn client_bind_addr_matches_server_address_family() {
+    let cases = [
+        ("127.0.0.1:4450", "0.0.0.0:0"),
+        ("93.184.216.34:443", "0.0.0.0:0"),
+        ("[::1]:4450", "[::]:0"),
+        ("[2606:4700::1]:443", "[::]:0"),
+        ("[::ffff:127.0.0.1]:4450", "[::]:0"),
+        ("[::ffff:10.0.0.1]:443", "[::]:0"),
+    ];
+    for (server, expected_bind) in cases {
+        let server: SocketAddr = server.parse().unwrap();
+        let expected_bind: SocketAddr = expected_bind.parse().unwrap();
+        let bind = client_bind_addr_for_server(server);
+        assert_eq!(bind, expected_bind, "server {server}");
+        assert!(bind.ip().is_unspecified(), "server {server}");
+        assert_eq!(bind.port(), 0, "server {server}");
+        assert_eq!(bind.is_ipv4(), server.is_ipv4(), "server {server}");
+        assert_eq!(bind.is_ipv6(), server.is_ipv6(), "server {server}");
+    }
+}
+
+#[tokio::test]
+async fn client_endpoint_binds_unspecified_family_matched_ephemeral_port() {
+    let (_server_config, cert_der) = configure_server().unwrap();
+    let ipv4 = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 4450);
+    let verified = client_endpoint(ServerTrust::CertificateDer(cert_der.clone()), ipv4).unwrap();
+    let local = verified.local_addr().unwrap();
+    assert!(local.ip().is_unspecified(), "{local}");
+    assert!(local.is_ipv4(), "{local}");
+    assert_ne!(local.port(), 0, "{local}");
+
+    let insecure = client_endpoint(ServerTrust::InsecureLocal, ipv4).unwrap();
+    let local = insecure.local_addr().unwrap();
+    assert!(local.ip().is_unspecified(), "{local}");
+    assert!(local.is_ipv4(), "{local}");
+    assert_ne!(local.port(), 0, "{local}");
+
+    let ipv6 = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 4450);
+    match client_endpoint(ServerTrust::CertificateDer(cert_der), ipv6) {
+        Ok(endpoint) => {
+            let local = endpoint.local_addr().unwrap();
+            assert!(local.ip().is_unspecified(), "{local}");
+            assert!(local.is_ipv6(), "{local}");
+            assert_ne!(local.port(), 0, "{local}");
+        }
+        Err(err) if is_address_family_unavailable(&err) => {
+            eprintln!("skipping IPv6 client bind assertion: {err}");
+        }
+        Err(err) => panic!("unexpected IPv6 client endpoint failure: {err}"),
+    }
+}
+
+#[test]
+fn malformed_certificate_der_fails_without_trust_fallback() {
+    let server_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 4450);
+    let err = client_endpoint(ServerTrust::CertificateDer(vec![0xff, 0x00]), server_addr)
+        .expect_err("malformed CertificateDer must fail");
+    assert!(!matches!(
+        err,
+        QuicTextStreamError::InsecureLocalRequiresLoopback(_)
+    ));
+    assert!(matches!(
+        err,
+        QuicTextStreamError::Rustls(_)
+            | QuicTextStreamError::Certificate(_)
+            | QuicTextStreamError::ClientConfig(_)
+    ));
+}
+
+#[tokio::test]
 async fn quic_receiver_renders_text_deltas_in_order() {
     let receiver = QuicTextStreamReceiver::bind(LOCAL_BIND).unwrap();
     let server_addr = receiver.local_addr().unwrap();
+    let server_cert = receiver.server_cert_der().to_vec();
+    let stream_id = vec![0x42; 32];
+    let start_event_id = MessageId::new(vec![0x24; 32]);
+    let receive = tokio::spawn(receiver.receive_once(start_event_id.clone(), None));
+
+    let sent = send_text_stream(SendTextStream {
+        server_addr,
+        server_name: "localhost".to_owned(),
+        trust: ServerTrust::CertificateDer(server_cert),
+        stream_id: stream_id.clone(),
+        start_event_id,
+        text: "hello over quic".to_owned(),
+        max_chunk_bytes: 5,
+        chunk_delay: Duration::ZERO,
+        crypto: None,
+        max_plaintext_frame_len: None,
+    })
+    .await
+    .unwrap();
+
+    let received = receive.await.unwrap().unwrap();
+    assert_eq!(received.stream_id, stream_id);
+    assert_eq!(received.text, "hello over quic");
+    assert_eq!(
+        received
+            .chunks
+            .iter()
+            .map(|chunk| chunk.text.as_str())
+            .collect::<Vec<_>>(),
+        vec!["hello", " over", " quic"]
+    );
+    assert_eq!(received.chunk_count, 3);
+    assert_eq!(sent.stream_id, stream_id);
+    assert_eq!(sent.chunk_count, 3);
+    assert_eq!(sent.transcript_hash, received.transcript_hash);
+}
+
+#[tokio::test]
+async fn quic_receiver_renders_text_deltas_over_ipv6_loopback() {
+    let ipv6_bind = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0);
+    let receiver = match QuicTextStreamReceiver::bind(ipv6_bind) {
+        Ok(receiver) => receiver,
+        Err(err) if is_address_family_unavailable(&err) => {
+            eprintln!("skipping IPv6 loopback send/receive: {err}");
+            return;
+        }
+        Err(err) => panic!("unexpected IPv6 receiver bind failure: {err}"),
+    };
+    let server_addr = receiver.local_addr().unwrap();
+    assert!(server_addr.is_ipv6(), "{server_addr}");
     let server_cert = receiver.server_cert_der().to_vec();
     let stream_id = vec![0x42; 32];
     let start_event_id = MessageId::new(vec![0x24; 32]);

--- a/crates/transport-quic-stream/src/tests.rs
+++ b/crates/transport-quic-stream/src/tests.rs
@@ -39,7 +39,13 @@ fn is_io_address_family_unavailable(err: &std::io::Error) -> bool {
     matches!(
         err.kind(),
         std::io::ErrorKind::AddrNotAvailable | std::io::ErrorKind::Unsupported
-    ) || matches!(err.raw_os_error(), Some(47 | 49 | 97 | 99))
+    ) || matches!(
+        err.raw_os_error(),
+        // Unix EAFNOSUPPORT/EADDRNOTAVAIL (macOS 47/49, Linux 97/99) and
+        // Windows WSAEAFNOSUPPORT (10047). Rust maps 10047 to Uncategorized,
+        // so ErrorKind matching alone would fail IPv6-less Windows hosts.
+        Some(47 | 49 | 97 | 99 | 10047)
+    )
 }
 
 fn is_address_family_unavailable(err: &QuicTextStreamError) -> bool {
@@ -47,6 +53,32 @@ fn is_address_family_unavailable(err: &QuicTextStreamError) -> bool {
         QuicTextStreamError::Io(io_err) => is_io_address_family_unavailable(io_err),
         _ => false,
     }
+}
+
+#[test]
+fn address_family_unavailable_recognizes_windows_wsaeafnosupport() {
+    let err = std::io::Error::from_raw_os_error(10047);
+    assert!(
+        is_io_address_family_unavailable(&err),
+        "WSAEAFNOSUPPORT (10047) must skip IPv6 setup instead of failing: {err:?}"
+    );
+    assert!(is_address_family_unavailable(&QuicTextStreamError::Io(err)));
+}
+
+#[test]
+fn address_family_unavailable_predicate_covers_documented_raw_codes() {
+    for code in [47, 49, 97, 99, 10047] {
+        let err = std::io::Error::from_raw_os_error(code);
+        assert!(
+            is_io_address_family_unavailable(&err),
+            "raw OS error {code} should be treated as address-family unavailable: {err:?}"
+        );
+    }
+    let unrelated = std::io::Error::from(std::io::ErrorKind::ConnectionRefused);
+    assert!(
+        !is_io_address_family_unavailable(&unrelated),
+        "unrelated I/O errors must not skip IPv6 tests: {unrelated:?}"
+    );
 }
 
 #[test]

--- a/crates/transport-quic-stream/src/tls.rs
+++ b/crates/transport-quic-stream/src/tls.rs
@@ -1,7 +1,7 @@
 //! TLS 1.3 setup for both peers: the self-signed server config, the ALPN-pinned
 //! client endpoint per trust mode, and the loopback-only insecure verifier.
 
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
 
 use quinn::crypto::rustls::{QuicClientConfig, QuicServerConfig};
@@ -11,7 +11,7 @@ use rustls_platform_verifier::BuilderVerifierExt;
 
 use crate::error::QuicTextStreamError;
 use crate::hardening::QuicPreviewTransportProfile;
-use crate::protocol::{LOCAL_BIND, QUIC_STREAM_ALPN_V1};
+use crate::protocol::QUIC_STREAM_ALPN_V1;
 use crate::receive::ServerTrust;
 
 pub(crate) fn configure_server() -> Result<(ServerConfig, Vec<u8>), QuicTextStreamError> {
@@ -107,9 +107,19 @@ pub(crate) fn client_endpoint(
     client_config.transport_config(Arc::new(
         QuicPreviewTransportProfile::client().transport_config()?,
     ));
-    let mut endpoint = Endpoint::client(LOCAL_BIND)?;
+    let mut endpoint = Endpoint::client(client_bind_addr_for_server(server_addr))?;
     endpoint.set_default_client_config(client_config);
     Ok(endpoint)
+}
+
+/// Family-matched unspecified client bind. Source wildcard selection is not
+/// authorization of the remote destination; callers must validate and pin
+/// `server_addr` before dialing.
+pub(crate) fn client_bind_addr_for_server(server_addr: SocketAddr) -> SocketAddr {
+    match server_addr {
+        SocketAddr::V4(_) => SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
+        SocketAddr::V6(_) => SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
+    }
 }
 
 #[derive(Debug)]

--- a/docs/marmot-architecture/overview/dial-safety.md
+++ b/docs/marmot-architecture/overview/dial-safety.md
@@ -1,7 +1,7 @@
 ---
 title: "Dial Safety"
 created: 2026-07-04
-updated: 2026-09-07
+updated: 2026-09-10
 tags: [marmot, overview, security, network, ssrf, transport]
 status: overview
 ---
@@ -50,7 +50,7 @@ loopback / private / link-local / CGNAT / metadata endpoint is an SSRF vector, a
 | OTLP and product analytics (reqwest, push) | `crates/marmot-app/src/collector_host_safety.rs`: structural URL gate → resolve once per attempt → validate every address → `resolve_to_addrs` pin; redirects and proxies disabled, TLS trust/SNI from the configured URL, 10s connect and 30s overall attempt limits. |
 | Agent-stream broker watch (quinn) | `crates/marmot-app/src/runtime/agent_stream_watch.rs`: `resolve_broker_addr` validates + pins; `broker_trust_for_candidate` keys `InsecureLocal` on the literal candidate host + `insecure_local`. |
 | Agent-connector broker dial (quinn) | `crates/agent-connector/src/quic.rs`: `resolve_quic_candidate_addr` validates + pins; `broker_trust_for_candidate` gated on `AgentConnectorConfig::allow_insecure_local_broker` + literal loopback. |
-| CLI stream (quinn) | `crates/cli/src/commands/stream.rs`: `resolve_quic_candidate_addr` (`socket_addr_is_unsafe`), `broker_trust` / `ensure_insecure_local_endpoint`. |
+| CLI stream (quinn) | `crates/cli/src/commands/stream.rs`: `resolve_quic_candidate_addr` (`socket_addr_is_unsafe`); explicit `stream send` `--connect` (direct and `--broker`) uses `broker_trust` / `stream_trust` → `ensure_public_quic_endpoint` (`reject_non_public_socket_addr(addr, false)`) or `ensure_insecure_local_endpoint`. A family-matched unspecified client bind is source routing only, not destination authorization. |
 | Nostr relays (nostr-sdk) | `crates/marmot-app/src/relay_plane/safety.rs`: `RelaySafetyPolicy::sanitize_endpoints` → `reject_unsafe_relay_host`, the single funnel for activation, group sync, publish, and directory routes. |
 | QUIC broker client connect timeout | Shared QUIC-preview hardening (`connect_with_timeout` / `QUIC_PREVIEW_CONNECT_TIMEOUT`, #710), applied at both broker client connects in `crates/transport-quic-broker/src/client.rs`. |
 


### PR DESCRIPTION
<!-- pip-control:v1 effect=repo:1055628515#730@3:draft-pr sha256=a35ff797a7ce570845051701f8c71db71efa6c0c5bcc6dd9915a3bafc24bf0b9 -->
### Problem

The direct QUIC client bound IPv4 loopback, so IPv6 and normally routed receivers were unreachable. After the family-matched bind landed, IPv6 setup tests could still fail on Windows hosts that lack IPv6 because WSAEAFNOSUPPORT was not treated as an address-family skip.

### Solution

Direct clients bind a family-matched unspecified address, and CLI explicit sends apply the public-address gate. IPv6 tests now treat Windows WSAEAFNOSUPPORT as the documented platform skip instead of failing.

[Implementation plan](https://github.com/marmot-protocol/mdk/issues/730#issuecomment-5615000125)

Fixes #730

<details>
<summary>Local checks and remediation details</summary>

Commit: `24903d0feb11b8bb509e5b24f6892151dda4847c`

### Local checks

- cargo test --locked -p transport-quic-stream: 40 passed; 0 failed; 0 doctests; IPv6 loopback bind, endpoint, and send/receive tests ran without an address-family skip; new WSAEAFNOSUPPORT predicate tests passed
- just fast-ci: passed
- git diff --check: passed

### Findings addressed

No findings required remediation.

### Review suggestions

- Added raw OS error 10047 to is_io_address_family_unavailable and a predicate regression that constructs Error::from_raw_os_error(10047). cargo test --locked -p transport-quic-stream: 40 passed, including address_family_unavailable_recognizes_windows_wsaeafnosupport.
- Same helper now matches 10047 alongside the existing Unix EAFNOSUPPORT/EADDRNOTAVAIL codes. Verified by address_family_unavailable_recognizes_windows_wsaeafnosupport and address_family_unavailable_predicate_covers_documented_raw_codes.
- Added the 10047 raw-code match and a dedicated Windows-code regression plus a table covering 47/49/97/99/10047 and a ConnectionRefused negative case.

Checks are builder-reported; CI and reviews are evaluated separately.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - `stream send --connect` now accepts only public unicast destinations by default.
  - Local exceptions are restricted to loopback with `--insecure-local`; pinned certificates do not override address validation.
  - Unsafe destinations return the stable `unsafe_quic_endpoint` error without exposing sensitive endpoint details.

- **Connectivity**
  - Direct QUIC connections now support IPv6 and off-host destinations using family-matched client bindings.

- **Documentation**
  - Updated CLI, transport, and architecture documentation with endpoint validation, local testing, trust, and connection behavior.

- **Tests**
  - Added coverage for unsafe destinations, IPv6 connectivity, trust handling, and diagnostic privacy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->