### PR TITLE
Support nprofile identities and shared profile pseudonyms in bindings

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -19,7 +19,10 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 - Account-reference decoding accepts `nprofile` and `nostr:nprofile` in
   addition to hex, `npub`, and existing URI forms. nprofile relay hints are
-  discarded.
+  discarded. Duplicate type-0 TLV entries keep the first key. After one
+  lowercase `nostr:` prefix, the nprofile fallback rejects encoded tokens
+  longer than 1023 UTF-8 bytes; a valid 1023-byte token still decodes when
+  wrapped. FFI wrapper normalization is unchanged.
 
 ## [0.9.21] - 2026-09-10
 

--- a/crates/marmot-app/src/ids.rs
+++ b/crates/marmot-app/src/ids.rs
@@ -1,4 +1,5 @@
 use cgka_traits::MemberId;
+use nostr::FromBech32;
 use nostr::ToBech32;
 use nostr::nips::nip19::Nip19Profile;
 use nostr::prelude::RelayUrl;
@@ -78,12 +79,22 @@ pub fn nprofile_for_account_id(
         .map_err(|_| AppError::InvalidPublicKey)
 }
 
-/// Normalize any public-key reference (npub bech32 or hex) into canonical
-/// hex account id. Public so embedders can resolve scanned/typed npubs.
+/// Normalize a public identity reference into a canonical hex account id.
+///
+/// Accepts hex, `npub`, one lowercase `nostr:npub` prefix, bare `nprofile`,
+/// and one lowercase `nostr:nprofile` prefix. Existing hex/npub/NIP-21
+/// behavior stays on [`PublicKey::parse`]; nprofile is a fallback that
+/// returns only `profile.public_key` hex and discards every relay hint.
+/// This helper does not trim whitespace. Failures map to
+/// [`AppError::InvalidPublicKey`] without echoing the input.
 pub fn account_id_hex_from_ref(reference: &str) -> Result<String, AppError> {
-    Ok(PublicKey::parse(reference)
-        .map_err(|_| AppError::InvalidPublicKey)?
-        .to_hex())
+    if let Ok(pubkey) = PublicKey::parse(reference) {
+        return Ok(pubkey.to_hex());
+    }
+    let profile_ref = reference.strip_prefix("nostr:").unwrap_or(reference);
+    Nip19Profile::from_bech32(profile_ref)
+        .map(|profile| profile.public_key.to_hex())
+        .map_err(|_| AppError::InvalidPublicKey)
 }
 
 pub(crate) fn npub_for_account_id_lossy(account_id_hex: &str) -> String {
@@ -92,17 +103,54 @@ pub(crate) fn npub_for_account_id_lossy(account_id_hex: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{nprofile_for_account_id, npub_for_account_id};
+    use super::{
+        account_id_hex_from_ref, nprofile_for_account_id, npub_for_account_id, parse_account_id_hex,
+    };
+    use crate::AppError;
+    use nostr::nips::nip01::Coordinate;
+    use nostr::nips::nip19::{Nip19Coordinate, Nip19Event};
+    use nostr::{EventId, Kind, SecretKey, ToBech32};
+    use nostr_sdk::prelude::PublicKey;
 
     const ACCOUNT_ID: &str = "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4";
+    const NPUB: &str = "npub14f8usejl26twx0dhuxjh9cas7keav9vr0v8nvtwtrjqx3vycc76qqh9nsy";
+    const BOOTSTRAP_NPROFILE: &str = "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dqpremhxue69uhhyetvv9uju\
+         et49emks6t5v4hx76tnv5hxx6rpwsq3uamnwvaz7tmjv4kxz7fww4ejuamgd96x2mn0d9ek2tnrdpshggcu28s";
+    const NO_RELAY_NPROFILE: &str =
+        "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dq7r0nz9";
+    const UNKNOWN_TLV_NPROFILE: &str =
+        "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0drrq3skycmyxne9kf";
+    const INVALID_RELAY_NPROFILE: &str =
+        "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dqpp9hx7apqvys82unvuca0cf";
+    const DUPLICATE_TYPE0_NPROFILE: &str = "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dqqyzamhwamhwamhwamhwamhwamhwamhwamhwamhwamhwamhwamhwamkq4uk7z";
+    const MISSING_TYPE0_NPROFILE: &str = "nprofile1qy2hwumn8ghj7etcv9khqmr99e5kuanpd35kghsdudn";
+    const SHORT_TYPE0_NPROFILE: &str = "nprofile1qqg25n7gve04d9hr8km7rftjuwc028ngcqe";
+    const TRUNCATED_HEADER_NPROFILE: &str = "nprofile1qqqsnhxh";
+    const TRUNCATED_VALUE_NPROFILE: &str = "nprofile1qqs25n7gve04d9hrdfl42d";
+    const WRONG_HRP_NOTE: &str =
+        "note1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dq4ueyyt";
+
+    fn assert_account_id(reference: &str) {
+        assert_eq!(
+            account_id_hex_from_ref(reference).expect("valid identity reference"),
+            ACCOUNT_ID
+        );
+    }
+
+    fn assert_invalid(reference: &str) {
+        assert!(
+            matches!(
+                account_id_hex_from_ref(reference),
+                Err(AppError::InvalidPublicKey)
+            ),
+            "expected InvalidPublicKey"
+        );
+    }
 
     #[test]
     fn npub_and_nprofile_match_bootstrap_vectors() {
         let npub = npub_for_account_id(ACCOUNT_ID).unwrap();
-        assert_eq!(
-            npub,
-            "npub14f8usejl26twx0dhuxjh9cas7keav9vr0v8nvtwtrjqx3vycc76qqh9nsy"
-        );
+        assert_eq!(npub, NPUB);
 
         let nprofile = nprofile_for_account_id(
             ACCOUNT_ID,
@@ -112,10 +160,100 @@ mod tests {
             ],
         )
         .unwrap();
-        assert_eq!(
-            nprofile,
-            "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dqpremhxue69uhhyetvv9uju\
-             et49emks6t5v4hx76tnv5hxx6rpwsq3uamnwvaz7tmjv4kxz7fww4ejuamgd96x2mn0d9ek2tnrdpshggcu28s"
+        assert_eq!(nprofile, BOOTSTRAP_NPROFILE);
+    }
+
+    #[test]
+    fn account_id_hex_from_ref_accepts_hex_npub_and_nprofile_spellings() {
+        let no_relay = nprofile_for_account_id(ACCOUNT_ID, &[]).unwrap();
+        assert_eq!(no_relay, NO_RELAY_NPROFILE);
+        let other_relays =
+            nprofile_for_account_id(ACCOUNT_ID, &["wss://relay.example.invalid".to_owned()])
+                .unwrap();
+        assert_ne!(other_relays, BOOTSTRAP_NPROFILE);
+
+        for reference in [
+            ACCOUNT_ID,
+            &ACCOUNT_ID.to_ascii_uppercase(),
+            NPUB,
+            &format!("nostr:{NPUB}"),
+            BOOTSTRAP_NPROFILE,
+            &format!("nostr:{BOOTSTRAP_NPROFILE}"),
+            NO_RELAY_NPROFILE,
+            &format!("nostr:{NO_RELAY_NPROFILE}"),
+            &other_relays,
+            UNKNOWN_TLV_NPROFILE,
+            INVALID_RELAY_NPROFILE,
+            DUPLICATE_TYPE0_NPROFILE,
+        ] {
+            assert_account_id(reference);
+        }
+    }
+
+    #[test]
+    fn account_id_hex_from_ref_keeps_untrimmed_whitespace_behavior() {
+        assert_invalid(&format!(" {ACCOUNT_ID}"));
+        assert_invalid(&format!("{NPUB} "));
+        assert_invalid(&format!(" {BOOTSTRAP_NPROFILE}"));
+    }
+
+    #[test]
+    fn account_id_hex_from_ref_rejects_checksum_damage_and_wrong_hrp() {
+        let mut damaged_npub = NPUB.to_owned();
+        damaged_npub.replace_range(damaged_npub.len() - 1.., "x");
+        assert_ne!(damaged_npub, NPUB);
+        assert_invalid(&damaged_npub);
+
+        let mut damaged_nprofile = NO_RELAY_NPROFILE.to_owned();
+        damaged_nprofile.replace_range(damaged_nprofile.len() - 1.., "x");
+        assert_ne!(damaged_nprofile, NO_RELAY_NPROFILE);
+        assert_invalid(&damaged_nprofile);
+
+        assert_invalid(WRONG_HRP_NOTE);
+        assert_invalid(
+            "NOSTR:nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dq7r0nz9",
         );
+        assert_invalid(&format!("nostr:nostr:{NO_RELAY_NPROFILE}"));
+    }
+
+    #[test]
+    fn account_id_hex_from_ref_rejects_event_and_secret_hrps() {
+        let public_key = PublicKey::parse(ACCOUNT_ID).unwrap();
+        let event_id = EventId::from_slice(&[0x22; 32]).unwrap();
+        let note = event_id.to_bech32().unwrap();
+        let nevent = Nip19Event::new(event_id)
+            .author(public_key)
+            .to_bech32()
+            .unwrap();
+        let naddr = Nip19Coordinate::new(Coordinate::new(Kind::Metadata, public_key), [])
+            .to_bech32()
+            .unwrap();
+        let nsec = SecretKey::from_slice(&[0x11; 32])
+            .unwrap()
+            .to_bech32()
+            .unwrap();
+
+        assert_invalid(&note);
+        assert_invalid(&nevent);
+        assert_invalid(&naddr);
+        assert_invalid(&nsec);
+    }
+
+    #[test]
+    fn account_id_hex_from_ref_rejects_truncated_and_missing_type0() {
+        assert_invalid(MISSING_TYPE0_NPROFILE);
+        assert_invalid(SHORT_TYPE0_NPROFILE);
+        assert_invalid(TRUNCATED_HEADER_NPROFILE);
+        assert_invalid(TRUNCATED_VALUE_NPROFILE);
+    }
+
+    #[test]
+    fn parse_account_id_hex_does_not_gain_nprofile() {
+        assert_eq!(parse_account_id_hex(ACCOUNT_ID).unwrap(), ACCOUNT_ID);
+        assert_eq!(parse_account_id_hex(NPUB).unwrap(), ACCOUNT_ID);
+        assert!(matches!(
+            parse_account_id_hex(NO_RELAY_NPROFILE),
+            Err(AppError::InvalidPublicKey)
+        ));
     }
 }

--- a/crates/marmot-app/src/ids.rs
+++ b/crates/marmot-app/src/ids.rs
@@ -79,22 +79,49 @@ pub fn nprofile_for_account_id(
         .map_err(|_| AppError::InvalidPublicKey)
 }
 
+/// Matches the currently locked Bech32/Bech32m code-length ceiling
+/// (`bech32` 0.11.1), not a universal NIP-19 protocol limit.
+const MAX_NPROFILE_REFERENCE_BYTES: usize = 1023;
+
 /// Normalize a public identity reference into a canonical hex account id.
 ///
 /// Accepts hex, `npub`, one lowercase `nostr:npub` prefix, bare `nprofile`,
 /// and one lowercase `nostr:nprofile` prefix. Existing hex/npub/NIP-21
 /// behavior stays on [`PublicKey::parse`]; nprofile is a fallback that
 /// returns only `profile.public_key` hex and discards every relay hint.
-/// This helper does not trim whitespace. Failures map to
-/// [`AppError::InvalidPublicKey`] without echoing the input.
+/// Duplicate type-0 TLV entries keep the first 32-byte key (SDK first-wins).
+///
+/// The fallback runs only after `PublicKey::parse` fails. It strips at most
+/// one exact lowercase `nostr:` prefix and then rejects encoded tokens
+/// longer than 1023 UTF-8 bytes, counting the
+/// HRP, separator, and checksum but excluding that one prefix. Decorated
+/// wrappers such as `marmot://profile/...` are not stripped here; FFI
+/// canonicalizes those before calling this helper. A valid 1023-byte token
+/// wrapped in `nostr:` therefore still decodes even though the complete
+/// wrapper is longer.
+///
+/// This helper does not trim whitespace, allocate, or normalize case. The
+/// legacy NIP-21 parser may still accept a colon-suffixed `nostr:<npub>:`
+/// form before the fallback runs. Failures map to
+/// [`AppError::InvalidPublicKey`] without echoing the input. The local
+/// token limit makes the fallback budget explicit; it does not bound
+/// `PublicKey::parse`, FFI allocation, or C NUL scanning.
 pub fn account_id_hex_from_ref(reference: &str) -> Result<String, AppError> {
     if let Ok(pubkey) = PublicKey::parse(reference) {
         return Ok(pubkey.to_hex());
     }
-    let profile_ref = reference.strip_prefix("nostr:").unwrap_or(reference);
+    let profile_ref = nprofile_fallback_token(reference)?;
     Nip19Profile::from_bech32(profile_ref)
         .map(|profile| profile.public_key.to_hex())
         .map_err(|_| AppError::InvalidPublicKey)
+}
+
+fn nprofile_fallback_token(reference: &str) -> Result<&str, AppError> {
+    let profile_ref = reference.strip_prefix("nostr:").unwrap_or(reference);
+    if profile_ref.len() > MAX_NPROFILE_REFERENCE_BYTES {
+        return Err(AppError::InvalidPublicKey);
+    }
+    Ok(profile_ref)
 }
 
 pub(crate) fn npub_for_account_id_lossy(account_id_hex: &str) -> String {
@@ -104,48 +131,15 @@ pub(crate) fn npub_for_account_id_lossy(account_id_hex: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        account_id_hex_from_ref, nprofile_for_account_id, npub_for_account_id, parse_account_id_hex,
+        MAX_NPROFILE_REFERENCE_BYTES, account_id_hex_from_ref, nprofile_fallback_token,
+        nprofile_for_account_id, npub_for_account_id, parse_account_id_hex,
     };
     use crate::AppError;
-    use nostr::nips::nip01::Coordinate;
-    use nostr::nips::nip19::{Nip19Coordinate, Nip19Event};
-    use nostr::{EventId, Kind, SecretKey, ToBech32};
-    use nostr_sdk::prelude::PublicKey;
 
-    const ACCOUNT_ID: &str = "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4";
-    const NPUB: &str = "npub14f8usejl26twx0dhuxjh9cas7keav9vr0v8nvtwtrjqx3vycc76qqh9nsy";
-    const BOOTSTRAP_NPROFILE: &str = "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dqpremhxue69uhhyetvv9uju\
-         et49emks6t5v4hx76tnv5hxx6rpwsq3uamnwvaz7tmjv4kxz7fww4ejuamgd96x2mn0d9ek2tnrdpshggcu28s";
-    const NO_RELAY_NPROFILE: &str =
-        "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dq7r0nz9";
-    const UNKNOWN_TLV_NPROFILE: &str =
-        "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0drrq3skycmyxne9kf";
-    const INVALID_RELAY_NPROFILE: &str =
-        "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dqpp9hx7apqvys82unvuca0cf";
-    const DUPLICATE_TYPE0_NPROFILE: &str = "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dqqyzamhwamhwamhwamhwamhwamhwamhwamhwamhwamhwamhwamhwamkq4uk7z";
-    const MISSING_TYPE0_NPROFILE: &str = "nprofile1qy2hwumn8ghj7etcv9khqmr99e5kuanpd35kghsdudn";
-    const SHORT_TYPE0_NPROFILE: &str = "nprofile1qqg25n7gve04d9hr8km7rftjuwc028ngcqe";
-    const TRUNCATED_HEADER_NPROFILE: &str = "nprofile1qqqsnhxh";
-    const TRUNCATED_VALUE_NPROFILE: &str = "nprofile1qqs25n7gve04d9hrdfl42d";
-    const WRONG_HRP_NOTE: &str =
-        "note1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dq4ueyyt";
-
-    fn assert_account_id(reference: &str) {
-        assert_eq!(
-            account_id_hex_from_ref(reference).expect("valid identity reference"),
-            ACCOUNT_ID
-        );
-    }
-
-    fn assert_invalid(reference: &str) {
-        assert!(
-            matches!(
-                account_id_hex_from_ref(reference),
-                Err(AppError::InvalidPublicKey)
-            ),
-            "expected InvalidPublicKey"
-        );
-    }
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/support/identity_reference_vectors.rs"
+    ));
 
     #[test]
     fn npub_and_nprofile_match_bootstrap_vectors() {
@@ -161,90 +155,71 @@ mod tests {
         )
         .unwrap();
         assert_eq!(nprofile, BOOTSTRAP_NPROFILE);
-    }
 
-    #[test]
-    fn account_id_hex_from_ref_accepts_hex_npub_and_nprofile_spellings() {
         let no_relay = nprofile_for_account_id(ACCOUNT_ID, &[]).unwrap();
         assert_eq!(no_relay, NO_RELAY_NPROFILE);
         let other_relays =
             nprofile_for_account_id(ACCOUNT_ID, &["wss://relay.example.invalid".to_owned()])
                 .unwrap();
+        assert_eq!(other_relays, OTHER_RELAY_NPROFILE);
         assert_ne!(other_relays, BOOTSTRAP_NPROFILE);
+    }
 
-        for reference in [
-            ACCOUNT_ID,
-            &ACCOUNT_ID.to_ascii_uppercase(),
-            NPUB,
-            &format!("nostr:{NPUB}"),
-            BOOTSTRAP_NPROFILE,
-            &format!("nostr:{BOOTSTRAP_NPROFILE}"),
-            NO_RELAY_NPROFILE,
-            &format!("nostr:{NO_RELAY_NPROFILE}"),
-            &other_relays,
-            UNKNOWN_TLV_NPROFILE,
-            INVALID_RELAY_NPROFILE,
-            DUPLICATE_TYPE0_NPROFILE,
-        ] {
-            assert_account_id(reference);
+    #[test]
+    fn account_id_hex_from_ref_matches_shared_corpus() {
+        for case in cases() {
+            match case.app_account_id_hex {
+                Some(expected) => {
+                    assert_eq!(
+                        account_id_hex_from_ref(&case.reference)
+                            .unwrap_or_else(|_| panic!("case {} should decode", case.name)),
+                        expected,
+                        "case {}",
+                        case.name
+                    );
+                }
+                None => {
+                    assert!(
+                        matches!(
+                            account_id_hex_from_ref(&case.reference),
+                            Err(AppError::InvalidPublicKey)
+                        ),
+                        "case {} should reject",
+                        case.name
+                    );
+                }
+            }
         }
     }
 
     #[test]
-    fn account_id_hex_from_ref_keeps_untrimmed_whitespace_behavior() {
-        assert_invalid(&format!(" {ACCOUNT_ID}"));
-        assert_invalid(&format!("{NPUB} "));
-        assert_invalid(&format!(" {BOOTSTRAP_NPROFILE}"));
-    }
-
-    #[test]
-    fn account_id_hex_from_ref_rejects_checksum_damage_and_wrong_hrp() {
-        let mut damaged_npub = NPUB.to_owned();
-        damaged_npub.replace_range(damaged_npub.len() - 1.., "x");
-        assert_ne!(damaged_npub, NPUB);
-        assert_invalid(&damaged_npub);
-
-        let mut damaged_nprofile = NO_RELAY_NPROFILE.to_owned();
-        damaged_nprofile.replace_range(damaged_nprofile.len() - 1.., "x");
-        assert_ne!(damaged_nprofile, NO_RELAY_NPROFILE);
-        assert_invalid(&damaged_nprofile);
-
-        assert_invalid(WRONG_HRP_NOTE);
-        assert_invalid(
-            "NOSTR:nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dq7r0nz9",
+    fn nprofile_fallback_token_rejects_oversized_tokens_before_sdk_decode() {
+        let accepted = "q".repeat(MAX_NPROFILE_REFERENCE_BYTES);
+        assert_eq!(
+            nprofile_fallback_token(&accepted).expect("1023-byte token stays eligible"),
+            accepted.as_str()
         );
-        assert_invalid(&format!("nostr:nostr:{NO_RELAY_NPROFILE}"));
-    }
+        let wrapped = format!("nostr:{accepted}");
+        assert_eq!(
+            nprofile_fallback_token(&wrapped).expect("prefix is excluded from the budget"),
+            accepted.as_str()
+        );
 
-    #[test]
-    fn account_id_hex_from_ref_rejects_event_and_secret_hrps() {
-        let public_key = PublicKey::parse(ACCOUNT_ID).unwrap();
-        let event_id = EventId::from_slice(&[0x22; 32]).unwrap();
-        let note = event_id.to_bech32().unwrap();
-        let nevent = Nip19Event::new(event_id)
-            .author(public_key)
-            .to_bech32()
-            .unwrap();
-        let naddr = Nip19Coordinate::new(Coordinate::new(Kind::Metadata, public_key), [])
-            .to_bech32()
-            .unwrap();
-        let nsec = SecretKey::from_slice(&[0x11; 32])
-            .unwrap()
-            .to_bech32()
-            .unwrap();
-
-        assert_invalid(&note);
-        assert_invalid(&nevent);
-        assert_invalid(&naddr);
-        assert_invalid(&nsec);
-    }
-
-    #[test]
-    fn account_id_hex_from_ref_rejects_truncated_and_missing_type0() {
-        assert_invalid(MISSING_TYPE0_NPROFILE);
-        assert_invalid(SHORT_TYPE0_NPROFILE);
-        assert_invalid(TRUNCATED_HEADER_NPROFILE);
-        assert_invalid(TRUNCATED_VALUE_NPROFILE);
+        let oversized = "q".repeat(MAX_NPROFILE_REFERENCE_BYTES + 1);
+        assert!(
+            matches!(
+                nprofile_fallback_token(&oversized),
+                Err(AppError::InvalidPublicKey)
+            ),
+            "1024-byte token must not reach Nip19Profile::from_bech32"
+        );
+        assert!(
+            matches!(
+                nprofile_fallback_token(&format!("nostr:{oversized}")),
+                Err(AppError::InvalidPublicKey)
+            ),
+            "prefixed oversized token must not reach Nip19Profile::from_bech32"
+        );
     }
 
     #[test]

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -59,7 +59,6 @@ use rand::RngCore;
 use rand::rngs::OsRng;
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use storage_sqlite::{
     SecurePruneAppEventsResult, SqliteAccountStorage, SqliteSharedStorage, StoredAppMessageQuery,
     TimelineProjectionUpdate,
@@ -93,6 +92,7 @@ mod key_package_records;
 #[cfg(test)]
 mod local_open_test_gate;
 mod media;
+mod profile_pseudonyms;
 #[cfg(feature = "media-benchmarks")]
 #[doc(hidden)]
 pub use media::MediaDownloadBenchmarkTransport;
@@ -213,6 +213,7 @@ pub use notifications::{
     build_notification_gift_wrap, build_notification_rumor_content, encrypted_push_token,
     parse_provider_token, push_token_fingerprint,
 };
+pub use profile_pseudonyms::{default_profile_pseudonym, random_profile_pseudonym};
 pub use relay_plane::{
     EngineReorgMetrics, MarmotRelayPlane, MarmotRelayPlaneAccountAdapter,
     RelayEndpointClassification, RelayEndpointPolicy, RelayPlaneHealth, RelayRollupEntry,
@@ -423,152 +424,6 @@ const DIRECTORY_FUTURE_CREATED_AT_CLEANUP_MARKER: &str =
 pub(crate) const MAX_SEEN_EVENT_IDS: usize = 16_384;
 const KIND_NOSTR_METADATA: u64 = 0;
 const KIND_NOSTR_CONTACT_LIST: u64 = 3;
-const DEFAULT_PROFILE_ADJECTIVES: &[&str] = &[
-    "Agile", "Amber", "Angry", "Balanced", "Bold", "Brave", "Breezy", "Bright", "Brisk", "Bubbly",
-    "Calm", "Caring", "Cheerful", "Clear", "Clever", "Coral", "Cosmic", "Cozy", "Crimson", "Crisp",
-    "Curious", "Daring", "Dawn", "Deep", "Diamond", "Dreamy", "Eager", "Earnest", "Easy",
-    "Electric", "Emerald", "Festive", "Fiery", "Fleet", "Forest", "Fresh", "Frosty", "Gentle",
-    "Glad", "Golden", "Graceful", "Grand", "Grateful", "Green", "Happy", "Hardy", "Hearty",
-    "Hidden", "Honest", "Hopeful", "Humble", "Indigo", "Ivory", "Jade", "Jolly", "Kind", "Lively",
-    "Loyal", "Lucky", "Majestic", "Maple", "Mellow", "Merry", "Mighty", "Mindful", "Misty",
-    "Modest", "Mossy", "Neat", "Nifty", "Nimble", "Noble", "Olive", "Open", "Patient", "Peaceful",
-    "Plum", "Polar", "Proud", "Quiet", "Radiant", "Rapid", "Ready", "Restful", "Rosy", "Ruby",
-    "Rustic", "Sage", "Scarlet", "Serene", "Sharp", "Shiny", "Silver", "Sincere", "Sky", "Smooth",
-    "Solar", "Solid", "Spirited", "Spry", "Steady", "Stellar", "Stormy", "Sturdy", "Sunlit",
-    "Sunny", "Swift", "Tame", "Tangy", "Tender", "Tidy", "Topaz", "Tranquil", "Trusty", "Twilight",
-    "Upbeat", "Valiant", "Verdant", "Vivid", "Warm", "Willing", "Winsome", "Wise", "Witty",
-    "Wondrous", "Woodland", "Young", "Zesty",
-];
-const DEFAULT_PROFILE_NOUNS: &[&str] = &[
-    "Albatross",
-    "Alpaca",
-    "Ant",
-    "Antelope",
-    "Armadillo",
-    "Badger",
-    "Bat",
-    "Bear",
-    "Beaver",
-    "Bee",
-    "Bison",
-    "Bluebird",
-    "Bobcat",
-    "Bullfrog",
-    "Bumblebee",
-    "Butterfly",
-    "Camel",
-    "Caribou",
-    "Cat",
-    "Caterpillar",
-    "Cheetah",
-    "Chickadee",
-    "Chinchilla",
-    "Chipmunk",
-    "Cobra",
-    "Condor",
-    "Cougar",
-    "Crab",
-    "Crane",
-    "Cricket",
-    "Crow",
-    "Deer",
-    "Dingo",
-    "Dolphin",
-    "Dove",
-    "Dragonfly",
-    "Duck",
-    "Eagle",
-    "Egret",
-    "Elephant",
-    "Elk",
-    "Falcon",
-    "Fawn",
-    "Ferret",
-    "Finch",
-    "Firefly",
-    "Flamingo",
-    "Flounder",
-    "Fox",
-    "Gazelle",
-    "Gecko",
-    "Giraffe",
-    "Goat",
-    "Goose",
-    "Gopher",
-    "Grouse",
-    "Hare",
-    "Hawk",
-    "Hedgehog",
-    "Heron",
-    "Hippo",
-    "Hornet",
-    "Horse",
-    "Hummingbird",
-    "Ibex",
-    "Iguana",
-    "Jackal",
-    "Jaguar",
-    "Jay",
-    "Kestrel",
-    "Kingfisher",
-    "Kiwi",
-    "Koala",
-    "Ladybug",
-    "Lark",
-    "Leopard",
-    "Lion",
-    "Llama",
-    "Lynx",
-    "Macaw",
-    "Magpie",
-    "Mallard",
-    "Manatee",
-    "Marmot",
-    "Meerkat",
-    "Mink",
-    "Mole",
-    "Mongoose",
-    "Monkey",
-    "Moose",
-    "Mouse",
-    "Narwhal",
-    "Newt",
-    "Nightingale",
-    "Octopus",
-    "Opossum",
-    "Orca",
-    "Oriole",
-    "Ostrich",
-    "Otter",
-    "Owl",
-    "Panda",
-    "Parrot",
-    "Peacock",
-    "Pelican",
-    "Penguin",
-    "Pheasant",
-    "Pigeon",
-    "Pony",
-    "Porcupine",
-    "Puffin",
-    "Quail",
-    "Rabbit",
-    "Raccoon",
-    "Ram",
-    "Raven",
-    "Reindeer",
-    "Rhino",
-    "Roadrunner",
-    "Robin",
-    "Salamander",
-    "Salmon",
-    "Seal",
-    "Swan",
-    "Tiger",
-    "Turtle",
-    "Wolf",
-    "Yak",
-];
 
 type AppRuntime = AccountDeviceRuntime<
     MarmotRelayPlaneAccountAdapter,
@@ -6423,18 +6278,6 @@ impl KeyPackagePublisher for AppKeyPackagePublisher {
 
 fn empty_key_package_lifecycle(stable_slot_id: String) -> cgka_traits::KeyPackageLifecycleState {
     cgka_traits::KeyPackageLifecycleState::slot_only(stable_slot_id)
-}
-
-fn default_profile_pseudonym(account_id_hex: &str) -> String {
-    let digest = Sha256::digest(account_id_hex.as_bytes());
-    let adjective_index =
-        u16::from_be_bytes([digest[0], digest[1]]) as usize % DEFAULT_PROFILE_ADJECTIVES.len();
-    let noun_index =
-        u16::from_be_bytes([digest[2], digest[3]]) as usize % DEFAULT_PROFILE_NOUNS.len();
-    format!(
-        "{} {}",
-        DEFAULT_PROFILE_ADJECTIVES[adjective_index], DEFAULT_PROFILE_NOUNS[noun_index]
-    )
 }
 
 fn unix_now_seconds() -> u64 {

--- a/crates/marmot-app/src/profile_pseudonyms.rs
+++ b/crates/marmot-app/src/profile_pseudonyms.rs
@@ -1,0 +1,310 @@
+//! Shared cosmetic display-pseudonym helpers.
+//!
+//! These names are presentation-only. They are not unique, anonymous, or a
+//! security primitive. [`default_profile_pseudonym`] hashes the supplied
+//! account-id text as UTF-8 without normalizing, decoding, trimming, or
+//! validating it. Consumers that start from a scanned reference should call
+//! [`crate::account_id_hex_from_ref`] first so the seed is the lowercase
+//! canonical hex account id.
+
+use rand::RngCore;
+use sha2::{Digest, Sha256};
+
+const DEFAULT_PROFILE_ADJECTIVES: &[&str] = &[
+    "Agile", "Amber", "Angry", "Balanced", "Bold", "Brave", "Breezy", "Bright", "Brisk", "Bubbly",
+    "Calm", "Caring", "Cheerful", "Clear", "Clever", "Coral", "Cosmic", "Cozy", "Crimson", "Crisp",
+    "Curious", "Daring", "Dawn", "Deep", "Diamond", "Dreamy", "Eager", "Earnest", "Easy",
+    "Electric", "Emerald", "Festive", "Fiery", "Fleet", "Forest", "Fresh", "Frosty", "Gentle",
+    "Glad", "Golden", "Graceful", "Grand", "Grateful", "Green", "Happy", "Hardy", "Hearty",
+    "Hidden", "Honest", "Hopeful", "Humble", "Indigo", "Ivory", "Jade", "Jolly", "Kind", "Lively",
+    "Loyal", "Lucky", "Majestic", "Maple", "Mellow", "Merry", "Mighty", "Mindful", "Misty",
+    "Modest", "Mossy", "Neat", "Nifty", "Nimble", "Noble", "Olive", "Open", "Patient", "Peaceful",
+    "Plum", "Polar", "Proud", "Quiet", "Radiant", "Rapid", "Ready", "Restful", "Rosy", "Ruby",
+    "Rustic", "Sage", "Scarlet", "Serene", "Sharp", "Shiny", "Silver", "Sincere", "Sky", "Smooth",
+    "Solar", "Solid", "Spirited", "Spry", "Steady", "Stellar", "Stormy", "Sturdy", "Sunlit",
+    "Sunny", "Swift", "Tame", "Tangy", "Tender", "Tidy", "Topaz", "Tranquil", "Trusty", "Twilight",
+    "Upbeat", "Valiant", "Verdant", "Vivid", "Warm", "Willing", "Winsome", "Wise", "Witty",
+    "Wondrous", "Woodland", "Young", "Zesty",
+];
+const DEFAULT_PROFILE_NOUNS: &[&str] = &[
+    "Albatross",
+    "Alpaca",
+    "Ant",
+    "Antelope",
+    "Armadillo",
+    "Badger",
+    "Bat",
+    "Bear",
+    "Beaver",
+    "Bee",
+    "Bison",
+    "Bluebird",
+    "Bobcat",
+    "Bullfrog",
+    "Bumblebee",
+    "Butterfly",
+    "Camel",
+    "Caribou",
+    "Cat",
+    "Caterpillar",
+    "Cheetah",
+    "Chickadee",
+    "Chinchilla",
+    "Chipmunk",
+    "Cobra",
+    "Condor",
+    "Cougar",
+    "Crab",
+    "Crane",
+    "Cricket",
+    "Crow",
+    "Deer",
+    "Dingo",
+    "Dolphin",
+    "Dove",
+    "Dragonfly",
+    "Duck",
+    "Eagle",
+    "Egret",
+    "Elephant",
+    "Elk",
+    "Falcon",
+    "Fawn",
+    "Ferret",
+    "Finch",
+    "Firefly",
+    "Flamingo",
+    "Flounder",
+    "Fox",
+    "Gazelle",
+    "Gecko",
+    "Giraffe",
+    "Goat",
+    "Goose",
+    "Gopher",
+    "Grouse",
+    "Hare",
+    "Hawk",
+    "Hedgehog",
+    "Heron",
+    "Hippo",
+    "Hornet",
+    "Horse",
+    "Hummingbird",
+    "Ibex",
+    "Iguana",
+    "Jackal",
+    "Jaguar",
+    "Jay",
+    "Kestrel",
+    "Kingfisher",
+    "Kiwi",
+    "Koala",
+    "Ladybug",
+    "Lark",
+    "Leopard",
+    "Lion",
+    "Llama",
+    "Lynx",
+    "Macaw",
+    "Magpie",
+    "Mallard",
+    "Manatee",
+    "Marmot",
+    "Meerkat",
+    "Mink",
+    "Mole",
+    "Mongoose",
+    "Monkey",
+    "Moose",
+    "Mouse",
+    "Narwhal",
+    "Newt",
+    "Nightingale",
+    "Octopus",
+    "Opossum",
+    "Orca",
+    "Oriole",
+    "Ostrich",
+    "Otter",
+    "Owl",
+    "Panda",
+    "Parrot",
+    "Peacock",
+    "Pelican",
+    "Penguin",
+    "Pheasant",
+    "Pigeon",
+    "Pony",
+    "Porcupine",
+    "Puffin",
+    "Quail",
+    "Rabbit",
+    "Raccoon",
+    "Ram",
+    "Raven",
+    "Reindeer",
+    "Rhino",
+    "Roadrunner",
+    "Robin",
+    "Salamander",
+    "Salmon",
+    "Seal",
+    "Swan",
+    "Tiger",
+    "Turtle",
+    "Wolf",
+    "Yak",
+];
+
+/// Deterministic adjective-noun display name for a canonical hex account id.
+///
+/// The seed is hashed as supplied UTF-8 text. This function does not
+/// normalize, decode, trim, or validate `account_id_hex`. Signup and
+/// fallback presentation keep this exact formula.
+pub fn default_profile_pseudonym(account_id_hex: &str) -> String {
+    let digest = Sha256::digest(account_id_hex.as_bytes());
+    let adjective_index =
+        u16::from_be_bytes([digest[0], digest[1]]) as usize % DEFAULT_PROFILE_ADJECTIVES.len();
+    let noun_index =
+        u16::from_be_bytes([digest[2], digest[3]]) as usize % DEFAULT_PROFILE_NOUNS.len();
+    format!(
+        "{} {}",
+        DEFAULT_PROFILE_ADJECTIVES[adjective_index], DEFAULT_PROFILE_NOUNS[noun_index]
+    )
+}
+
+/// Random cosmetic display name from the shared wordlists.
+///
+/// Draws 32 random bytes, lowercase-hex encodes them, and delegates to
+/// [`default_profile_pseudonym`]. This does not generate a signing key or
+/// create an account. Collisions are permitted.
+pub fn random_profile_pseudonym() -> String {
+    random_profile_pseudonym_with_rng(&mut rand::thread_rng())
+}
+
+fn random_profile_pseudonym_with_rng<R: RngCore>(rng: &mut R) -> String {
+    let mut bytes = [0u8; 32];
+    rng.fill_bytes(&mut bytes);
+    default_profile_pseudonym(&hex::encode(bytes))
+}
+
+#[cfg(test)]
+fn is_known_profile_pseudonym(name: &str) -> bool {
+    let Some((adjective, noun)) = name.split_once(' ') else {
+        return false;
+    };
+    if noun.contains(' ') {
+        return false;
+    }
+    DEFAULT_PROFILE_ADJECTIVES.contains(&adjective) && DEFAULT_PROFILE_NOUNS.contains(&noun)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DEFAULT_PROFILE_ADJECTIVES, DEFAULT_PROFILE_NOUNS, default_profile_pseudonym,
+        is_known_profile_pseudonym, random_profile_pseudonym, random_profile_pseudonym_with_rng,
+    };
+    use rand::RngCore;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    const BOOTSTRAP_ACCOUNT: &str =
+        "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4";
+
+    #[test]
+    fn default_profile_word_lists_keep_expected_shape() {
+        assert_profile_word_list("adjectives", DEFAULT_PROFILE_ADJECTIVES);
+        assert_profile_word_list("nouns", DEFAULT_PROFILE_NOUNS);
+        assert_eq!(
+            DEFAULT_PROFILE_ADJECTIVES.len() * DEFAULT_PROFILE_NOUNS.len(),
+            16_384
+        );
+    }
+
+    #[test]
+    fn deterministic_names_match_frozen_vectors() {
+        assert_eq!(default_profile_pseudonym(BOOTSTRAP_ACCOUNT), "Loyal Crane");
+        assert_eq!(default_profile_pseudonym(&"0".repeat(64)), "Solar Mallard");
+        assert_eq!(default_profile_pseudonym(&"bb".repeat(32)), "Wise Grouse");
+    }
+
+    #[test]
+    fn deterministic_names_are_stable_and_hash_raw_utf8() {
+        assert_eq!(
+            default_profile_pseudonym(BOOTSTRAP_ACCOUNT),
+            default_profile_pseudonym(BOOTSTRAP_ACCOUNT)
+        );
+        assert_ne!(
+            default_profile_pseudonym(BOOTSTRAP_ACCOUNT),
+            default_profile_pseudonym(&BOOTSTRAP_ACCOUNT.to_ascii_uppercase())
+        );
+        assert_ne!(
+            default_profile_pseudonym(BOOTSTRAP_ACCOUNT),
+            default_profile_pseudonym(&format!(" {BOOTSTRAP_ACCOUNT}"))
+        );
+        assert_eq!(
+            default_profile_pseudonym("not-a-public-key"),
+            default_profile_pseudonym("not-a-public-key")
+        );
+    }
+
+    #[test]
+    fn seeded_random_roll_delegates_to_the_deterministic_helper() {
+        let mut rng = StdRng::seed_from_u64(959);
+        let mut bytes = [0u8; 32];
+        let mut expected_rng = StdRng::seed_from_u64(959);
+        expected_rng.fill_bytes(&mut bytes);
+        let name = random_profile_pseudonym_with_rng(&mut rng);
+        assert_eq!(name, default_profile_pseudonym(&hex::encode(bytes)));
+        assert!(is_known_profile_pseudonym(&name));
+    }
+
+    #[test]
+    fn random_helper_smoke_stays_in_the_shared_tables() {
+        let name = random_profile_pseudonym();
+        assert!(is_known_profile_pseudonym(&name), "{name}");
+    }
+
+    #[test]
+    fn seeded_corpus_covers_the_full_vocabulary() {
+        let mut adjectives = std::collections::BTreeSet::new();
+        let mut nouns = std::collections::BTreeSet::new();
+        let mut names = std::collections::BTreeSet::new();
+        for index in 0u32..4_096 {
+            let name = default_profile_pseudonym(&format!("{index:064x}"));
+            let (adjective, noun) = name.split_once(' ').expect("adjective noun");
+            adjectives.insert(adjective.to_owned());
+            nouns.insert(noun.to_owned());
+            names.insert(name);
+        }
+        assert_eq!(adjectives.len(), DEFAULT_PROFILE_ADJECTIVES.len());
+        assert_eq!(nouns.len(), DEFAULT_PROFILE_NOUNS.len());
+        assert_eq!(names.len(), 3_663);
+    }
+
+    fn assert_profile_word_list(name: &str, words: &[&str]) {
+        assert_eq!(words.len(), 128, "{name} should have 128 entries");
+        for word in words {
+            assert!(!word.is_empty(), "{name} should not contain empty words");
+            let mut chars = word.chars();
+            assert!(
+                chars.next().is_some_and(|ch| ch.is_ascii_uppercase()),
+                "{name} word should start uppercase: {word}"
+            );
+            assert!(
+                chars.all(|ch| ch.is_ascii_lowercase()),
+                "{name} word should be title-cased ASCII: {word}"
+            );
+        }
+        for pair in words.windows(2) {
+            assert!(
+                pair[0] < pair[1],
+                "{name} should be sorted and unique: {} before {}",
+                pair[0],
+                pair[1]
+            );
+        }
+    }
+}

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -9495,40 +9495,6 @@ fn legacy_projection_update_json_defaults_new_streaming_fields() {
     );
 }
 
-#[test]
-fn default_profile_word_lists_keep_expected_shape() {
-    assert_profile_word_list("adjectives", DEFAULT_PROFILE_ADJECTIVES);
-    assert_profile_word_list("nouns", DEFAULT_PROFILE_NOUNS);
-    assert_eq!(
-        DEFAULT_PROFILE_ADJECTIVES.len() * DEFAULT_PROFILE_NOUNS.len(),
-        16_384
-    );
-}
-
-fn assert_profile_word_list(name: &str, words: &[&str]) {
-    assert_eq!(words.len(), 128, "{name} should have 128 entries");
-    for word in words {
-        assert!(!word.is_empty(), "{name} should not contain empty words");
-        let mut chars = word.chars();
-        assert!(
-            chars.next().is_some_and(|ch| ch.is_ascii_uppercase()),
-            "{name} word should start uppercase: {word}"
-        );
-        assert!(
-            chars.all(|ch| ch.is_ascii_lowercase()),
-            "{name} word should be title-cased ASCII: {word}"
-        );
-    }
-    for pair in words.windows(2) {
-        assert!(
-            pair[0] < pair[1],
-            "{name} should be sorted and unique: {} before {}",
-            pair[0],
-            pair[1]
-        );
-    }
-}
-
 fn relay_delivery(marker: &str, pubkey: String) -> cgka_traits::TransportDelivery {
     // `to_transport_message` verifies the id against the event hash (#351), so
     // the distinguishing marker lives in the content and the id is computed.

--- a/crates/marmot-app/tests/support/identity_reference_vectors.rs
+++ b/crates/marmot-app/tests/support/identity_reference_vectors.rs
@@ -1,0 +1,273 @@
+// Shared identity-reference regression corpus.
+//
+// Test-only data included by app, UniFFI, and C tests. This is not a
+// production export and does not implement a decoder.
+//
+// Structured boundary and malformed nprofile literals were produced with
+// the locked nostr 0.44.8 / bech32 0.11.1 encoder from explicit TLV
+// bytes. Wrapper, checksum-mutation, and oversized cases are built with
+// `std` string construction.
+
+#[allow(dead_code)]
+pub struct IdentityReferenceCase {
+    pub name: &'static str,
+    pub reference: String,
+    pub app_account_id_hex: Option<&'static str>,
+    pub ffi_account_id_hex: Option<&'static str>,
+}
+
+/// Canonical lowercase hex account id used by every accepted vector.
+pub const ACCOUNT_ID: &str = "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4";
+/// Bech32 npub for ACCOUNT_ID.
+pub const NPUB: &str = "npub14f8usejl26twx0dhuxjh9cas7keav9vr0v8nvtwtrjqx3vycc76qqh9nsy";
+/// nprofile TLV: type-0 ACCOUNT_ID plus two bootstrap relay URLs (wss://relay.eu.whitenoise.chat, wss://relay.us.whitenoise.chat).
+pub const BOOTSTRAP_NPROFILE: &str = concat!(
+    "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dqpremhxue69uhhyet",
+    "vv9ujuet49emks6t5v4hx76tnv5hxx6rpwsq3uamnwvaz7tmjv4kxz7fww4ejuamgd96x2mn0d9ek2tn",
+    "rdpshggcu28s"
+);
+/// nprofile TLV: type-0 ACCOUNT_ID only.
+pub const NO_RELAY_NPROFILE: &str = "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dq7r0nz9";
+/// nprofile TLV: type-0 ACCOUNT_ID plus one example.invalid relay hint.
+pub const OTHER_RELAY_NPROFILE: &str = concat!(
+    "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dqprdmhxue69uhhyet",
+    "vv9ujuetcv9khqmr99e5kuanpd35kg3k65qt"
+);
+/// nprofile TLV: type-0 ACCOUNT_ID plus one unknown TLV entry that the SDK ignores.
+pub const UNKNOWN_TLV_NPROFILE: &str = "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0drrq3skycmyxne9kf";
+/// nprofile TLV: type-0 ACCOUNT_ID plus a type-1 value that is not a valid relay URL; the SDK discards the hint.
+pub const INVALID_RELAY_NPROFILE: &str = "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dqpp9hx7apqvys82unvuca0cf";
+/// nprofile TLV: type-0 ACCOUNT_ID followed by a second distinct type-0 key (0xbb repeating). SDK first-wins keeps ACCOUNT_ID.
+pub const DUPLICATE_TYPE0_NPROFILE: &str = concat!(
+    "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dqqyzamhwamhwamhwa",
+    "mhwamhwamhwamhwamhwamhwamhwamhwamhwamkq4uk7z"
+);
+/// nprofile TLV: relay hint only; no type-0 pubkey.
+pub const MISSING_TYPE0_NPROFILE: &str = "nprofile1qy2hwumn8ghj7etcv9khqmr99e5kuanpd35kghsdudn";
+/// nprofile TLV: type-0 value shorter than 32 bytes.
+pub const SHORT_TYPE0_NPROFILE: &str = "nprofile1qqg25n7gve04d9hr8km7rftjuwc028ngcqe";
+/// nprofile TLV: truncated header (type present, length/value missing).
+pub const TRUNCATED_HEADER_NPROFILE: &str = "nprofile1qqqsnhxh";
+/// nprofile TLV: type-0 header claims more value bytes than remain.
+pub const TRUNCATED_VALUE_NPROFILE: &str = "nprofile1qqs25n7gve04d9hrdfl42d";
+/// Valid Bech32 checksum with note HRP over nprofile-shaped data.
+pub const WRONG_HRP_NOTE: &str = "note1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dq4ueyyt";
+/// Valid note encoding of a synthetic all-0x22 EventId; not an identity reference.
+pub const NOTE_EVENT_HRP: &str = "note1yg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3qmtdh3n";
+/// Valid nevent for the synthetic EventId authored by ACCOUNT_ID.
+pub const NEVENT_EVENT_HRP: &str = concat!(
+    "nevent1qqszyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygszyz4yljrxtatfdceak",
+    "ls62uhrkr6m84s4sdas7d3devwgq69snrrmg7zexkt"
+);
+/// Valid naddr for kind 0 / ACCOUNT_ID.
+pub const NADDR_EVENT_HRP: &str = "naddr1qqqqyg92flyxvh6kjm3nmdlp54ew8v84k0tptqmmpumzmjcusp5tpxx8kspsgqqqqqqqjuu87v";
+/// Synthetic nsec for SecretKey([0x11; 32]). Rejection fixture only; never a real credential.
+pub const NSEC_SYNTHETIC_REJECTION: &str = "nsec1zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs4rm7hz";
+/// Valid 1022-byte nprofile: type-0 ACCOUNT_ID plus unknown 0xff extension padding (629 TLV bytes).
+pub const BOUNDARY_1022_NPROFILE: &str = concat!(
+    "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0d8llad95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6ttll7kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd94l60tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95ksutn624"
+);
+/// Valid 1023-byte nprofile: type-0 ACCOUNT_ID plus unknown 0xff extension padding (630 TLV bytes).
+pub const BOUNDARY_1023_NPROFILE: &str = concat!(
+    "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0d8llad95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6ttll7kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd94l6stfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6v7xa0l"
+);
+/// Valid 1023-byte nprofile: type-0 ACCOUNT_ID, eight wss://r{0-7}.example.invalid relays, plus 0xff extensions (630 TLV bytes).
+pub const BOUNDARY_1023_EIGHT_RELAY_NPROFILE: &str = concat!(
+    "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dqprpmhxue69uhhyvp",
+    "wv4uxzmtsd3jju6twweskc6tyqyv8wumn8ghj7u339ejhsctdwpkx2tnfdemxzmrfvsq3samnwvaz7tm",
+    "jxghx27rpd4cxcefwd9h8vctvd9jqzxrhwden5te0wgejuetcv9khqmr99e5kuanpd35kgqgcwaehxw3",
+    "09aergtn90psk6urvv5hxjmnkv9kxjeqprpmhxue69uhhydfwv4uxzmtsd3jju6twweskc6tyqyv8wum",
+    "n8ghj7u3k9ejhsctdwpkx2tnfdemxzmrfvsq3samnwvaz7tmjxuhx27rpd4cxcefwd9h8vctvd9j0ll6",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95khls9d95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj",
+    "6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6tfd95kj6n8net0"
+);
+
+fn accepted(name: &'static str, reference: impl Into<String>) -> IdentityReferenceCase {
+    IdentityReferenceCase {
+        name,
+        reference: reference.into(),
+        app_account_id_hex: Some(ACCOUNT_ID),
+        ffi_account_id_hex: Some(ACCOUNT_ID),
+    }
+}
+
+fn rejected(name: &'static str, reference: impl Into<String>) -> IdentityReferenceCase {
+    IdentityReferenceCase {
+        name,
+        reference: reference.into(),
+        app_account_id_hex: None,
+        ffi_account_id_hex: None,
+    }
+}
+
+fn app_only(name: &'static str, reference: impl Into<String>) -> IdentityReferenceCase {
+    IdentityReferenceCase {
+        name,
+        reference: reference.into(),
+        app_account_id_hex: Some(ACCOUNT_ID),
+        ffi_account_id_hex: None,
+    }
+}
+
+fn ffi_only(name: &'static str, reference: impl Into<String>) -> IdentityReferenceCase {
+    IdentityReferenceCase {
+        name,
+        reference: reference.into(),
+        app_account_id_hex: None,
+        ffi_account_id_hex: Some(ACCOUNT_ID),
+    }
+}
+
+fn damaged_checksum(token: &str) -> String {
+    let mut damaged = token.to_owned();
+    let last = damaged.len() - 1;
+    damaged.replace_range(last.., "x");
+    damaged
+}
+
+fn oversized_nprofile(len: usize) -> String {
+    let prefix = "nprofile1";
+    assert!(len >= prefix.len());
+    let mut token = String::from(prefix);
+    token.push_str(&"q".repeat(len - prefix.len()));
+    token
+}
+
+pub fn cases() -> Vec<IdentityReferenceCase> {
+    let cases = vec![
+        accepted("hex_lowercase", ACCOUNT_ID),
+        accepted("hex_uppercase", ACCOUNT_ID.to_ascii_uppercase()),
+        accepted("npub", NPUB),
+        accepted("nostr_npub", format!("nostr:{NPUB}")),
+        accepted("bootstrap_nprofile", BOOTSTRAP_NPROFILE),
+        accepted("nostr_bootstrap_nprofile", format!("nostr:{BOOTSTRAP_NPROFILE}")),
+        accepted("no_relay_nprofile", NO_RELAY_NPROFILE),
+        accepted("nostr_no_relay_nprofile", format!("nostr:{NO_RELAY_NPROFILE}")),
+        accepted("other_relay_nprofile", OTHER_RELAY_NPROFILE),
+        accepted("unknown_tlv_nprofile", UNKNOWN_TLV_NPROFILE),
+        accepted("invalid_relay_nprofile", INVALID_RELAY_NPROFILE),
+        accepted("duplicate_type0_first_wins", DUPLICATE_TYPE0_NPROFILE),
+        ffi_only("whitespace_hex", format!(" {ACCOUNT_ID}")),
+        ffi_only("trailing_whitespace_npub", format!("{NPUB} ")),
+        ffi_only("whitespace_nprofile", format!(" {NO_RELAY_NPROFILE}")),
+        ffi_only(
+            "profile_link_nprofile_query",
+            format!("marmot://profile/{NO_RELAY_NPROFILE}?from=qr"),
+        ),
+        ffi_only(
+            "profile_link_nprofile_fragment",
+            format!("marmot://profile/{NO_RELAY_NPROFILE}#frag"),
+        ),
+        ffi_only(
+            "profile_link_nprofile_trailing_slash",
+            format!("marmot://profile/{NO_RELAY_NPROFILE}/"),
+        ),
+        ffi_only(
+            "profile_link_npub_query",
+            format!("marmot://profile/{NPUB}?from=qr"),
+        ),
+        ffi_only(
+            "double_nostr_npub",
+            format!("nostr:nostr:{NPUB}"),
+        ),
+        ffi_only(
+            "double_nostr_nprofile",
+            format!("nostr:nostr:{NO_RELAY_NPROFILE}"),
+        ),
+        app_only(
+            "legacy_colon_suffix_npub",
+            format!("nostr:{NPUB}:{}", "x".repeat(4096)),
+        ),
+        rejected("empty", ""),
+        rejected("ordinary_invalid", "not-a-public-key"),
+        rejected("uppercase_nostr_nprofile", format!("NOSTR:{NO_RELAY_NPROFILE}")),
+        rejected("damaged_npub_checksum", damaged_checksum(NPUB)),
+        rejected("damaged_nprofile_checksum", damaged_checksum(NO_RELAY_NPROFILE)),
+        rejected("wrong_hrp_note_shaped", WRONG_HRP_NOTE),
+        rejected("note_event_hrp", NOTE_EVENT_HRP),
+        rejected("nevent_event_hrp", NEVENT_EVENT_HRP),
+        rejected("naddr_event_hrp", NADDR_EVENT_HRP),
+        rejected("nsec_synthetic", NSEC_SYNTHETIC_REJECTION),
+        rejected("missing_type0", MISSING_TYPE0_NPROFILE),
+        rejected("short_type0", SHORT_TYPE0_NPROFILE),
+        rejected("truncated_header", TRUNCATED_HEADER_NPROFILE),
+        rejected("truncated_value", TRUNCATED_VALUE_NPROFILE),
+        accepted("boundary_1022_bare", BOUNDARY_1022_NPROFILE),
+        accepted("boundary_1022_nostr", format!("nostr:{BOUNDARY_1022_NPROFILE}")),
+        ffi_only(
+            "boundary_1022_profile_link",
+            format!("marmot://profile/{BOUNDARY_1022_NPROFILE}?from=qr"),
+        ),
+        accepted("boundary_1023_bare", BOUNDARY_1023_NPROFILE),
+        accepted("boundary_1023_nostr", format!("nostr:{BOUNDARY_1023_NPROFILE}")),
+        ffi_only(
+            "boundary_1023_profile_link",
+            format!("marmot://profile/{BOUNDARY_1023_NPROFILE}?from=qr"),
+        ),
+        accepted("boundary_1023_eight_relays_bare", BOUNDARY_1023_EIGHT_RELAY_NPROFILE),
+        accepted(
+            "boundary_1023_eight_relays_nostr",
+            format!("nostr:{BOUNDARY_1023_EIGHT_RELAY_NPROFILE}"),
+        ),
+        ffi_only(
+            "boundary_1023_eight_relays_profile_link",
+            format!("marmot://profile/{BOUNDARY_1023_EIGHT_RELAY_NPROFILE}?from=qr"),
+        ),
+        rejected("oversized_1024", oversized_nprofile(1024)),
+        rejected("oversized_4096", oversized_nprofile(4096)),
+        rejected("oversized_1000000", oversized_nprofile(1_000_000)),
+        rejected("oversized_1024_nostr", format!("nostr:{}", oversized_nprofile(1024))),
+    ];
+
+    assert!(
+        !cases.is_empty(),
+        "identity-reference corpus must be nonempty"
+    );
+    let mut names = std::collections::BTreeSet::new();
+    for case in &cases {
+        assert!(
+            names.insert(case.name),
+            "duplicate identity-reference case name: {}",
+            case.name
+        );
+    }
+    assert_eq!(BOUNDARY_1022_NPROFILE.len(), 1022);
+    assert_eq!(BOUNDARY_1023_NPROFILE.len(), 1023);
+    assert_eq!(BOUNDARY_1023_EIGHT_RELAY_NPROFILE.len(), 1023);
+    let colon_suffix = cases
+        .iter()
+        .find(|case| case.name == "legacy_colon_suffix_npub")
+        .expect("legacy colon-suffix case");
+    assert_eq!(colon_suffix.reference.len(), 4166);
+    cases
+}

--- a/crates/marmot-c/CHANGELOG.md
+++ b/crates/marmot-c/CHANGELOG.md
@@ -9,6 +9,10 @@ Versions track the workspace version; releases are tagged `marmotc-v<version>`.
 
 ### Added
 
+- `marmot_default_profile_pseudonym` and `marmot_random_profile_pseudonym`
+  for the shared cosmetic display-name helpers. Free the owned UTF-8
+  strings with `marmot_string_free`. Additive functions; existing status
+  values and struct layouts are unchanged.
 - Additive `MarmotMarkdownBlock::Details` with an indirect `MarmotMarkdownDetails`
   payload for bounded `<details>` / `<summary>` display blocks. Existing block
   discriminants and union stride are unchanged; C consumers must regenerate
@@ -18,6 +22,9 @@ Versions track the workspace version; releases are tagged `marmotc-v<version>`.
 
 ### Changed
 
+- `marmot_account_id_hex` now decodes `nprofile` / `nostr:nprofile`
+  references and discards relay hints. Existing hex, `npub`, and
+  `marmot://profile/` forms keep their established OK-plus-NULL contract.
 - Search results include `is_followed_by_searcher`; streaming updates include keyed `updated_results` replacements
   and a `CachedResultsFound` trigger. Consumers must merge by account ID, including across radius pages, and use
   the explicit follow flag instead of radius 1 for badges. C consumers must rebuild against the matching generated

--- a/crates/marmot-c/CHANGELOG.md
+++ b/crates/marmot-c/CHANGELOG.md
@@ -19,6 +19,11 @@ Versions track the workspace version; releases are tagged `marmotc-v<version>`.
 - `marmot_account_id_hex` now decodes `nprofile` / `nostr:nprofile`
   references and discards relay hints. Existing hex, `npub`, and
   `marmot://profile/` forms keep their established OK-plus-NULL contract.
+  Duplicate type-0 TLV entries keep the first key. After wrapper
+  normalization, encoded tokens longer than 1023 UTF-8 bytes are
+  rejected; a valid 1023-byte token still decodes when wrapped.
+- `marmot_normalize_member_ref` documents the same nprofile spellings,
+  first-wins type-0 rule, and 1023-byte encoded-token limit.
 
 ## [0.9.21] - 2026-09-10
 

--- a/crates/marmot-c/README.md
+++ b/crates/marmot-c/README.md
@@ -59,6 +59,15 @@ behind `MarmotMarkdownDetails`. Existing discriminants and union stride stay
 the same; regenerate `marmot.h` and consumer bindings to handle the new tag.
 Older clients cannot render it.
 
+`marmot_account_id_hex` now accepts `nprofile` and `nostr:nprofile`
+references (plus the existing hex/`npub`/`marmot://profile/` forms) and
+discards relay hints. `marmot_default_profile_pseudonym` hashes the
+supplied canonical hex account-id text; decode a scanned reference
+first. `marmot_random_profile_pseudonym` is a cosmetic random roll from
+the same wordlists. Free those strings with `marmot_string_free`.
+Regenerate `marmot.h` after pulling this surface. Android mention/QR
+migration remains a separate consumer issue.
+
 `examples/smoke.c` is a worked example covering lifecycle, Markdown
 tagged-union walking, offline reads, the error taxonomy, and best-effort
 identity creation. `./crates/marmot-c/c-smoke.sh` builds and runs it

--- a/crates/marmot-c/README.md
+++ b/crates/marmot-c/README.md
@@ -59,14 +59,21 @@ behind `MarmotMarkdownDetails`. Existing discriminants and union stride stay
 the same; regenerate `marmot.h` and consumer bindings to handle the new tag.
 Older clients cannot render it.
 
-`marmot_account_id_hex` now accepts `nprofile` and `nostr:nprofile`
-references (plus the existing hex/`npub`/`marmot://profile/` forms) and
-discards relay hints. `marmot_default_profile_pseudonym` hashes the
-supplied canonical hex account-id text; decode a scanned reference
-first. `marmot_random_profile_pseudonym` is a cosmetic random roll from
-the same wordlists. Free those strings with `marmot_string_free`.
-Regenerate `marmot.h` after pulling this surface. Android mention/QR
-migration remains a separate consumer issue.
+`marmot_account_id_hex` and `marmot_normalize_member_ref` now accept
+`nprofile` and `nostr:nprofile` references (plus the existing
+hex/`npub`/`marmot://profile/` forms) and discard relay hints.
+Duplicate type-0 TLV entries keep the first key. After wrapper
+normalization, encoded tokens longer than 1023 UTF-8 bytes are
+rejected; a valid 1023-byte token still decodes when wrapped. The
+legacy NIP-21 parser may still accept a colon-suffixed
+`nostr:<npub>:` form before that fallback. `marmot_default_profile_pseudonym`
+hashes the supplied canonical hex account-id text; decode a scanned
+reference first. `marmot_random_profile_pseudonym` is a cosmetic
+random roll from the same wordlists. Free those strings with
+`marmot_string_free` and normalized records with
+`marmot_member_ref_free`. Regenerate `marmot.h` after pulling this
+surface. Android mention/QR migration remains a separate consumer
+issue.
 
 `examples/smoke.c` is a worked example covering lifecycle, Markdown
 tagged-union walking, offline reads, the error taxonomy, and best-effort

--- a/crates/marmot-c/examples/smoke.c
+++ b/crates/marmot-c/examples/smoke.c
@@ -210,6 +210,23 @@ int main(int argc, char **argv) {
     check(st == MARMOT_STATUS_OK, "npub lookup call succeeds");
     marmot_string_free(npub);
 
+    char *account_hex = NULL;
+    const char *bootstrap_id =
+        "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4";
+    st = marmot_account_id_hex(client, bootstrap_id, &account_hex);
+    check(st == MARMOT_STATUS_OK && account_hex != NULL, "account_id_hex hex");
+    marmot_string_free(account_hex);
+
+    char *pseudonym = NULL;
+    st = marmot_default_profile_pseudonym(client, bootstrap_id, &pseudonym);
+    check(st == MARMOT_STATUS_OK && pseudonym != NULL, "default profile pseudonym");
+    marmot_string_free(pseudonym);
+
+    char *random_name = NULL;
+    st = marmot_random_profile_pseudonym(client, &random_name);
+    check(st == MARMOT_STATUS_OK && random_name != NULL, "random profile pseudonym");
+    marmot_string_free(random_name);
+
     /* ---- boundary validation ------------------------------------------ */
     /* Out-of-range enum discriminants are rejected instead of becoming
      * invalid Rust enum values. */

--- a/crates/marmot-c/include/marmot.h
+++ b/crates/marmot-c/include/marmot.h
@@ -4731,7 +4731,12 @@ MarmotStatus marmot_create_group(const struct MarmotClient *client,
 
 /**
  * Normalize a member reference (hex, `npub`, `nostr:npub...`,
- * `marmot://profile/...`). Free with `marmot_member_ref_free`.
+ * `nprofile`, `nostr:nprofile...`, and `marmot://profile/...`).
+ * nprofile relay hints are discarded. Duplicate type-0 TLV entries
+ * keep the first key. After wrapper normalization, encoded tokens
+ * longer than 1023 UTF-8 bytes are rejected; a valid 1023-byte
+ * token still decodes when wrapped. Free with
+ * `marmot_member_ref_free`.
  *
  * # Safety
  * `client` must be a live handle; string arguments must be valid
@@ -6483,7 +6488,10 @@ MarmotStatus marmot_npub(const struct MarmotClient *client, const char *account_
  * Hex account id for an `npub`/hex/`nprofile` reference; NULL with
  * `MARMOT_STATUS_OK` when the input does not decode. Accepts hex,
  * `npub`, `nostr:npub`, `nprofile`, `nostr:nprofile`, and
- * `marmot://profile/` links. nprofile relay hints are discarded. Free
+ * `marmot://profile/` links. nprofile relay hints are discarded.
+ * Duplicate type-0 TLV entries keep the first key. After wrapper
+ * normalization, encoded tokens longer than 1023 UTF-8 bytes are
+ * rejected; a valid 1023-byte token still decodes when wrapped. Free
  * with `marmot_string_free`.
  *
  * # Safety

--- a/crates/marmot-c/include/marmot.h
+++ b/crates/marmot-c/include/marmot.h
@@ -6343,9 +6343,11 @@ MarmotStatus marmot_display_name(const struct MarmotClient *client,
 MarmotStatus marmot_npub(const struct MarmotClient *client, const char *account_id_hex, char **out);
 
 /**
- * Hex account id for an `npub`/hex reference; NULL with
- * `MARMOT_STATUS_OK` when the input does not decode. Free with
- * `marmot_string_free`.
+ * Hex account id for an `npub`/hex/`nprofile` reference; NULL with
+ * `MARMOT_STATUS_OK` when the input does not decode. Accepts hex,
+ * `npub`, `nostr:npub`, `nprofile`, `nostr:nprofile`, and
+ * `marmot://profile/` links. nprofile relay hints are discarded. Free
+ * with `marmot_string_free`.
  *
  * # Safety
  * `client` must be a live handle; `reference` a valid string; `out`
@@ -6354,6 +6356,28 @@ MarmotStatus marmot_npub(const struct MarmotClient *client, const char *account_
 MarmotStatus marmot_account_id_hex(const struct MarmotClient *client,
                                    const char *reference,
                                    char **out);
+
+/**
+ * Deterministic cosmetic display name for a canonical hex account id.
+ * Free with `marmot_string_free`. Decode a scanned reference with
+ * `marmot_account_id_hex` first; the seed is hashed as supplied text.
+ *
+ * # Safety
+ * Same as `marmot_account_id_hex`.
+ */
+MarmotStatus marmot_default_profile_pseudonym(const struct MarmotClient *client,
+                                              const char *account_id_hex,
+                                              char **out);
+
+/**
+ * Random cosmetic display name from the shared wordlists. Free with
+ * `marmot_string_free`. This does not create an account or generate a
+ * signing key.
+ *
+ * # Safety
+ * `client` must be a live handle; `out` valid.
+ */
+MarmotStatus marmot_random_profile_pseudonym(const struct MarmotClient *client, char **out);
 
 /**
  * Aggregate relay-pool health. Free with `marmot_relay_health_free`.

--- a/crates/marmot-c/src/commands.rs
+++ b/crates/marmot-c/src/commands.rs
@@ -1158,9 +1158,11 @@ pub unsafe extern "C" fn marmot_npub(
     })
 }
 
-/// Hex account id for an `npub`/hex reference; NULL with
-/// `MARMOT_STATUS_OK` when the input does not decode. Free with
-/// `marmot_string_free`.
+/// Hex account id for an `npub`/hex/`nprofile` reference; NULL with
+/// `MARMOT_STATUS_OK` when the input does not decode. Accepts hex,
+/// `npub`, `nostr:npub`, `nprofile`, `nostr:nprofile`, and
+/// `marmot://profile/` links. nprofile relay hints are discarded. Free
+/// with `marmot_string_free`.
 ///
 /// # Safety
 /// `client` must be a live handle; `reference` a valid string; `out`
@@ -1177,6 +1179,55 @@ pub unsafe extern "C" fn marmot_account_id_hex(
         let reference = try_arg!(unsafe { required_str(reference) });
         deliver_plain_opt_string(client.marmot.account_id_hex(reference), out)
     })
+}
+
+/// Deterministic cosmetic display name for a canonical hex account id.
+/// Free with `marmot_string_free`. Decode a scanned reference with
+/// `marmot_account_id_hex` first; the seed is hashed as supplied text.
+///
+/// # Safety
+/// Same as `marmot_account_id_hex`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn marmot_default_profile_pseudonym(
+    client: *const MarmotClient,
+    account_id_hex: *const c_char,
+    out: *mut *mut c_char,
+) -> MarmotStatus {
+    ffi_guard(|| {
+        try_arg!(unsafe { crate::preflight_out_ptr(out) });
+        let client = try_arg!(unsafe { client_ref(client) });
+        let account_id_hex = try_arg!(unsafe { required_str(account_id_hex) });
+        deliver_plain_string(client.marmot.default_profile_pseudonym(account_id_hex), out)
+    })
+}
+
+/// Random cosmetic display name from the shared wordlists. Free with
+/// `marmot_string_free`. This does not create an account or generate a
+/// signing key.
+///
+/// # Safety
+/// `client` must be a live handle; `out` valid.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn marmot_random_profile_pseudonym(
+    client: *const MarmotClient,
+    out: *mut *mut c_char,
+) -> MarmotStatus {
+    ffi_guard(|| {
+        try_arg!(unsafe { crate::preflight_out_ptr(out) });
+        let client = try_arg!(unsafe { client_ref(client) });
+        deliver_plain_string(client.marmot.random_profile_pseudonym(), out)
+    })
+}
+
+fn deliver_plain_string(value: String, out: *mut *mut c_char) -> MarmotStatus {
+    let ptr = crate::memory::owned_c_string(value);
+    match unsafe { write_out(out, ptr) } {
+        Ok(()) => MarmotStatus::Ok,
+        Err(status) => {
+            unsafe { crate::memory::free_c_string(ptr) };
+            status
+        }
+    }
 }
 
 fn deliver_plain_opt_string(value: Option<String>, out: *mut *mut c_char) -> MarmotStatus {
@@ -2674,4 +2725,82 @@ pub unsafe extern "C" fn marmot_set_product_analytics_activity(
             ),
         )
     })
+}
+
+#[cfg(test)]
+mod identity_pointer_tests {
+    use super::{
+        marmot_account_id_hex, marmot_default_profile_pseudonym, marmot_random_profile_pseudonym,
+    };
+    use crate::MarmotStatus;
+    use std::ffi::CString;
+    use std::ptr;
+
+    #[test]
+    fn identity_wrappers_reject_null_out_before_work() {
+        let account =
+            CString::new("aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4")
+                .unwrap();
+        assert_eq!(
+            unsafe { marmot_account_id_hex(ptr::null(), account.as_ptr(), ptr::null_mut()) },
+            MarmotStatus::NullPointer
+        );
+        assert_eq!(
+            unsafe {
+                marmot_default_profile_pseudonym(ptr::null(), account.as_ptr(), ptr::null_mut())
+            },
+            MarmotStatus::NullPointer
+        );
+        assert_eq!(
+            unsafe { marmot_random_profile_pseudonym(ptr::null(), ptr::null_mut()) },
+            MarmotStatus::NullPointer
+        );
+    }
+
+    #[test]
+    fn identity_wrappers_clear_out_when_client_or_input_is_null() {
+        let account =
+            CString::new("aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4")
+                .unwrap();
+        let mut out = 0x10 as *mut std::ffi::c_char;
+        assert_eq!(
+            unsafe { marmot_account_id_hex(ptr::null(), account.as_ptr(), &raw mut out) },
+            MarmotStatus::NullPointer
+        );
+        assert!(out.is_null());
+
+        out = 0x10 as *mut std::ffi::c_char;
+        assert_eq!(
+            unsafe {
+                marmot_default_profile_pseudonym(ptr::null(), account.as_ptr(), &raw mut out)
+            },
+            MarmotStatus::NullPointer
+        );
+        assert!(out.is_null());
+
+        out = 0x10 as *mut std::ffi::c_char;
+        assert_eq!(
+            unsafe { marmot_random_profile_pseudonym(ptr::null(), &raw mut out) },
+            MarmotStatus::NullPointer
+        );
+        assert!(out.is_null());
+    }
+
+    #[test]
+    fn deliver_plain_string_balances_owned_output() {
+        let _guard = crate::memory::audit::test_lock();
+        #[cfg(feature = "alloc-audit")]
+        let start = crate::memory::audit::live_allocations();
+
+        let mut out = std::ptr::null_mut();
+        assert_eq!(
+            super::deliver_plain_string("Loyal Crane".to_owned(), &raw mut out),
+            MarmotStatus::Ok
+        );
+        assert!(!out.is_null());
+        unsafe { crate::memory::free_c_string(out) };
+
+        #[cfg(feature = "alloc-audit")]
+        assert_eq!(crate::memory::audit::live_allocations(), start);
+    }
 }

--- a/crates/marmot-c/src/commands.rs
+++ b/crates/marmot-c/src/commands.rs
@@ -623,7 +623,12 @@ c_cmd! {
     async fn marmot_create_group(account_ref: str, name: str, member_refs/member_refs_len: str_arr, description: opt_str) -> string = create_group;
 
     /// Normalize a member reference (hex, `npub`, `nostr:npub...`,
-    /// `marmot://profile/...`). Free with `marmot_member_ref_free`.
+    /// `nprofile`, `nostr:nprofile...`, and `marmot://profile/...`).
+    /// nprofile relay hints are discarded. Duplicate type-0 TLV entries
+    /// keep the first key. After wrapper normalization, encoded tokens
+    /// longer than 1023 UTF-8 bytes are rejected; a valid 1023-byte
+    /// token still decodes when wrapped. Free with
+    /// `marmot_member_ref_free`.
     sync fn marmot_normalize_member_ref(member_ref: str) -> rec(MarmotMemberRef) = normalize_member_ref;
 
     /// Membership roster for `group_id_hex`. Free with
@@ -1162,7 +1167,10 @@ pub unsafe extern "C" fn marmot_npub(
 /// Hex account id for an `npub`/hex/`nprofile` reference; NULL with
 /// `MARMOT_STATUS_OK` when the input does not decode. Accepts hex,
 /// `npub`, `nostr:npub`, `nprofile`, `nostr:nprofile`, and
-/// `marmot://profile/` links. nprofile relay hints are discarded. Free
+/// `marmot://profile/` links. nprofile relay hints are discarded.
+/// Duplicate type-0 TLV entries keep the first key. After wrapper
+/// normalization, encoded tokens longer than 1023 UTF-8 bytes are
+/// rejected; a valid 1023-byte token still decodes when wrapped. Free
 /// with `marmot_string_free`.
 ///
 /// # Safety

--- a/crates/marmot-c/tests/identity_pseudonym.rs
+++ b/crates/marmot-c/tests/identity_pseudonym.rs
@@ -7,13 +7,20 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use marmot_c::commands::{
-    marmot_account_id_hex, marmot_default_profile_pseudonym, marmot_random_profile_pseudonym,
+    marmot_account_id_hex, marmot_default_profile_pseudonym, marmot_normalize_member_ref,
+    marmot_random_profile_pseudonym,
 };
 use marmot_c::secret_store::{MarmotSecretStore, MarmotSecretStoreStatus};
+use marmot_c::types::group::{MarmotMemberRef, marmot_member_ref_free};
 use marmot_c::{
     MarmotClient, MarmotStatus, marmot_client_free, marmot_client_new_with_secret_store,
     marmot_client_shutdown, marmot_string_free,
 };
+
+include!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../marmot-app/tests/support/identity_reference_vectors.rs"
+));
 
 static ENTRIES: Mutex<Vec<(String, String)>> = Mutex::new(Vec::new());
 static DESTROYED: AtomicBool = AtomicBool::new(false);
@@ -136,45 +143,68 @@ fn take_string(ptr: *mut c_char) -> Option<String> {
 fn account_id_hex_and_pseudonyms_are_offline() {
     let root = tempfile::tempdir().expect("temp dir");
     let client = open_client(&root);
-    let account_id = "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4";
-    let npub = "npub14f8usejl26twx0dhuxjh9cas7keav9vr0v8nvtwtrjqx3vycc76qqh9nsy";
-    let nprofile = "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dq7r0nz9";
-    let unknown_tlv =
-        "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0drrq3skycmyxne9kf";
-    let invalid_relay =
-        "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dqpp9hx7apqvys82unvuca0cf";
+    for case in cases() {
+        let input = CString::new(case.reference.clone())
+            .unwrap_or_else(|_| panic!("case {} must be a C string", case.name));
 
-    for reference in [
-        account_id,
-        npub,
-        &format!("nostr:{npub}"),
-        nprofile,
-        &format!("nostr:{nprofile}"),
-        &format!(" {nprofile}"),
-        &format!("marmot://profile/{nprofile}?from=qr"),
-        unknown_tlv,
-        invalid_relay,
-    ] {
-        let input = CString::new(reference.to_owned()).unwrap();
-        let mut out: *mut c_char = 0x10 as *mut c_char;
-        let status = unsafe { marmot_account_id_hex(client, input.as_ptr(), &raw mut out) };
-        assert_eq!(status, MarmotStatus::Ok);
-        assert_eq!(take_string(out).as_deref(), Some(account_id));
-    }
+        let mut hex_out: *mut c_char = 0x10 as *mut c_char;
+        let hex_status = unsafe { marmot_account_id_hex(client, input.as_ptr(), &raw mut hex_out) };
+        match case.ffi_account_id_hex {
+            Some(expected) => {
+                assert_eq!(hex_status, MarmotStatus::Ok, "case {}", case.name);
+                assert_eq!(
+                    take_string(hex_out).as_deref(),
+                    Some(expected),
+                    "case {}",
+                    case.name
+                );
+            }
+            None => {
+                assert_eq!(hex_status, MarmotStatus::Ok, "case {}", case.name);
+                assert!(
+                    hex_out.is_null(),
+                    "case {} optional decode stays OK plus NULL",
+                    case.name
+                );
+            }
+        }
 
-    for invalid in [
-        "nprofile1qqqsnhxh",
-        "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dq7r0nzx",
-        "note1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dq4ueyyt",
-        "nprofile1qy2hwumn8ghj7etcv9khqmr99e5kuanpd35kghsdudn",
-    ] {
-        let input = CString::new(invalid).unwrap();
-        let mut out: *mut c_char = 0x10 as *mut c_char;
-        assert_eq!(
-            unsafe { marmot_account_id_hex(client, input.as_ptr(), &raw mut out) },
-            MarmotStatus::Ok
-        );
-        assert!(out.is_null(), "non-decoding reference stays OK plus NULL");
+        let mut typed_out: *mut MarmotMemberRef = 0x10 as *mut MarmotMemberRef;
+        let typed_status =
+            unsafe { marmot_normalize_member_ref(client, input.as_ptr(), &raw mut typed_out) };
+        match case.ffi_account_id_hex {
+            Some(expected) => {
+                assert_eq!(typed_status, MarmotStatus::Ok, "case {}", case.name);
+                assert!(!typed_out.is_null(), "case {}", case.name);
+                let record = unsafe { &*typed_out };
+                let member_ref = unsafe { CStr::from_ptr(record.member_ref) }
+                    .to_str()
+                    .expect("utf-8");
+                let account_id = unsafe { CStr::from_ptr(record.account_id_hex) }
+                    .to_str()
+                    .expect("utf-8");
+                let npub = unsafe { CStr::from_ptr(record.npub) }
+                    .to_str()
+                    .expect("utf-8");
+                assert_eq!(member_ref, expected, "case {}", case.name);
+                assert_eq!(account_id, expected, "case {}", case.name);
+                assert_eq!(npub, NPUB, "case {}", case.name);
+                unsafe { marmot_member_ref_free(typed_out) };
+            }
+            None => {
+                assert_eq!(
+                    typed_status,
+                    MarmotStatus::InvalidIdentity,
+                    "case {}",
+                    case.name
+                );
+                assert!(
+                    typed_out.is_null(),
+                    "case {} typed normalize clears the output",
+                    case.name
+                );
+            }
+        }
     }
 
     let mut out: *mut c_char = 0x10 as *mut c_char;
@@ -190,7 +220,14 @@ fn account_id_hex_and_pseudonyms_are_offline() {
     );
     assert!(out.is_null());
 
-    let account = CString::new(account_id).unwrap();
+    let mut typed_null: *mut MarmotMemberRef = 0x10 as *mut MarmotMemberRef;
+    assert_eq!(
+        unsafe { marmot_normalize_member_ref(client, ptr::null(), &raw mut typed_null) },
+        MarmotStatus::NullPointer
+    );
+    assert!(typed_null.is_null());
+
+    let account = CString::new(ACCOUNT_ID).unwrap();
     let mut name_out: *mut c_char = 0x10 as *mut c_char;
     assert_eq!(
         unsafe { marmot_default_profile_pseudonym(client, account.as_ptr(), &raw mut name_out) },

--- a/crates/marmot-c/tests/identity_pseudonym.rs
+++ b/crates/marmot-c/tests/identity_pseudonym.rs
@@ -1,0 +1,212 @@
+//! Offline identity decode and profile-pseudonym ABI coverage using a
+//! host secret store so the platform keychain is never required.
+
+use std::ffi::{CStr, CString, c_char, c_void};
+use std::ptr;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use marmot_c::commands::{
+    marmot_account_id_hex, marmot_default_profile_pseudonym, marmot_random_profile_pseudonym,
+};
+use marmot_c::secret_store::{MarmotSecretStore, MarmotSecretStoreStatus};
+use marmot_c::{
+    MarmotClient, MarmotStatus, marmot_client_free, marmot_client_new_with_secret_store,
+    marmot_client_shutdown, marmot_string_free,
+};
+
+static ENTRIES: Mutex<Vec<(String, String)>> = Mutex::new(Vec::new());
+static DESTROYED: AtomicBool = AtomicBool::new(false);
+
+unsafe extern "C" fn has(_user_data: *mut c_void, key: *const c_char, out: *mut u8) -> u32 {
+    let key = unsafe { CStr::from_ptr(key) }.to_str().unwrap().to_owned();
+    let present = ENTRIES.lock().unwrap().iter().any(|(k, _)| *k == key);
+    unsafe { out.write(u8::from(present)) };
+    MarmotSecretStoreStatus::Ok as u32
+}
+
+unsafe extern "C" fn write_secret(
+    _user_data: *mut c_void,
+    label: *const c_char,
+    _account: *const c_char,
+    secret: *const c_char,
+) -> u32 {
+    let label = unsafe { CStr::from_ptr(label) }
+        .to_str()
+        .unwrap()
+        .to_owned();
+    let secret = unsafe { CStr::from_ptr(secret) }
+        .to_str()
+        .unwrap()
+        .to_owned();
+    ENTRIES.lock().unwrap().push((label, secret));
+    MarmotSecretStoreStatus::Ok as u32
+}
+
+unsafe extern "C" fn load_secret(
+    _user_data: *mut c_void,
+    label: *const c_char,
+    _account: *const c_char,
+    out: *mut *mut c_char,
+) -> u32 {
+    let label = unsafe { CStr::from_ptr(label) }
+        .to_str()
+        .unwrap()
+        .to_owned();
+    let found = ENTRIES
+        .lock()
+        .unwrap()
+        .iter()
+        .find(|(k, _)| *k == label)
+        .map(|(_, secret)| secret.clone());
+    let Some(secret) = found else {
+        return MarmotSecretStoreStatus::NotFound as u32;
+    };
+    unsafe { out.write(CString::new(secret).unwrap().into_raw()) };
+    MarmotSecretStoreStatus::Ok as u32
+}
+
+unsafe extern "C" fn remove_secret(
+    _user_data: *mut c_void,
+    label: *const c_char,
+    _account: *const c_char,
+) -> u32 {
+    let label = unsafe { CStr::from_ptr(label) }
+        .to_str()
+        .unwrap()
+        .to_owned();
+    ENTRIES.lock().unwrap().retain(|(k, _)| *k != label);
+    MarmotSecretStoreStatus::Ok as u32
+}
+
+unsafe extern "C" fn free_secret(_user_data: *mut c_void, secret: *mut c_char) {
+    drop(unsafe { CString::from_raw(secret) });
+}
+
+unsafe extern "C" fn destroy(_user_data: *mut c_void) {
+    DESTROYED.store(true, Ordering::SeqCst);
+}
+
+fn host_store() -> MarmotSecretStore {
+    MarmotSecretStore {
+        user_data: ptr::null_mut(),
+        has_secret_for_label: Some(has),
+        has_secret_for_account_id: Some(has),
+        write_secret: Some(write_secret),
+        load_secret: Some(load_secret),
+        remove_secret: Some(remove_secret),
+        free_secret: Some(free_secret),
+        destroy: Some(destroy),
+    }
+}
+
+fn open_client(root: &tempfile::TempDir) -> *mut MarmotClient {
+    let root_path = CString::new(root.path().to_str().expect("utf-8 temp path")).unwrap();
+    let relay = CString::new("wss://relay.example.org").unwrap();
+    let relays = [relay.as_ptr()];
+    let store = host_store();
+    let mut client: *mut MarmotClient = ptr::null_mut();
+    let status = unsafe {
+        marmot_client_new_with_secret_store(
+            root_path.as_ptr(),
+            relays.as_ptr(),
+            1,
+            &raw const store,
+            &raw mut client,
+        )
+    };
+    assert_eq!(status, MarmotStatus::Ok, "host store must need no keystore");
+    assert!(!client.is_null());
+    client
+}
+
+fn take_string(ptr: *mut c_char) -> Option<String> {
+    if ptr.is_null() {
+        return None;
+    }
+    let value = unsafe { CStr::from_ptr(ptr) }
+        .to_str()
+        .expect("utf-8")
+        .to_owned();
+    unsafe { marmot_string_free(ptr) };
+    Some(value)
+}
+
+#[test]
+fn account_id_hex_and_pseudonyms_are_offline() {
+    let root = tempfile::tempdir().expect("temp dir");
+    let client = open_client(&root);
+    let account_id = "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4";
+    let npub = "npub14f8usejl26twx0dhuxjh9cas7keav9vr0v8nvtwtrjqx3vycc76qqh9nsy";
+    let nprofile = "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dq7r0nz9";
+    let unknown_tlv =
+        "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0drrq3skycmyxne9kf";
+    let invalid_relay =
+        "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dqpp9hx7apqvys82unvuca0cf";
+
+    for reference in [
+        account_id,
+        npub,
+        &format!("nostr:{npub}"),
+        nprofile,
+        &format!("nostr:{nprofile}"),
+        &format!(" {nprofile}"),
+        &format!("marmot://profile/{nprofile}?from=qr"),
+        unknown_tlv,
+        invalid_relay,
+    ] {
+        let input = CString::new(reference.to_owned()).unwrap();
+        let mut out: *mut c_char = 0x10 as *mut c_char;
+        let status = unsafe { marmot_account_id_hex(client, input.as_ptr(), &raw mut out) };
+        assert_eq!(status, MarmotStatus::Ok);
+        assert_eq!(take_string(out).as_deref(), Some(account_id));
+    }
+
+    for invalid in [
+        "nprofile1qqqsnhxh",
+        "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dq7r0nzx",
+        "note1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dq4ueyyt",
+        "nprofile1qy2hwumn8ghj7etcv9khqmr99e5kuanpd35kghsdudn",
+    ] {
+        let input = CString::new(invalid).unwrap();
+        let mut out: *mut c_char = 0x10 as *mut c_char;
+        assert_eq!(
+            unsafe { marmot_account_id_hex(client, input.as_ptr(), &raw mut out) },
+            MarmotStatus::Ok
+        );
+        assert!(out.is_null(), "non-decoding reference stays OK plus NULL");
+    }
+
+    let mut out: *mut c_char = 0x10 as *mut c_char;
+    assert_eq!(
+        unsafe { marmot_account_id_hex(client, ptr::null(), &raw mut out) },
+        MarmotStatus::NullPointer
+    );
+    assert!(out.is_null());
+    out = 0x10 as *mut c_char;
+    assert_eq!(
+        unsafe { marmot_default_profile_pseudonym(client, ptr::null(), &raw mut out) },
+        MarmotStatus::NullPointer
+    );
+    assert!(out.is_null());
+
+    let account = CString::new(account_id).unwrap();
+    let mut name_out: *mut c_char = 0x10 as *mut c_char;
+    assert_eq!(
+        unsafe { marmot_default_profile_pseudonym(client, account.as_ptr(), &raw mut name_out) },
+        MarmotStatus::Ok
+    );
+    assert_eq!(take_string(name_out).as_deref(), Some("Loyal Crane"));
+
+    let mut random_out: *mut c_char = 0x10 as *mut c_char;
+    assert_eq!(
+        unsafe { marmot_random_profile_pseudonym(client, &raw mut random_out) },
+        MarmotStatus::Ok
+    );
+    let random = take_string(random_out).expect("random name");
+    assert!(random.split_once(' ').is_some());
+
+    unsafe { marmot_client_shutdown(client) };
+    unsafe { marmot_client_free(client) };
+    assert!(DESTROYED.load(Ordering::SeqCst));
+}

--- a/crates/marmot-uniffi/README.md
+++ b/crates/marmot-uniffi/README.md
@@ -20,6 +20,22 @@ same UniFFI surface, and releases publish it once.
 bindings to handle the new tag; older generated sources cannot render it.
 No generated Swift or Kotlin files are committed here.
 
+## Identity references and profile pseudonyms
+
+`accountIdHex` / `normalizeMemberRef` now accept `nprofile` and
+`nostr:nprofile` mentions and QR scans in addition to hex, `npub`,
+`nostr:npub`, and `marmot://profile/` links. Relay hints inside an
+nprofile are discarded and never used for routing or directory mutation.
+Decode a scanned reference first, then pass the canonical lowercase hex
+account id to `defaultProfilePseudonym` so the shared text-hash seed is
+preserved. `randomProfilePseudonym` replaces client-owned random-roll
+wordlists; it is cosmetic, may collide, and does not create an account.
+
+Regenerate Swift/Kotlin bindings after pulling this surface. Android
+mention/QR/edit-profile migration remains
+[whitenoise-android#1584](https://github.com/marmot-protocol/whitenoise-android/issues/1584);
+MDK completion enables that follow-through but does not replace it.
+
 See [`DISTRIBUTION.md`](DISTRIBUTION.md) for immutable Apple and Android artifacts, exact release and snapshot URLs,
 checksums, provenance, and generated-source synchronization rules.
 

--- a/crates/marmot-uniffi/README.md
+++ b/crates/marmot-uniffi/README.md
@@ -26,10 +26,17 @@ No generated Swift or Kotlin files are committed here.
 `nostr:nprofile` mentions and QR scans in addition to hex, `npub`,
 `nostr:npub`, and `marmot://profile/` links. Relay hints inside an
 nprofile are discarded and never used for routing or directory mutation.
-Decode a scanned reference first, then pass the canonical lowercase hex
-account id to `defaultProfilePseudonym` so the shared text-hash seed is
-preserved. `randomProfilePseudonym` replaces client-owned random-roll
-wordlists; it is cosmetic, may collide, and does not create an account.
+Duplicate type-0 TLV entries keep the first key. After FFI wrapper
+normalization, the nprofile fallback rejects encoded tokens longer than
+1023 UTF-8 bytes (the locked Bech32/Bech32m ceiling); a valid 1023-byte
+token still decodes when wrapped in `nostr:` or `marmot://profile/...`.
+The app helper does not strip those wrappers itself, and the legacy
+NIP-21 parser may still accept a colon-suffixed `nostr:<npub>:` form
+before the fallback runs. Decode a scanned reference first, then pass
+the canonical lowercase hex account id to `defaultProfilePseudonym` so
+the shared text-hash seed is preserved. `randomProfilePseudonym`
+replaces client-owned random-roll wordlists; it is cosmetic, may
+collide, and does not create an account.
 
 Regenerate Swift/Kotlin bindings after pulling this surface. Android
 mention/QR/edit-profile migration remains

--- a/crates/marmot-uniffi/src/commands/directory.rs
+++ b/crates/marmot-uniffi/src/commands/directory.rs
@@ -28,13 +28,33 @@ impl Marmot {
         marmot_app::npub_for_account_id(&account_id_hex).ok()
     }
 
-    /// Normalize a public-key reference (npub or hex) to canonical hex.
-    /// `None` if it isn't a valid public key. Used to resolve a scanned or
-    /// deep-linked npub back to the account id the rest of the API expects.
+    /// Normalize a public-key reference (hex, `npub`, `nostr:npub`,
+    /// `nprofile`, `nostr:nprofile`, or a `marmot://profile/` link) to
+    /// canonical hex. `None` if it isn't a valid public identity
+    /// reference. nprofile relay hints are discarded. Used to resolve a
+    /// scanned or deep-linked mention back to the account id the rest of
+    /// the API expects.
     pub fn account_id_hex(&self, reference: String) -> Option<String> {
         normalize_member_ref_ffi(&reference)
             .ok()
             .map(|normalized| normalized.account_id_hex)
+    }
+
+    /// Deterministic cosmetic display name for a canonical hex account id.
+    ///
+    /// The seed is hashed as supplied UTF-8 text and is not normalized.
+    /// Decode a scanned reference with [`Self::account_id_hex`] first.
+    /// This does not start networking or mutate a profile.
+    pub fn default_profile_pseudonym(&self, account_id_hex: String) -> String {
+        marmot_app::default_profile_pseudonym(&account_id_hex)
+    }
+
+    /// Random cosmetic display name from the shared wordlists.
+    ///
+    /// This does not generate a signing key, create an account, or
+    /// promise uniqueness or anonymity.
+    pub fn random_profile_pseudonym(&self) -> String {
+        marmot_app::random_profile_pseudonym()
     }
 
     /// Parse plaintext message content into the same Markdown AST returned on
@@ -512,5 +532,66 @@ mod tests {
             SearchUpdateTriggerFfi::SearchCompleted
         ));
         assert!(subscription.next_update().await.is_none());
+    }
+
+    #[test]
+    fn account_id_hex_and_pseudonyms_are_offline_and_match_app_helpers() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+        let runtime = app.runtime();
+        let kit = Marmot { app, runtime };
+        let account_id = "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4";
+        let npub = "npub14f8usejl26twx0dhuxjh9cas7keav9vr0v8nvtwtrjqx3vycc76qqh9nsy";
+        let nprofile = marmot_app::nprofile_for_account_id(account_id, &[]).expect("nprofile");
+
+        for reference in [
+            account_id,
+            npub,
+            &format!("nostr:{npub}"),
+            nprofile.as_str(),
+            &format!("nostr:{nprofile}"),
+            &format!("marmot://profile/{nprofile}?from=qr"),
+        ] {
+            assert_eq!(
+                kit.account_id_hex(reference.to_owned()).as_deref(),
+                Some(account_id)
+            );
+        }
+        assert_eq!(kit.account_id_hex("not-a-public-key".to_owned()), None);
+        assert_eq!(
+            kit.account_id_hex("nprofile1qqqsnhxh".to_owned()),
+            None,
+            "truncated nprofile stays optional None"
+        );
+        assert_eq!(
+            kit.account_id_hex(format!(" {account_id}")).as_deref(),
+            Some(account_id),
+            "FFI trims whitespace before decoding"
+        );
+
+        assert_eq!(
+            kit.default_profile_pseudonym(account_id.to_owned()),
+            marmot_app::default_profile_pseudonym(account_id)
+        );
+        assert_eq!(
+            kit.default_profile_pseudonym(account_id.to_owned()),
+            "Loyal Crane"
+        );
+        let random = kit.random_profile_pseudonym();
+        let (adjective, noun) = random.split_once(' ').expect("adjective noun");
+        assert!(!noun.contains(' '));
+        assert!(
+            adjective
+                .chars()
+                .next()
+                .is_some_and(|ch| ch.is_ascii_uppercase())
+        );
+        assert!(
+            noun.chars()
+                .next()
+                .is_some_and(|ch| ch.is_ascii_uppercase())
+        );
+        assert!(adjective.chars().skip(1).all(|ch| ch.is_ascii_lowercase()));
+        assert!(noun.chars().skip(1).all(|ch| ch.is_ascii_lowercase()));
     }
 }

--- a/crates/marmot-uniffi/src/commands/directory.rs
+++ b/crates/marmot-uniffi/src/commands/directory.rs
@@ -31,9 +31,12 @@ impl Marmot {
     /// Normalize a public-key reference (hex, `npub`, `nostr:npub`,
     /// `nprofile`, `nostr:nprofile`, or a `marmot://profile/` link) to
     /// canonical hex. `None` if it isn't a valid public identity
-    /// reference. nprofile relay hints are discarded. Used to resolve a
-    /// scanned or deep-linked mention back to the account id the rest of
-    /// the API expects.
+    /// reference. nprofile relay hints are discarded. Duplicate type-0
+    /// TLV entries keep the first key. After wrapper normalization, the
+    /// nprofile fallback rejects encoded tokens longer than 1023 UTF-8
+    /// bytes; a valid 1023-byte token still decodes when wrapped. Used
+    /// to resolve a scanned or deep-linked mention back to the account
+    /// id the rest of the API expects.
     pub fn account_id_hex(&self, reference: String) -> Option<String> {
         normalize_member_ref_ffi(&reference)
             .ok()
@@ -225,6 +228,11 @@ mod tests {
     use crate::conversions::{
         MatchQualityFfi, MatchedFieldFfi, SearchUpdateTriggerFfi, UserSearchUpdateFfi,
     };
+
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../marmot-app/tests/support/identity_reference_vectors.rs"
+    ));
 
     async fn wait_for_network_ready(runtime: &MarmotAppRuntime, account_ref: &str) {
         tokio::time::timeout(std::time::Duration::from_secs(10), async {
@@ -540,41 +548,21 @@ mod tests {
         let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
         let runtime = app.runtime();
         let kit = Marmot { app, runtime };
-        let account_id = "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4";
-        let npub = "npub14f8usejl26twx0dhuxjh9cas7keav9vr0v8nvtwtrjqx3vycc76qqh9nsy";
-        let nprofile = marmot_app::nprofile_for_account_id(account_id, &[]).expect("nprofile");
-
-        for reference in [
-            account_id,
-            npub,
-            &format!("nostr:{npub}"),
-            nprofile.as_str(),
-            &format!("nostr:{nprofile}"),
-            &format!("marmot://profile/{nprofile}?from=qr"),
-        ] {
+        for case in cases() {
             assert_eq!(
-                kit.account_id_hex(reference.to_owned()).as_deref(),
-                Some(account_id)
+                kit.account_id_hex(case.reference.clone()).as_deref(),
+                case.ffi_account_id_hex,
+                "case {}",
+                case.name
             );
         }
-        assert_eq!(kit.account_id_hex("not-a-public-key".to_owned()), None);
-        assert_eq!(
-            kit.account_id_hex("nprofile1qqqsnhxh".to_owned()),
-            None,
-            "truncated nprofile stays optional None"
-        );
-        assert_eq!(
-            kit.account_id_hex(format!(" {account_id}")).as_deref(),
-            Some(account_id),
-            "FFI trims whitespace before decoding"
-        );
 
         assert_eq!(
-            kit.default_profile_pseudonym(account_id.to_owned()),
-            marmot_app::default_profile_pseudonym(account_id)
+            kit.default_profile_pseudonym(ACCOUNT_ID.to_owned()),
+            marmot_app::default_profile_pseudonym(ACCOUNT_ID)
         );
         assert_eq!(
-            kit.default_profile_pseudonym(account_id.to_owned()),
+            kit.default_profile_pseudonym(ACCOUNT_ID.to_owned()),
             "Loyal Crane"
         );
         let random = kit.random_profile_pseudonym();

--- a/crates/marmot-uniffi/src/commands/group.rs
+++ b/crates/marmot-uniffi/src/commands/group.rs
@@ -569,7 +569,9 @@ impl Marmot {
     }
 
     /// Normalize a member reference for group-management UI. Accepts hex,
-    /// `npub`, `nostr:npub...`, and `marmot://profile/...` references.
+    /// `npub`, `nostr:npub...`, `nprofile`, `nostr:nprofile...`, and
+    /// `marmot://profile/...` references. nprofile relay hints are
+    /// discarded and never used for routing or membership authorization.
     pub fn normalize_member_ref(&self, member_ref: String) -> Result<MemberRefFfi, MarmotKitError> {
         normalize_member_ref_ffi(&member_ref)
     }

--- a/crates/marmot-uniffi/src/commands/group.rs
+++ b/crates/marmot-uniffi/src/commands/group.rs
@@ -572,6 +572,10 @@ impl Marmot {
     /// `npub`, `nostr:npub...`, `nprofile`, `nostr:nprofile...`, and
     /// `marmot://profile/...` references. nprofile relay hints are
     /// discarded and never used for routing or membership authorization.
+    /// Duplicate type-0 TLV entries keep the first key. After wrapper
+    /// normalization, the nprofile fallback rejects encoded tokens longer
+    /// than 1023 UTF-8 bytes; a valid 1023-byte token still decodes when
+    /// wrapped.
     pub fn normalize_member_ref(&self, member_ref: String) -> Result<MemberRefFfi, MarmotKitError> {
         normalize_member_ref_ffi(&member_ref)
     }

--- a/crates/marmot-uniffi/src/conversions/group.rs
+++ b/crates/marmot-uniffi/src/conversions/group.rs
@@ -809,6 +809,57 @@ mod group_roster_tests {
     }
 
     #[test]
+    fn normalize_member_ref_ffi_accepts_nprofile_and_rejects_malformed() {
+        let account_id = "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4";
+        let npub = "npub14f8usejl26twx0dhuxjh9cas7keav9vr0v8nvtwtrjqx3vycc76qqh9nsy";
+        let nprofile = marmot_app::nprofile_for_account_id(account_id, &[]).expect("nprofile");
+        let bootstrap = marmot_app::nprofile_for_account_id(
+            account_id,
+            &[
+                "wss://relay.eu.whitenoise.chat".to_owned(),
+                "wss://relay.us.whitenoise.chat".to_owned(),
+            ],
+        )
+        .expect("bootstrap nprofile");
+        let unknown_tlv =
+            "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0drrq3skycmyxne9kf";
+        let invalid_relay = "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dqpp9hx7apqvys82unvuca0cf";
+
+        for reference in [
+            account_id,
+            npub,
+            &format!("nostr:{npub}"),
+            nprofile.as_str(),
+            &format!("nostr:{nprofile}"),
+            bootstrap.as_str(),
+            unknown_tlv,
+            invalid_relay,
+            &format!(" {nprofile}"),
+            &format!("marmot://profile/{nprofile}?from=qr"),
+        ] {
+            let normalized = normalize_member_ref_ffi(reference).expect("valid identity ref");
+            assert_eq!(normalized.account_id_hex, account_id);
+        }
+
+        for reference in [
+            "nprofile1qqqsnhxh",
+            "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dq7r0nzx",
+            "note1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dq4ueyyt",
+            "nprofile1qy2hwumn8ghj7etcv9khqmr99e5kuanpd35kghsdudn",
+            "nprofile1qqg25n7gve04d9hr8km7rftjuwc028ngcqe",
+            "nprofile1qqs25n7gve04d9hrdfl42d",
+        ] {
+            assert!(
+                matches!(
+                    normalize_member_ref_ffi(reference),
+                    Err(MarmotKitError::InvalidIdentity { .. })
+                ),
+                "expected InvalidIdentity"
+            );
+        }
+    }
+
+    #[test]
     fn member_ids_page_row_preserves_group_member_and_admin_identifiers() {
         let ffi = AppGroupMemberIdsFfi::from(AppGroupMemberIds {
             group_id_hex: "01".repeat(16),

--- a/crates/marmot-uniffi/src/conversions/group.rs
+++ b/crates/marmot-uniffi/src/conversions/group.rs
@@ -808,54 +808,33 @@ mod group_roster_tests {
         assert_eq!(ffi.members[0].display_name.as_deref(), Some("Alice"));
     }
 
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../marmot-app/tests/support/identity_reference_vectors.rs"
+    ));
+
     #[test]
-    fn normalize_member_ref_ffi_accepts_nprofile_and_rejects_malformed() {
-        let account_id = "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4";
-        let npub = "npub14f8usejl26twx0dhuxjh9cas7keav9vr0v8nvtwtrjqx3vycc76qqh9nsy";
-        let nprofile = marmot_app::nprofile_for_account_id(account_id, &[]).expect("nprofile");
-        let bootstrap = marmot_app::nprofile_for_account_id(
-            account_id,
-            &[
-                "wss://relay.eu.whitenoise.chat".to_owned(),
-                "wss://relay.us.whitenoise.chat".to_owned(),
-            ],
-        )
-        .expect("bootstrap nprofile");
-        let unknown_tlv =
-            "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0drrq3skycmyxne9kf";
-        let invalid_relay = "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dqpp9hx7apqvys82unvuca0cf";
-
-        for reference in [
-            account_id,
-            npub,
-            &format!("nostr:{npub}"),
-            nprofile.as_str(),
-            &format!("nostr:{nprofile}"),
-            bootstrap.as_str(),
-            unknown_tlv,
-            invalid_relay,
-            &format!(" {nprofile}"),
-            &format!("marmot://profile/{nprofile}?from=qr"),
-        ] {
-            let normalized = normalize_member_ref_ffi(reference).expect("valid identity ref");
-            assert_eq!(normalized.account_id_hex, account_id);
-        }
-
-        for reference in [
-            "nprofile1qqqsnhxh",
-            "nprofile1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dq7r0nzx",
-            "note1qqs25n7gve04d9hr8km7rftjuwc0tv7kzkphkrek9h93eqrgkzvv0dq4ueyyt",
-            "nprofile1qy2hwumn8ghj7etcv9khqmr99e5kuanpd35kghsdudn",
-            "nprofile1qqg25n7gve04d9hr8km7rftjuwc028ngcqe",
-            "nprofile1qqs25n7gve04d9hrdfl42d",
-        ] {
-            assert!(
-                matches!(
-                    normalize_member_ref_ffi(reference),
-                    Err(MarmotKitError::InvalidIdentity { .. })
-                ),
-                "expected InvalidIdentity"
-            );
+    fn normalize_member_ref_ffi_matches_shared_corpus() {
+        for case in cases() {
+            match case.ffi_account_id_hex {
+                Some(expected) => {
+                    let normalized = normalize_member_ref_ffi(&case.reference)
+                        .unwrap_or_else(|_| panic!("case {} should decode", case.name));
+                    assert_eq!(normalized.account_id_hex, expected, "case {}", case.name);
+                    assert_eq!(normalized.member_ref, expected, "case {}", case.name);
+                    assert_eq!(normalized.npub, NPUB, "case {}", case.name);
+                }
+                None => {
+                    assert!(
+                        matches!(
+                            normalize_member_ref_ffi(&case.reference),
+                            Err(MarmotKitError::InvalidIdentity { .. })
+                        ),
+                        "case {} should reject",
+                        case.name
+                    );
+                }
+            }
         }
     }
 

--- a/crates/marmot-uniffi/tests/smoke.rs
+++ b/crates/marmot-uniffi/tests/smoke.rs
@@ -22,6 +22,11 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 
+include!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../marmot-app/tests/support/identity_reference_vectors.rs"
+));
+
 /// `Marmot::new` opens a Keychain-backed secret store, which on the real
 /// targets (iOS/macOS) is always present but in headless CI (Linux Secret
 /// Service, no D-Bus daemon) is not. Install an in-memory mock as the default
@@ -304,39 +309,42 @@ fn normalize_member_ref_accepts_profile_and_nostr_forms() {
         vec!["wss://relay.invalid.test".to_string()],
     )
     .expect("open marmot kit");
-    let account_id = "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4";
-    let npub = "npub14f8usejl26twx0dhuxjh9cas7keav9vr0v8nvtwtrjqx3vycc76qqh9nsy";
-
-    let nprofile = marmot_app::nprofile_for_account_id(account_id, &[]).expect("nprofile");
-    for reference in [
-        account_id.to_string(),
-        npub.to_string(),
-        format!("nostr:{npub}"),
-        nprofile.clone(),
-        format!("nostr:{nprofile}"),
-        format!("marmot://profile/{npub}?from=qr"),
-        format!("marmot://profile/{nprofile}?from=qr"),
-    ] {
-        let normalized = kit
-            .normalize_member_ref(reference.clone())
-            .expect("normalize member ref");
-        assert_eq!(normalized.member_ref, account_id);
-        assert_eq!(normalized.account_id_hex, account_id);
-        assert_eq!(normalized.npub, npub);
-        assert_eq!(
-            kit.account_id_hex(reference),
-            Some(account_id.to_string()),
-            "legacy account_id_hex should accept the same references"
-        );
+    for case in cases() {
+        match case.ffi_account_id_hex {
+            Some(expected) => {
+                let normalized = kit
+                    .normalize_member_ref(case.reference.clone())
+                    .unwrap_or_else(|_| panic!("case {} should normalize", case.name));
+                assert_eq!(normalized.member_ref, expected, "case {}", case.name);
+                assert_eq!(normalized.account_id_hex, expected, "case {}", case.name);
+                assert_eq!(normalized.npub, NPUB, "case {}", case.name);
+                assert_eq!(
+                    kit.account_id_hex(case.reference).as_deref(),
+                    Some(expected),
+                    "case {}",
+                    case.name
+                );
+            }
+            None => {
+                assert!(
+                    matches!(
+                        kit.normalize_member_ref(case.reference.clone()),
+                        Err(MarmotKitError::InvalidIdentity { .. })
+                    ),
+                    "case {} should reject",
+                    case.name
+                );
+                assert_eq!(
+                    kit.account_id_hex(case.reference),
+                    None,
+                    "case {}",
+                    case.name
+                );
+            }
+        }
     }
-
-    assert!(matches!(
-        kit.normalize_member_ref("not-a-member-ref".into())
-            .expect_err("invalid member ref should fail"),
-        MarmotKitError::InvalidIdentity { .. }
-    ));
     assert_eq!(
-        kit.default_profile_pseudonym(account_id.to_owned()),
+        kit.default_profile_pseudonym(ACCOUNT_ID.to_owned()),
         "Loyal Crane"
     );
     let random = kit.random_profile_pseudonym();

--- a/crates/marmot-uniffi/tests/smoke.rs
+++ b/crates/marmot-uniffi/tests/smoke.rs
@@ -307,11 +307,15 @@ fn normalize_member_ref_accepts_profile_and_nostr_forms() {
     let account_id = "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4";
     let npub = "npub14f8usejl26twx0dhuxjh9cas7keav9vr0v8nvtwtrjqx3vycc76qqh9nsy";
 
+    let nprofile = marmot_app::nprofile_for_account_id(account_id, &[]).expect("nprofile");
     for reference in [
         account_id.to_string(),
         npub.to_string(),
         format!("nostr:{npub}"),
+        nprofile.clone(),
+        format!("nostr:{nprofile}"),
         format!("marmot://profile/{npub}?from=qr"),
+        format!("marmot://profile/{nprofile}?from=qr"),
     ] {
         let normalized = kit
             .normalize_member_ref(reference.clone())
@@ -331,6 +335,15 @@ fn normalize_member_ref_accepts_profile_and_nostr_forms() {
             .expect_err("invalid member ref should fail"),
         MarmotKitError::InvalidIdentity { .. }
     ));
+    assert_eq!(
+        kit.default_profile_pseudonym(account_id.to_owned()),
+        "Loyal Crane"
+    );
+    let random = kit.random_profile_pseudonym();
+    assert!(
+        random.split_once(' ').is_some(),
+        "random pseudonym should be two words"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Accept `nprofile` and `nostr:nprofile` identity references through the app, UniFFI, and C APIs, returning the embedded public key and discarding relay hints. Expose deterministic and random profile-pseudonym helpers through both bindings using the existing wordlists and deterministic formula.

The decoder keeps legacy public-key parsing first and applies an explicit 1023-byte limit only to the nprofile fallback. One shared 49-case corpus covers valid, malformed, boundary-sized, oversized, and wrapped inputs across all decoder surfaces, preserving intentional app/FFI normalization differences and the existing C ownership and error contracts.

Merged current `master`, preserving both identity and media release notes, and clarified the wrapper/size-limit documentation. No dependency or workspace version changes.

Fixes #959. Android adoption remains tracked separately in [whitenoise-android#1584](https://github.com/marmot-protocol/whitenoise-android/issues/1584).

[Accepted implementation plan](https://github.com/marmot-protocol/mdk/issues/959#issuecomment-5645601619).

Validation on signed follow-up commit `a44be29a4ab39b44892315579c65420d506027bb`:

- `CARGO_INCREMENTAL=0 just fast-ci` passed, including default and diagnostics-feature checks/Clippy.
- App identity tests: four passed; UniFFI normalization tests: two passed, including the public smoke surface.
- `cargo test -p marmot-c --locked --features alloc-audit`: 49 passed.
- `c-smoke.sh --debug` passed static and shared linkage. Valgrind was unavailable.
- `just c-header` regenerated the header with no diff.
- [Current-head CI](https://github.com/marmot-protocol/mdk/actions/runs/34758557282) and [binary workflow](https://github.com/marmot-protocol/mdk/actions/runs/34758557273) are running. [Full CI on the reviewed parent](https://github.com/marmot-protocol/mdk/actions/runs/34754782073) passed.

Self-review completed on parent `7b084c64488f69171d2e2da69b04750378c67a62`: [Cursor Grok](https://github.com/marmot-protocol/mdk/pull/1780#pullrequestreview-5190709223) and [Claude Opus](https://github.com/marmot-protocol/mdk/pull/1780#pullrequestreview-5190722350) both recommended merge, with no blocking findings. The follow-up reuses the existing C string-delivery helper while retaining allocation coverage, shortens decoder documentation, explicitly documents silent mismatched-seed behavior, and guards the shared checksum-mutation fixture.

The explicit 1023-byte fallback budget is retained as required by the accepted plan. It matches the locked dependency's existing limit and skips redundant fallback scanning; it is not a new NIP-19 protocol limit or a claim of unbounded-DoS remediation. The deterministic pseudonym seed remains raw text to preserve the existing formula and contract.

Datawav's fresh review is requested. The self-review approvals cover the parent above; no second reviewer round was dispatched after the cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added deterministic and random profile pseudonym generation across C, UniFFI, and application APIs.
  - Added support for `nprofile` and `nostr:nprofile` identity references, including relay-hint handling and duplicate-key rules.
  - Added structured media attachment outcomes, rejection categories, and stable attachment ordering while preserving valid attachments.

- **Bug Fixes**
  - Added validation for oversized identity-reference tokens, including the 1023-byte limit.

- **Documentation**
  - Expanded identity decoding, pseudonym, media, and memory-management guidance across public documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->