### PR TITLE
Delete legacy forensic audit logs on app startup

### DIFF
--- a/crates/marmot-app/AGENTS.md
+++ b/crates/marmot-app/AGENTS.md
@@ -51,9 +51,12 @@ App runtime bridge for the first real Marmot app surfaces.
 - Record into distinct v4 files and upload only strictly validated v4 snapshots. Never migrate or send v1-v3
   or key-reveal files. Reject removed/unknown fields and duplicate keys before HTTP; cache ineligible file verdicts
   by size and mtime without retry cooldowns. On exclusive-root startup, `audit_log/legacy_cleanup.rs` deletes
-  reserved v1-v3 filenames and their segments without reading payloads, even when recording is disabled.
+  reserved v1-v3 filenames and their segments from `accounts/` and failed-wipe `.wipe-tombstones/` remnants
+  without reading payloads, even when recording is disabled. Match the frozen 32-lowercase-hex legacy engine ID,
+  not the current audit ID width; pin the live layout through AccountHome-backed tests.
   Keep this after lease acquisition and before exposing the app; never traverse symlinks or delete v4/future
-  filenames, custom names, or the separate key-reveal log. Cleanup errors are nonfatal and retry on next open.
+  filenames, names outside the reserved legacy forms, or the separate key-reveal log. Unexpected containers
+  and other cleanup errors are reported with aggregate counts, are nonfatal, and retry on next open.
   Account/device names are forbidden in rows and headers; hardware model is system-sourced, never a label.
 - Keep audit uploads incremental (mdk#1181). An audit file whose size and mtime still match its checkpoint entry is
   never re-read or re-posted; only the growing active file re-transfers, bounded by the recorder's segment threshold.

--- a/crates/marmot-app/AGENTS.md
+++ b/crates/marmot-app/AGENTS.md
@@ -50,7 +50,10 @@ App runtime bridge for the first real Marmot app surfaces.
   unit tests live in its own `#[cfg(test)] mod tests`.
 - Record into distinct v4 files and upload only strictly validated v4 snapshots. Never migrate or send v1-v3
   or key-reveal files. Reject removed/unknown fields and duplicate keys before HTTP; cache ineligible file verdicts
-  by size and mtime without retry cooldowns. Keep legacy files available locally for inspection/deletion.
+  by size and mtime without retry cooldowns. On exclusive-root startup, `audit_log/legacy_cleanup.rs` deletes
+  reserved v1-v3 filenames and their segments without reading payloads, even when recording is disabled.
+  Keep this after lease acquisition and before exposing the app; never traverse symlinks or delete v4/future
+  filenames, custom names, or the separate key-reveal log. Cleanup errors are nonfatal and retry on next open.
   Account/device names are forbidden in rows and headers; hardware model is system-sourced, never a label.
 - Keep audit uploads incremental (mdk#1181). An audit file whose size and mtime still match its checkpoint entry is
   never re-read or re-posted; only the growing active file re-transfers, bounded by the recorder's segment threshold.
@@ -70,7 +73,7 @@ App runtime bridge for the first real Marmot app surfaces.
   and retries like any other rejection.
   Shutdown cancels pending or in-flight automatic work; unacknowledged files remain on disk.
   Tests may shorten the window per runtime via `test-policy-overrides`; paused-clock tests pin the production default.
-  Retention/deletion of sealed segments is mdk#1014, not this contract.
+  Retention/deletion of v4 sealed segments is mdk#1014, not this contract.
 - Keep the upload checkpoint's cost proportional to the account's *live* audit files, not to its history. `retain_present`
   prunes entries for files that are gone, so the sidecar is O(live `audit-*.jsonl` files) — but nothing deletes sealed
   segments (mdk#1014), so that bound grows with cumulative audit volume, and each tracker run stats every file and

--- a/crates/marmot-app/src/audit_log.rs
+++ b/crates/marmot-app/src/audit_log.rs
@@ -26,6 +26,9 @@ use crate::conversions::{audit_log_settings_from_storage, audit_log_settings_to_
 use crate::error::AppError;
 use crate::{MarmotApp, config};
 
+mod legacy_cleanup;
+pub(crate) use legacy_cleanup::cleanup_legacy_audit_logs;
+
 const AUDIT_LOG_CONTENT_TYPE: &str = "application/x-ndjson";
 const AUDIT_DEVICE_ID_FILE: &str = "audit-device-id";
 /// Always-on, append-only per-account key-reveal audit log (mdk#543).

--- a/crates/marmot-app/src/audit_log.rs
+++ b/crates/marmot-app/src/audit_log.rs
@@ -719,8 +719,8 @@ impl MarmotApp {
         // live-recorder match fail, so a delete would remove the visible file
         // while the recorder kept appending to the orphaned inode.
         let account_dir = fs::canonicalize(&account_dir).unwrap_or(account_dir);
-        // Start a distinct v4 file. Legacy files remain enumerable for local
-        // inspection/deletion, but the upload gate rejects their contents.
+        // Start a distinct v4 file. Exclusive-root startup retires legacy files;
+        // any that survive cleanup still fail the upload gate.
         let audit_path = marmot_forensics::default_jsonl_path(&account_dir, &engine_id_hex);
         match marmot_forensics::JsonlRecorder::open_with_account_ref(
             &audit_path,

--- a/crates/marmot-app/src/audit_log/legacy_cleanup.rs
+++ b/crates/marmot-app/src/audit_log/legacy_cleanup.rs
@@ -4,6 +4,11 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
+// These describe the on-disk history, independently of future account layout
+// or audit ID changes. Never redirect cleanup outside the exclusively leased root.
+const LEGACY_CONTAINERS: [&str; 2] = ["accounts", ".wipe-tombstones"];
+const LEGACY_ENGINE_ID_HEX_LEN: usize = 32;
+
 #[derive(Default)]
 struct CleanupCounts {
     deleted: usize,
@@ -11,12 +16,14 @@ struct CleanupCounts {
 }
 
 /// Only call while holding the root lease, before exposing the new app to callers.
-/// Scan every account directory, including signed-out or unreadable accounts,
+/// Scan account directories and failed-wipe remnants, including unreadable accounts,
 /// independently of audit consent. Failed deletions are retried on the next open.
 pub(crate) fn cleanup_legacy_audit_logs(root: &Path) {
     let mut counts = CleanupCounts::default();
-    if clean_accounts(&root.join("accounts"), &mut counts).is_err() {
-        counts.failed += 1;
+    for container in LEGACY_CONTAINERS {
+        if clean_container(&root.join(container), &mut counts).is_err() {
+            counts.failed += 1;
+        }
     }
     if counts.failed > 0 {
         tracing::warn!(
@@ -36,16 +43,22 @@ pub(crate) fn cleanup_legacy_audit_logs(root: &Path) {
     }
 }
 
-fn clean_accounts(accounts: &Path, counts: &mut CleanupCounts) -> io::Result<()> {
+fn clean_container(container: &Path, counts: &mut CleanupCounts) -> io::Result<()> {
     // The constructor already verified and exclusively leased the root. Do not
-    // follow links in the accounts container or either level beneath it.
-    match fs::symlink_metadata(accounts) {
-        Ok(metadata) if !metadata.is_dir() => return Ok(()),
+    // follow links in a container or either level beneath it. An unexpected
+    // container is observable as a cleanup failure; only absence is a quiet no-op.
+    match fs::symlink_metadata(container) {
+        Ok(metadata) if !metadata.is_dir() => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "legacy audit container is not a real directory",
+            ));
+        }
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
         Err(error) => return Err(error),
         Ok(_) => {}
     }
-    for entry in fs::read_dir(accounts)? {
+    for entry in fs::read_dir(container)? {
         let result = (|| {
             let entry = entry?;
             if entry.file_type()?.is_dir() {
@@ -86,7 +99,8 @@ fn clean_account(account: &Path, counts: &mut CleanupCounts) -> io::Result<()> {
 
 /// The app's reserved filename convention, not the broad upload/listing glob.
 /// This also removes empty, corrupt, or truncated legacy logs without reading
-/// their sensitive contents. Custom-named logs and non-legacy versions stay put.
+/// their sensitive contents. Names outside the reserved forms stay put; a
+/// custom file that collides with a reserved legacy name is still deleted.
 fn is_legacy_audit_file_name(name: &str) -> bool {
     let Some(stem) = name
         .strip_prefix("audit-")
@@ -111,8 +125,60 @@ fn is_legacy_audit_file_name(name: &str) -> bool {
         .or_else(|| stem.strip_suffix("-v2"))
         .or_else(|| stem.strip_suffix("-v3"))
         .unwrap_or(stem);
-    engine_id.len() == super::AUDIT_ID_BYTES * 2
-        && engine_id.bytes().all(|byte| byte.is_ascii_hexdigit())
+    engine_id.len() == LEGACY_ENGINE_ID_HEX_LEN
+        && engine_id
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+#[cfg(test)]
+mod classifier_tests {
+    use super::*;
+
+    #[test]
+    fn legacy_audit_cleanup_matches_the_frozen_filename_convention() {
+        let engine = "0123456789abcdef0123456789abcdef";
+        for version in ["", "-v1", "-v2", "-v3"] {
+            for segment in ["", "-seg000001", "-seg1000000", "-seg4294967295"] {
+                let name = format!("audit-{engine}{version}{segment}.jsonl");
+                assert!(is_legacy_audit_file_name(&name), "{name}");
+            }
+        }
+        for suffix in [
+            "-v4",
+            "-v5",
+            "-v10",
+            "-v30",
+            "-v1-v1",
+            "-v3-seg",
+            "-v3-seg1",
+            "-v3-seg00000a",
+            "-v3-seg4294967296",
+            "-v3-seg000001-seg000002",
+            "-v4-seg000001",
+        ] {
+            let name = format!("audit-{engine}{suffix}.jsonl");
+            assert!(!is_legacy_audit_file_name(&name), "{name}");
+        }
+        for other_id in [
+            engine.to_uppercase(),
+            "g".repeat(32),
+            "a".repeat(31),
+            "a".repeat(33),
+            "é".repeat(16),
+        ] {
+            let name = format!("audit-{other_id}-v3.jsonl");
+            assert!(!is_legacy_audit_file_name(&name), "{name}");
+        }
+        for name in [
+            "audit-key-reveal.jsonl".to_owned(),
+            "audit-custom-v3.jsonl".to_owned(),
+            format!("audit-{engine}-v3.jsonl.tmp"),
+            format!("other-{engine}-v3.jsonl"),
+        ] {
+            assert!(!is_legacy_audit_file_name(&name), "{name}");
+        }
+    }
 }
 
 #[cfg(all(test, unix))]
@@ -136,35 +202,26 @@ mod tests {
     #[test]
     fn legacy_audit_cleanup_deletes_only_reserved_old_names_at_startup() {
         let root = tempfile::tempdir().unwrap();
-        let account = root.path().join("accounts/alice");
-        // No valid account record is required to retire the old plaintext files.
-        fs::create_dir_all(&account).unwrap();
-        let mut old_files = Vec::new();
-        for version in ["", "-v1", "-v2", "-v3"] {
-            for segment in ["", "-seg000001", "-seg1000000", "-seg4294967295"] {
-                let name = format!("audit-{ENGINE}{version}{segment}.jsonl");
-                fs::write(account.join(&name), b"PRIVATE_OLD_CONTENT\n{truncated").unwrap();
-                old_files.push(name);
-            }
+        let home = AccountHome::open(root.path());
+        home.create_account("alice").unwrap();
+        // Use AccountHome's actual layout so drift cannot leave the test green.
+        let account = home.account_dir("alice");
+        let old_files = ["", "-v2", "-v3", "-v3-seg000001"]
+            .map(|suffix| format!("audit-{ENGINE}{suffix}.jsonl"));
+        for name in &old_files {
+            fs::write(account.join(name), b"PRIVATE_OLD_CONTENT\n{truncated").unwrap();
         }
-        let mut preserved = vec![
+        let preserved = [
             "audit-key-reveal.jsonl".to_owned(),
             "audit-upload-checkpoint.json".to_owned(),
             "audit-device-id".to_owned(),
             "session.db".to_owned(),
             "audit-custom-v3.jsonl".to_owned(),
             format!("audit-{ENGINE}-v3.jsonl.tmp"),
-            format!("audit-{ENGINE}-v3-seg1.jsonl"),
-            format!("audit-{ENGINE}-v3-seg4294967296.jsonl"),
-            format!("audit-{ENGINE}-v3-seg000001-seg000002.jsonl"),
+            format!("audit-{ENGINE}-v4.jsonl"),
+            format!("audit-{ENGINE}-v4-seg000001.jsonl"),
+            format!("audit-{ENGINE}-v5.jsonl"),
         ];
-        for version in ["v4", "v5", "v30"] {
-            preserved.push(format!("audit-{ENGINE}-{version}.jsonl"));
-            preserved.push(format!("audit-{ENGINE}-{version}-seg000001.jsonl"));
-        }
-        for other_id in ["g".repeat(32), "a".repeat(31), "a".repeat(33)] {
-            preserved.push(format!("audit-{other_id}-v3.jsonl"));
-        }
         for name in &preserved {
             fs::write(account.join(name), b"KEEP_EXACT_BYTES").unwrap();
         }
@@ -195,7 +252,7 @@ mod tests {
     #[test]
     fn legacy_audit_cleanup_waits_for_exclusive_root_ownership() {
         let root = tempfile::tempdir().unwrap();
-        let account = root.path().join("accounts/alice");
+        let account = AccountHome::open(root.path()).account_dir("alice");
         fs::create_dir_all(&account).unwrap();
         let file = account.join(format!("audit-{ENGINE}-v3.jsonl"));
         fs::write(&file, b"OLD_ACTIVE_RECORDER").unwrap();
@@ -216,40 +273,141 @@ mod tests {
 
     #[test]
     fn legacy_audit_cleanup_does_not_follow_links_at_any_scan_level() {
+        for container in LEGACY_CONTAINERS {
+            let root = tempfile::tempdir().unwrap();
+            let external = tempfile::tempdir().unwrap();
+            let name = format!("audit-{ENGINE}-v3.jsonl");
+            let target = external.path().join(&name);
+            fs::write(&target, b"EXTERNAL_BYTES").unwrap();
+            let external_account = external.path().join("victim");
+            fs::create_dir(&external_account).unwrap();
+            let nested_target = external_account.join(&name);
+            fs::write(&nested_target, b"EXTERNAL_ACCOUNT_BYTES").unwrap();
+            let accounts = root.path().join(container);
+            symlink(external.path(), &accounts).unwrap();
+            drop(open_app(root.path()).unwrap());
+            assert_eq!(fs::read(&target).unwrap(), b"EXTERNAL_BYTES");
+            assert_eq!(fs::read(&nested_target).unwrap(), b"EXTERNAL_ACCOUNT_BYTES");
+            fs::remove_file(&accounts).unwrap();
+            fs::create_dir(&accounts).unwrap();
+            symlink(external.path(), accounts.join("linked-account")).unwrap();
+            let real_account = accounts.join("real-account");
+            fs::create_dir(&real_account).unwrap();
+            symlink(&target, real_account.join(&name)).unwrap();
+            drop(open_app(root.path()).unwrap());
+            assert_eq!(fs::read(target).unwrap(), b"EXTERNAL_BYTES");
+            assert!(
+                fs::symlink_metadata(real_account.join(name))
+                    .unwrap()
+                    .is_symlink()
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_audit_cleanup_never_scans_an_unleased_account_home() {
         let root = tempfile::tempdir().unwrap();
         let external = tempfile::tempdir().unwrap();
-        let name = format!("audit-{ENGINE}-v3.jsonl");
-        let target = external.path().join(&name);
-        fs::write(&target, b"EXTERNAL_BYTES").unwrap();
-        let external_account = external.path().join("victim");
-        fs::create_dir(&external_account).unwrap();
-        let nested_target = external_account.join(&name);
-        fs::write(&nested_target, b"EXTERNAL_ACCOUNT_BYTES").unwrap();
-        let accounts = root.path().join("accounts");
-        symlink(external.path(), &accounts).unwrap();
-        drop(open_app(root.path()).unwrap());
-        assert_eq!(fs::read(&target).unwrap(), b"EXTERNAL_BYTES");
-        assert_eq!(fs::read(&nested_target).unwrap(), b"EXTERNAL_ACCOUNT_BYTES");
-        fs::remove_file(&accounts).unwrap();
-        fs::create_dir(&accounts).unwrap();
-        symlink(external.path(), accounts.join("linked-account")).unwrap();
-        let real_account = accounts.join("real-account");
-        fs::create_dir(&real_account).unwrap();
-        symlink(&target, real_account.join(&name)).unwrap();
-        drop(open_app(root.path()).unwrap());
-        assert_eq!(fs::read(target).unwrap(), b"EXTERNAL_BYTES");
-        assert!(
-            fs::symlink_metadata(real_account.join(name))
-                .unwrap()
-                .is_symlink()
+        let home = AccountHome::open(external.path());
+        let account = home.account_dir("alice");
+        fs::create_dir_all(&account).unwrap();
+        let file = account.join(format!("audit-{ENGINE}-v3.jsonl"));
+        fs::write(&file, b"OUTSIDE_LEASED_ROOT").unwrap();
+        // A mismatched embedding must never redirect deletion to the unleased
+        // AccountHome, whether the constructor accepts or rejects that config.
+        let _app = MarmotApp::try_with_relays_and_account_home_and_config(
+            root.path(),
+            Vec::new(),
+            home,
+            MarmotAppConfig::default(),
         );
+        assert_eq!(fs::read(file).unwrap(), b"OUTSIDE_LEASED_ROOT");
+    }
+
+    #[test]
+    fn legacy_audit_cleanup_reports_invalid_containers_and_continues() {
+        let root = tempfile::tempdir().unwrap();
+        let accounts = root.path().join("accounts");
+        fs::write(&accounts, b"UNEXPECTED_CONTAINER_FILE").unwrap();
+        let mut counts = CleanupCounts::default();
+        assert!(clean_container(&accounts, &mut counts).is_err());
+        let remnant = root.path().join(".wipe-tombstones/orphan");
+        fs::create_dir_all(&remnant).unwrap();
+        let old = remnant.join(format!("audit-{ENGINE}-v3.jsonl"));
+        fs::write(&old, b"OLD").unwrap();
+        drop(open_app(root.path()).unwrap());
+        assert!(!old.exists());
+        assert_eq!(fs::read(&accounts).unwrap(), b"UNEXPECTED_CONTAINER_FILE");
+        fs::remove_file(&accounts).unwrap();
+        symlink(&remnant, &accounts).unwrap();
+        assert!(clean_container(&accounts, &mut counts).is_err());
+    }
+
+    #[test]
+    fn legacy_audit_cleanup_removes_logs_left_by_a_failed_account_wipe() {
+        use marmot_account::{
+            AccountHomeResult, AccountSecretStore, AccountSummary, LocalFileSecretStore,
+        };
+
+        struct FailSecretRemoval(LocalFileSecretStore);
+        impl AccountSecretStore for FailSecretRemoval {
+            fn has_secret_for_label(&self, label: &str) -> AccountHomeResult<bool> {
+                self.0.has_secret_for_label(label)
+            }
+            fn write_secret(
+                &self,
+                account: &AccountSummary,
+                keys: &nostr::Keys,
+            ) -> AccountHomeResult<()> {
+                self.0.write_secret(account, keys)
+            }
+            fn load_secret(&self, account: &AccountSummary) -> AccountHomeResult<nostr::Keys> {
+                self.0.load_secret(account)
+            }
+            fn remove_secret(&self, _account: &AccountSummary) -> AccountHomeResult<()> {
+                Err(io::Error::from(io::ErrorKind::PermissionDenied).into())
+            }
+        }
+
+        let root = tempfile::tempdir().unwrap();
+        let home = AccountHome::open_with_secret_store(
+            root.path(),
+            std::sync::Arc::new(FailSecretRemoval(LocalFileSecretStore::new(root.path()))),
+        );
+        home.create_account("alice").unwrap();
+        let account = home.account_dir("alice");
+        let old = format!("audit-{ENGINE}-v2.jsonl");
+        let v4 = format!("audit-{ENGINE}-v4.jsonl");
+        for name in [&old, &v4, "audit-key-reveal.jsonl"] {
+            fs::write(account.join(name), b"PRESERVED_UNTIL_CLEANUP").unwrap();
+        }
+        // Exercise the real rename-to-tombstone path. A credential-store error
+        // after the rename leaves the removed account's files outside accounts/.
+        assert!(home.remove_account("alice").is_err());
+        let remnant = fs::read_dir(root.path().join(".wipe-tombstones"))
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap()
+            .path();
+        assert!(!account.exists());
+        assert!(remnant.join(&old).exists());
+        drop(open_app(root.path()).unwrap());
+        assert!(!remnant.join(old).exists());
+        for name in [&v4, "audit-key-reveal.jsonl"] {
+            assert_eq!(
+                fs::read(remnant.join(name)).unwrap(),
+                b"PRESERVED_UNTIL_CLEANUP"
+            );
+        }
     }
 
     #[test]
     fn legacy_audit_cleanup_failure_does_not_block_open_and_retries_later() {
         let root = tempfile::tempdir().unwrap();
-        let blocked = root.path().join("accounts/blocked");
-        let healthy = root.path().join("accounts/healthy");
+        let home = AccountHome::open(root.path());
+        let blocked = home.account_dir("blocked");
+        let healthy = home.account_dir("healthy");
         fs::create_dir_all(&blocked).unwrap();
         fs::create_dir_all(&healthy).unwrap();
         let name = format!("audit-{ENGINE}-v2.jsonl");

--- a/crates/marmot-app/src/audit_log/legacy_cleanup.rs
+++ b/crates/marmot-app/src/audit_log/legacy_cleanup.rs
@@ -1,0 +1,277 @@
+//! Retire the app's v1-v3 forensic files after acquiring exclusive root ownership.
+
+use std::fs;
+use std::io;
+use std::path::Path;
+
+#[derive(Default)]
+struct CleanupCounts {
+    deleted: usize,
+    failed: usize,
+}
+
+/// Only call while holding the root lease, before exposing the new app to callers.
+/// Scan every account directory, including signed-out or unreadable accounts,
+/// independently of audit consent. Failed deletions are retried on the next open.
+pub(crate) fn cleanup_legacy_audit_logs(root: &Path) {
+    let mut counts = CleanupCounts::default();
+    if clean_accounts(&root.join("accounts"), &mut counts).is_err() {
+        counts.failed += 1;
+    }
+    if counts.failed > 0 {
+        tracing::warn!(
+            target: "marmot_app::audit_log",
+            method = "cleanup_legacy_audit_logs",
+            deleted = counts.deleted,
+            failed = counts.failed,
+            "legacy forensic audit cleanup incomplete; will retry on next app open"
+        );
+    } else if counts.deleted > 0 {
+        tracing::info!(
+            target: "marmot_app::audit_log",
+            method = "cleanup_legacy_audit_logs",
+            deleted = counts.deleted,
+            "removed legacy forensic audit files"
+        );
+    }
+}
+
+fn clean_accounts(accounts: &Path, counts: &mut CleanupCounts) -> io::Result<()> {
+    // The constructor already verified and exclusively leased the root. Do not
+    // follow links in the accounts container or either level beneath it.
+    match fs::symlink_metadata(accounts) {
+        Ok(metadata) if !metadata.is_dir() => return Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+        Ok(_) => {}
+    }
+    for entry in fs::read_dir(accounts)? {
+        let result = (|| {
+            let entry = entry?;
+            if entry.file_type()?.is_dir() {
+                clean_account(&entry.path(), counts)?;
+            }
+            Ok::<_, io::Error>(())
+        })();
+        if result.is_err() {
+            counts.failed += 1;
+        }
+    }
+    Ok(())
+}
+
+fn clean_account(account: &Path, counts: &mut CleanupCounts) -> io::Result<()> {
+    for entry in fs::read_dir(account)? {
+        let result = (|| {
+            let entry = entry?;
+            let name = entry.file_name();
+            if !name.to_str().is_some_and(is_legacy_audit_file_name)
+                || !entry.file_type()?.is_file()
+            {
+                return Ok(());
+            }
+            match fs::remove_file(entry.path()) {
+                Ok(()) => counts.deleted += 1,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+            }
+            Ok::<_, io::Error>(())
+        })();
+        if result.is_err() {
+            counts.failed += 1;
+        }
+    }
+    Ok(())
+}
+
+/// The app's reserved filename convention, not the broad upload/listing glob.
+/// This also removes empty, corrupt, or truncated legacy logs without reading
+/// their sensitive contents. Custom-named logs and non-legacy versions stay put.
+fn is_legacy_audit_file_name(name: &str) -> bool {
+    let Some(stem) = name
+        .strip_prefix("audit-")
+        .and_then(|name| name.strip_suffix(".jsonl"))
+    else {
+        return false;
+    };
+    let stem = if let Some((base, index)) = stem.rsplit_once("-seg") {
+        // Recorder indices are u32, padded to at least six decimal digits.
+        if index.len() < 6
+            || !index.bytes().all(|byte| byte.is_ascii_digit())
+            || index.parse::<u32>().is_err()
+        {
+            return false;
+        }
+        base
+    } else {
+        stem
+    };
+    let engine_id = stem
+        .strip_suffix("-v1")
+        .or_else(|| stem.strip_suffix("-v2"))
+        .or_else(|| stem.strip_suffix("-v3"))
+        .unwrap_or(stem);
+    engine_id.len() == super::AUDIT_ID_BYTES * 2
+        && engine_id.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use crate::{AppError, MarmotApp, MarmotAppConfig, MarmotRootRuntimeLease};
+    use marmot_account::AccountHome;
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    const ENGINE: &str = "0123456789abcdef0123456789abcdef";
+
+    fn open_app(root: &Path) -> Result<MarmotApp, AppError> {
+        MarmotApp::try_with_relays_and_account_home_and_config(
+            root,
+            Vec::new(),
+            AccountHome::open(root),
+            MarmotAppConfig::default(),
+        )
+    }
+
+    #[test]
+    fn legacy_audit_cleanup_deletes_only_reserved_old_names_at_startup() {
+        let root = tempfile::tempdir().unwrap();
+        let account = root.path().join("accounts/alice");
+        // No valid account record is required to retire the old plaintext files.
+        fs::create_dir_all(&account).unwrap();
+        let mut old_files = Vec::new();
+        for version in ["", "-v1", "-v2", "-v3"] {
+            for segment in ["", "-seg000001", "-seg1000000", "-seg4294967295"] {
+                let name = format!("audit-{ENGINE}{version}{segment}.jsonl");
+                fs::write(account.join(&name), b"PRIVATE_OLD_CONTENT\n{truncated").unwrap();
+                old_files.push(name);
+            }
+        }
+        let mut preserved = vec![
+            "audit-key-reveal.jsonl".to_owned(),
+            "audit-upload-checkpoint.json".to_owned(),
+            "audit-device-id".to_owned(),
+            "session.db".to_owned(),
+            "audit-custom-v3.jsonl".to_owned(),
+            format!("audit-{ENGINE}-v3.jsonl.tmp"),
+            format!("audit-{ENGINE}-v3-seg1.jsonl"),
+            format!("audit-{ENGINE}-v3-seg4294967296.jsonl"),
+            format!("audit-{ENGINE}-v3-seg000001-seg000002.jsonl"),
+        ];
+        for version in ["v4", "v5", "v30"] {
+            preserved.push(format!("audit-{ENGINE}-{version}.jsonl"));
+            preserved.push(format!("audit-{ENGINE}-{version}-seg000001.jsonl"));
+        }
+        for other_id in ["g".repeat(32), "a".repeat(31), "a".repeat(33)] {
+            preserved.push(format!("audit-{other_id}-v3.jsonl"));
+        }
+        for name in &preserved {
+            fs::write(account.join(name), b"KEEP_EXACT_BYTES").unwrap();
+        }
+        let nested = account.join("nested");
+        fs::create_dir(&nested).unwrap();
+        let nested_old = nested.join(&old_files[0]);
+        fs::write(&nested_old, b"NOT_AN_ACCOUNT_AUDIT").unwrap();
+        let fake_file = account.join(format!("audit-{}-v3.jsonl", "ab".repeat(16)));
+        fs::create_dir(&fake_file).unwrap();
+
+        let app = open_app(root.path()).unwrap();
+        assert!(!app.audit_log_settings().unwrap().enabled);
+        for name in old_files {
+            assert!(!account.join(name).exists());
+        }
+        for name in &preserved {
+            assert_eq!(fs::read(account.join(name)).unwrap(), b"KEEP_EXACT_BYTES");
+        }
+        assert!(fake_file.is_dir());
+        assert_eq!(fs::read(&nested_old).unwrap(), b"NOT_AN_ACCOUNT_AUDIT");
+        drop(app);
+        drop(open_app(root.path()).unwrap()); // Idempotent, including with audit disabled.
+        for name in preserved {
+            assert_eq!(fs::read(account.join(name)).unwrap(), b"KEEP_EXACT_BYTES");
+        }
+    }
+
+    #[test]
+    fn legacy_audit_cleanup_waits_for_exclusive_root_ownership() {
+        let root = tempfile::tempdir().unwrap();
+        let account = root.path().join("accounts/alice");
+        fs::create_dir_all(&account).unwrap();
+        let file = account.join(format!("audit-{ENGINE}-v3.jsonl"));
+        fs::write(&file, b"OLD_ACTIVE_RECORDER").unwrap();
+        let owner = MarmotRootRuntimeLease::try_acquire(root.path()).unwrap();
+        assert!(matches!(open_app(root.path()), Err(AppError::RuntimeBusy)));
+        assert_eq!(fs::read(&file).unwrap(), b"OLD_ACTIVE_RECORDER");
+        drop(owner);
+        let app = open_app(root.path()).unwrap();
+        assert!(!file.exists());
+        // A new v4 recorder remains live and untouched by a rejected second open.
+        app.account_home().create_account("bob").unwrap();
+        let recorder = app.build_audit_recorder("bob", true);
+        let path = recorder.audit_log_path().unwrap();
+        let before = fs::read(&path).unwrap();
+        assert!(matches!(open_app(root.path()), Err(AppError::RuntimeBusy)));
+        assert_eq!(fs::read(path).unwrap(), before);
+    }
+
+    #[test]
+    fn legacy_audit_cleanup_does_not_follow_links_at_any_scan_level() {
+        let root = tempfile::tempdir().unwrap();
+        let external = tempfile::tempdir().unwrap();
+        let name = format!("audit-{ENGINE}-v3.jsonl");
+        let target = external.path().join(&name);
+        fs::write(&target, b"EXTERNAL_BYTES").unwrap();
+        let external_account = external.path().join("victim");
+        fs::create_dir(&external_account).unwrap();
+        let nested_target = external_account.join(&name);
+        fs::write(&nested_target, b"EXTERNAL_ACCOUNT_BYTES").unwrap();
+        let accounts = root.path().join("accounts");
+        symlink(external.path(), &accounts).unwrap();
+        drop(open_app(root.path()).unwrap());
+        assert_eq!(fs::read(&target).unwrap(), b"EXTERNAL_BYTES");
+        assert_eq!(fs::read(&nested_target).unwrap(), b"EXTERNAL_ACCOUNT_BYTES");
+        fs::remove_file(&accounts).unwrap();
+        fs::create_dir(&accounts).unwrap();
+        symlink(external.path(), accounts.join("linked-account")).unwrap();
+        let real_account = accounts.join("real-account");
+        fs::create_dir(&real_account).unwrap();
+        symlink(&target, real_account.join(&name)).unwrap();
+        drop(open_app(root.path()).unwrap());
+        assert_eq!(fs::read(target).unwrap(), b"EXTERNAL_BYTES");
+        assert!(
+            fs::symlink_metadata(real_account.join(name))
+                .unwrap()
+                .is_symlink()
+        );
+    }
+
+    #[test]
+    fn legacy_audit_cleanup_failure_does_not_block_open_and_retries_later() {
+        let root = tempfile::tempdir().unwrap();
+        let blocked = root.path().join("accounts/blocked");
+        let healthy = root.path().join("accounts/healthy");
+        fs::create_dir_all(&blocked).unwrap();
+        fs::create_dir_all(&healthy).unwrap();
+        let name = format!("audit-{ENGINE}-v2.jsonl");
+        fs::write(blocked.join(&name), b"OLD").unwrap();
+        fs::write(healthy.join(&name), b"OLD").unwrap();
+        // Probe whether this test process bypasses directory permissions (root).
+        let probe = blocked.join("permission-probe");
+        fs::write(&probe, b"").unwrap();
+        fs::set_permissions(&blocked, fs::Permissions::from_mode(0o500)).unwrap();
+        if fs::remove_file(&probe).is_ok() {
+            fs::set_permissions(&blocked, fs::Permissions::from_mode(0o700)).unwrap();
+            eprintln!("permission failure scenario requires an unprivileged test process");
+            return;
+        }
+        let result = open_app(root.path());
+        // Restore permissions before assertions so temp cleanup works on failure.
+        fs::set_permissions(&blocked, fs::Permissions::from_mode(0o700)).unwrap();
+        let app = result.unwrap();
+        assert!(blocked.join(&name).exists());
+        assert!(!healthy.join(&name).exists());
+        drop(app);
+        drop(open_app(root.path()).unwrap());
+        assert!(!blocked.join(name).exists());
+    }
+}

--- a/crates/marmot-app/src/audit_log/legacy_cleanup.rs
+++ b/crates/marmot-app/src/audit_log/legacy_cleanup.rs
@@ -419,7 +419,6 @@ mod tests {
         fs::set_permissions(&blocked, fs::Permissions::from_mode(0o500)).unwrap();
         if fs::remove_file(&probe).is_ok() {
             fs::set_permissions(&blocked, fs::Permissions::from_mode(0o700)).unwrap();
-            eprintln!("permission failure scenario requires an unprivileged test process");
             return;
         }
         let result = open_app(root.path());

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1602,6 +1602,7 @@ impl MarmotApp {
     ) -> Result<Self, AppError> {
         let root = root.as_ref().to_path_buf();
         let lease = MarmotRootRuntimeLease::try_acquire(&root)?;
+        audit_log::cleanup_legacy_audit_logs(&root);
         let app =
             Self::with_relays_and_account_home_and_config(&root, relay_urls, account_home, config);
         *app.root_runtime_lease

--- a/crates/marmot-uniffi/README.md
+++ b/crates/marmot-uniffi/README.md
@@ -29,6 +29,9 @@ object, subscription objects, records, enums, and error variants.
 ## Audit v4 adoption
 
 Audit uploads now accept only `marmot-forensics-audit/v4`; old local files are never migrated or sent.
+App construction automatically removes recognized v1-v3 forensic files and rotated segments after acquiring the
+root lease, even with recording disabled. V4 files and the separate key-reveal log are preserved; failures are
+nonfatal and retried on the next open. No additional Swift/Kotlin cleanup call is needed.
 Regenerate Swift/Kotlin bindings and use `AuditLogTrackerConfigV4Ffi` with
 `AuditLogUploadSourceV4Ffi.hardwareModel` in place of the old source record and its `deviceLabel`.
 The versioned config type changes the setter ABI checksum so old generated bindings cannot silently

--- a/crates/marmot-uniffi/README.md
+++ b/crates/marmot-uniffi/README.md
@@ -30,8 +30,9 @@ object, subscription objects, records, enums, and error variants.
 
 Audit uploads now accept only `marmot-forensics-audit/v4`; old local files are never migrated or sent.
 App construction automatically removes recognized v1-v3 forensic files and rotated segments after acquiring the
-root lease, even with recording disabled. V4 files and the separate key-reveal log are preserved; failures are
-nonfatal and retried on the next open. No additional Swift/Kotlin cleanup call is needed.
+root lease, including files in failed account-wipe remnants, even with recording disabled. V4 files and the separate
+key-reveal log are preserved; failures are nonfatal and retried on the next open. No additional Swift/Kotlin cleanup
+call is needed.
 Regenerate Swift/Kotlin bindings and use `AuditLogTrackerConfigV4Ffi` with
 `AuditLogUploadSourceV4Ffi.hardwareModel` in place of the old source record and its `deviceLabel`.
 The versioned config type changes the setter ABI checksum so old generated bindings cannot silently

--- a/docs/marmot-architecture/audit-logging.md
+++ b/docs/marmot-architecture/audit-logging.md
@@ -1114,24 +1114,37 @@ separate from this SDK change.
 
 ### Legacy local cleanup
 
+Legacy forensic logs are permanently retired on upgrade. This replaces the interim v4-cutover policy of retaining
+v1-v3 files for manual inspection. Those files no longer have a supported upload path, and older FullData-mode
+logs can contain decrypted content in plaintext outside SQLCipher. Orphaned/unreadable account directories are
+not exposed by `audit_log_files()`, so leaving cleanup to the host's list/delete UI would miss them.
+The policy is automatic with no host opt-out or per-file callback. It removes these diagnostic artifacts, not
+account identities: account directory names and ordinary account data remain. Hosts should refresh any cached
+file listing after opening a new runtime; historical file paths are not durable handles.
+
 `MarmotApp::try_with_relays_and_account_home_and_config` removes the app's legacy forensic files after acquiring
 the exclusive root lease and before exposing the app or opening recorders. Swift/Kotlin constructors already use
 this path; no new host call is required. Cleanup runs regardless of the recording toggle or upload configuration.
 Constructors for tests/embeddings with externally coordinated ownership do not run this cleanup.
 
-The scan is limited to regular files directly inside `<root>/accounts/<account-directory>/`, including directories
-whose account records are missing, unreadable, or signed out. It recognizes the reserved app filenames
-`audit-<32-hex-engine-id>.jsonl` and `audit-<32-hex-engine-id>-v1.jsonl` / `-v2.jsonl` / `-v3.jsonl`, plus their
-`-seg<index>.jsonl` siblings (u32 decimal index, padded to at least six digits). Classification is by that historical
+The scan is limited to regular files directly inside `<root>/accounts/<account-directory>/` and
+`<root>/.wipe-tombstones/<account-remnant>/`, including failed wipes and directories whose account records are
+missing, unreadable, or signed out. These are fixed historical namespaces inside the leased root. It recognizes
+the reserved app filenames `audit-<32-lowercase-hex-engine-id>.jsonl` and the `-v1.jsonl` / `-v2.jsonl` / `-v3.jsonl`
+variants, plus their `-seg<index>.jsonl` siblings (u32 decimal index, padded to at least six digits). Classification is by that historical
 filename convention, so empty, corrupt, or partially written files are removed too; payloads are not read or copied.
 This is distinct from the upload gate, which always validates content.
 
-V4/future filenames, custom names, temporary files, databases, the device ID, and `audit-key-reveal.jsonl` are
-preserved. Symlinks are skipped at every scan level, nested directories are not traversed, and files outside the
-leased root are not scanned. Cleanup is idempotent; a scan/deletion failure does not prevent startup or processing
+V4/future filenames, names outside those reserved forms, temporary files, databases, the device ID, and
+`audit-key-reveal.jsonl` are preserved. A custom file that uses a reserved legacy name is also deleted. Symlinks
+are skipped at every scan level; a symlinked or non-directory container is reported as a cleanup failure.
+Nested directories are not traversed, and files outside the leased root are not scanned. Cleanup is idempotent;
+a scan/deletion failure does not prevent startup or processing
 other accounts/files, and a later exclusive-root open retries. Logs contain only deleted/failed counts. Remaining
 legacy files still fail the v4 upload gate. Cleanup does not rewrite the upload-checkpoint sidecar; the tracker
 retains its existing pruning behavior. This retirement does not introduce ongoing v4 retention limits.
+There is no date-based sunset: direct upgrades from old builds, restored backups, and previous deletion failures
+can reintroduce legacy files later. Removing the scan requires an explicit change to those upgrade/restore guarantees.
 
 ### Tracker config
 

--- a/docs/marmot-architecture/audit-logging.md
+++ b/docs/marmot-architecture/audit-logging.md
@@ -24,8 +24,8 @@ The retained deterministic hashes, raw group/message/transport identifiers, time
 | Local JSONL recording | Implemented by `marmot-forensics::JsonlRecorder`, installed into each `AccountDeviceSession` only when app-level `AuditLogSettings.enabled` is true before that account session opens. |
 | Default behavior | Off. Without an installed recorder, the engine uses `NoopRecorder` and emits no JSONL records. |
 | File shape | Append-only JSONL/NDJSON, one `AuditEvent` per line, schema version `marmot-forensics-audit/v4`; the line-level JSON Schema is [`audit-log-event.v4.schema.json`](../../crates/marmot-forensics/schema/audit-log-event.v4.schema.json). |
-| Local file location | `<account_dir>/audit-<engine_id>-v4.jsonl` for app-opened account sessions, sealed into `-seg<NNNNNN>` siblings at 1 MiB. Existing v1/v2/v3 files are not rewritten or appended to. |
-| Upload/listing | App and bindings list all local `audit-*.jsonl` files for inspection/deletion. Both explicit and tracker uploads accept only valid v4 snapshots; legacy and key-reveal files stay local. |
+| Local file location | `<account_dir>/audit-<engine_id>-v4.jsonl` for app-opened account sessions, sealed into `-seg<NNNNNN>` siblings at 1 MiB. Exclusive-root startup deletes recognized v1/v2/v3 files and segments. |
+| Upload/listing | App and bindings list remaining local `audit-*.jsonl` files for inspection/deletion. Both explicit and tracker uploads accept only valid v4 snapshots; any legacy files left after cleanup and the separate key-reveal log are never sent. |
 | Static bundle analyzer | Not present in the current repo path. The current artifact model is raw append-only JSONL audit logs. |
 
 ## Source map
@@ -1111,6 +1111,27 @@ No v1-v3 migration or sanitization is performed. Historical schemas remain commi
 new app and default recorder paths use v4. Deploy Goggles v4-only acceptance before the historical server purge.
 Rejected bodies must not be stored as quarantined artifacts by Goggles. Client adoption and server deployment are
 separate from this SDK change.
+
+### Legacy local cleanup
+
+`MarmotApp::try_with_relays_and_account_home_and_config` removes the app's legacy forensic files after acquiring
+the exclusive root lease and before exposing the app or opening recorders. Swift/Kotlin constructors already use
+this path; no new host call is required. Cleanup runs regardless of the recording toggle or upload configuration.
+Constructors for tests/embeddings with externally coordinated ownership do not run this cleanup.
+
+The scan is limited to regular files directly inside `<root>/accounts/<account-directory>/`, including directories
+whose account records are missing, unreadable, or signed out. It recognizes the reserved app filenames
+`audit-<32-hex-engine-id>.jsonl` and `audit-<32-hex-engine-id>-v1.jsonl` / `-v2.jsonl` / `-v3.jsonl`, plus their
+`-seg<index>.jsonl` siblings (u32 decimal index, padded to at least six digits). Classification is by that historical
+filename convention, so empty, corrupt, or partially written files are removed too; payloads are not read or copied.
+This is distinct from the upload gate, which always validates content.
+
+V4/future filenames, custom names, temporary files, databases, the device ID, and `audit-key-reveal.jsonl` are
+preserved. Symlinks are skipped at every scan level, nested directories are not traversed, and files outside the
+leased root are not scanned. Cleanup is idempotent; a scan/deletion failure does not prevent startup or processing
+other accounts/files, and a later exclusive-root open retries. Logs contain only deleted/failed counts. Remaining
+legacy files still fail the v4 upload gate. Cleanup does not rewrite the upload-checkpoint sidecar; the tracker
+retains its existing pruning behavior. This retirement does not introduce ongoing v4 retention limits.
 
 ### Tracker config
 

--- a/docs/marmot-architecture/overview/current-state.md
+++ b/docs/marmot-architecture/overview/current-state.md
@@ -188,8 +188,8 @@ This repository now has the main engine candidate:
 - `crates/marmot-markdown` — CommonMark and Nostr-aware display parser for app message rendering.
 - `crates/marmot-forensics` — opt-in v4 JSONL forensic audit schema and recorder traits. Account/device display names
   are excluded; platform, app version and optional system hardware model are retained. App uploads validate v4-only
-  snapshots. Exclusive-root app startup removes recognized legacy forensic files and segments while preserving
-  v4 files and the separate key-reveal log. See [audit logging](../audit-logging.md).
+  snapshots. Exclusive-root app startup removes recognized legacy forensic files and segments, including failed-wipe
+  remnants, while preserving v4 files and the separate key-reveal log. See [audit logging](../audit-logging.md).
 - `crates/marmot-uniffi` — UniFFI bindings and build scripts for Swift/Kotlin app runtimes.
 - `crates/agent-control` — `marmot.agent-control.v2` DTOs and newline-delimited JSON framing for agent integrations.
 - `crates/agent-stream-compose` — reusable live-preview stream composition over the QUIC broker publisher.

--- a/docs/marmot-architecture/overview/current-state.md
+++ b/docs/marmot-architecture/overview/current-state.md
@@ -188,7 +188,8 @@ This repository now has the main engine candidate:
 - `crates/marmot-markdown` — CommonMark and Nostr-aware display parser for app message rendering.
 - `crates/marmot-forensics` — opt-in v4 JSONL forensic audit schema and recorder traits. Account/device display names
   are excluded; platform, app version and optional system hardware model are retained. App uploads validate v4-only
-  snapshots and leave legacy files local. See [audit logging](../audit-logging.md).
+  snapshots. Exclusive-root app startup removes recognized legacy forensic files and segments while preserving
+  v4 files and the separate key-reveal log. See [audit logging](../audit-logging.md).
 - `crates/marmot-uniffi` — UniFFI bindings and build scripts for Swift/Kotlin app runtimes.
 - `crates/agent-control` — `marmot.agent-control.v2` DTOs and newline-delimited JSON framing for agent integrations.
 - `crates/agent-stream-compose` — reusable live-preview stream composition over the QUIC broker publisher.


### PR DESCRIPTION
After #1779, MDK writes and uploads only v4 forensic audit logs. Legacy files no longer have a supported upload path, but can retain account/device labels and, in older FullData-mode logs, decrypted content as plaintext outside SQLCipher. Legacy files in orphaned account directories or failed-wipe remnants are also absent from the host-facing audit listing. This change permanently deletes recognized v1-v3 forensic files when an app acquires exclusive ownership of its data root, before any recorder opens.

Cleanup runs even with audit recording disabled or uploads unconfigured. Swift/Kotlin and C app constructors already use this open path, so adopting the updated MDK requires no additional cleanup call.

### Retention decision

Automatic retirement is the requested policy for this follow-up, replacing #1779's interim preservation of legacy files for manual inspection. There is no per-host opt-out or per-file callback; deletion is reported through aggregate logs. This removes obsolete diagnostic artifacts, not account identities or other local state: account directory names and ordinary account data remain. Hosts should refresh any cached audit listing after a new runtime opens.

There is no date-based sunset: users can upgrade directly from older builds, restore old backups, or retry previously failed cleanup. Removing this scan later requires an explicit change to those upgrade/restore guarantees.

### Deletion boundary

- Scan regular files directly under `<root>/accounts/<account-directory>/` and `<root>/.wipe-tombstones/<account-remnant>/`, including signed-out accounts, failed wipes, and directories with missing/unreadable account records. Keep the historical namespaces fixed inside the leased root; never follow a mismatched `AccountHome` into an unleased root.
- Delete the reserved `audit-<32-lowercase-hex-engine-id>.jsonl` and `audit-<32-lowercase-hex-engine-id>-v1/v2/v3.jsonl` filename forms, including their padded numeric `-seg<index>.jsonl` segments. Match the historical naming convention without reading sensitive payloads, so corrupted or truncated legacy files can also be removed.
- Preserve v4/future filenames, `audit-key-reveal.jsonl`, databases, device IDs, checkpoint sidecars, filenames outside the reserved legacy forms, and temporary files. A custom file that collides with a reserved legacy name is also deleted. Skip symlinks at every scan level and do not recurse into account subdirectories.
- Continue after individual failures, log only aggregate deleted/failed counts, and retry on the next exclusive-root open. A busy root prevents cleanup entirely; symlinked or non-directory containers are reported as failures without preventing startup. Constructors intended for tests/embeddings with externally coordinated ownership do not run it.

The v4 upload gate remains unchanged and blocks any legacy files that could not be removed. This does not introduce general v4 retention, change the schema/bindings, bump a release version, or delete server data.

### Validation

- `just fast-ci`.
- App audit unit tests: 39 passed, including startup cleanup, preservation boundaries, disabled recording, idempotence, symlink isolation, exclusive ownership, and nonfatal deletion failure followed by retry. This includes a platform-independent filename matrix, AccountHome-backed layout fixtures, real failed-wipe tombstone coverage, and isolation from a mismatched/unleased AccountHome.
- Root-runtime-lease tests: 5 passed; audit upload integration tests: 25 passed; UniFFI smoke tests: 29 passed.

The permission-failure test runs on unprivileged hosts; it skips that scenario if the test process can bypass directory permissions. It exercised the failure/retry path locally.

