### PR TITLE
Refresh, validate, and migrate invitation KeyPackages

### DIFF
--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -2347,6 +2347,7 @@ pub(crate) fn classify_engine_error(error: &EngineError) -> (SubjectFailureCateg
         | EngineError::InvalidCredentialIdentity(_)
         | EngineError::InvalidAccountIdentityProof(_)
         | EngineError::InvalidKeyPackageLifetime { .. }
+        | EngineError::InvalidKeyPackageCapabilities { .. }
         | EngineError::UnsupportedCiphersuite { .. }
         | EngineError::InvalidAppMessagePayload(_)
         // A halted group refusing new work is deliberate, not a protocol
@@ -2421,6 +2422,7 @@ fn observe_engine_error(error: &EngineError) -> String {
         EngineError::InvalidCredentialIdentity(_) => "invalid_credential_identity",
         EngineError::InvalidAccountIdentityProof(_) => "invalid_account_identity_proof",
         EngineError::InvalidKeyPackageLifetime { .. } => "invalid_key_package_lifetime",
+        EngineError::InvalidKeyPackageCapabilities { .. } => "invalid_key_package_capabilities",
         EngineError::UnsupportedCiphersuite { .. } => "unsupported_ciphersuite",
         EngineError::InvalidAppMessagePayload(_) => "invalid_app_message_payload",
         EngineError::UnknownPending => "unknown_pending",
@@ -2641,6 +2643,17 @@ mod tests {
             classify_engine_error(&EngineError::Serialize("malformed internal state".into()));
         assert_eq!(category, SubjectFailureCategory::Protocol);
         assert_eq!(code, "serialize");
+    }
+
+    #[test]
+    fn invalid_key_package_capabilities_are_an_expected_refusal() {
+        let error = EngineError::InvalidKeyPackageCapabilities {
+            member: cgka_traits::MemberId::new(vec![0xBB; 32]),
+        };
+        let (category, code) = classify_engine_error(&error);
+        assert_eq!(category, SubjectFailureCategory::ExpectedRefusal);
+        assert_eq!(code, "invalid_key_package_capabilities");
+        assert_eq!(code, error.privacy_safe_kind());
     }
 
     #[test]

--- a/crates/cgka-engine/README.md
+++ b/crates/cgka-engine/README.md
@@ -62,9 +62,11 @@ adding members. They also reject LeafNode capabilities that explicitly advertise
 extension or proposal types. Unknown capability values remain accepted for protocol extensibility.
 
 Recipients whose published packages contain the former default-capability advertisement must generate a fresh
-package using the corrected client. Updating the app or republishing can reuse the existing artifact, so neither
-alone guarantees repair. The refusal is `InvalidKeyPackageCapabilities`, with an authenticated member id for typed
-callers and identity-free diagnostic text; it is classified as an expected refusal rather than a resource failure.
+package using the corrected client. The account runtime records a per-account-device generator revision and
+MarmotApp attempts a one-time fresh publication on activation after upgrading. Offline or signing failures remain
+retryable; the revision advances only with an acknowledged replacement. The refusal is `InvalidKeyPackageCapabilities`,
+with an authenticated member id for typed callers and identity-free diagnostic text; it is classified as an expected
+refusal rather than a resource failure.
 
 This membership check does not change local private-bundle retention or historical Welcome processing. Directory
 metadata can still describe an older package; that does not make it eligible for a new membership operation.

--- a/crates/cgka-engine/README.md
+++ b/crates/cgka-engine/README.md
@@ -61,6 +61,13 @@ Create and Invite validate transported KeyPackages through OpenMLS and the Marmo
 adding members. They also reject LeafNode capabilities that explicitly advertise RFC 9420 section 7.2 default
 extension or proposal types. Unknown capability values remain accepted for protocol extensibility.
 
+This is an explicit admission policy beyond the [RFC 9420 section 7.3 validation checks](https://www.rfc-editor.org/rfc/rfc9420.html#section-7.3):
+OpenMLS accepts these advertisements, but MDK chooses to keep known nonconforming signed leaves out of new
+membership state. An inviter cannot repair a signed advertisement. The accepted compatibility cost is that
+Create/Invite to a peer still publishing an affected package fails with `InvalidKeyPackageCapabilities` until that
+peer regenerates and publishes a conforming package. Automatic migration in this release only helps recipients
+that upgrade and activate successfully; it cannot repair packages on peers that have not upgraded.
+
 Recipients whose published packages contain the former default-capability advertisement must generate a fresh
 package using the corrected client. The account runtime records a per-account-device generator revision and
 MarmotApp attempts a one-time fresh publication on activation after upgrading. Offline or signing failures remain

--- a/crates/cgka-engine/README.md
+++ b/crates/cgka-engine/README.md
@@ -55,6 +55,15 @@ still agree after the world gets messy.
 
 See [`tests/AGENTS.md`](tests/AGENTS.md) for the test file map.
 
+## KeyPackage validation before membership changes
+
+Create and Invite validate transported KeyPackages through OpenMLS and the Marmot identity/profile checks before
+adding members. They also reject LeafNode capabilities that explicitly advertise RFC 9420 section 7.2 default
+extension or proposal types. Unknown capability values remain accepted for protocol extensibility.
+
+This membership check does not change local private-bundle retention or historical Welcome processing. Directory
+metadata can still describe an older package; that does not make it eligible for a new membership operation.
+
 ## Promoting state-bearing app components
 
 `upgrade_group_capabilities` only promotes state-bearing app components whose

--- a/crates/cgka-engine/README.md
+++ b/crates/cgka-engine/README.md
@@ -61,6 +61,11 @@ Create and Invite validate transported KeyPackages through OpenMLS and the Marmo
 adding members. They also reject LeafNode capabilities that explicitly advertise RFC 9420 section 7.2 default
 extension or proposal types. Unknown capability values remain accepted for protocol extensibility.
 
+Recipients whose published packages contain the former default-capability advertisement must generate a fresh
+package using the corrected client. Updating the app or republishing can reuse the existing artifact, so neither
+alone guarantees repair. The refusal is `InvalidKeyPackageCapabilities`, with an authenticated member id for typed
+callers and identity-free diagnostic text; it is classified as an expected refusal rather than a resource failure.
+
 This membership check does not change local private-bundle retention or historical Welcome processing. Directory
 metadata can still describe an older package; that does not make it eligible for a new membership operation.
 

--- a/crates/cgka-engine/src/key_package.rs
+++ b/crates/cgka-engine/src/key_package.rs
@@ -338,9 +338,15 @@ impl<S: StorageProvider> Engine<S> {
 }
 
 /// Enforce the RFC 9420 section 7.2 advertisement rule before using a
-/// KeyPackage for a new membership operation. Keep this out of the shared
-/// storage/maintenance validator: old private bundles may still be needed to
-/// process Welcomes sent before the peer refreshed its public KeyPackage.
+/// KeyPackage for a new membership operation. This is an intentional admission
+/// policy beyond RFC 9420 section 7.3 / OpenMLS validation: avoid copying known
+/// nonconforming signed leaves into new membership state. The inviter cannot
+/// repair the advertisement without invalidating its signature; the recipient
+/// must regenerate it. This accepts a cross-version availability cost until
+/// affected recipients upgrade and publish a conforming package.
+/// Keep this out of the shared storage/maintenance validator: old private
+/// bundles may still be needed to process Welcomes sent before the peer
+/// refreshed its public KeyPackage.
 fn validate_invitee_capabilities(
     key_package: &MlsKeyPackage,
     member: cgka_traits::MemberId,

--- a/crates/cgka-engine/src/key_package.rs
+++ b/crates/cgka-engine/src/key_package.rs
@@ -323,6 +323,7 @@ impl<S: StorageProvider> Engine<S> {
 
         let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
         let key_package = validate_key_package(kp_in, provider.crypto())?;
+        validate_invitee_capabilities(&key_package)?;
         // foundation/key-packages.md: reject a KeyPackage whose credential
         // identity is not a valid Marmot account identity. This single gate
         // covers both the create-group and invite invitee paths.
@@ -334,6 +335,31 @@ impl<S: StorageProvider> Engine<S> {
         ensure_key_package_profile(kp, protocol_profile)?;
         Ok(key_package)
     }
+}
+
+/// Enforce the RFC 9420 section 7.2 advertisement rule before using a
+/// KeyPackage for a new membership operation. Keep this out of the shared
+/// storage/maintenance validator: old private bundles may still be needed to
+/// process Welcomes sent before the peer refreshed its public KeyPackage.
+fn validate_invitee_capabilities(key_package: &MlsKeyPackage) -> Result<(), EngineError> {
+    use crate::capabilities::{DEFAULT_MLS_EXTENSION_TYPES, DEFAULT_MLS_PROPOSAL_TYPES};
+
+    let capabilities = key_package.leaf_node().capabilities();
+    if capabilities
+        .extensions()
+        .iter()
+        .any(|kind| DEFAULT_MLS_EXTENSION_TYPES.contains(&u16::from(*kind)))
+        || capabilities
+            .proposals()
+            .iter()
+            .any(|kind| DEFAULT_MLS_PROPOSAL_TYPES.contains(&u16::from(*kind)))
+    {
+        return Err(EngineError::Backend(
+            "key_package validate: default capabilities must not be advertised (RFC 9420 section 7.2)"
+                .into(),
+        ));
+    }
+    Ok(())
 }
 
 fn ensure_key_package_profile(

--- a/crates/cgka-engine/src/key_package.rs
+++ b/crates/cgka-engine/src/key_package.rs
@@ -323,16 +323,16 @@ impl<S: StorageProvider> Engine<S> {
 
         let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
         let key_package = validate_key_package(kp_in, provider.crypto())?;
-        validate_invitee_capabilities(&key_package)?;
         // foundation/key-packages.md: reject a KeyPackage whose credential
         // identity is not a valid Marmot account identity. This single gate
         // covers both the create-group and invite invitee paths.
-        crate::identity::validated_member_id_of_leaf(key_package.leaf_node())?;
+        let member = crate::identity::validated_member_id_of_leaf(key_package.leaf_node())?;
         let protocol_profile = crate::account_identity_proof::validate_leaf_account_identity_proof(
             key_package.leaf_node(),
             key_package.ciphersuite(),
         )?;
         ensure_key_package_profile(kp, protocol_profile)?;
+        validate_invitee_capabilities(&key_package, member)?;
         Ok(key_package)
     }
 }
@@ -341,7 +341,10 @@ impl<S: StorageProvider> Engine<S> {
 /// KeyPackage for a new membership operation. Keep this out of the shared
 /// storage/maintenance validator: old private bundles may still be needed to
 /// process Welcomes sent before the peer refreshed its public KeyPackage.
-fn validate_invitee_capabilities(key_package: &MlsKeyPackage) -> Result<(), EngineError> {
+fn validate_invitee_capabilities(
+    key_package: &MlsKeyPackage,
+    member: cgka_traits::MemberId,
+) -> Result<(), EngineError> {
     use crate::capabilities::{DEFAULT_MLS_EXTENSION_TYPES, DEFAULT_MLS_PROPOSAL_TYPES};
 
     let capabilities = key_package.leaf_node().capabilities();
@@ -354,10 +357,7 @@ fn validate_invitee_capabilities(key_package: &MlsKeyPackage) -> Result<(), Engi
             .iter()
             .any(|kind| DEFAULT_MLS_PROPOSAL_TYPES.contains(&u16::from(*kind)))
     {
-        return Err(EngineError::Backend(
-            "key_package validate: default capabilities must not be advertised (RFC 9420 section 7.2)"
-                .into(),
-        ));
+        return Err(EngineError::InvalidKeyPackageCapabilities { member });
     }
     Ok(())
 }

--- a/crates/cgka-engine/src/maintenance.rs
+++ b/crates/cgka-engine/src/maintenance.rs
@@ -10,7 +10,7 @@ use cgka_traits::error::EngineError;
 use cgka_traits::maintenance::{
     DurableGroupEvolution, DurableTransportFanout, GroupMaintenanceState, KeyPackageLifecycleState,
     MaintenanceObligation, MaintenancePhase, PendingKeyPackageReplacement,
-    PeriodicMaintenancePolicy, TransportFanoutTarget,
+    PeriodicMaintenancePolicy, RetainedKeyPackagePrivateMaterial, TransportFanoutTarget,
 };
 use cgka_traits::storage::StorageProvider;
 use cgka_traits::transport::Timestamp;
@@ -55,7 +55,21 @@ impl<S: StorageProvider> Engine<S> {
             let key_package = self.build_fresh_key_package(storage)?;
             let metadata = crate::key_package::key_package_metadata(&key_package)?;
             let mut staged = state.clone();
+            // An older pending artifact may have reached a relay even without
+            // a recorded ACK. Retain its private material when superseding it;
+            // the replacement and this ownership transfer commit together.
+            if let Some(previous) = staged.pending_replacement.take() {
+                staged
+                    .retained_private_material
+                    .push(RetainedKeyPackagePrivateMaterial {
+                        key_package: previous.key_package,
+                        key_package_ref: previous.key_package_ref,
+                        not_after: previous.not_after,
+                        replaced_at: authored_created_at,
+                    });
+            }
             staged.pending_replacement = Some(PendingKeyPackageReplacement {
+                generation_revision: cgka_traits::maintenance::KEY_PACKAGE_GENERATION_REVISION,
                 key_package: key_package.clone(),
                 key_package_ref: hex::decode(&metadata.key_package_ref_hex)
                     .map_err(|error| EngineError::Serialize(error.to_string()))?,

--- a/crates/cgka-engine/tests/group_creation.rs
+++ b/crates/cgka-engine/tests/group_creation.rs
@@ -2411,6 +2411,173 @@ async fn create_group_rejects_relabelled_legacy_key_package_profile() {
     );
 }
 
+/// Build a correctly signed package so a rejection proves semantic validation,
+/// rather than a broken signature caused by editing serialized bytes.
+fn key_package_with_advertised_capabilities(
+    profile: ProtocolProfile,
+    extra_extensions: &[u16],
+    extra_proposals: &[u16],
+) -> cgka_traits::engine::KeyPackage {
+    let identity_seed = b"capability-invitee";
+    let ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+    let provider = openmls_rust_crypto::OpenMlsRustCrypto::default();
+    let signer = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
+    let identity = pad32(identity_seed);
+    let credential = CredentialWithKey {
+        credential: BasicCredential::new(identity.clone()).into(),
+        signature_key: signer.public().into(),
+    };
+    let mut dictionary = AppDataDictionary::new();
+    let mut components = default_group_components();
+    components.insert(APP_COMPONENTS_COMPONENT_ID);
+    let mut extensions = Vec::new();
+    let mut extension_types = vec![ExtensionType::AppDataDictionary];
+    if profile == ProtocolProfile::Current {
+        components.insert(ACCOUNT_IDENTITY_PROOF_COMPONENT_ID);
+        dictionary.insert(
+            ACCOUNT_IDENTITY_PROOF_COMPONENT_ID,
+            account_identity_proof_component(
+                &identity,
+                &signer.to_public_vec(),
+                ciphersuite,
+                ciphersuite.signature_algorithm(),
+                1_700_000_000,
+                proof_signer(identity_seed).as_ref(),
+            )
+            .unwrap(),
+        );
+    } else {
+        extensions.push(
+            account_identity_proof_extension(
+                &identity,
+                &signer.to_public_vec(),
+                ciphersuite,
+                ciphersuite.signature_algorithm(),
+                proof_signer(identity_seed).as_ref(),
+            )
+            .unwrap(),
+        );
+        extension_types.push(ExtensionType::from(ACCOUNT_IDENTITY_PROOF_EXTENSION_TYPE));
+    }
+    dictionary.insert(
+        APP_COMPONENTS_COMPONENT_ID,
+        encode_components_list(&components),
+    );
+    extensions.push(Extension::AppDataDictionary(
+        AppDataDictionaryExtension::new(dictionary),
+    ));
+    extension_types.extend(extra_extensions.iter().copied().map(ExtensionType::from));
+    let mut proposals = vec![openmls::prelude::ProposalType::AppDataUpdate];
+    proposals.extend(
+        extra_proposals
+            .iter()
+            .copied()
+            .map(openmls::prelude::ProposalType::from),
+    );
+    let bundle = MlsKeyPackage::builder()
+        .leaf_node_capabilities(Capabilities::new(
+            None,
+            Some(&[ciphersuite]),
+            Some(&extension_types),
+            Some(&proposals),
+            None,
+        ))
+        .leaf_node_extensions(Extensions::from_vec(extensions).unwrap())
+        .build(ciphersuite, &provider, &signer, credential)
+        .unwrap();
+    let message: MlsMessageOut = bundle.key_package().clone().into();
+    cgka_traits::engine::KeyPackage::new(message.tls_serialize_detached().unwrap())
+        .with_protocol_profile(profile)
+}
+
+#[tokio::test]
+async fn create_and_invite_reject_explicit_default_key_package_capabilities() {
+    for profile in [ProtocolProfile::Current, ProtocolProfile::Legacy] {
+        let storage = SqliteAccountStorage::in_memory().unwrap();
+        let mut alice = build_profile_client_on_storage(b"alice", storage.clone(), profile);
+        // Test every forbidden id separately, including the historical 0x0003
+        // RequiredCapabilities advertisement. Directory metadata stays usable
+        // for discovery and private-bundle maintenance.
+        for (extensions, proposals) in (1..=5)
+            .map(|id| (vec![id], vec![]))
+            .chain((1..=7).map(|id| (vec![], vec![id])))
+        {
+            let kp = key_package_with_advertised_capabilities(profile, &extensions, &proposals);
+            key_package_metadata(&kp).expect("valid signatures, identity, and lifetime");
+            let error = alice
+                .create_group(CreateGroupRequest {
+                    name: "invalid-capabilities".into(),
+                    description: String::new(),
+                    members: vec![kp],
+                    required_features: vec![],
+                    app_components: vec![],
+                    initial_admins: vec![],
+                })
+                .await
+                .expect_err("forbidden advertisement must fail before group creation");
+            assert!(
+                matches!(error, EngineError::Backend(ref message)
+                if message.contains("default capabilities must not be advertised")),
+                "{error:?}"
+            );
+            assert!(storage.list_groups().unwrap().is_empty());
+        }
+        let (group_id, result) = alice
+            .create_group(CreateGroupRequest {
+                name: "existing".into(),
+                description: String::new(),
+                members: vec![],
+                required_features: vec![],
+                app_components: vec![],
+                initial_admins: vec![],
+            })
+            .await
+            .unwrap();
+        if let SendResult::GroupCreated { pending, .. } = result {
+            alice.confirm_published(pending).await.unwrap();
+        }
+        let epoch = alice.epoch(&group_id).unwrap();
+        let members = alice.members(&group_id).unwrap();
+        for (extensions, proposals) in (1..=5)
+            .map(|id| (vec![id], vec![]))
+            .chain((1..=7).map(|id| (vec![], vec![id])))
+        {
+            let kp = key_package_with_advertised_capabilities(profile, &extensions, &proposals);
+            let error = alice
+                .send(SendIntent::Invite {
+                    group_id: group_id.clone(),
+                    key_packages: vec![kp],
+                    initial_admins: vec![],
+                })
+                .await
+                .expect_err("forbidden advertisement must fail before an Add commit");
+            assert!(
+                matches!(error, EngineError::Backend(ref message)
+                if message.contains("default capabilities must not be advertised")),
+                "{error:?}"
+            );
+            assert_eq!(alice.epoch(&group_id).unwrap(), epoch);
+            assert_eq!(alice.members(&group_id).unwrap(), members);
+        }
+        // RFC 9420 section 7.2 requires unknown capability values to be ignored.
+        // A valid retry also proves rejection left no pending commit behind.
+        let kp = key_package_with_advertised_capabilities(profile, &[0x0a0a], &[0x0a0a]);
+        let result = alice
+            .send(SendIntent::Invite {
+                group_id: group_id.clone(),
+                key_packages: vec![kp],
+                initial_admins: vec![],
+            })
+            .await
+            .expect("unknown capabilities remain usable");
+        let SendResult::GroupEvolution { pending, .. } = result else {
+            panic!("expected invite")
+        };
+        alice.confirm_published(pending).await.unwrap();
+        assert_eq!(alice.members(&group_id).unwrap().len(), 2);
+    }
+}
+
 #[tokio::test]
 async fn fresh_key_packages_omit_default_mls_capabilities() {
     for profile in [ProtocolProfile::Current, ProtocolProfile::Legacy] {

--- a/crates/cgka-engine/tests/group_creation.rs
+++ b/crates/cgka-engine/tests/group_creation.rs
@@ -2495,6 +2495,13 @@ async fn create_and_invite_reject_explicit_default_key_package_capabilities() {
     for profile in [ProtocolProfile::Current, ProtocolProfile::Legacy] {
         let storage = SqliteAccountStorage::in_memory().unwrap();
         let mut alice = build_profile_client_on_storage(b"alice", storage.clone(), profile);
+        let mut bob = build_profile_client_on_storage(
+            b"valid-first-invitee",
+            SqliteAccountStorage::in_memory().unwrap(),
+            profile,
+        );
+        let valid_first = bob.fresh_key_package().await.unwrap();
+        let rejected_member = MemberId::new(pad32(b"capability-invitee"));
         // Test every forbidden id separately, including the historical 0x0003
         // RequiredCapabilities advertisement. Directory metadata stays usable
         // for discovery and private-bundle maintenance.
@@ -2508,7 +2515,7 @@ async fn create_and_invite_reject_explicit_default_key_package_capabilities() {
                 .create_group(CreateGroupRequest {
                     name: "invalid-capabilities".into(),
                     description: String::new(),
-                    members: vec![kp],
+                    members: vec![valid_first.clone(), kp],
                     required_features: vec![],
                     app_components: vec![],
                     initial_admins: vec![],
@@ -2516,8 +2523,8 @@ async fn create_and_invite_reject_explicit_default_key_package_capabilities() {
                 .await
                 .expect_err("forbidden advertisement must fail before group creation");
             assert!(
-                matches!(error, EngineError::Backend(ref message)
-                if message.contains("default capabilities must not be advertised")),
+                matches!(error, EngineError::InvalidKeyPackageCapabilities { ref member }
+                    if member == &rejected_member),
                 "{error:?}"
             );
             assert!(storage.list_groups().unwrap().is_empty());
@@ -2546,14 +2553,14 @@ async fn create_and_invite_reject_explicit_default_key_package_capabilities() {
             let error = alice
                 .send(SendIntent::Invite {
                     group_id: group_id.clone(),
-                    key_packages: vec![kp],
+                    key_packages: vec![valid_first.clone(), kp],
                     initial_admins: vec![],
                 })
                 .await
                 .expect_err("forbidden advertisement must fail before an Add commit");
             assert!(
-                matches!(error, EngineError::Backend(ref message)
-                if message.contains("default capabilities must not be advertised")),
+                matches!(error, EngineError::InvalidKeyPackageCapabilities { ref member }
+                    if member == &rejected_member),
                 "{error:?}"
             );
             assert_eq!(alice.epoch(&group_id).unwrap(), epoch);

--- a/crates/cgka-engine/tests/publish_lifecycle.rs
+++ b/crates/cgka-engine/tests/publish_lifecycle.rs
@@ -1652,6 +1652,7 @@ fn key_package_bundle_and_lifecycle_intent_roll_back_together() {
         publication_targets: Vec::new(),
         refresh_at: None,
         upgrade_rotation_recorded: false,
+        generation_revision: 0,
         last_consumed_key_package_ref: None,
         last_consumed_at: None,
         retained_private_material: Vec::new(),
@@ -1669,6 +1670,36 @@ fn key_package_bundle_and_lifecycle_intent_roll_back_together() {
     );
     assert!(handle.key_package_lifecycle().unwrap().is_none());
     assert!(state.pending_replacement.is_none());
+
+    engine
+        .stage_key_package_replacement(&mut state, Timestamp(10_000), 60, Vec::new())
+        .unwrap();
+    state
+        .pending_replacement
+        .as_mut()
+        .unwrap()
+        .generation_revision = 0;
+    engine.put_key_package_lifecycle(&state).unwrap();
+    let old_state = state.clone();
+    let old_bundles = handle.stored_key_package_bundles().unwrap();
+    lifecycle_fault.arm(1);
+    engine
+        .stage_key_package_replacement(&mut state, Timestamp(10_001), 60, Vec::new())
+        .expect_err("superseding an old pending bundle must also be atomic");
+    assert_eq!(state, old_state);
+    assert_eq!(
+        handle.key_package_lifecycle().unwrap(),
+        Some(old_state.clone())
+    );
+    assert_eq!(handle.stored_key_package_bundles().unwrap(), old_bundles);
+    engine
+        .stage_key_package_replacement(&mut state, Timestamp(10_001), 60, Vec::new())
+        .unwrap();
+    assert_eq!(
+        state.retained_private_material[0].key_package,
+        old_state.pending_replacement.unwrap().key_package
+    );
+    assert_eq!(handle.stored_key_package_bundles().unwrap().len(), 2);
 }
 
 #[tokio::test]

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -34,6 +34,10 @@ versioning through the workspace version in the root `Cargo.toml`.
   revision advances only after a relay acknowledges the replacement, with retries across restarts. Older pending
   publications are superseded in the same slot with a newer timestamp while preserving their private bundles.
   Previous unused private bundles remain available until expiry; historical Welcome processing is unchanged.
+  **Compatibility:** inviting a peer still advertising an affected package fails with `InvalidKeyPackageCapabilities`
+  until that peer generates and publishes a conforming package. An upgraded sender cannot repair a recipient that
+  has not upgraded; automatic regeneration requires the recipient to upgrade, activate, and obtain a relay ACK.
+  This is a deliberate stricter admission policy to keep nonconforming signed leaves out of new membership state.
   The engine reports `InvalidKeyPackageCapabilities` with the affected member for typed callers, while diagnostic
   text omits identities and classifies the error as a deliberate protocol refusal.
 

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -30,8 +30,10 @@ versioning through the workspace version in the root `Cargo.toml`.
   sibling accounts; unavailable relay material no longer falls back to cached packages. MarmotKit's prewarm
   `reusedMembers` remains present but always returns zero. Prewarm caches only discovery routes.
 - Create and Invite reject packages advertising RFC 9420 default capabilities. Recipients with older affected
-  packages must use a client with the corrected generator and generate a fresh package; updating or republishing
-  alone may reuse the old artifact. Private-bundle retention and historical Welcome processing are unchanged.
+  packages automatically regenerate on account activation after upgrading. A durable per-account-device generator
+  revision advances only after a relay acknowledges the replacement, with retries across restarts. Older pending
+  publications are superseded in the same slot with a newer timestamp while preserving their private bundles.
+  Previous unused private bundles remain available until expiry; historical Welcome processing is unchanged.
   The engine reports `InvalidKeyPackageCapabilities` with the affected member for typed callers, while diagnostic
   text omits identities and classifies the error as a deliberate protocol refusal.
 

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -26,6 +26,15 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ### Changed
 
+- Group creation, invites, and composition prewarming fetch current KeyPackages from relays, including for local
+  sibling accounts; unavailable relay material no longer falls back to cached packages. MarmotKit's prewarm
+  `reusedMembers` remains present but always returns zero. Prewarm caches only discovery routes.
+- Create and Invite reject packages advertising RFC 9420 default capabilities. Recipients with older affected
+  packages must use a client with the corrected generator and generate a fresh package; updating or republishing
+  alone may reuse the old artifact. Private-bundle retention and historical Welcome processing are unchanged.
+  The engine reports `InvalidKeyPackageCapabilities` with the affected member for typed callers, while diagnostic
+  text omits identities and classifies the error as a deliberate protocol refusal.
+
 - User search includes cached public identities from every connected account and delivers Vertex matches without
   waiting for graph traversal. Swift/Kotlin and C expose a cache-only search and explicit selected-account follow
   labels. Streaming consumers must apply `updated_results` as keyed replacements; CLI search merges them into one

--- a/crates/marmot-account/README.md
+++ b/crates/marmot-account/README.md
@@ -32,6 +32,8 @@ Only a relay acknowledgement promotes the current revision; remaining targets ke
 An old pending replacement is superseded with a strictly newer authoring timestamp in the same stable slot, and
 its private bundle is retained until expiry because publication may already have occurred. Previous unused current
 bundles retain their existing expiry/consumption policy. Ordinary releases do not bump the generator revision.
+Paused maintenance can finish a prepared current-revision publication, but waits for resume before replacing an
+older pending revision because that requires generating new private material.
 
 ## Routing model
 

--- a/crates/marmot-account/README.md
+++ b/crates/marmot-account/README.md
@@ -20,6 +20,19 @@ key storage, and runtime coordination with a `TransportAdapter`.
 - Keeps transport routing policy generic so the first implementation can be Nostr without baking Nostr into the session
   or engine crates.
 
+## KeyPackage generator upgrades
+
+The lifecycle records the generator revision independently of app versions. Records written before revision
+tracking default to zero; revision 1 regenerates packages to omit RFC 9420 default capability advertisements.
+MarmotApp attempts the upgrade on account activation, and `run_due_maintenance` retries durable publication work.
+Embedders that use `AccountDeviceRuntime` directly must drive maintenance themselves.
+
+Fresh private material, its revision, and replacement intent are stored atomically before signing/publication.
+Only a relay acknowledgement promotes the current revision; remaining targets keep their existing fanout retries.
+An old pending replacement is superseded with a strictly newer authoring timestamp in the same stable slot, and
+its private bundle is retained until expiry because publication may already have occurred. Previous unused current
+bundles retain their existing expiry/consumption policy. Ordinary releases do not bump the generator revision.
+
 ## Routing model
 
 `AccountHome` is the durable app-core boundary for local account setup. It keeps public summaries separate from secret

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -1477,10 +1477,17 @@ where
             }
         }
         let key_package_due = self.key_package_network_maintenance_due()?;
+        // Paused maintenance may finish existing publication intent, but an
+        // obsolete pending generator revision requires fresh private material
+        // and therefore waits for resume like every other new preparation.
         let key_package_prepared = self
             .session
             .key_package_lifecycle()?
-            .is_some_and(|lifecycle| lifecycle.pending_replacement.is_some());
+            .is_some_and(|lifecycle| {
+                lifecycle.pending_replacement.is_some_and(|pending| {
+                    pending.generation_revision >= KEY_PACKAGE_GENERATION_REVISION
+                })
+            });
         if key_package_due && (!self.maintenance_paused || key_package_prepared) {
             let started = self.monotonic_clock.elapsed();
             let result = self.publish_fresh_key_package().await;

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -17,6 +17,7 @@ use cgka_traits::engine::{
 use cgka_traits::engine_state::PendingStateRef;
 use cgka_traits::group::{Group, Member};
 use cgka_traits::ingest::IngestOutcome;
+use cgka_traits::maintenance::KEY_PACKAGE_GENERATION_REVISION;
 use cgka_traits::maintenance::{
     DurableGroupEvolution, DurableTransportFanout, GroupEvolutionPhase, GroupEvolutionSemantic,
     GroupMaintenanceStatus, KeyPackageLifecycleState, MaintenanceObligation, MaintenancePhase,
@@ -796,6 +797,7 @@ where
                     publication_targets: Vec::new(),
                     refresh_at: None,
                     upgrade_rotation_recorded: false,
+                    generation_revision: 0,
                     last_consumed_key_package_ref: None,
                     last_consumed_at: None,
                     retained_private_material: Vec::new(),
@@ -810,10 +812,22 @@ where
             .into());
         }
 
-        if lifecycle.pending_replacement.is_none() {
+        if lifecycle
+            .pending_replacement
+            .as_ref()
+            .is_none_or(|pending| pending.generation_revision < KEY_PACKAGE_GENERATION_REVISION)
+        {
             let created_at = Timestamp(
                 lifecycle
                     .authored_event_created_at
+                    .into_iter()
+                    .chain(
+                        lifecycle
+                            .pending_replacement
+                            .as_ref()
+                            .map(|pending| pending.authored_created_at),
+                    )
+                    .max()
                     .map(|previous| previous.0.saturating_add(1))
                     .unwrap_or(now.0)
                     .max(now.0),
@@ -1017,6 +1031,7 @@ where
             cgka_traits::MaintenancePhase::Fanout
         };
         lifecycle.upgrade_rotation_recorded = true;
+        lifecycle.generation_revision = replacement.generation_revision;
         lifecycle.last_consumed_key_package_ref = None;
         lifecycle.last_consumed_at = None;
         let retired = if previous_was_consumed {
@@ -1039,13 +1054,32 @@ where
         Ok(self.session.durably_owned_key_packages()?)
     }
 
+    /// Whether account activation owes a generator-policy upgrade. A pending
+    /// replacement owns the work until ACK; its revision prevents regenerating
+    /// on every retry while the acknowledged current revision is still old.
+    pub fn key_package_generation_upgrade_due(&self) -> AccountResult<bool> {
+        Ok(self
+            .session
+            .key_package_lifecycle()?
+            .is_some_and(|lifecycle| {
+                lifecycle.pending_replacement.as_ref().map_or_else(
+                    || {
+                        lifecycle.current_key_package.is_some()
+                            && lifecycle.generation_revision < KEY_PACKAGE_GENERATION_REVISION
+                    },
+                    |pending| pending.generation_revision < KEY_PACKAGE_GENERATION_REVISION,
+                )
+            }))
+    }
+
     pub fn key_package_network_maintenance_due(&self) -> AccountResult<bool> {
         let now = self.wall_clock.now();
         Ok(match self.session.key_package_lifecycle()? {
             None => true,
             Some(lifecycle) => match lifecycle.pending_replacement.as_ref() {
                 Some(pending) => {
-                    pending.signed_event.is_none()
+                    pending.generation_revision < KEY_PACKAGE_GENERATION_REVISION
+                        || pending.signed_event.is_none()
                         || pending
                             .targets
                             .iter()
@@ -1057,6 +1091,7 @@ where
                             == lifecycle.current_key_package_ref
                         || lifecycle.refresh_at.is_some_and(|deadline| deadline <= now)
                         || !lifecycle.upgrade_rotation_recorded
+                        || lifecycle.generation_revision < KEY_PACKAGE_GENERATION_REVISION
                 }
             },
         })
@@ -1067,7 +1102,8 @@ where
             .session
             .key_package_lifecycle()?
             .is_some_and(|lifecycle| {
-                lifecycle.authored_signed_event.is_some()
+                lifecycle.generation_revision >= KEY_PACKAGE_GENERATION_REVISION
+                    && lifecycle.authored_signed_event.is_some()
                     && lifecycle.publication_targets.iter().any(|target| {
                         matches!(
                             target.state,
@@ -1160,7 +1196,8 @@ where
                     && lifecycle.last_consumed_key_package_ref != lifecycle.current_key_package_ref
                     && (lifecycle.current_key_package.is_none()
                         || lifecycle.refresh_at.is_some_and(|deadline| deadline <= now)
-                        || !lifecycle.upgrade_rotation_recorded)
+                        || !lifecycle.upgrade_rotation_recorded
+                        || lifecycle.generation_revision < KEY_PACKAGE_GENERATION_REVISION)
             }
         })
     }
@@ -4578,7 +4615,9 @@ fn current_key_package_republish_blocker(
         Some("missing_authored_signed_event")
     } else if lifecycle.last_consumed_key_package_ref == lifecycle.current_key_package_ref {
         Some("current_key_package_ref_consumed")
-    } else if !lifecycle.upgrade_rotation_recorded {
+    } else if !lifecycle.upgrade_rotation_recorded
+        || lifecycle.generation_revision < KEY_PACKAGE_GENERATION_REVISION
+    {
         Some("upgrade_rotation_required")
     } else {
         None

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -317,22 +317,24 @@ async fn welcome_for_key_package(
         })
         .await
         .unwrap();
-    match &created.effects.publish[0] {
+    let welcomes = match &created.effects.publish[0] {
         PublishWork::GroupCreated { welcomes, pending } => {
             inviter.confirm_published(*pending).await.unwrap();
             welcomes
-                .iter()
-                .find(|message| {
-                    matches!(
-                        &message.envelope,
-                        TransportEnvelope::Welcome { recipient: addressed } if addressed == recipient
-                    )
-                })
-                .expect("welcome addressed to key package owner")
-                .clone()
         }
-        other => panic!("expected GroupCreated publish work, got {other:?}"),
-    }
+        PublishWork::FoundingGroupCreated { welcomes } => welcomes,
+        _ => panic!("expected group creation publish work"),
+    };
+    welcomes
+        .iter()
+        .find(|message| {
+            matches!(
+                &message.envelope,
+                TransportEnvelope::Welcome { recipient: addressed } if addressed == recipient
+            )
+        })
+        .expect("welcome addressed to key package owner")
+        .clone()
 }
 
 /// MIP-03 self-remove feature registration, mirroring the cgka-session
@@ -669,6 +671,7 @@ impl TransportRoutingPolicy for MismatchedPendingGroupRouting {
 }
 
 include!("runtime/frozen_fanout.rs");
+include!("runtime/key_package_generation_upgrade.rs");
 
 #[derive(Clone, Default)]
 struct RecordingKeyPackages {

--- a/crates/marmot-account/tests/runtime/key_package_generation_upgrade.rs
+++ b/crates/marmot-account/tests/runtime/key_package_generation_upgrade.rs
@@ -81,6 +81,8 @@ async fn key_package_generation_upgrade_retries_across_restart_and_rotates_only_
         Arc::new(TestMonotonicClock::default()),
         Arc::new(TestRandom::new(7)),
     );
+    // Pause still permits completion of this already prepared current-revision artifact.
+    restarted.pause_maintenance();
     restarted.run_due_maintenance().await.unwrap();
     let promoted = restarted.key_package_maintenance_status().unwrap().unwrap();
     assert_eq!(
@@ -201,6 +203,19 @@ async fn key_package_generation_upgrade_supersedes_old_pending_bundles_without_d
         );
         assert!(restarted.key_package_generation_upgrade_due().unwrap());
         assert!(restarted.key_package_network_maintenance_due().unwrap());
+        restarted.pause_maintenance();
+        restarted.run_due_maintenance().await.unwrap();
+        assert_eq!(
+            restarted.key_package_maintenance_status().unwrap(),
+            Some(old.clone()),
+            "paused maintenance must neither replace nor publish obsolete pending material"
+        );
+        assert_eq!(
+            restarted.durably_owned_key_packages().unwrap(),
+            vec![old_pending.key_package.clone()]
+        );
+        assert!(publisher.publications().is_empty());
+        restarted.resume_maintenance();
         restarted.run_due_maintenance().await.unwrap();
         let upgraded = restarted.key_package_maintenance_status().unwrap().unwrap();
         assert_eq!(

--- a/crates/marmot-account/tests/runtime/key_package_generation_upgrade.rs
+++ b/crates/marmot-account/tests/runtime/key_package_generation_upgrade.rs
@@ -1,0 +1,385 @@
+// Generator migrations use actual private bundles and restartable SQLCipher
+// state. Removing the revision fields models the pre-migration JSON format.
+fn without_key_package_generation_revision(
+    lifecycle: &cgka_traits::KeyPackageLifecycleState,
+) -> cgka_traits::KeyPackageLifecycleState {
+    let mut value = serde_json::to_value(lifecycle).unwrap();
+    value.as_object_mut().unwrap().remove("generation_revision");
+    if let Some(pending) = value["pending_replacement"].as_object_mut() {
+        pending.remove("generation_revision");
+    }
+    serde_json::from_value(value).unwrap()
+}
+
+#[tokio::test]
+async fn key_package_generation_upgrade_retries_across_restart_and_rotates_only_once() {
+    use cgka_traits::maintenance::KEY_PACKAGE_GENERATION_REVISION;
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("generation upgrade key").unwrap();
+    let policy = StaticTransportRouting::new(vec![])
+        .key_package_endpoints(vec![TransportEndpoint("wss://keys.example".into())]);
+    let publisher = FlakyKeyPackages::new(0);
+    let wall = Arc::new(TestWallClock::new(50_000));
+    let mut runtime = AccountDeviceRuntime::new(
+        current_session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        policy.clone(),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(7)),
+    );
+    let old_package = runtime.publish_fresh_key_package().await.unwrap();
+    let mut before = without_key_package_generation_revision(
+        &runtime.key_package_maintenance_status().unwrap().unwrap(),
+    );
+    assert!(
+        before.upgrade_rotation_recorded,
+        "the old boolean alone cannot trigger this migration"
+    );
+    assert_eq!(before.generation_revision, 0);
+    before.publication_targets[0].state = cgka_traits::TransportFanoutAttemptState::Unattempted;
+    runtime
+        .session()
+        .put_key_package_lifecycle(&before)
+        .unwrap();
+    assert!(
+        !runtime.key_package_has_pending_fanout().unwrap(),
+        "superseded generator bytes must not fan out"
+    );
+    assert!(runtime.key_package_generation_upgrade_due().unwrap());
+    assert!(runtime.key_package_maintenance_requires_catch_up().unwrap());
+    *publisher.remaining_failures.lock().unwrap() = 1;
+    runtime.run_due_maintenance().await.unwrap();
+    let failed = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        failed.generation_revision, 0,
+        "failure must not complete the migration"
+    );
+    assert_eq!(failed.current_key_package, Some(old_package.clone()));
+    let pending = failed.pending_replacement.unwrap();
+    assert_eq!(pending.generation_revision, KEY_PACKAGE_GENERATION_REVISION);
+    assert_ne!(pending.key_package, old_package);
+    assert!(
+        !runtime.key_package_generation_upgrade_due().unwrap(),
+        "a new pending bundle owns the retry"
+    );
+    drop(runtime);
+
+    wall.set(50_060);
+    let mut restarted = AccountDeviceRuntime::new(
+        current_session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        policy.clone(),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(7)),
+    );
+    restarted.run_due_maintenance().await.unwrap();
+    let promoted = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        promoted.generation_revision,
+        KEY_PACKAGE_GENERATION_REVISION
+    );
+    assert_eq!(
+        promoted.current_key_package,
+        Some(pending.key_package.clone())
+    );
+    assert_eq!(promoted.authored_signed_event, pending.signed_event);
+    assert_eq!(promoted.stable_slot_id, before.stable_slot_id);
+    assert!(promoted.authored_event_created_at > before.authored_event_created_at);
+    assert_eq!(promoted.retained_private_material.len(), 1);
+    assert_eq!(
+        promoted.retained_private_material[0].not_after,
+        before.current_not_after.unwrap()
+    );
+    assert!(
+        restarted
+            .durably_owned_key_packages()
+            .unwrap()
+            .contains(&old_package)
+    );
+    assert_eq!(
+        publisher.publications()[1],
+        publisher.publications()[2],
+        "retry must reuse exact publication intent"
+    );
+
+    // An invitation prepared using the previous package still joins after ACK.
+    let mut bob = current_session(dir.path().join("bob.sqlite"), &key, b"bob");
+    let welcome = welcome_for_key_package(
+        &mut bob,
+        &restarted.session().self_id(),
+        old_package,
+        "late invite",
+    )
+    .await;
+    let joined = restarted.session_mut().ingest(welcome).await.unwrap();
+    assert!(!matches!(
+        joined.outcome,
+        cgka_traits::IngestOutcome::Ignored { .. }
+    ));
+    drop(restarted);
+    let mut reopened = AccountDeviceRuntime::new(
+        current_session(database, &key, b"alice"),
+        RecordingAdapter::default(),
+        policy,
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(7)),
+    );
+    assert!(!reopened.key_package_generation_upgrade_due().unwrap());
+    reopened.run_due_maintenance().await.unwrap();
+    assert_eq!(
+        publisher.publications().len(),
+        3,
+        "reopening must not rotate the upgraded package again"
+    );
+}
+
+#[tokio::test]
+async fn key_package_generation_upgrade_supersedes_old_pending_bundles_without_deleting_them() {
+    use cgka_traits::maintenance::KEY_PACKAGE_GENERATION_REVISION;
+    for signed in [false, true] {
+        let dir = tempfile::tempdir().unwrap();
+        let database = dir.path().join("alice.sqlite");
+        let key = SqlCipherKey::new("pending generation upgrade key").unwrap();
+        let policy = StaticTransportRouting::new(vec![])
+            .key_package_endpoints(vec![TransportEndpoint("wss://keys.example".into())]);
+        let publisher = RecordingKeyPackages::default();
+        let wall = Arc::new(TestWallClock::new(50_000));
+        let mut runtime = AccountDeviceRuntime::new(
+            current_session(database.clone(), &key, b"alice"),
+            RecordingAdapter::default(),
+            policy.clone(),
+            publisher.clone(),
+        )
+        .with_maintenance_sources(
+            wall.clone(),
+            Arc::new(TestMonotonicClock::default()),
+            Arc::new(TestRandom::new(7)),
+        );
+        runtime
+            .prepare_fresh_key_package(
+                TransportRoutingPolicy::key_package_endpoints(&policy).to_vec(),
+            )
+            .await
+            .unwrap();
+        let mut old = without_key_package_generation_revision(
+            &runtime.key_package_maintenance_status().unwrap().unwrap(),
+        );
+        let pending = old.pending_replacement.as_mut().unwrap();
+        if !signed {
+            pending.signed_event = None;
+        }
+        // Simulate a possible-exposure failure whose retry is not due yet.
+        pending.targets[0].state = cgka_traits::TransportFanoutAttemptState::AttemptedFailed;
+        pending.targets[0].last_attempt_at = Some(Timestamp(50_000));
+        pending.targets[0].attempt_count = 1;
+        let old_pending = pending.clone();
+        runtime.session().put_key_package_lifecycle(&old).unwrap();
+        drop(runtime);
+        let mut restarted = AccountDeviceRuntime::new(
+            current_session(database, &key, b"alice"),
+            RecordingAdapter::default(),
+            policy,
+            publisher.clone(),
+        )
+        .with_maintenance_sources(
+            wall,
+            Arc::new(TestMonotonicClock::default()),
+            Arc::new(TestRandom::new(7)),
+        );
+        assert!(restarted.key_package_generation_upgrade_due().unwrap());
+        assert!(restarted.key_package_network_maintenance_due().unwrap());
+        restarted.run_due_maintenance().await.unwrap();
+        let upgraded = restarted.key_package_maintenance_status().unwrap().unwrap();
+        assert_eq!(
+            upgraded.generation_revision,
+            KEY_PACKAGE_GENERATION_REVISION
+        );
+        assert_ne!(
+            upgraded.current_key_package,
+            Some(old_pending.key_package.clone())
+        );
+        assert_eq!(upgraded.authored_event_created_at, Some(Timestamp(50_001)));
+        assert_eq!(upgraded.stable_slot_id, old.stable_slot_id);
+        assert_eq!(
+            upgraded.retained_private_material[0].key_package,
+            old_pending.key_package
+        );
+        assert_eq!(
+            upgraded.retained_private_material[0].not_after,
+            old_pending.not_after
+        );
+        assert!(
+            restarted
+                .durably_owned_key_packages()
+                .unwrap()
+                .contains(&old_pending.key_package)
+        );
+        assert_eq!(
+            publisher.publications().len(),
+            1,
+            "old pending artifact must never be republished"
+        );
+        let package = upgraded.current_key_package.unwrap();
+        let metadata = cgka_engine::key_package::key_package_metadata(&package).unwrap();
+        assert!(
+            metadata
+                .mls_extensions
+                .iter()
+                .all(|id| !(1..=5).contains(id))
+        );
+        assert!(
+            metadata
+                .mls_proposals
+                .iter()
+                .all(|id| !(1..=7).contains(id))
+        );
+    }
+}
+
+#[derive(Clone, Default)]
+struct UpgradeAckKeyPackages(PartialFanoutKeyPackages);
+
+#[async_trait]
+impl KeyPackagePublisher for UpgradeAckKeyPackages {
+    async fn prepare_key_package(
+        &self,
+        publication: KeyPackagePublication,
+    ) -> Result<cgka_traits::SignedPublicationArtifact, KeyPackagePublishError> {
+        Ok(test_key_package_artifact(&publication))
+    }
+
+    async fn publish_prepared_key_package(
+        &self,
+        publication: &KeyPackagePublication,
+        artifact: &cgka_traits::SignedPublicationArtifact,
+    ) -> Result<KeyPackagePublishReceipt, KeyPackagePublishError> {
+        let mut calls = self.0.publications.lock().unwrap();
+        calls.push((publication.clone(), artifact.clone()));
+        let accepted_count = match calls.len() {
+            1 => 0,
+            2 => 1,
+            _ => publication.endpoints.len(),
+        };
+        Ok(KeyPackagePublishReceipt {
+            accepted: publication
+                .endpoints
+                .iter()
+                .take(accepted_count)
+                .cloned()
+                .collect(),
+            failed: publication
+                .endpoints
+                .iter()
+                .skip(accepted_count)
+                .cloned()
+                .collect(),
+        })
+    }
+}
+
+#[tokio::test]
+async fn key_package_generation_upgrade_requires_ack_and_resumes_remaining_fanout() {
+    use cgka_traits::maintenance::KEY_PACKAGE_GENERATION_REVISION;
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("generation upgrade ack key").unwrap();
+    let policy = StaticTransportRouting::new(vec![]).key_package_endpoints(vec![
+        TransportEndpoint("wss://keys-a.example".into()),
+        TransportEndpoint("wss://keys-b.example".into()),
+    ]);
+    let mut initial = AccountDeviceRuntime::new(
+        current_session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        policy.clone(),
+        RecordingKeyPackages::default(),
+    );
+    initial.publish_fresh_key_package().await.unwrap();
+    let old = without_key_package_generation_revision(
+        &initial.key_package_maintenance_status().unwrap().unwrap(),
+    );
+    initial.session().put_key_package_lifecycle(&old).unwrap();
+    drop(initial);
+    // Use the actual authoring time to stay within the monotonic event skew guard.
+    let now = old.authored_event_created_at.unwrap().0;
+    let wall = Arc::new(TestWallClock::new(now));
+    let publisher = UpgradeAckKeyPackages::default();
+    let mut runtime = AccountDeviceRuntime::new(
+        current_session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        policy.clone(),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(7)),
+    );
+    runtime.run_due_maintenance().await.unwrap();
+    let unacknowledged = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(unacknowledged.generation_revision, 0);
+    assert_eq!(
+        unacknowledged.current_key_package_ref,
+        old.current_key_package_ref
+    );
+    let replacement = unacknowledged.pending_replacement.unwrap();
+    wall.set(now + 60);
+    runtime.run_due_maintenance().await.unwrap();
+    let acknowledged = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        acknowledged.generation_revision,
+        KEY_PACKAGE_GENERATION_REVISION
+    );
+    assert_eq!(
+        acknowledged.current_key_package_ref,
+        Some(replacement.key_package_ref.clone())
+    );
+    assert!(runtime.key_package_has_pending_fanout().unwrap());
+    assert_eq!(publisher.0.publications()[0], publisher.0.publications()[1]);
+    drop(runtime);
+    wall.set(now + 180);
+    let mut restarted = AccountDeviceRuntime::new(
+        current_session(database, &key, b"alice"),
+        RecordingAdapter::default(),
+        policy,
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(7)),
+    );
+    restarted.run_due_maintenance().await.unwrap();
+    let finished = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        finished.generation_revision,
+        KEY_PACKAGE_GENERATION_REVISION
+    );
+    assert_eq!(
+        finished.current_key_package_ref,
+        Some(replacement.key_package_ref)
+    );
+    assert!(!restarted.key_package_has_pending_fanout().unwrap());
+    let calls = publisher.0.publications();
+    assert_eq!(calls.len(), 3);
+    assert_eq!(
+        calls[2].1, calls[0].1,
+        "fanout after restart must reuse the upgraded artifact"
+    );
+    assert_eq!(
+        calls[2].0.endpoints,
+        vec![TransportEndpoint("wss://keys-b.example".into())]
+    );
+}

--- a/crates/marmot-app/README.md
+++ b/crates/marmot-app/README.md
@@ -86,7 +86,13 @@ strangers; the final action reuses discovery routes but fetches packages again b
 also applies to another account on the same installation: its local package record is not an invitation shortcut,
 and its published package must be reachable on relays. Relay freshness is not proof that the recipient still owns
 private material; it avoids authorizing from a stale local copy. Each prewarm call requests a fresh readiness signal,
-so hosts should debounce roster changes. The process-local prewarm cache retains only bounded relay metadata.
+so hosts should debounce roster changes. The process-local prewarm cache retains only bounded relay metadata;
+only completed discovery and advertised-outbox metadata hops can renew its freshness deadline. A usable package
+returned after an incomplete metadata hop does not make previously cached routes fresh.
+
+Directory diagnostics (`key-package check` / `fetch`) may still describe cached public packages. Their availability
+result is advisory and does not guarantee a fresh relay lookup or acceptance by the Create/Invite admission policy.
+
 New Nostr-routed groups generate
 `marmot.transport.nostr.routing.v1` at creation, store the component bytes in
 signed MLS app data, and project the decoded `nostr_group_id` plus relay list into group subscriptions and publish

--- a/crates/marmot-app/README.md
+++ b/crates/marmot-app/README.md
@@ -82,7 +82,11 @@ Group creation and invites still take pubkeys at the action boundary. The app ca
 requested roster and fetches current KeyPackages in bounded multi-author relay batches before building the MLS add.
 Cached packages remain useful for discovery, but cannot authorize an invitation or substitute for a failed relay
 lookup. Hosts may prewarm that same bounded composition lookup without reserving packages or durably admitting
-strangers; the final action reuses discovery routes but fetches packages again before the mutation validates them.
+strangers; the final action reuses discovery routes but fetches packages again before the mutation validates them. This
+also applies to another account on the same installation: its local package record is not an invitation shortcut,
+and its published package must be reachable on relays. Relay freshness is not proof that the recipient still owns
+private material; it avoids authorizing from a stale local copy. Each prewarm call requests a fresh readiness signal,
+so hosts should debounce roster changes. The process-local prewarm cache retains only bounded relay metadata.
 New Nostr-routed groups generate
 `marmot.transport.nostr.routing.v1` at creation, store the component bytes in
 signed MLS app data, and project the decoded `nostr_group_id` plus relay list into group subscriptions and publish

--- a/crates/marmot-app/README.md
+++ b/crates/marmot-app/README.md
@@ -79,9 +79,11 @@ separate cache reads, membership, provider response, profile hydration, and netw
 queries or identities.
 
 Group creation and invites still take pubkeys at the action boundary. The app canonicalizes and deduplicates the
-requested roster, reuses current cached KeyPackages, and resolves cold members in bounded multi-author relay batches
-before building the MLS add. Hosts may prewarm that same bounded composition lookup without reserving packages or
-durably admitting strangers; the final mutation revalidates every package. New Nostr-routed groups generate
+requested roster and fetches current KeyPackages in bounded multi-author relay batches before building the MLS add.
+Cached packages remain useful for discovery, but cannot authorize an invitation or substitute for a failed relay
+lookup. Hosts may prewarm that same bounded composition lookup without reserving packages or durably admitting
+strangers; the final action reuses discovery routes but fetches packages again before the mutation validates them.
+New Nostr-routed groups generate
 `marmot.transport.nostr.routing.v1` at creation, store the component bytes in
 signed MLS app data, and project the decoded `nostr_group_id` plus relay list into group subscriptions and publish
 targets.

--- a/crates/marmot-app/src/app_telemetry.rs
+++ b/crates/marmot-app/src/app_telemetry.rs
@@ -60,7 +60,6 @@ pub(crate) enum AppPerformanceOperation {
     GroupCreateQueueWait,
     GroupCreateKeyPackageLookup,
     GroupMemberKeyPackagePrewarm,
-    GroupCreateKeyPackageCacheReuse,
     GroupCreateKeyPackageNetworkResolution,
     GroupCreateImagePreprocess,
     GroupCreateImageUpload,
@@ -318,6 +317,7 @@ pub struct AppPerformanceSnapshot {
     #[serde(default)]
     pub group_member_key_package_prewarm: AppPerformanceOperationSnapshot,
     #[serde(default)]
+    /// Retired counter retained for export/API compatibility; no new samples.
     pub group_create_key_package_cache_reuse: AppPerformanceOperationSnapshot,
     #[serde(default)]
     pub group_create_key_package_network_resolution: AppPerformanceOperationSnapshot,
@@ -811,11 +811,6 @@ impl AppPerformanceTelemetry {
             AppPerformanceOperation::GroupMemberKeyPackagePrewarm => {
                 inner
                     .group_member_key_package_prewarm
-                    .record(duration, success);
-            }
-            AppPerformanceOperation::GroupCreateKeyPackageCacheReuse => {
-                inner
-                    .group_create_key_package_cache_reuse
                     .record(duration, success);
             }
             AppPerformanceOperation::GroupCreateKeyPackageNetworkResolution => {
@@ -1502,7 +1497,6 @@ mod tests {
             AppPerformanceOperation::GroupCreateQueueWait,
             AppPerformanceOperation::GroupCreateKeyPackageLookup,
             AppPerformanceOperation::GroupMemberKeyPackagePrewarm,
-            AppPerformanceOperation::GroupCreateKeyPackageCacheReuse,
             AppPerformanceOperation::GroupCreateKeyPackageNetworkResolution,
             AppPerformanceOperation::GroupCreateImagePreprocess,
             AppPerformanceOperation::GroupCreateImageUpload,
@@ -1520,11 +1514,11 @@ mod tests {
         }
 
         let snapshot = telemetry.snapshot();
+        assert_eq!(snapshot.group_create_key_package_cache_reuse.attempts, 0);
         for stage in [
             snapshot.group_create_queue_wait,
             snapshot.group_create_key_package_lookup,
             snapshot.group_member_key_package_prewarm,
-            snapshot.group_create_key_package_cache_reuse,
             snapshot.group_create_key_package_network_resolution,
             snapshot.group_create_image_preprocess,
             snapshot.group_create_image_upload,

--- a/crates/marmot-app/src/app_telemetry.rs
+++ b/crates/marmot-app/src/app_telemetry.rs
@@ -316,8 +316,8 @@ pub struct AppPerformanceSnapshot {
     pub group_create_key_package_lookup: AppPerformanceOperationSnapshot,
     #[serde(default)]
     pub group_member_key_package_prewarm: AppPerformanceOperationSnapshot,
-    #[serde(default)]
     /// Retired counter retained for export/API compatibility; no new samples.
+    #[serde(default)]
     pub group_create_key_package_cache_reuse: AppPerformanceOperationSnapshot,
     #[serde(default)]
     pub group_create_key_package_network_resolution: AppPerformanceOperationSnapshot,

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -1529,16 +1529,14 @@ impl AppClient {
             key_packages.is_ok(),
         );
         let resolved = key_packages?;
-        record_app_performance(
-            telemetry,
-            if resolved.stats.network_resolved_members == 0 {
-                AppPerformanceOperation::GroupCreateKeyPackageCacheReuse
-            } else {
-                AppPerformanceOperation::GroupCreateKeyPackageNetworkResolution
-            },
-            key_package_elapsed,
-            true,
-        );
+        if resolved.stats.unique_members > 0 {
+            record_app_performance(
+                telemetry,
+                AppPerformanceOperation::GroupCreateKeyPackageNetworkResolution,
+                key_package_elapsed,
+                true,
+            );
+        }
         let members = resolved.key_packages;
         self.refresh_routing()?;
         let nostr_routing = self.app.new_nostr_routing()?;

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -1183,9 +1183,9 @@ impl AppClient {
         Ok(self.runtime.publish_fresh_key_package().await?)
     }
 
-    /// Resolve and cache the current composition roster without reserving or
-    /// consuming any KeyPackage. Group creation revalidates the cached bytes
-    /// and the MLS mutation boundary retains its ordinary validation.
+    /// Fetch current relay KeyPackages for the composition roster without
+    /// reserving or consuming them. Group creation fetches again before the
+    /// MLS mutation; cached packages only inform discovery.
     pub async fn prewarm_group_member_key_packages(
         &self,
         member_refs: &[&str],

--- a/crates/marmot-app/src/directory/member_key_packages.rs
+++ b/crates/marmot-app/src/directory/member_key_packages.rs
@@ -21,8 +21,8 @@ use transport_nostr_adapter::{
 };
 
 use crate::key_package_records::{
-    fresh_or_cached_key_package, fresh_relay_list_status_from_records,
-    latest_fresh_key_package_from_records, merge_relay_list_status,
+    fresh_relay_list_status_from_records, latest_fresh_key_package_from_records,
+    merge_relay_list_status,
 };
 use crate::relay_plane::{DirectoryEventQuery, DirectoryFetchOutcome};
 use crate::{AccountRelayListStatus, AppError, FetchedKeyPackage, MarmotApp};
@@ -45,7 +45,7 @@ const MEMBER_PREWARM_CACHE_TTL: Duration = Duration::from_secs(5 * 60);
 
 #[derive(Clone)]
 struct MemberKeyPackagePrewarmEntry {
-    fetched: FetchedKeyPackage,
+    relay_lists: AccountRelayListStatus,
     inserted_at: Instant,
 }
 
@@ -53,24 +53,11 @@ struct MemberKeyPackagePrewarmEntry {
 mod tests {
     use super::*;
 
-    fn fetched(account_id_hex: String) -> FetchedKeyPackage {
-        FetchedKeyPackage {
-            account_id_hex,
-            key_package: KeyPackage::new(vec![1]),
-            key_package_id: "slot".to_owned(),
-            key_package_ref_hex: "ref".to_owned(),
-            key_package_event_id: String::new(),
-            created_at: 1,
-            source_relays: Vec::new(),
-            relay_lists: AccountRelayListStatus::empty(),
-        }
-    }
-
     #[test]
     fn composition_prewarm_cache_is_bounded_and_expires_entries() {
         let mut cache = MemberKeyPackagePrewarmCache::default();
         for index in 0..=MEMBER_PREWARM_CACHE_LIMIT {
-            cache.insert(fetched(format!("{index:064x}")));
+            cache.insert(format!("{index:064x}"), AccountRelayListStatus::empty());
         }
         assert_eq!(cache.entries.len(), MEMBER_PREWARM_CACHE_LIMIT);
         assert!(cache.get(&format!("{:064x}", 0)).is_none());
@@ -80,20 +67,6 @@ mod tests {
             Instant::now() - MEMBER_PREWARM_CACHE_TTL - Duration::from_secs(1);
         assert!(cache.get(&newest).is_none());
         assert!(!cache.order.contains(&newest));
-    }
-
-    #[test]
-    fn package_refresh_does_not_renew_routes_that_expired_during_fetch() {
-        let mut cache = MemberKeyPackagePrewarmCache::default();
-        let id = "01".repeat(32);
-        cache.insert(fetched(id.clone()));
-        cache.entries.get_mut(&id).unwrap().inserted_at =
-            Instant::now() - MEMBER_PREWARM_CACHE_TTL - Duration::from_secs(1);
-        cache.insert(fetched(id.clone()));
-        assert!(
-            cache.get(&id).is_none(),
-            "the next lookup must refresh expired routes"
-        );
     }
 
     #[tokio::test]
@@ -135,31 +108,23 @@ pub(crate) struct MemberKeyPackagePrewarmCache {
 }
 
 impl MemberKeyPackagePrewarmCache {
-    fn get(&mut self, account_id_hex: &str) -> Option<FetchedKeyPackage> {
+    fn get(&mut self, account_id_hex: &str) -> Option<AccountRelayListStatus> {
         self.remove_expired();
         self.entries
             .get(account_id_hex)
-            .map(|entry| entry.fetched.clone())
+            .map(|entry| entry.relay_lists.clone())
     }
 
-    fn insert(&mut self, fetched: FetchedKeyPackage) {
-        let account_id_hex = fetched.account_id_hex.clone();
-        // Refreshing package bytes does not prove that reused relay routes are
-        // fresh. Preserve their original deadline until the entry expires and
-        // the resolver performs discovery again.
-        let inserted_at = self
-            .entries
-            .get(&account_id_hex)
-            .map(|entry| entry.inserted_at)
-            .unwrap_or_else(Instant::now);
+    /// Insert freshly discovered routes, never a package-refresh result.
+    fn insert(&mut self, account_id_hex: String, relay_lists: AccountRelayListStatus) {
         self.remove_expired();
         self.order.retain(|existing| existing != &account_id_hex);
         self.order.push_back(account_id_hex.clone());
         self.entries.insert(
             account_id_hex,
             MemberKeyPackagePrewarmEntry {
-                fetched,
-                inserted_at,
+                relay_lists,
+                inserted_at: Instant::now(),
             },
         );
         while self.entries.len() > MEMBER_PREWARM_CACHE_LIMIT {
@@ -167,14 +132,6 @@ impl MemberKeyPackagePrewarmCache {
                 break;
             };
             self.entries.remove(&oldest);
-        }
-    }
-
-    /// Keep relay readiness discovered after the KeyPackage was cached in sync
-    /// with the process-local prewarm entry.
-    fn update_relay_lists(&mut self, account_id_hex: &str, relay_lists: &AccountRelayListStatus) {
-        if let Some(entry) = self.entries.get_mut(account_id_hex) {
-            entry.fetched.relay_lists = relay_lists.clone();
         }
     }
 
@@ -212,8 +169,6 @@ pub struct MemberKeyPackagePrewarmSummary {
 pub(crate) struct MemberKeyPackageResolutionStats {
     pub(crate) requested_members: usize,
     pub(crate) unique_members: usize,
-    pub(crate) reused_members: usize,
-    pub(crate) network_resolved_members: usize,
 }
 
 impl From<MemberKeyPackageResolutionStats> for MemberKeyPackagePrewarmSummary {
@@ -221,8 +176,8 @@ impl From<MemberKeyPackageResolutionStats> for MemberKeyPackagePrewarmSummary {
         Self {
             requested_members: stats.requested_members as u64,
             unique_members: stats.unique_members as u64,
-            reused_members: stats.reused_members as u64,
-            network_resolved_members: stats.network_resolved_members as u64,
+            reused_members: 0,
+            network_resolved_members: stats.unique_members as u64,
         }
     }
 }
@@ -287,8 +242,9 @@ impl MarmotApp {
     ///
     /// The roster must also resolve a safe Marmot inbox route for every member;
     /// missing routes return [`AppError::MissingMemberInboxRoute`]. Successfully
-    /// fetched packages and relay metadata remain cached even when another
-    /// member fails readiness. A later create call can reuse discovery routes,
+    /// discovered routes remain cached even when another member fails readiness.
+    /// Every call fetches packages for a fresh readiness signal; hosts should
+    /// debounce composition changes. A later create call can reuse discovery routes,
     /// but fetches KeyPackages again because prewarmed material may have been
     /// consumed in the meantime.
     pub async fn prewarm_group_member_key_packages(
@@ -388,9 +344,7 @@ impl MarmotApp {
         // Even a valid, unexpired cached package may have been consumed on
         // another device. Every purpose, including composition prewarm, must
         // fetch current relay publications; only discovery routes are reused.
-        let unresolved = (0..targets.len()).collect::<Vec<_>>();
         let mut fresh_prewarmed_routes = HashSet::new();
-        let reused_members = 0;
         for (index, target) in targets.iter_mut().enumerate() {
             // Recovery deliberately refreshes routes as well as packages.
             if purpose == MemberResolutionPurpose::CommitFresh {
@@ -401,9 +355,9 @@ impl MarmotApp {
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .get(&target.account_id_hex);
-            if let Some(fetched) = prefetched {
+            if let Some(relay_lists) = prefetched {
                 target.relay_lists =
-                    merge_relay_list_status(target.relay_lists.clone(), fetched.relay_lists);
+                    merge_relay_list_status(target.relay_lists.clone(), relay_lists);
                 target.cached_relay_lists = target.relay_lists.clone();
                 if !target.relay_lists.nip65.relays.is_empty()
                     && !self
@@ -439,38 +393,25 @@ impl MarmotApp {
                 outcomes[index] = Some(Err(error));
             }
         }
-        if !unresolved.is_empty() {
-            let key_package_unresolved = unresolved
-                .iter()
-                .copied()
-                .filter(|index| outcomes[*index].is_none())
-                .collect::<Vec<_>>();
-            self.resolve_missing_key_packages(
-                &targets,
-                &key_package_unresolved,
-                &mut outcomes,
-                purpose,
-            )
-            .await;
-        }
+        let key_package_unresolved = (0..targets.len())
+            .filter(|index| outcomes[*index].is_none())
+            .collect::<Vec<_>>();
+        self.resolve_missing_key_packages(
+            &targets,
+            &key_package_unresolved,
+            &mut outcomes,
+            purpose,
+        )
+        .await;
 
         if let Some(observation) = directory_observation {
-            let unresolved: HashSet<_> = unresolved.iter().copied().collect();
-            for (index, outcome) in outcomes.iter().enumerate() {
+            for outcome in &outcomes {
                 let outcome = match outcome {
                     Some(Ok(_)) => "success",
                     Some(Err(AppError::MissingKeyPackage(_))) | None => "empty",
                     Some(Err(_)) => "failure",
                 };
-                observation.directory_sample(
-                    outcome,
-                    if unresolved.contains(&index) {
-                        "network"
-                    } else {
-                        "cache"
-                    },
-                    1,
-                );
+                observation.directory_sample(outcome, "network", 1);
             }
         }
         match purpose {
@@ -493,8 +434,14 @@ impl MarmotApp {
                     .member_key_package_prewarm_cache
                     .lock()
                     .unwrap_or_else(|poisoned| poisoned.into_inner());
-                for target in &targets {
-                    cache.update_relay_lists(&target.account_id_hex, &target.relay_lists);
+                for (index, target) in targets.iter().enumerate() {
+                    // Only new discovery renews the route deadline. A package
+                    // fetch through reused routes says nothing about their age.
+                    if !fresh_prewarmed_routes.contains(&index)
+                        && matches!(outcomes[index], Some(Ok(_)))
+                    {
+                        cache.insert(target.account_id_hex.clone(), target.relay_lists.clone());
+                    }
                 }
             }
         }
@@ -533,13 +480,11 @@ impl MarmotApp {
             stats: MemberKeyPackageResolutionStats {
                 requested_members: member_refs.len(),
                 unique_members: targets.len(),
-                reused_members,
-                network_resolved_members: unresolved.len(),
             },
         })
     }
 
-    fn accept_prefetched_key_package(
+    fn accept_fetched_key_package(
         &self,
         purpose: MemberResolutionPurpose,
         fetched: FetchedKeyPackage,
@@ -552,11 +497,7 @@ impl MarmotApp {
             MemberResolutionPurpose::Commit | MemberResolutionPurpose::CommitFresh => {
                 self.remember_directory_key_package(&fetched)?
             }
-            MemberResolutionPurpose::Prewarm => self
-                .member_key_package_prewarm_cache
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .insert(fetched),
+            MemberResolutionPurpose::Prewarm => {}
         }
         Ok(key_package)
     }
@@ -907,12 +848,15 @@ impl MarmotApp {
                     account_records,
                     self.directory_freshness(),
                 )
-                .and_then(|selection| fresh_or_cached_key_package(account_id, selection, None));
+                .and_then(|selection| {
+                    selection
+                        .value
+                        .ok_or_else(|| AppError::MissingKeyPackage(account_id.clone()))
+                });
                 match selected {
                     Ok(mut fetched) => {
                         fetched.relay_lists = targets[index].relay_lists.clone();
-                        outcomes[index] =
-                            Some(self.accept_prefetched_key_package(purpose, fetched));
+                        outcomes[index] = Some(self.accept_fetched_key_package(purpose, fetched));
                     }
                     Err(_) => fallback.push(index),
                 }
@@ -961,15 +905,15 @@ impl MarmotApp {
                             .map_err(|error| {
                                 AppError::RelayDirectory(format!("fetch key packages: {error}"))
                             })?;
-                        let mut fetched = fresh_or_cached_key_package(
+                        let mut fetched = latest_fresh_key_package_from_records(
                             &target.account_id_hex,
-                            latest_fresh_key_package_from_records(
-                                &target.account_id_hex,
-                                records,
-                                app.directory_freshness(),
-                            )?,
-                            None,
-                        )?;
+                            records,
+                            app.directory_freshness(),
+                        )?
+                        .value
+                        .ok_or_else(|| {
+                            AppError::MissingKeyPackage(target.account_id_hex.clone())
+                        })?;
                         fetched.relay_lists = target.relay_lists;
                         Ok::<_, AppError>(fetched)
                     }
@@ -982,9 +926,8 @@ impl MarmotApp {
             .collect::<Vec<_>>()
             .await;
         for (index, result) in fallback_results {
-            outcomes[index] = Some(
-                result.and_then(|fetched| self.accept_prefetched_key_package(purpose, fetched)),
-            );
+            outcomes[index] =
+                Some(result.and_then(|fetched| self.accept_fetched_key_package(purpose, fetched)));
         }
     }
 }

--- a/crates/marmot-app/src/directory/member_key_packages.rs
+++ b/crates/marmot-app/src/directory/member_key_packages.rs
@@ -2,10 +2,10 @@
 //!
 //! The create and invite paths know the whole requested roster before they
 //! mutate MLS state. Resolve that set as a set: canonicalize aliases, collapse
-//! duplicate account ids, reuse validated local/directory entries, and batch
-//! cold relay work by compatible endpoint set. The legacy one-member resolver
-//! remains the bounded fallback for relay/query shapes that do not support a
-//! multi-author request.
+//! duplicate account ids, reuse discovery routes, and fetch current KeyPackages
+//! from relays before every invitation. Cached packages are discovery hints, not
+//! evidence that a recipient still owns the private bundle. Unsupported batch
+//! queries fall back to bounded single-author relay requests.
 
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -22,7 +22,7 @@ use transport_nostr_adapter::{
 
 use crate::key_package_records::{
     fresh_or_cached_key_package, fresh_relay_list_status_from_records,
-    latest_fresh_key_package_from_records, merge_relay_list_status, validated_cached_key_package,
+    latest_fresh_key_package_from_records, merge_relay_list_status,
 };
 use crate::relay_plane::{DirectoryEventQuery, DirectoryFetchOutcome};
 use crate::{AccountRelayListStatus, AppError, FetchedKeyPackage, MarmotApp};
@@ -82,8 +82,22 @@ mod tests {
         assert!(!cache.order.contains(&newest));
     }
 
+    #[test]
+    fn package_refresh_does_not_renew_routes_that_expired_during_fetch() {
+        let mut cache = MemberKeyPackagePrewarmCache::default();
+        let id = "01".repeat(32);
+        cache.insert(fetched(id.clone()));
+        cache.entries.get_mut(&id).unwrap().inserted_at =
+            Instant::now() - MEMBER_PREWARM_CACHE_TTL - Duration::from_secs(1);
+        cache.insert(fetched(id.clone()));
+        assert!(
+            cache.get(&id).is_none(),
+            "the next lookup must refresh expired routes"
+        );
+    }
+
     #[tokio::test]
-    async fn composition_prewarm_reuse_preserves_original_freshness_deadline() {
+    async fn composition_prewarm_route_reuse_preserves_original_freshness_deadline() {
         let (_directory, app, accounts, _fetcher) =
             crate::tests::member_resolution_fixture(1, false).await;
         let id = &accounts[0].account_id_hex;
@@ -100,6 +114,9 @@ mod tests {
             .inserted_at = original;
         for _ in 0..3 {
             app.prewarm_group_member_key_packages(&[id.as_str()])
+                .await
+                .unwrap();
+            app.resolve_member_key_packages(&[id.as_str()])
                 .await
                 .unwrap();
         }
@@ -126,15 +143,23 @@ impl MemberKeyPackagePrewarmCache {
     }
 
     fn insert(&mut self, fetched: FetchedKeyPackage) {
-        self.remove_expired();
         let account_id_hex = fetched.account_id_hex.clone();
+        // Refreshing package bytes does not prove that reused relay routes are
+        // fresh. Preserve their original deadline until the entry expires and
+        // the resolver performs discovery again.
+        let inserted_at = self
+            .entries
+            .get(&account_id_hex)
+            .map(|entry| entry.inserted_at)
+            .unwrap_or_else(Instant::now);
+        self.remove_expired();
         self.order.retain(|existing| existing != &account_id_hex);
         self.order.push_back(account_id_hex.clone());
         self.entries.insert(
             account_id_hex,
             MemberKeyPackagePrewarmEntry {
                 fetched,
-                inserted_at: Instant::now(),
+                inserted_at,
             },
         );
         while self.entries.len() > MEMBER_PREWARM_CACHE_LIMIT {
@@ -176,8 +201,8 @@ pub struct MemberKeyPackagePrewarmSummary {
     pub requested_members: u64,
     /// Canonical account ids after aliases and duplicates are collapsed.
     pub unique_members: u64,
-    /// Packages satisfied by validated local state, durable directory state,
-    /// or the process-local prewarm cache.
+    /// Retained for API compatibility; always zero because packages must be
+    /// fetched from relays. Discovery routes may still be reused.
     pub reused_members: u64,
     /// Packages that required relay resolution during this call.
     pub network_resolved_members: u64,
@@ -205,7 +230,6 @@ impl From<MemberKeyPackageResolutionStats> for MemberKeyPackagePrewarmSummary {
 #[derive(Clone)]
 struct MemberTarget {
     account_id_hex: String,
-    local_label: Option<String>,
     relay_lists: AccountRelayListStatus,
     cached_relay_lists: AccountRelayListStatus,
     relay_records: Vec<crate::relay_plane::DirectoryRelayEventRecord>,
@@ -226,9 +250,10 @@ impl MarmotApp {
     /// Resolve a roster as one deterministic set.
     ///
     /// Account aliases are canonicalized and duplicate account ids collapse to
-    /// their first input position. On error, the error belonging to the first
-    /// unresolved canonical member is returned even if later relay work
-    /// completed earlier.
+    /// their first input position. Every package is fetched from relays; cached
+    /// packages are never a fallback if that lookup fails. On error, the error
+    /// belonging to the first unresolved canonical member is returned even if
+    /// later relay work completed earlier.
     pub async fn resolve_member_key_packages(
         &self,
         member_refs: &[&str],
@@ -263,9 +288,9 @@ impl MarmotApp {
     /// The roster must also resolve a safe Marmot inbox route for every member;
     /// missing routes return [`AppError::MissingMemberInboxRoute`]. Successfully
     /// fetched packages and relay metadata remain cached even when another
-    /// member fails readiness. A later create call re-reads and validates the
-    /// cached bytes, and the MLS mutation boundary still performs its ordinary
-    /// lifetime/single-use validation.
+    /// member fails readiness. A later create call can reuse discovery routes,
+    /// but fetches KeyPackages again because prewarmed material may have been
+    /// consumed in the meantime.
     pub async fn prewarm_group_member_key_packages(
         &self,
         member_refs: &[&str],
@@ -351,7 +376,6 @@ impl MarmotApp {
                 .unwrap_or_else(AccountRelayListStatus::empty);
             targets.push(MemberTarget {
                 account_id_hex,
-                local_label: local.map(|account| account.label),
                 relay_lists: relay_lists.clone(),
                 cached_relay_lists: relay_lists,
                 relay_records: Vec::new(),
@@ -361,32 +385,15 @@ impl MarmotApp {
         let mut outcomes = (0..targets.len())
             .map(|_| None)
             .collect::<Vec<Option<Result<KeyPackage, AppError>>>>();
-        let mut unresolved = Vec::new();
+        // Even a valid, unexpired cached package may have been consumed on
+        // another device. Every purpose, including composition prewarm, must
+        // fetch current relay publications; only discovery routes are reused.
+        let unresolved = (0..targets.len()).collect::<Vec<_>>();
         let mut fresh_prewarmed_routes = HashSet::new();
-        let mut reused_members = 0usize;
+        let reused_members = 0;
         for (index, target) in targets.iter_mut().enumerate() {
+            // Recovery deliberately refreshes routes as well as packages.
             if purpose == MemberResolutionPurpose::CommitFresh {
-                unresolved.push(index);
-                continue;
-            }
-            if let Some(label) = &target.local_label
-                && let Some(key_package) = self.validated_current_local_key_package(label)
-                && let Ok(key_package) =
-                    self.validate_member_key_package_current(&target.account_id_hex, key_package)
-            {
-                outcomes[index] = Some(Ok(key_package));
-                reused_members += 1;
-                continue;
-            }
-            let cached = self.directory_entry_for_account_id(&target.account_id_hex)?;
-            if let Some(key_package) = cached.and_then(|entry| entry.key_package)
-                && let Ok(key_package) =
-                    validated_cached_key_package(&target.account_id_hex, &key_package)
-                && let Ok(key_package) =
-                    self.validate_member_key_package_current(&target.account_id_hex, key_package)
-            {
-                outcomes[index] = Some(Ok(key_package));
-                reused_members += 1;
                 continue;
             }
             let prefetched = self
@@ -394,49 +401,28 @@ impl MarmotApp {
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .get(&target.account_id_hex);
-            if let Some(mut fetched) = prefetched {
-                target.relay_lists = merge_relay_list_status(
-                    target.relay_lists.clone(),
-                    fetched.relay_lists.clone(),
-                );
+            if let Some(fetched) = prefetched {
+                target.relay_lists =
+                    merge_relay_list_status(target.relay_lists.clone(), fetched.relay_lists);
                 target.cached_relay_lists = target.relay_lists.clone();
-                fetched.relay_lists = target.relay_lists.clone();
-                // Reuse must not restart the observation TTL. Only newly
-                // fetched packages enter through accept_prefetched_key_package.
-                let accepted = self.validate_member_key_package_current(
-                    &fetched.account_id_hex,
-                    fetched.key_package.clone(),
-                );
-                let accepted = accepted.and_then(|key_package| {
-                    if purpose == MemberResolutionPurpose::Commit {
-                        self.remember_directory_key_package(&fetched)?;
-                    }
-                    Ok(key_package)
-                });
-                if let Ok(key_package) = accepted {
-                    if !target.relay_lists.nip65.relays.is_empty()
-                        && !self
-                            .retain_safe_discovered_endpoints(
-                                target
-                                    .relay_lists
-                                    .inbox
-                                    .relays
-                                    .iter()
-                                    .cloned()
-                                    .map(TransportEndpoint)
-                                    .collect(),
-                                "member prewarm inbox readiness",
-                            )
-                            .is_empty()
-                    {
-                        fresh_prewarmed_routes.insert(index);
-                    }
-                    outcomes[index] = Some(Ok(key_package));
-                    reused_members += 1;
-                    continue;
+                if !target.relay_lists.nip65.relays.is_empty()
+                    && !self
+                        .retain_safe_discovered_endpoints(
+                            target
+                                .relay_lists
+                                .inbox
+                                .relays
+                                .iter()
+                                .cloned()
+                                .map(TransportEndpoint)
+                                .collect(),
+                            "member prewarm inbox readiness",
+                        )
+                        .is_empty()
+                {
+                    fresh_prewarmed_routes.insert(index);
                 }
             }
-            unresolved.push(index);
         }
 
         // Durable projections have unknown observation age and need a bounded
@@ -916,19 +902,12 @@ impl MarmotApp {
                     .filter(|record| record.event.pubkey == *account_id)
                     .cloned()
                     .collect::<Vec<_>>();
-                let cached = if purpose == MemberResolutionPurpose::CommitFresh {
-                    None
-                } else {
-                    self.directory_entry_for_account_id(account_id)
-                        .ok()
-                        .flatten()
-                };
                 let selected = latest_fresh_key_package_from_records(
                     account_id,
                     account_records,
                     self.directory_freshness(),
                 )
-                .and_then(|selection| fresh_or_cached_key_package(account_id, selection, cached));
+                .and_then(|selection| fresh_or_cached_key_package(account_id, selection, None));
                 match selected {
                     Ok(mut fetched) => {
                         fetched.relay_lists = targets[index].relay_lists.clone();
@@ -982,11 +961,6 @@ impl MarmotApp {
                             .map_err(|error| {
                                 AppError::RelayDirectory(format!("fetch key packages: {error}"))
                             })?;
-                        let cached = if purpose == MemberResolutionPurpose::CommitFresh {
-                            None
-                        } else {
-                            app.directory_entry_for_account_id(&target.account_id_hex)?
-                        };
                         let mut fetched = fresh_or_cached_key_package(
                             &target.account_id_hex,
                             latest_fresh_key_package_from_records(
@@ -994,7 +968,7 @@ impl MarmotApp {
                                 records,
                                 app.directory_freshness(),
                             )?,
-                            cached,
+                            None,
                         )?;
                         fetched.relay_lists = target.relay_lists;
                         Ok::<_, AppError>(fetched)

--- a/crates/marmot-app/src/directory/member_key_packages.rs
+++ b/crates/marmot-app/src/directory/member_key_packages.rs
@@ -190,6 +190,12 @@ struct MemberTarget {
     relay_records: Vec<crate::relay_plane::DirectoryRelayEventRecord>,
 }
 
+#[derive(Default)]
+struct RelayListResolution {
+    completed: HashSet<usize>,
+    errors: Vec<(usize, AppError)>,
+}
+
 #[allow(dead_code)]
 fn member_resolution_future_is_send(app: &MarmotApp) {
     fn assert_send<T: Send>(_: T) {}
@@ -346,7 +352,7 @@ impl MarmotApp {
         // Even a valid, unexpired cached package may have been consumed on
         // another device. Every purpose, including composition prewarm, must
         // fetch current relay publications; only discovery routes are reused.
-        let mut fresh_prewarmed_routes = HashSet::new();
+        let mut reused_prewarmed_routes = HashSet::new();
         for (index, target) in targets.iter_mut().enumerate() {
             // Recovery deliberately refreshes routes as well as packages.
             if purpose == MemberResolutionPurpose::CommitFresh {
@@ -376,7 +382,7 @@ impl MarmotApp {
                         )
                         .is_empty()
                 {
-                    fresh_prewarmed_routes.insert(index);
+                    reused_prewarmed_routes.insert(index);
                 }
             }
         }
@@ -385,15 +391,13 @@ impl MarmotApp {
         // refresh. Process-local prewarm entries have an enforced TTL and were
         // already resolved through the outbox path during composition.
         let relay_list_unresolved = (0..targets.len())
-            .filter(|index| !fresh_prewarmed_routes.contains(index))
+            .filter(|index| !reused_prewarmed_routes.contains(index))
             .collect::<Vec<_>>();
-        if !relay_list_unresolved.is_empty() {
-            for (index, error) in self
-                .resolve_missing_relay_lists(&mut targets, &relay_list_unresolved)
-                .await
-            {
-                outcomes[index] = Some(Err(error));
-            }
+        let relay_list_resolution = self
+            .resolve_missing_relay_lists(&mut targets, &relay_list_unresolved)
+            .await;
+        for (index, error) in relay_list_resolution.errors {
+            outcomes[index] = Some(Err(error));
         }
         let key_package_unresolved = (0..targets.len())
             .filter(|index| outcomes[*index].is_none())
@@ -437,9 +441,10 @@ impl MarmotApp {
                     .lock()
                     .unwrap_or_else(|poisoned| poisoned.into_inner());
                 for (index, target) in targets.iter().enumerate() {
-                    // Only new discovery renews the route deadline. A package
-                    // fetch through reused routes says nothing about their age.
-                    if !fresh_prewarmed_routes.contains(&index)
+                    // Only completed discovery renews the route deadline.
+                    // A usable package can arrive after an incomplete metadata
+                    // hop retained an older durable inbox/outbox projection.
+                    if relay_list_resolution.completed.contains(&index)
                         && matches!(outcomes[index], Some(Ok(_)))
                     {
                         cache.insert(target.account_id_hex.clone(), target.relay_lists.clone());
@@ -672,14 +677,14 @@ impl MarmotApp {
         &self,
         targets: &mut [MemberTarget],
         unresolved: &[usize],
-    ) -> Vec<(usize, AppError)> {
+    ) -> RelayListResolution {
         let needs_discovery = unresolved.to_vec();
         if needs_discovery.is_empty() {
-            return Vec::new();
+            return RelayListResolution::default();
         }
         let endpoints = self.directory_source_relays(&[]);
         if endpoints.is_empty() {
-            return Vec::new();
+            return RelayListResolution::default();
         }
         let completed_discovery = self
             .resolve_relay_list_hop(targets, vec![(endpoints.clone(), needs_discovery.clone())])
@@ -724,7 +729,12 @@ impl MarmotApp {
         let completed_outbox = self
             .resolve_relay_list_hop(targets, by_outboxes.into_iter().collect())
             .await;
-        needs_discovery
+        let completed = completed_discovery
+            .iter()
+            .copied()
+            .filter(|index| !attempted_outbox.contains(index) || completed_outbox.contains(index))
+            .collect();
+        let errors = needs_discovery
             .into_iter()
             .filter(|index| {
                 let has_inbox = !self
@@ -752,7 +762,8 @@ impl MarmotApp {
                     ),
                 )
             })
-            .collect()
+            .collect();
+        RelayListResolution { completed, errors }
     }
 
     async fn resolve_missing_key_packages(

--- a/crates/marmot-app/src/directory/member_key_packages.rs
+++ b/crates/marmot-app/src/directory/member_key_packages.rs
@@ -239,6 +239,8 @@ impl MarmotApp {
     }
 
     /// Prewarm group composition without reserving or consuming any package.
+    /// Success reports relay/metadata readiness only; final Create/Invite
+    /// re-fetches packages and enforces the engine's membership policy.
     ///
     /// The roster must also resolve a safe Marmot inbox route for every member;
     /// missing routes return [`AppError::MissingMemberInboxRoute`]. Successfully

--- a/crates/marmot-app/src/error.rs
+++ b/crates/marmot-app/src/error.rs
@@ -429,6 +429,7 @@ fn engine_error_class(error: &cgka_traits::error::EngineError) -> SyncErrorClass
         | EngineError::InvalidAppMessagePayload(_)
         | EngineError::InvalidAccountIdentityProof(_)
         | EngineError::InvalidKeyPackageLifetime { .. }
+        | EngineError::InvalidKeyPackageCapabilities { .. }
         | EngineError::InvalidWelcome
         | EngineError::Serialize(_)
         | EngineError::ForkedEpoch { .. }
@@ -537,6 +538,24 @@ mod tests {
     use crate::SyncFailureClassification;
     use cgka_traits::error::EngineError;
     use cgka_traits::types::{EpochId, GroupId};
+
+    #[test]
+    fn invalid_key_package_capabilities_preserve_member_and_protocol_classification() {
+        let member = cgka_traits::MemberId::new(vec![0xBB; 32]);
+        let error = AppError::Session(cgka_session::SessionError::Engine(
+            EngineError::InvalidKeyPackageCapabilities {
+                member: member.clone(),
+            },
+        ));
+        assert_eq!(
+            error.privacy_safe_kind(),
+            "invalid_key_package_capabilities"
+        );
+        assert_eq!(error.sync_error_class(), crate::SyncErrorClass::Protocol);
+        assert!(matches!(error.as_engine_error(),
+            Some(EngineError::InvalidKeyPackageCapabilities { member: rejected }) if rejected == &member));
+        assert!(!error.to_string().contains(&hex::encode(member.as_slice())));
+    }
 
     // Kind strings leave the runtime: `account_error_message` interpolates
     // them into messages the CLI daemon persists and host apps log. Pin the

--- a/crates/marmot-app/src/key_package_records.rs
+++ b/crates/marmot-app/src/key_package_records.rs
@@ -197,6 +197,7 @@ fn cached_key_package_from_entry(
     }))
 }
 
+#[cfg(test)]
 pub(crate) fn validated_cached_key_package(
     account_id_hex: &str,
     key_package: &DirectoryKeyPackage,

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1883,6 +1883,26 @@ impl MarmotApp {
                 }
             }
         }
+        // A generator revision is account-device state, independent of the
+        // strict protocol-profile cutover markers. Local-only/frozen opens
+        // must not start network maintenance.
+        if self.cursor_persistence() == CursorPersistence::Advance {
+            let result = async {
+                if client.runtime.key_package_generation_upgrade_due()? {
+                    client.runtime.publish_fresh_key_package().await?;
+                }
+                Ok::<_, marmot_account::AccountError>(())
+            }
+            .await;
+            if let Err(error) = result {
+                tracing::warn!(
+                    target: "marmot_app::key_packages",
+                    method = "finish_client_open_network_maintenance",
+                    error_kind = AppError::from(error).privacy_safe_kind(),
+                    "key package generator upgrade remains retryable"
+                );
+            }
+        }
     }
 
     pub fn status(&self, label: &str) -> Result<AppStatus, AppError> {

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -5899,9 +5899,13 @@ impl MarmotApp {
     }
 
     #[cfg(test)]
-    fn with_test_relay_client(mut self, client: Arc<dyn NostrRelayClient>) -> Self {
-        self.relay_plane = MarmotRelayPlane::new_with_loopback(
+    fn with_test_relay_client<C>(mut self, client: Arc<C>) -> Self
+    where
+        C: NostrRelayClient + crate::relay_plane::DirectoryRelayFetcher + 'static,
+    {
+        self.relay_plane = MarmotRelayPlane::new_with_directory_fetcher_for_test(
             None,
+            client.clone(),
             client.clone(),
             self.config.allow_loopback_relay_endpoints,
         );

--- a/crates/marmot-app/src/relay_plane/mod.rs
+++ b/crates/marmot-app/src/relay_plane/mod.rs
@@ -596,16 +596,18 @@ impl MarmotRelayPlane {
 
     #[cfg(test)]
     pub(crate) fn new_with_directory_fetcher_for_test(
+        subscription_rebuild_lookback: Option<Duration>,
         relay_client: Arc<dyn NostrRelayClient>,
         directory_fetcher: Arc<dyn DirectoryRelayFetcher>,
+        allow_loopback: bool,
     ) -> Self {
         Self::from_adapter(
-            Some(Duration::from_secs(120)),
+            subscription_rebuild_lookback,
             NostrTransportAdapter::new(relay_client),
             None,
             None,
             directory_fetcher,
-            false,
+            allow_loopback,
         )
     }
 

--- a/crates/marmot-app/src/relay_plane/tests.rs
+++ b/crates/marmot-app/src/relay_plane/tests.rs
@@ -371,6 +371,16 @@ async fn notification_recovery_closes_account_delivery_and_signals_directory_reb
         .expect("inbound recovery must not take the outbound publisher down");
 }
 
+#[async_trait::async_trait]
+impl DirectoryRelayFetcher for RecordingRelayClient {
+    async fn fetch_directory_events(
+        &self,
+        _request: DirectoryFetchRequest,
+    ) -> Result<Vec<DirectoryRelayEventRecord>, String> {
+        Ok(Vec::new())
+    }
+}
+
 #[tokio::test]
 async fn managed_account_worker_reopens_transport_after_notification_recovery() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/marmot-app/src/runtime/onboarding/tests.rs
+++ b/crates/marmot-app/src/runtime/onboarding/tests.rs
@@ -483,8 +483,12 @@ fn options() -> OnboardingOptions {
 fn runtime(path: &std::path::Path, network: Arc<Network>) -> MarmotAppRuntime {
     let mut app = MarmotApp::with_relay(path, "wss://default.example")
         .with_test_relay_client(network.clone());
-    app.relay_plane =
-        MarmotRelayPlane::new_with_directory_fetcher_for_test(network.clone(), network);
+    app.relay_plane = MarmotRelayPlane::new_with_directory_fetcher_for_test(
+        Some(Duration::from_secs(120)),
+        network.clone(),
+        network,
+        false,
+    );
     MarmotAppRuntime::new(app)
 }
 async fn fixture() -> (

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -844,6 +844,34 @@ impl ScriptedPushRelayClient {
     }
 }
 
+// Directory reads must use the same simulated relay publications as writes;
+// invitation tests can no longer rely on a local KeyPackage cache shortcut.
+#[async_trait]
+impl crate::relay_plane::DirectoryRelayFetcher for ScriptedPushRelayClient {
+    async fn fetch_directory_events(
+        &self,
+        request: crate::relay_plane::DirectoryFetchRequest,
+    ) -> Result<Vec<crate::relay_plane::DirectoryRelayEventRecord>, String> {
+        Ok(self
+            .published_events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|event| {
+                request
+                    .queries
+                    .iter()
+                    .any(|query| query.kind == event.kind && query.authors.contains(&event.pubkey))
+            })
+            .cloned()
+            .map(|event| crate::relay_plane::DirectoryRelayEventRecord {
+                endpoints: request.endpoints.clone(),
+                event,
+            })
+            .collect())
+    }
+}
+
 #[async_trait]
 impl NostrRelayClient for ScriptedPushRelayClient {
     async fn subscribe(
@@ -7854,41 +7882,9 @@ async fn member_key_package_falls_back_to_current_directory_for_local_account() 
 
 #[tokio::test]
 async fn member_key_package_set_canonicalizes_and_deduplicates_in_input_order() {
-    let directory = tempfile::tempdir().unwrap();
-    let home = AccountHome::open(directory.path());
-    let bob = home.create_account("bob").unwrap();
-    let carol = home.create_account("carol").unwrap();
-    let app = MarmotApp::with_relay(directory.path(), "wss://relay.example");
-
-    for account in [&bob, &carol] {
-        let current = fresh_key_package_for_account(&app, account, false).await;
-        let metadata = cgka_engine::key_package::key_package_metadata(&current).unwrap();
-        let mut relay_lists = AccountRelayListStatus::empty();
-        relay_lists.inbox.created_at = 1;
-        relay_lists.inbox.relays = vec!["wss://inbox.example".into()];
-        relay_lists.refresh();
-        app.save_directory_entry(&UserDirectoryRecord {
-            account_id_hex: account.account_id_hex.clone(),
-            npub: npub_for_account_id_lossy(&account.account_id_hex),
-            local_account: Some(UserDirectoryLocalAccount {
-                label: account.label.clone(),
-                local_signing: true,
-            }),
-            profile: None,
-            follows: Vec::new(),
-            follow_source_relays: Vec::new(),
-            relay_lists,
-            key_package: Some(DirectoryKeyPackage {
-                key_package_id: format!("{}-slot", account.label),
-                key_package_ref_hex: metadata.key_package_ref_hex,
-                key_package_event_id: String::new(),
-                key_package_hex: hex::encode(current.bytes()),
-                created_at: 1,
-                source_relays: Vec::new(),
-            }),
-        })
-        .unwrap();
-    }
+    let (_directory, app, accounts, _fetcher) = member_resolution_fixture(2, false).await;
+    let bob = accounts[0].clone();
+    let carol = accounts[1].clone();
 
     let bob_npub = npub_for_account_id_lossy(&bob.account_id_hex);
     let resolved = app
@@ -7998,7 +7994,12 @@ pub(crate) async fn member_resolution_fixture(
                 String::new(),
             ));
     }
-    app.relay_plane = MarmotRelayPlane::new_with_directory_fetcher_for_test(relay, fetcher.clone());
+    app.relay_plane = MarmotRelayPlane::new_with_directory_fetcher_for_test(
+        Some(Duration::from_secs(120)),
+        relay,
+        fetcher.clone(),
+        false,
+    );
     (directory, app, accounts, fetcher)
 }
 
@@ -8357,11 +8358,11 @@ async fn missing_inbox_is_discovered_when_nip65_is_cached() {
         "a cached NIP-65 list must not suppress independent inbox discovery"
     );
     assert!(
-        requests.iter().all(|request| request
+        requests.iter().any(|request| request
             .queries
             .iter()
-            .all(|query| query.kind != KIND_MARMOT_KEY_PACKAGE)),
-        "the KeyPackage fetched during failed prewarm must remain reusable"
+            .any(|query| query.kind == KIND_MARMOT_KEY_PACKAGE)),
+        "the KeyPackage fetched during failed prewarm must still be refreshed"
     );
 }
 
@@ -8464,13 +8465,13 @@ async fn invite_with_key_package_but_no_inbox_route_fails_before_commit() {
     client
         .invite_members(&group_id, &[account_id.as_str()])
         .await
-        .expect("the explicit retry should reuse the unconsumed KeyPackage");
+        .expect("the explicit retry should refetch the unconsumed KeyPackage");
     assert_eq!(client.group_mls_state(&group_id).unwrap().member_count, 2);
-    assert!(fetcher.requests.lock().unwrap().iter().all(|request| {
+    assert!(fetcher.requests.lock().unwrap().iter().any(|request| {
         request
             .queries
             .iter()
-            .all(|query| query.kind != KIND_MARMOT_KEY_PACKAGE)
+            .any(|query| query.kind == KIND_MARMOT_KEY_PACKAGE)
     }));
 }
 
@@ -8518,13 +8519,13 @@ async fn create_group_with_key_package_but_no_inbox_route_fails_before_group_cre
     let group_id = client
         .create_group("create route readiness", &[account_id.as_str()])
         .await
-        .expect("the explicit retry should reuse the unconsumed KeyPackage");
+        .expect("the explicit retry should refetch the unconsumed KeyPackage");
     assert_eq!(client.group_mls_state(&group_id).unwrap().member_count, 2);
-    assert!(fetcher.requests.lock().unwrap().iter().all(|request| {
+    assert!(fetcher.requests.lock().unwrap().iter().any(|request| {
         request
             .queries
             .iter()
-            .all(|query| query.kind != KIND_MARMOT_KEY_PACKAGE)
+            .any(|query| query.kind == KIND_MARMOT_KEY_PACKAGE)
     }));
 }
 
@@ -8580,7 +8581,7 @@ async fn mixed_invite_route_readiness_does_not_consume_key_packages_or_mutate_me
     client
         .invite_members(&group_id, &member_refs)
         .await
-        .expect("the explicit retry should reuse both fetched KeyPackages");
+        .expect("the explicit retry should refetch both unconsumed KeyPackages");
     assert_eq!(client.group_mls_state(&group_id).unwrap().member_count, 3);
     assert!(
         fetcher
@@ -8588,11 +8589,11 @@ async fn mixed_invite_route_readiness_does_not_consume_key_packages_or_mutate_me
             .lock()
             .unwrap()
             .iter()
-            .all(|request| request
+            .any(|request| request
                 .queries
                 .iter()
-                .all(|query| query.kind != KIND_MARMOT_KEY_PACKAGE)),
-        "the failed preflight must not consume or discard valid fetched KeyPackages"
+                .any(|query| query.kind == KIND_MARMOT_KEY_PACKAGE)),
+        "the retry must refetch packages even though failed preflight did not consume them"
     );
 }
 
@@ -8634,18 +8635,147 @@ async fn thirty_incremental_invites_with_large_directory_cache_converge_without_
     }
 }
 
-/// Fresh reinvites must not resurrect a cached package when relays only return
+/// The public directory is shared by accounts on a device. Its old package may
+/// still validate cryptographically even after the recipient has rotated it.
+#[tokio::test]
+async fn member_key_package_resolution_refreshes_shared_directory_and_prewarm() {
+    let (_directory, app, accounts, fetcher) = member_resolution_fixture(1, false).await;
+    let recipient = &accounts[0];
+    let members = [recipient.account_id_hex.as_str()];
+    let old = app
+        .resolve_member_key_packages(&members)
+        .await
+        .unwrap()
+        .remove(0);
+    let old_directory = app
+        .directory_entry_for_account_id(&recipient.account_id_hex)
+        .unwrap()
+        .unwrap()
+        .key_package
+        .unwrap();
+
+    write_json(
+        app.key_package_record_path(&recipient.label),
+        &KeyPackageRecord {
+            account_label: recipient.label.clone(),
+            account_id_hex: recipient.account_id_hex.clone(),
+            key_package_id: old_directory.key_package_id.clone(),
+            key_package_ref_hex: old_directory.key_package_ref_hex.clone(),
+            key_package_event_id: old_directory.key_package_event_id.clone(),
+            published_at: old_directory.created_at,
+            key_package_hex: old_directory.key_package_hex.clone(),
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        app.validated_current_local_key_package(&recipient.label),
+        Some(old.clone())
+    );
+
+    // A new sender on the same installation sees the existing shared directory.
+    app.account_home().create_account("new-sender").unwrap();
+    let refreshed = fresh_key_package_for_account(&app, recipient, false).await;
+    {
+        let mut events = fetcher.events.lock().unwrap();
+        events.retain(|event| event.kind != KIND_MARMOT_KEY_PACKAGE);
+        events.push(member_resolution_key_package_event(
+            recipient,
+            refreshed.clone(),
+        ));
+    }
+    let prewarm = app
+        .prewarm_group_member_key_packages(&members)
+        .await
+        .unwrap();
+    assert_eq!(prewarm.reused_members, 0);
+    assert_eq!(prewarm.network_resolved_members, 1);
+    assert_eq!(
+        app.directory_entry_for_account_id(&recipient.account_id_hex)
+            .unwrap()
+            .unwrap()
+            .key_package
+            .unwrap()
+            .key_package_hex,
+        old_directory.key_package_hex,
+        "prewarm must preserve the durable discovery projection"
+    );
+
+    // Rotation after prewarming must also be observed at the invitation boundary.
+    let latest = fresh_key_package_for_account(&app, recipient, false).await;
+    assert_ne!(old, latest);
+    assert_ne!(refreshed, latest);
+    {
+        let mut events = fetcher.events.lock().unwrap();
+        events.retain(|event| event.kind != KIND_MARMOT_KEY_PACKAGE);
+        events.push(member_resolution_key_package_event(
+            recipient,
+            latest.clone(),
+        ));
+    }
+    fetcher.requests.lock().unwrap().clear();
+    assert_eq!(
+        app.resolve_member_key_packages(&members).await.unwrap(),
+        vec![latest]
+    );
+    let requests = fetcher.requests.lock().unwrap();
+    assert_eq!(
+        requests.len(),
+        1,
+        "prewarmed routes should avoid repeating discovery"
+    );
+    assert_eq!(requests[0].queries[0].kind, KIND_MARMOT_KEY_PACKAGE);
+}
+
+#[tokio::test]
+async fn member_key_package_resolution_fails_closed_after_cached_prewarm() {
+    for relay_failure in [false, true] {
+        let (_directory, app, accounts, fetcher) = member_resolution_fixture(1, false).await;
+        let members = [accounts[0].account_id_hex.as_str()];
+        app.resolve_member_key_packages(&members).await.unwrap();
+        app.prewarm_group_member_key_packages(&members)
+            .await
+            .unwrap();
+        if relay_failure {
+            *fetcher.failing_single_author.lock().unwrap() = Some(members[0].to_owned());
+        } else {
+            fetcher
+                .events
+                .lock()
+                .unwrap()
+                .retain(|event| event.kind != KIND_MARMOT_KEY_PACKAGE);
+        }
+        assert!(
+            app.resolve_member_key_packages(&members).await.is_err(),
+            "neither a relay error nor a relay miss may authorize using the cached package"
+        );
+        assert!(
+            app.prewarm_group_member_key_packages(&members)
+                .await
+                .is_err(),
+            "prewarm must also refresh instead of returning cached readiness"
+        );
+        assert!(
+            app.directory_entry_for_account_id(members[0])
+                .unwrap()
+                .unwrap()
+                .key_package
+                .is_some(),
+            "failed refresh must preserve cached discovery information"
+        );
+    }
+}
+
+/// Invitations and prewarming must not resurrect a cached package when relays only return
 /// future-dated records, including when the batch falls back to single authors.
 #[tokio::test]
-async fn fresh_reinvite_resolution_never_falls_back_to_cached_key_packages() {
+async fn member_key_package_resolution_never_falls_back_to_cached_key_packages() {
     for reject_batch in [false, true] {
         let (_directory, app, accounts, fetcher) = member_resolution_fixture(2, false).await;
         let members = accounts
             .iter()
             .map(|account| account.account_id_hex.clone())
             .collect::<Vec<_>>();
-        let cached = app
-            .resolve_fresh_reinvite_key_packages(&members)
+        app.resolve_fresh_reinvite_key_packages(&members)
             .await
             .unwrap();
         for member in &members {
@@ -8680,19 +8810,19 @@ async fn fresh_reinvite_resolution_never_falls_back_to_cached_key_packages() {
             }),
             "single-author fallback must also reject cached material"
         );
-        let ordinary = app
-            .resolve_member_key_packages(&members.iter().map(String::as_str).collect::<Vec<_>>())
+        let refs = members.iter().map(String::as_str).collect::<Vec<_>>();
+        let ordinary = app.resolve_member_key_packages(&refs).await.unwrap_err();
+        assert!(matches!(ordinary, AppError::MissingKeyPackage(id) if id == members[0]));
+        let prewarm = app
+            .prewarm_group_member_key_packages(&refs)
             .await
-            .unwrap();
-        assert_eq!(
-            ordinary, cached,
-            "ordinary resolution still permits cached packages"
-        );
+            .unwrap_err();
+        assert!(matches!(prewarm, AppError::MissingKeyPackage(id) if id == members[0]));
     }
 }
 
 #[tokio::test]
-async fn member_key_package_set_batches_shared_relay_and_reuses_prewarm() {
+async fn member_key_package_set_batches_shared_relay_and_reuses_prewarm_routes() {
     let (_directory, app, accounts, fetcher) = member_resolution_fixture(8, false).await;
     let members = accounts
         .iter()
@@ -8752,8 +8882,8 @@ async fn member_key_package_set_batches_shared_relay_and_reuses_prewarm() {
     assert_eq!(resolved.len(), 8);
     assert_eq!(
         fetcher.requests.lock().unwrap().len(),
-        3,
-        "fresh prewarm entries must eliminate create-time relay requests"
+        4,
+        "create must reuse discovery routes but fetch KeyPackages again"
     );
 }
 
@@ -8793,8 +8923,8 @@ async fn member_key_package_set_reuses_completed_discovery_when_it_is_the_outbox
     );
     assert_eq!(
         fetcher.requests.lock().unwrap().len(),
-        2,
-        "fresh prewarm must not repeat either query"
+        3,
+        "create must repeat only the KeyPackage query"
     );
 }
 
@@ -8894,12 +9024,12 @@ async fn relay_list_fallback_failure_preserves_valid_siblings_and_input_order() 
         .prewarm_group_member_key_packages(&[accounts[1].account_id_hex.as_str()])
         .await
         .expect("the valid sibling should remain reusable after the partial failure");
-    assert_eq!(summary.reused_members, 1);
-    assert_eq!(summary.network_resolved_members, 0);
+    assert_eq!(summary.reused_members, 0);
+    assert_eq!(summary.network_resolved_members, 1);
     assert_eq!(
         fetcher.requests.lock().unwrap().len(),
-        requests_after_partial,
-        "reusing the valid sibling must not issue another relay request"
+        requests_after_partial + 1,
+        "reuse the valid sibling routes but refresh its KeyPackage"
     );
 }
 
@@ -8954,12 +9084,12 @@ async fn malformed_batch_member_does_not_discard_valid_member_prewarm() {
         .prewarm_group_member_key_packages(&[valid_account.as_str()])
         .await
         .expect("the valid member from the partial batch remains safely reusable");
-    assert_eq!(summary.reused_members, 1);
-    assert_eq!(summary.network_resolved_members, 0);
+    assert_eq!(summary.reused_members, 0);
+    assert_eq!(summary.network_resolved_members, 1);
     assert_eq!(
         fetcher.requests.lock().unwrap().len(),
-        requests_after_partial,
-        "reusing the valid partial result must not issue another relay request"
+        requests_after_partial + 1,
+        "reuse the valid partial routes but refresh its KeyPackage"
     );
 }
 

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -7044,6 +7044,7 @@ async fn generated_identity_restart_resumes_every_durable_setup_phase() {
             lifecycle.publication_targets = replacement.targets;
             lifecycle.refresh_at = Some(replacement.refresh_at);
             lifecycle.upgrade_rotation_recorded = true;
+            lifecycle.generation_revision = replacement.generation_revision;
             storage.put_key_package_lifecycle(&lifecycle).unwrap();
         }
         runtime.shutdown().await;
@@ -7192,6 +7193,106 @@ async fn confirmed_generated_bootstrap_republishes_when_projection_is_missing() 
         "projection recovery should issue one idempotent bootstrap batch"
     );
     runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn key_package_generation_upgrade_runs_once_per_account_on_activation() {
+    use cgka_traits::maintenance::KEY_PACKAGE_GENERATION_REVISION;
+    let directory = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(directory.path());
+    home.create_account("alice").unwrap();
+    home.create_account("bob").unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(directory.path(), "wss://relay.example")
+        .with_test_relay_client(relay.clone());
+    for label in ["alice", "bob"] {
+        let mut client = app.client(label).await.unwrap();
+        client.runtime.publish_fresh_key_package().await.unwrap();
+        let storage = app.account_storage(label).unwrap();
+        let mut lifecycle = storage.key_package_lifecycle().unwrap().unwrap();
+        assert_eq!(
+            lifecycle.generation_revision,
+            KEY_PACKAGE_GENERATION_REVISION
+        );
+        lifecycle.generation_revision = 0;
+        storage.put_key_package_lifecycle(&lifecycle).unwrap();
+    }
+    let before = app
+        .account_storage("alice")
+        .unwrap()
+        .key_package_lifecycle()
+        .unwrap()
+        .unwrap();
+    // A frozen notification/read pass leaves this network migration pending.
+    let frozen = MarmotApp::with_relay_and_config(
+        directory.path(),
+        "wss://relay.example",
+        MarmotAppConfig {
+            cursor_persistence: CursorPersistence::Frozen,
+            ..Default::default()
+        },
+    )
+    .with_test_relay_client(relay);
+    drop(frozen.client("alice").await.unwrap());
+    assert_eq!(
+        app.account_storage("alice")
+            .unwrap()
+            .key_package_lifecycle()
+            .unwrap(),
+        Some(before.clone())
+    );
+    drop(frozen);
+
+    drop(app.client("alice").await.unwrap());
+    let upgraded = app
+        .account_storage("alice")
+        .unwrap()
+        .key_package_lifecycle()
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        upgraded.generation_revision,
+        KEY_PACKAGE_GENERATION_REVISION
+    );
+    assert_ne!(
+        upgraded.current_key_package_ref,
+        before.current_key_package_ref
+    );
+    assert_eq!(upgraded.stable_slot_id, before.stable_slot_id);
+    assert!(
+        upgraded
+            .retained_private_material
+            .iter()
+            .any(|old| Some(&old.key_package) == before.current_key_package.as_ref())
+    );
+    assert_eq!(
+        app.account_storage("bob")
+            .unwrap()
+            .key_package_lifecycle()
+            .unwrap()
+            .unwrap()
+            .generation_revision,
+        0,
+        "opening one account cannot complete another account's migration"
+    );
+    drop(app.client("alice").await.unwrap());
+    assert_eq!(
+        app.account_storage("alice")
+            .unwrap()
+            .key_package_lifecycle()
+            .unwrap(),
+        Some(upgraded)
+    );
+    drop(app.client("bob").await.unwrap());
+    assert_eq!(
+        app.account_storage("bob")
+            .unwrap()
+            .key_package_lifecycle()
+            .unwrap()
+            .unwrap()
+            .generation_revision,
+        KEY_PACKAGE_GENERATION_REVISION
+    );
 }
 
 #[tokio::test]

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -8773,8 +8773,6 @@ async fn member_key_package_resolution_refreshes_shared_directory_and_prewarm() 
         Some(old.clone())
     );
 
-    // A new sender on the same installation sees the existing shared directory.
-    app.account_home().create_account("new-sender").unwrap();
     let refreshed = fresh_key_package_for_account(&app, recipient, false).await;
     {
         let mut events = fetcher.events.lock().unwrap();
@@ -8986,6 +8984,38 @@ async fn member_key_package_set_batches_shared_relay_and_reuses_prewarm_routes()
         4,
         "create must reuse discovery routes but fetch KeyPackages again"
     );
+}
+
+#[tokio::test]
+async fn member_key_package_prewarm_does_not_renew_routes_after_incomplete_discovery() {
+    for incomplete in ["wss://directory.example", "wss://shared.example"] {
+        let (_directory, app, accounts, fetcher) = member_resolution_fixture(1, false).await;
+        let members = [accounts[0].account_id_hex.as_str()];
+        app.resolve_member_key_packages(&members).await.unwrap();
+        // Keep a usable durable inbox, but make its relay refresh incomplete.
+        // A successful KeyPackage fetch does not establish route freshness.
+        fetcher
+            .events
+            .lock()
+            .unwrap()
+            .retain(|event| event.kind != KIND_MARMOT_INBOX_RELAY_LIST);
+        *fetcher.incomplete_endpoint.lock().unwrap() = Some(incomplete.to_owned());
+        app.prewarm_group_member_key_packages(&members)
+            .await
+            .unwrap();
+        fetcher.requests.lock().unwrap().clear();
+        *fetcher.incomplete_endpoint.lock().unwrap() = None;
+        app.resolve_member_key_packages(&members).await.unwrap();
+        assert!(
+            fetcher.requests.lock().unwrap().iter().any(|request| {
+                request
+                    .queries
+                    .iter()
+                    .any(|query| query.kind == KIND_MARMOT_INBOX_RELAY_LIST)
+            }),
+            "Create must refresh metadata after an incomplete prewarm hop"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/marmot-app/src/tests/message_journeys.rs
+++ b/crates/marmot-app/src/tests/message_journeys.rs
@@ -14,6 +14,16 @@ struct CrashRelay {
 }
 
 #[async_trait]
+impl crate::relay_plane::DirectoryRelayFetcher for CrashRelay {
+    async fn fetch_directory_events(
+        &self,
+        request: crate::relay_plane::DirectoryFetchRequest,
+    ) -> Result<Vec<crate::relay_plane::DirectoryRelayEventRecord>, String> {
+        self.inner.fetch_directory_events(request).await
+    }
+}
+
+#[async_trait]
 impl NostrRelayClient for CrashRelay {
     async fn subscribe(
         &self,

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -11568,6 +11568,10 @@ async fn outbox_resolved_inbox_survives_restart_and_delivers_exact_welcome() {
         .await
         .expect("reactivation must resolve kind 10050 from the advertised outbox");
 
+    // Moving the advertised outbox requires publishing the public package
+    // there as well. Invitation resolution must not rely on the local cache.
+    runtime.publish_key_package(&carol_id).await.unwrap();
+
     let mut events = runtime.subscribe();
     let group_id = runtime
         .create_group(

--- a/crates/marmot-c/CHANGELOG.md
+++ b/crates/marmot-c/CHANGELOG.md
@@ -18,6 +18,12 @@ Versions track the workspace version; releases are tagged `marmotc-v<version>`.
 
 ### Changed
 
+- Group creation, invites, and composition prewarming fetch current KeyPackages from relays, including for local
+  sibling accounts; cached packages no longer substitute when resolution fails. Prewarm retains discovery routes
+  only, and `MarmotMemberKeyPackagePrewarmSummary::reused_members` remains present but always returns zero.
+- Create and Invite reject KeyPackages that explicitly advertise RFC 9420 default extension/proposal capabilities.
+  Local private-bundle retention and historical Welcome processing are unchanged.
+
 - Search results include `is_followed_by_searcher`; streaming updates include keyed `updated_results` replacements
   and a `CachedResultsFound` trigger. Consumers must merge by account ID, including across radius pages, and use
   the explicit follow flag instead of radius 1 for badges. C consumers must rebuild against the matching generated

--- a/crates/marmot-c/CHANGELOG.md
+++ b/crates/marmot-c/CHANGELOG.md
@@ -22,7 +22,12 @@ Versions track the workspace version; releases are tagged `marmotc-v<version>`.
   sibling accounts; cached packages no longer substitute when resolution fails. Prewarm retains discovery routes
   only, and `MarmotMemberKeyPackagePrewarmSummary::reused_members` remains present but always returns zero.
 - Create and Invite reject KeyPackages that explicitly advertise RFC 9420 default extension/proposal capabilities.
-  Local private-bundle retention and historical Welcome processing are unchanged.
+  **Compatibility:** inviting a peer still publishing an affected package fails (`InvalidKeyPackageCapabilities` in
+  the Rust engine) until that peer generates and publishes a conforming package. Upgraded recipients automatically
+  regenerate once on account activation; the durable generator revision advances only after a relay ACK, with
+  retries across restarts. Peers that have not upgraded are not repaired by a sender's upgrade. This deliberately
+  keeps nonconforming signed leaves out of new membership state. Previous unused private bundles retain their
+  expiry/consumption policy and historical Welcome processing is unchanged.
 
 - Search results include `is_followed_by_searcher`; streaming updates include keyed `updated_results` replacements
   and a `CachedResultsFound` trigger. Consumers must merge by account ID, including across radius pages, and use

--- a/crates/traits/src/error.rs
+++ b/crates/traits/src/error.rs
@@ -118,6 +118,12 @@ pub enum EngineError {
         not_after: Option<u64>,
     },
 
+    /// An invitee advertises default MLS capabilities forbidden by RFC 9420
+    /// section 7.2. Keep the authenticated member available to typed callers,
+    /// but omit its identity from Display and diagnostic classification.
+    #[error("invalid KeyPackage capabilities: recipient must generate a new conforming KeyPackage")]
+    InvalidKeyPackageCapabilities { member: MemberId },
+
     /// Epoch fork detected that the current recovery manager could not
     /// resolve, usually because no pre-commit snapshot was available.
     /// Recoverable same-epoch commit races roll back and replay internally.
@@ -233,6 +239,7 @@ impl EngineError {
             EngineError::InvalidAppMessagePayload(_) => "invalid_app_message_payload",
             EngineError::InvalidAccountIdentityProof(_) => "invalid_account_identity_proof",
             EngineError::InvalidKeyPackageLifetime { .. } => "invalid_key_package_lifetime",
+            EngineError::InvalidKeyPackageCapabilities { .. } => "invalid_key_package_capabilities",
             EngineError::ForkedEpoch { .. } => "forked_epoch",
             EngineError::QueuedOutboundAtCapacity { .. } => "queued_outbound_at_capacity",
             EngineError::GroupUnrecoverableRepairRequired { .. } => {

--- a/crates/traits/src/maintenance.rs
+++ b/crates/traits/src/maintenance.rs
@@ -228,8 +228,16 @@ pub struct SignedPublicationArtifact {
     pub bytes: Vec<u8>,
 }
 
+/// Durable generator policy revision, independent of app/workspace versions.
+/// Revision 1 omits RFC 9420 section 7.2 default capability advertisements.
+/// Bump only when existing published packages must be regenerated.
+pub const KEY_PACKAGE_GENERATION_REVISION: u32 = 1;
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PendingKeyPackageReplacement {
+    /// Generator policy that produced this exact bundle. Missing on pre-migration records.
+    #[serde(default)]
+    pub generation_revision: u32,
     pub key_package: KeyPackage,
     pub key_package_ref: Vec<u8>,
     /// Transport authoring time selected before signing. The private bundle
@@ -275,6 +283,10 @@ pub struct KeyPackageLifecycleState {
     pub publication_targets: Vec<TransportFanoutTarget>,
     pub refresh_at: Option<Timestamp>,
     pub upgrade_rotation_recorded: bool,
+    /// Generator policy of the acknowledged current package, promoted atomically
+    /// with that package. Zero denotes records written before revision tracking.
+    #[serde(default)]
+    pub generation_revision: u32,
     /// The reference proven to have been consumed by a successfully processed
     /// MLS Welcome. This comes from the Welcome's encrypted-group-secrets
     /// entries matched against local bundles, never from a transport tag.
@@ -307,6 +319,7 @@ impl KeyPackageLifecycleState {
             publication_targets: Vec::new(),
             refresh_at: None,
             upgrade_rotation_recorded: false,
+            generation_revision: 0,
             last_consumed_key_package_ref: None,
             last_consumed_at: None,
             retained_private_material: Vec::new(),

--- a/crates/traits/tests/error_display.rs
+++ b/crates/traits/tests/error_display.rs
@@ -25,6 +25,10 @@ fn engine_error_display_does_not_expose_group_or_member_ids() {
             member: member_id.clone(),
         }
         .to_string(),
+        EngineError::InvalidKeyPackageCapabilities {
+            member: member_id.clone(),
+        }
+        .to_string(),
         EngineError::AdminCannotSelfRemove {
             group_id: group_id.clone(),
         }

--- a/docs/marmot-architecture/invitation-recovery.md
+++ b/docs/marmot-architecture/invitation-recovery.md
@@ -4,7 +4,8 @@ When a locally published invite loses branch selection, its Welcome may already 
 on the recipient. The inviter's success report does not prove that the invitation survived convergence (#1735).
 
 The engine retains the original invitation intent with a durable recovery record. The app resolves fresh KeyPackages
-using the ordinary safe directory-discovery path, bypassing the initial cache/prewarm shortcut. The engine rejects
+using the ordinary safe directory-discovery path. Every invite fetches fresh packages; recovery additionally
+refreshes relay discovery instead of reusing prewarmed routes. The engine rejects
 packages consumed by the lost invitation, changed or duplicate recipient identities, and loss of inviter authority.
 Only recipients absent from the canonical roster are invited again. Fresh intent replaces the recovery record in the
 same transaction that queues it; publication uses the ordinary outbound queue and acknowledgement rules.

--- a/docs/marmot-architecture/telemetry.md
+++ b/docs/marmot-architecture/telemetry.md
@@ -1,7 +1,7 @@
 ---
 title: "Telemetry, Logging, and Tracing Inventory"
 created: 2026-06-10
-updated: 2026-09-08
+updated: 2026-09-10
 tags: [marmot, architecture, telemetry, logging, tracing, privacy]
 status: current
 ---
@@ -240,10 +240,10 @@ Collected operations:
 | `inbound_delivery_projection` | Worker claims a live relay delivery through ingestion, incidental publication, and projection broadcast. | Includes non-chat deliveries that reach ingestion and failures. Excludes known receipts skipped before ingestion, transport queue residence, startup/catch-up batches, and host rendering. |
 | `host_outbound_message_visible` | Host measures user send action through first rendered local bubble. | Report `OutboundMessageVisible` through the existing host-performance API; never infer it from SDK completion. |
 | `host_inbound_message_visible` | Host receives a message update through its first rendered frame. | Report `InboundMessageVisible`. This measures host rendering delay, not sender-to-recipient latency. |
-| `group_create_key_package_lookup` | Total create-time member KeyPackage lookup from canonicalization through validated result collection. | Preserved aggregate dimension; includes either cache-only reuse or create-time relay resolution below. |
-| `group_member_key_package_prewarm` | Host/runtime composition prewarm for the current member set. | Aggregate duration only. No member count label, account/relay identity, reservation, or package consumption. |
-| `group_create_key_package_cache_reuse` | Successful create-time lookup when every canonical member was satisfied by revalidated local/directory state. | Closed operation name, not a caller-supplied label. A prewarm should shift the later Create wait into this bucket. |
-| `group_create_key_package_network_resolution` | Successful create-time lookup that required relay-list or KeyPackage network work for at least one canonical member. | Closed operation name, not a member-count or relay label. |
+| `group_create_key_package_lookup` | Total create-time member KeyPackage lookup from canonicalization through validated result collection. | Preserved aggregate dimension, including failures and empty rosters. Every non-empty roster fetches KeyPackages from relays. |
+| `group_member_key_package_prewarm` | Host/runtime composition prewarm for the current member set. | Every call fetches KeyPackages; bounded discovery routes may be reused. Aggregate duration only, with no member count label, identity, reservation, or package consumption. |
+| `group_create_key_package_cache_reuse` | Retired operation; retained in the snapshot/export schema for compatibility. | Create no longer emits samples, including for empty rosters. A prewarm only reuses discovery routes; final KeyPackages still come from relays. |
+| `group_create_key_package_network_resolution` | Successful create-time lookup for a non-empty roster; every member requires a relay KeyPackage fetch. | Closed operation name, not a member-count or relay label. |
 | `group_create_queue_wait` | Time from enqueueing `CreateGroup` until the account worker begins it. | Separates worker contention from create work. |
 | `group_create_image_preprocess` | Prepared founding-image validation, dimension inspection, encryption, and SQLCipher staging. | Contains no network time. Rejections occur before encryption and upload. |
 | `group_create_image_upload` | Optional initial image selection/upload. | Recorded only when an initial image was supplied. |
@@ -256,7 +256,7 @@ Collected operations:
 | `group_create_post_mutation_catch_up` | Detached account catch-up scheduled after the create command response. | Also contributes to aggregate account catch-up telemetry. |
 | `group_create_total_caller_latency` | Public runtime create entry through the row-bearing worker response. | Includes queue wait, lookup, canonical MLS persistence, derived-index preparation, app projection persistence, and response handoff; excludes Welcome fanout and detached catch-up. |
 | `group_invite_members` | `AccountManager::invite_members()`, from command dispatch through worker response, post-mutation catch-up, and audit-tracker scheduling. | Measures the public runtime invite envelope after any UniFFI admin preflight. |
-| `group_invite_key_package_lookup` | Invite path KeyPackage resolution for every requested member before routing refresh. | Captures local cached lookups plus relay directory fetches used to obtain invitee KeyPackages. |
+| `group_invite_key_package_lookup` | Invite path KeyPackage resolution for every requested member before routing refresh. | Captures fresh relay KeyPackage resolution, including discovery work when bounded route metadata cannot be reused. |
 | `group_invite_routing_refresh` | Invite path `AppClient::refresh_routing()` after KeyPackage lookup and before pre-send runtime sync. | Captures local route/projection refresh work that affects publish targets. |
 | `group_invite_pre_send_sync` | Invite path `AppClient::sync_runtime_groups()` immediately before engine send. | Separates pre-send relay/runtime sync from MLS commit and publish. |
 | `group_invite_engine_publish` | Invite path `AccountDeviceRuntime::send_with_audit_context()` plus publish-failure check. | Covers MLS Add/Commit staging, commit publish, local publish confirmation, and Welcome publish. |


### PR DESCRIPTION
A recipient can rotate or consume a KeyPackage while the sender's cached public package still validates. Group creation and ordinary invites could then construct a Welcome using obsolete material, including material cached by another account on the same installation.

Fetch invitation KeyPackages from relays for composition prewarming and the final Create/Invite action, without cached-package fallback when resolution fails. This also applies to local sibling accounts. Fresh resolution avoids stale local authorization; it cannot prove that a recipient still holds the matching private bundle. Prewarming remains advisory and retains only bounded discovery routes. Existing batching, deterministic error ordering, and single-author relay fallback remain intact. Prewarm route freshness is renewed only after discovery and any advertised-outbox metadata hop complete; a successful package fetch cannot make an older cached route fresh. Exported prewarm and telemetry reuse fields remain compatible and return zero.

Create and Invite also reject correctly signed KeyPackages whose LeafNode capabilities explicitly advertise default extension or proposal types forbidden by RFC 9420 section 7.2. Unknown capabilities remain accepted. `InvalidKeyPackageCapabilities` carries the authenticated recipient for typed callers, omits identities from diagnostic text, and is classified as an expected protocol refusal. This check does not affect historical Welcome processing or private-bundle validation.

The refusal is a deliberate admission policy beyond RFC 9420 section 7.3 / OpenMLS validation: keep known nonconforming signed leaves out of new membership state. An inviter cannot repair the advertisement without invalidating its signature. The accepted compatibility cost is that an upgraded sender cannot invite a peer still publishing an affected package until that recipient regenerates and publishes a conforming package. The migration below helps recipients that upgrade and activate successfully; it cannot repair peers that have not upgraded. Cohort and C-binding release notes call out this break explicitly.

Automatically regenerate older local packages on account activation using a durable per-account-device generator revision, independent of app/workspace versions. Pre-migration records default to revision zero. Revision 1 marks packages generated without the forbidden default advertisements. Persist fresh private material and pending intent atomically, then advance the acknowledged revision only after a relay accepts the replacement. Failed signing or publication remains retryable across restarts; remaining relay fanout continues after promotion. Ordinary releases do not bump this revision. Paused maintenance may finish a prepared current-revision artifact, but generating a replacement for an older pending revision waits for resume.

Older pending artifacts may already have reached a relay. Supersede them in the same stable slot with a newer timestamp, retaining their private bundles until expiry. Previous unused current bundles retain the existing expiry/consumption policy. Frozen notification/read opens do not initiate this migration. Direct account-runtime embedders must continue driving maintenance.

Regression coverage includes cache and relay resolution, all forbidden capability IDs in both profiles, attributed refusal before membership mutation, migration on account activation, account isolation, frozen opens, restart and signing/publication intent, zero-ACK refusal, partial-ACK fanout, delayed Welcome decryption, and atomic rollback while superseding an old pending bundle.

Validation:

- `just fast-ci`
- `cargo test -p marmot-account --locked`, plus the final migration regressions covering pause/resume
- App member-KeyPackage, inbox-route, and prewarm/TTL tests, including incomplete discovery and outbox completion
- The preceding head also passed the full engine suite, app library suite (1,142 passed, two diagnostics ignored), traits tests, and required GitHub CI. This follow-up changes route-cache admission and paused maintenance; the cryptographic refusal and generator implementation are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * KeyPackages are now freshly resolved from relays for group creation, invitations, and recovery.
  * Accounts automatically regenerate outdated KeyPackages after activation, with retry support and retained private material.
  * Successful package publication now requires relay acknowledgment.

* **Bug Fixes**
  * Group creation and invitations reject packages advertising unsupported MLS capabilities without leaving partial state.
  * Error messages use privacy-safe labels and do not expose member identities.

* **Documentation**
  * Updated guidance for KeyPackage compatibility, regeneration, recovery, and telemetry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->