### PR TITLE
chore(release): prepare 0.9.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-connector"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "agent-control",
  "agent-stream-compose",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "agent-control"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "serde",
  "serde_json",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "agent-stream-compose"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -877,7 +877,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgka-conformance-simulator"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-engine"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-session"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-traits"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "async-trait",
  "criterion",
@@ -1209,7 +1209,7 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convergence-campaign-runner"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "async-trait",
  "cgka-conformance-simulator",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "fs-private"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "libc",
  "tempfile",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "incident-replay"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "cgka-conformance-simulator",
  "fs-private",
@@ -3412,7 +3412,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-account"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -3444,7 +3444,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-app"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "agent-stream-compose",
  "async-trait",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-c"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "keyring-core",
  "libc",
@@ -3508,7 +3508,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-forensics"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "fs-private",
  "jsonschema",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-markdown"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "serde",
  "serde_json",
@@ -3528,7 +3528,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-terminal-harness"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "agent-control",
  "async-trait",
@@ -3548,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-uniffi"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "cgka-engine",
  "cgka-traits",
@@ -5819,7 +5819,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-sqlite"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "cgka-traits",
  "fs-private",
@@ -6437,7 +6437,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-adapter"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6457,7 +6457,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-peeler"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6475,7 +6475,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-broker"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "cgka-traits",
  "clap",
@@ -6494,7 +6494,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-stream"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
@@ -7441,7 +7441,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wn-cli"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "agent-stream-compose",
  "cgka-traits",
@@ -7474,7 +7474,7 @@ dependencies = [
 
 [[package]]
 name = "wn-codex"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "async-trait",
  "clap",
@@ -7488,7 +7488,7 @@ dependencies = [
 
 [[package]]
 name = "wn-opencode"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "async-trait",
  "clap",
@@ -7503,7 +7503,7 @@ dependencies = [
 
 [[package]]
 name = "wn-pi"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.9.20"
+version = "0.9.21"
 license = "MIT"
 publish = false
 

--- a/crates/cgka-conformance-simulator/vectors/admin-handover.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-handover.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-handover/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "admin-handover/v1",

--- a/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-policy-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "admin-policy-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "concurrent-invite-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "concurrent-invite-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-committer-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "convergence-committer-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-witness-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "convergence-witness-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/conversation.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/conversation.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "conversation/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "conversation/v1",

--- a/crates/cgka-conformance-simulator/vectors/cross-route-own-commit-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/cross-route-own-commit-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "cross-route-own-commit-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "cross-route-own-commit-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "current-profile-required-set/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "application_profile": {
     "name": "current",

--- a/crates/cgka-conformance-simulator/vectors/deferred-tick-catchup.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/deferred-tick-catchup.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "deferred-tick-catchup/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "deferred-tick-catchup/v1",

--- a/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "delayed-past-epoch-app-message/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "delayed-past-epoch-app-message/v1",

--- a/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "drop-queued/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "drop-queued/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "group-data-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "group-data-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-profile-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-profile-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-profile-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "group-profile-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "convergence-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "membership-fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "membership-fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incremental-growth.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incremental-growth.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "incremental-growth/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "incremental-growth/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-member/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "invite-member/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "invite-publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/late-welcome-backfill.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/late-welcome-backfill.v1.json
@@ -1,7 +1,7 @@
 {
  "scenario_name": "late-welcome-backfill/v1",
  "vector_version": "1",
- "conformance_version": "0.9.20",
+ "conformance_version": "0.9.21",
  "seed": null,
  "scenario": {
   "name": "late-welcome-backfill/v1",

--- a/crates/cgka-conformance-simulator/vectors/latecomer-forward-secrecy.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/latecomer-forward-secrecy.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "latecomer-forward-secrecy/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "latecomer-forward-secrecy/v1",

--- a/crates/cgka-conformance-simulator/vectors/leaver-removal-secrecy.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/leaver-removal-secrecy.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "leaver-removal-secrecy/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "leaver-removal-secrecy/v1",

--- a/crates/cgka-conformance-simulator/vectors/multigroup-isolation.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/multigroup-isolation.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "multigroup-isolation/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "multigroup-isolation/v1",

--- a/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "partition-clear-leave/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "partition-clear-leave/v1",

--- a/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "queue-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "queue-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/readd-after-eviction.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/readd-after-eviction.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "readd-after-eviction/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "readd-after-eviction/v1",

--- a/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "restart-delivery-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "restart-delivery-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/route-equivalence.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/route-equivalence.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "route-equivalence/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "route-equivalence/v1",

--- a/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "three-client-message-exchange/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.20",
+  "conformance_version": "0.9.21",
   "seed": null,
   "scenario": {
     "name": "three-client-message-exchange/v1",

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,26 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+## [0.9.21] - 2026-09-10
+
+### Release notes
+
+- Host-driven agent stream publishing is available through the runtime,
+  Swift/Kotlin, and C bindings.
+- Audit uploads use the v4 schema and hardware model metadata. Hosts must
+  adopt the v4 tracker config and regenerate bindings; startup removes
+  recognized legacy v1-v3 forensic files while preserving v4 and key-reveal logs.
+- Account storage advances through migrations 68–69 for bounded media-retention
+  and chat-readiness queries. Back up before upgrading; downgrade is unsupported.
+  Re-upgrade or restore a pre-upgrade database/export. See the
+  [storage-format contract](../../docs/marmot-architecture/storage-format-v2.md).
+  Upgrades from before 0.9.15 also cross migration 47: keep at least 3.25 times
+  the account database size free for its history-table rebuild.
+- Epoch-gap backfill intents are discarded for groups this device has left or
+  been removed from. Chat-list and media-retention database work is bounded.
+- Update generated source and native libraries together. C consumers must
+  rebuild against the matching header because record layouts changed.
+
 ### Added
 
 - App-message Markdown now emits a structured `Details` block for structural

--- a/crates/marmot-c/CHANGELOG.md
+++ b/crates/marmot-c/CHANGELOG.md
@@ -7,6 +7,13 @@ Versions track the workspace version; releases are tagged `marmotc-v<version>`.
 
 ## [Unreleased]
 
+## [0.9.21] - 2026-09-10
+
+This cohort also exposes host-driven agent stream publishing and the v4 audit
+tracker configuration. Rebuild with the matching header and library. Account
+storage advances through migrations 68–69; back up before upgrading because
+downgrade is unsupported. See the [cohort upgrade notes](../cli/CHANGELOG.md#0921---2026-09-10).
+
 ### Added
 
 - Additive `MarmotMarkdownBlock::Details` with an indirect `MarmotMarkdownDetails`

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -23,7 +23,7 @@ Choose the runtime you already use:
 | Pi | Terminal harness | Repository and coding tasks through Pi |
 
 The guided installers prompt on the terminal for the White Noise account that
-may invite and message the agent. They install release `wn-agent-v0.9.20`, create
+may invite and message the agent. They install release `wn-agent-v0.9.21`, create
 an isolated White Noise identity for the selected connector, and start same-user
 services where supported. Download each installer with its adjacent checksum,
 verify it, and only then execute the local file:
@@ -50,7 +50,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.21"
 ```
 
 ### Hermes
@@ -110,7 +110,7 @@ install_verified "$base_url/install-pi-marmot.sh" \
 
 ### Finish In White Noise
 
-Release 0.9.20 records the new agent's `npub` and `nprofile` in the
+Release 0.9.21 records the new agent's `npub` and `nprofile` in the
 `bootstrap.json` path printed at completion. Display them with:
 
 ```sh

--- a/integrations/codex/marmot/README.md
+++ b/integrations/codex/marmot/README.md
@@ -54,7 +54,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.21"
 install_verified "$base_url/install-codex-marmot.sh" \
   "$base_url/install-codex-marmot.sh.sha256" \
   --yes --allow-welcomer npub1...

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -138,7 +138,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.21"
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256"
 ```
@@ -155,7 +155,7 @@ repeated or given a comma-separated list to authorize multiple senders:
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.21"
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256" \
   --yes \
@@ -171,7 +171,7 @@ with `--generate-identity`). To preserve an existing Nostr identity, place its
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.21"
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256" \
   --yes \
@@ -201,7 +201,7 @@ To accept Marmot messages from any sender (explicit opt-in):
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.21"
 install_verified "$base_url/install-hermes-marmot.sh" \
   "$base_url/install-hermes-marmot.sh.sha256" \
   --yes --allow-all-users

--- a/integrations/openclaw/marmot/README.md
+++ b/integrations/openclaw/marmot/README.md
@@ -82,7 +82,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.21"
 install_verified "$base_url/install-openclaw-marmot.sh" \
   "$base_url/install-openclaw-marmot.sh.sha256"
 ```
@@ -102,7 +102,7 @@ an `npub` or raw hex public key:
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.21"
 install_verified "$base_url/install-openclaw-marmot.sh" \
   "$base_url/install-openclaw-marmot.sh.sha256" \
   --yes --allow-welcomer npub1...
@@ -116,7 +116,7 @@ with `--generate-identity`). To preserve an existing Nostr identity, place its
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.21"
 install_verified "$base_url/install-openclaw-marmot.sh" \
   "$base_url/install-openclaw-marmot.sh.sha256" \
   --yes \

--- a/integrations/opencode/marmot/README.md
+++ b/integrations/opencode/marmot/README.md
@@ -56,7 +56,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.21"
 install_verified "$base_url/install-opencode-marmot.sh" \
   "$base_url/install-opencode-marmot.sh.sha256"
 ```
@@ -67,7 +67,7 @@ as either an `npub` or raw hex public key:
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.21"
 install_verified "$base_url/install-opencode-marmot.sh" \
   "$base_url/install-opencode-marmot.sh.sha256" \
   --yes --allow-welcomer npub1...

--- a/integrations/pi/marmot/README.md
+++ b/integrations/pi/marmot/README.md
@@ -48,7 +48,7 @@ install_verified() (
   bash "$tmpdir/$installer_script" "$@"
 )
 
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.21"
 install_verified "$base_url/install-pi-marmot.sh" \
   "$base_url/install-pi-marmot.sh.sha256"
 ```
@@ -58,7 +58,7 @@ For noninteractive setup, provide the allowed inviter and prompt sender:
 Run this example in the same shell where `install_verified` above was defined.
 
 ```sh
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.21"
 install_verified "$base_url/install-pi-marmot.sh" \
   "$base_url/install-pi-marmot.sh.sha256" \
   --yes --allow-welcomer npub1...

--- a/release.md
+++ b/release.md
@@ -354,7 +354,7 @@ workspace release looks like:
 ```sh
 (
 set -eu
-base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20"
+base_url="https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.21"
 
 install_verified() (
   set -eu

--- a/scripts/install-hermes-marmot.sh
+++ b/scripts/install-hermes-marmot.sh
@@ -118,7 +118,7 @@ Hermes accepts after gateway restart via $HERMES_HOME/.env.
 
 Verified download (then choose one invocation below):
   set -eu
-  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20
+  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.21
   tmpdir="$(mktemp -d)"
   trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
   installer_script=install-hermes-marmot.sh

--- a/scripts/install-openclaw-marmot.sh
+++ b/scripts/install-openclaw-marmot.sh
@@ -110,7 +110,7 @@ Environment:
 
 Verified download (then choose one invocation below):
   set -eu
-  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.20
+  base_url=https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.21
   tmpdir="$(mktemp -d)"
   trap 'rm -rf "$tmpdir"' 0 HUP INT TERM
   installer_script=install-openclaw-marmot.sh


### PR DESCRIPTION
Prepare the 0.9.21 compatibility cohort for MDK, MarmotKit (iOS, macOS, and Android), Marmot C, and WN Agent.

Synchronizes the 26 workspace package versions, all 31 conformance fixtures, installer pins, and changelogs. External dependencies remain unchanged. Release notes cover the binding API changes, v4 audit configuration, KeyPackage admission and regeneration, and migrations 68–69 with backup and downgrade guidance.

Validation passed: `just fast-ci`, Tamarin, canonical vectors, 178 UniFFI tests, 45 C binding tests with allocation auditing, 551 storage tests, the 2,048-row storage upgrade benchmark, five installer dry runs, workspace doctests, all four Android ABIs, and iOS/macOS bundles with SwiftPM consumer compilation and linking. All 5,546 distinct default-suite tests have passing results across the full run, continuation, and serial rechecks. Parallel runs encountered 30 short process/UI deadline failures under build load; all 30 passed serially in 14 seconds. Slow thread-cleanup reports also have clean passing results. PR and merged-commit CI passed, including the diagnostics-enabled test matrix.

Published all four tracks at `fdd398a80f1626f1713787cebe416f7890b5b204`. Verified all 65 downloaded assets against GitHub digests, sibling checksums, manifests, source/version metadata, and lockfile hashes. Both published SwiftPM consumer checks passed; downloaded Apple Silicon agent/harness executables passed smoke checks. MDK is Latest; WN Agent retains the release workflow's prerelease classification.
