### PR TITLE
fix(engine): retire a terminal group's deferred-peel rows so they stop charging the account budget

### DIFF
--- a/crates/cgka-engine/src/disband.rs
+++ b/crates/cgka-engine/src/disband.rs
@@ -15,6 +15,7 @@ use cgka_traits::app_components::{
 use cgka_traits::engine::SendResult;
 use cgka_traits::engine_state::{EpochState, StagedCommitHandle};
 use cgka_traits::error::EngineError;
+use cgka_traits::message::DeferredMessageMetadata;
 use cgka_traits::storage::{
     DisbandCandidate, DisbandFailureReason, DisbandRequest, DisbandRequestStatus, StorageError,
     StorageProvider,
@@ -545,8 +546,8 @@ impl<S: StorageProvider> Engine<S> {
             announced: false,
         };
 
-        self.storage
-            .with_transaction(|storage| -> Result<(), EngineError> {
+        let retired_deferred_rows = self.storage.with_transaction(
+            |storage| -> Result<Vec<DeferredMessageMetadata>, EngineError> {
                 storage.put_disband_tombstone(group_id, &tombstone)?;
                 let mut group = storage.get_group(group_id)?;
                 group.epoch = epoch;
@@ -573,6 +574,16 @@ impl<S: StorageProvider> Engine<S> {
                 }
                 storage.delete_convergence_pass(group_id)?;
                 storage.delete_deferred_peel_generation(group_id)?;
+                // The generation barrier is gone and the rows it tracked
+                // must go with it (see
+                // `Engine::retire_deferred_peel_rows_for_terminal_group`).
+                // Durably retired on this transaction, not after it: the early
+                // return above makes a re-entry after a crash skip this body
+                // forever.
+                let retired_deferred_rows =
+                    crate::message_processor::fail_deferred_peel_rows_in_terminal_group(
+                        storage, group_id,
+                    )?;
                 for snapshot in storage.list_group_snapshots(group_id)? {
                     storage.release_group_snapshot(group_id, &snapshot)?;
                 }
@@ -597,8 +608,10 @@ impl<S: StorageProvider> Engine<S> {
                 mls_group.delete(tx_provider.storage()).map_err(|error| {
                     EngineError::Backend(format!("delete MLS group: {error:?}"))
                 })?;
-                Ok(())
-            })?;
+                Ok(retired_deferred_rows)
+            },
+        )?;
+        self.release_retired_deferred_peel_rows(&retired_deferred_rows);
 
         self.transport_group_id_index
             .retain(|_, mapped_group| mapped_group != group_id);

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -1816,6 +1816,11 @@ impl<S: StorageProvider> Engine<S> {
                 // removed-copy send gate.
                 self.discard_queued_outbound_intents_for_removed_group(group_id)
                     .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
+                // Same for retained inbound rows: see
+                // `retire_deferred_peel_rows_for_terminal_group` for why no
+                // later sweep can reach them.
+                self.retire_deferred_peel_rows_for_terminal_group(group_id)
+                    .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
             }
             self.push_group_state_change(
                 group_id,

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -1599,6 +1599,13 @@ impl<S: StorageProvider> Engine<S> {
                     // intents so later drains do not re-fail them forever
                     // against the removed-copy send gate.
                     self.discard_queued_outbound_intents_for_removed_group(&group_id)?;
+                    // And retire the deferred-peel backlog (see
+                    // `retire_deferred_peel_rows_for_terminal_group`). This
+                    // seam owns that here rather than deferring to
+                    // `realize_self_eviction`: the transaction above already
+                    // wrote `removed`, so a later realization early-returns
+                    // without ever reaching it.
+                    self.retire_deferred_peel_rows_for_terminal_group(&group_id)?;
                 } else if after_ids.contains(self.identity.self_id()) {
                     if self.load_leave_request_state(&group_id)?.is_some() {
                         // A SelfRemove proposal is valid only in its
@@ -2246,6 +2253,10 @@ impl<S: StorageProvider> Engine<S> {
         // leaving them to re-fail through the removed-copy send gate on every
         // later drain.
         self.discard_queued_outbound_intents_for_removed_group(group_id)?;
+        // Same for retained inbound work: see
+        // `retire_deferred_peel_rows_for_terminal_group` for why no later
+        // sweep can reach these rows.
+        self.retire_deferred_peel_rows_for_terminal_group(group_id)?;
         // Deliberately LAST, after the marker write — not before it like the
         // convergence path (which has no attribution read). The notification
         // is already enqueued above, so a failure here cannot lose it; it only

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -14,6 +14,7 @@ mod store;
 
 pub(crate) use ingest::avatar_component_snapshot;
 pub(crate) use send::merge_capabilities;
+pub(crate) use store::fail_deferred_peel_rows_in_terminal_group;
 #[cfg(feature = "test-conformance-snapshot")]
 pub(crate) use store::normalized_deferred_peel_lifecycle;
 pub(crate) use store::transition_staged_invite_welcomes;
@@ -752,7 +753,8 @@ impl<S: StorageProvider> Engine<S> {
         // Terminal gate before queueing: a local copy marked removed (realized
         // self-eviction) must never accept or queue outbound work. Checked
         // again in `do_send_ready` so queued-intent drains for a copy removed
-        // after queueing hit the same deterministic error.
+        // after queueing hit the same deterministic error. Disband reaches the
+        // tombstone gate above first, so the message below stays accurate.
         if group.as_ref().is_some_and(|group| group.removed) {
             return Err(EngineError::InvalidTransition(
                 cgka_traits::engine_state::InvalidTransition {
@@ -965,14 +967,19 @@ impl<S: StorageProvider> Engine<S> {
         if self.sync_unrecoverable_halt_from_record(group_id, group.as_ref()) {
             return Ok(false);
         }
-        // Terminal: a removed copy must never publish, and the removed-copy
+        // Terminal: a terminal copy must never publish, and the terminal-copy
         // gate in `do_send_ready` would turn every queued record into a
         // permanent drain error that the app retries forever. Discard the
-        // queue and report nothing to drain. This is the defense-in-depth
-        // side; the marker sites (realization, commit-apply seam, convergence
-        // reorg) also purge at the moment the copy becomes removed.
-        if group.is_some_and(|group| group.removed) {
+        // queue, retire the deferred-peel backlog, and report nothing to
+        // drain. This gate is also what keeps the sweep away from a *removed*
+        // copy, which stays `Stable` — so it owes the retirement itself, and
+        // it is the only recovery if a crash lands between a marker site's
+        // record write and its own purge. The marker sites (realization,
+        // commit-apply seam, convergence reorg, disband settle) purge both at
+        // the moment the copy becomes terminal.
+        if group.is_some_and(|group| group.is_terminal()) {
             self.discard_queued_outbound_intents_for_removed_group(group_id)?;
+            self.retire_deferred_peel_rows_for_terminal_group(group_id)?;
             return Ok(false);
         }
         if let Some(state) = self.epoch_manager.state(group_id)
@@ -1655,7 +1662,7 @@ impl<S: StorageProvider> Engine<S> {
         if delay.is_some()
             && self
                 .stored_group_record(group_id)?
-                .is_none_or(|group| group.removed)
+                .is_none_or(|group| group.is_terminal())
         {
             // Input-only convergence can realize our eviction while fanout
             // blocks the outbound drain. Removed copies exit that drain before
@@ -2921,10 +2928,21 @@ impl<S: StorageProvider> Engine<S> {
     /// cap-rejection audit re-arms so a fresh cap-full episode is recorded
     /// once more.
     pub(crate) fn note_peel_deferred_row_retired(&mut self, record: &MessageRecord) {
+        self.note_peel_deferred_row_retired_by_id(&record.group_id, &record.id);
+    }
+
+    /// [`Self::note_peel_deferred_row_retired`] keyed by the only two fields
+    /// it reads, for callers holding metadata rather than a whole record (the
+    /// payload bytes come from `deferred_payload_bytes_by_id`, not the row).
+    pub(crate) fn note_peel_deferred_row_retired_by_id(
+        &mut self,
+        group_id: &GroupId,
+        id: &MessageId,
+    ) {
         let account_was_full = self.deferred_peel_account.counted
             && self.deferred_peel_account.bytes >= self.deferred_peel_account_byte_limit;
-        let local_reopened = if let Some(state) = self.deferred_peel.get_mut(&record.group_id) {
-            let Some(payload_bytes) = state.deferred_payload_bytes_by_id.remove(&record.id) else {
+        let local_reopened = if let Some(state) = self.deferred_peel.get_mut(group_id) {
+            let Some(payload_bytes) = state.deferred_payload_bytes_by_id.remove(id) else {
                 return;
             };
             state.deferred_rows = state.deferred_rows.saturating_sub(1);
@@ -2950,7 +2968,7 @@ impl<S: StorageProvider> Engine<S> {
             for state in self.deferred_peel.values_mut() {
                 state.cap_rejection_audited = false;
             }
-        } else if local_reopened && let Some(state) = self.deferred_peel.get_mut(&record.group_id) {
+        } else if local_reopened && let Some(state) = self.deferred_peel.get_mut(group_id) {
             state.cap_rejection_audited = false;
         }
     }

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -54,7 +54,9 @@ impl<S: StorageProvider> Engine<S> {
         // fail with an opaque `UseAfterEviction` backend error anyway. Gate
         // here (not just `do_send`) so queued-intent drains hit the same
         // deterministic terminal error. Every intent kind is blocked,
-        // including `Leave` — there is nothing left to leave.
+        // including `Leave` — there is nothing left to leave. Disband reaches
+        // the tombstone gate above first, so the message below stays
+        // accurate.
         let group = self.stored_group_record(&group_id)?;
         if group.as_ref().is_some_and(|group| group.removed) {
             return Err(EngineError::InvalidTransition(

--- a/crates/cgka-engine/src/message_processor/store.rs
+++ b/crates/cgka-engine/src/message_processor/store.rs
@@ -32,6 +32,35 @@ fn fresh_deferred_peel_lifecycle(
     }
 }
 
+/// Durable half of `Engine::retire_deferred_peel_rows_for_terminal_group`:
+/// flip every `PeelDeferred` row of a terminal group to `Failed` and hand back
+/// what was retired, for the caller's in-memory reconciliation. Takes `&S` so
+/// it can run inside a storage transaction.
+///
+/// Enumerates metadata, never payloads: this runs inside the disband write
+/// transaction, where loading up to `MAX_PEEL_DEFERRED_BYTES_PER_GROUP` of
+/// ciphertext nobody reads would be copied and held across the commit.
+///
+/// A partial application is a valid state, so the callers that run this
+/// outside a transaction need no compensation: some rows retired and the rest
+/// still `PeelDeferred` is exactly what a re-entry finishes, and rows whose
+/// in-memory slot was never returned stay conservatively charged until the
+/// next open recounts them.
+#[must_use = "every returned row still owes its in-memory capacity slot; pass \
+              them to Engine::release_retired_deferred_peel_rows once the \
+              durable flip is committed, or the group's deferred-peel budget \
+              stays charged for the rest of this engine incarnation"]
+pub(crate) fn fail_deferred_peel_rows_in_terminal_group<S: StorageProvider>(
+    storage: &S,
+    group_id: &GroupId,
+) -> Result<Vec<DeferredMessageMetadata>, EngineError> {
+    let retired = storage.list_deferred_message_metadata(group_id)?;
+    for row in &retired {
+        storage.update_message_state(&row.id, MessageState::Failed)?;
+    }
+    Ok(retired)
+}
+
 /// Promote or retire the non-deliverable Welcome artifacts produced beside one
 /// staged invite commit.
 ///
@@ -721,6 +750,74 @@ impl<S: StorageProvider> Engine<S> {
             });
         self.note_peel_deferred_row_retired(record);
         Ok(())
+    }
+
+    /// Retire this group's whole `PeelDeferred` backlog because the local copy
+    /// has become terminal — removed or disbanded.
+    ///
+    /// Why nothing else will: the only production driver that reaches the
+    /// deferred-peel sweep is `advance_convergence_inputs`, and its single
+    /// door is `prepare_convergence_input_advance`, whose terminal gate
+    /// refuses a terminal group before any sweep runs. A *disbanded* copy is
+    /// refused twice over (its `EpochState::Disbanded` also fails that
+    /// function's `Stable` check), but a *removed* copy stays `Stable` — the
+    /// terminal gate is the whole reason its rows never come back. (The `pub`
+    /// `retry_deferred_peels` would sweep a removed group happily; no
+    /// production path calls it.) So without this the rows sit forever holding
+    /// their share of the account byte budget — reconstructed from durable
+    /// rows on every open — and their per-group row slots.
+    ///
+    /// Silent by construction: the rows leave the retry lifecycle the way
+    /// [`Self::mark_raw_transport_message_failed_if_awaiting_retry`] retires
+    /// one, with no `TransportObjectResourceRefused` — nothing was refused,
+    /// the group they belonged to is gone.
+    ///
+    /// The tradeoff, taken deliberately: `removed` is reversible (branch
+    /// selection can supersede the removal that set it — see
+    /// `cgka_traits::group::Group::removed` and the heal in
+    /// `distributed_convergence::emit_convergence_events`), and a `Failed` row
+    /// blocks same-id redelivery, so a heal cannot get these rows back. That
+    /// is the same bet
+    /// [`Self::discard_queued_outbound_intents_for_removed_group`] already
+    /// makes beside every call site here, and the window is narrow because
+    /// the terminal gate refuses further advances until the heal lands.
+    pub(crate) fn retire_deferred_peel_rows_for_terminal_group(
+        &mut self,
+        group_id: &GroupId,
+    ) -> Result<(), EngineError> {
+        let retired = fail_deferred_peel_rows_in_terminal_group(&self.storage, group_id)?;
+        self.release_retired_deferred_peel_rows(&retired);
+        Ok(())
+    }
+
+    /// In-memory half of [`Self::retire_deferred_peel_rows_for_terminal_group`]:
+    /// return each retired row's capacity slot and record the transition.
+    ///
+    /// Split from the durable half so a caller already inside a storage
+    /// transaction — `disband::settle_disband_after_convergence`, whose
+    /// idempotent re-entry never re-runs the settle body — can keep the row
+    /// flip inside that transaction and reconcile the engine's own counters
+    /// after it commits. Safe in that order: the counters are derived state,
+    /// rebuilt from the durable rows by
+    /// `ensure_peel_deferred_usage_initialized` on the next open, so a crash
+    /// between the two loses nothing.
+    pub(crate) fn release_retired_deferred_peel_rows(
+        &mut self,
+        retired: &[DeferredMessageMetadata],
+    ) {
+        for row in retired {
+            self.audit_group(
+                &row.group_id,
+                crate::audit_helpers::message_state_transition_event(
+                    hex::encode(row.id.as_slice()),
+                    Some(MessageState::PeelDeferred),
+                    MessageState::Failed,
+                    Some(row.epoch),
+                    "terminal_group",
+                ),
+            );
+            self.note_peel_deferred_row_retired_by_id(&row.group_id, &row.id);
+        }
     }
 
     pub(crate) fn mark_raw_transport_message_failed_if_awaiting_retry(

--- a/crates/cgka-engine/src/message_processor/store.rs
+++ b/crates/cgka-engine/src/message_processor/store.rs
@@ -35,17 +35,21 @@ fn fresh_deferred_peel_lifecycle(
 /// Durable half of `Engine::retire_deferred_peel_rows_for_terminal_group`:
 /// flip every `PeelDeferred` row of a terminal group to `Failed` and hand back
 /// what was retired, for the caller's in-memory reconciliation. Takes `&S` so
-/// it can run inside a storage transaction.
+/// it runs inside the caller's storage transaction.
+///
+/// All rows flip or none do, and that is a contract on the caller: run this
+/// inside a transaction — the disband settle's own, or the one
+/// `Engine::retire_deferred_peel_rows_for_terminal_group` opens. Without one,
+/// each write autocommits, so a mid-loop failure would leave earlier rows
+/// durably `Failed` while the error skips the in-memory release: those rows
+/// would keep their capacity slot with no transition audit, and a retry
+/// enumerates only `PeelDeferred` rows so it would never revisit them. Inside
+/// a transaction a failed retire instead leaves every row `PeelDeferred` for
+/// the next pass, and nothing is ever charged without its audit row.
 ///
 /// Enumerates metadata, never payloads: this runs inside the disband write
 /// transaction, where loading up to `MAX_PEEL_DEFERRED_BYTES_PER_GROUP` of
 /// ciphertext nobody reads would be copied and held across the commit.
-///
-/// A partial application is a valid state, so the callers that run this
-/// outside a transaction need no compensation: some rows retired and the rest
-/// still `PeelDeferred` is exactly what a re-entry finishes, and rows whose
-/// in-memory slot was never returned stay conservatively charged until the
-/// next open recounts them.
 #[must_use = "every returned row still owes its in-memory capacity slot; pass \
               them to Engine::release_retired_deferred_peel_rows once the \
               durable flip is committed, or the group's deferred-peel budget \
@@ -785,7 +789,13 @@ impl<S: StorageProvider> Engine<S> {
         &mut self,
         group_id: &GroupId,
     ) -> Result<(), EngineError> {
-        let retired = fail_deferred_peel_rows_in_terminal_group(&self.storage, group_id)?;
+        // One durable unit: see the free function's contract. Nesting is
+        // safe — the SQLite backend reuses a same-thread outer transaction
+        // rather than beginning a second one — so a caller that already holds
+        // one loses nothing by coming through here.
+        let retired = self.storage.with_transaction(|storage| {
+            fail_deferred_peel_rows_in_terminal_group(storage, group_id)
+        })?;
         self.release_retired_deferred_peel_rows(&retired);
         Ok(())
     }

--- a/crates/cgka-engine/src/own_commit_intent.rs
+++ b/crates/cgka-engine/src/own_commit_intent.rs
@@ -171,7 +171,7 @@ impl<S: StorageProvider> Engine<S> {
                 None,
             )));
         };
-        if group.removed || group.disbanded.is_some() {
+        if group.is_terminal() {
             return Ok(Some((
                 report(
                     SupersededIntentOutcome::NotMember,
@@ -468,10 +468,7 @@ impl<S: StorageProvider> Engine<S> {
             outcome,
             reason,
         };
-        if group
-            .as_ref()
-            .is_none_or(|group| group.removed || group.disbanded.is_some())
-        {
+        if group.as_ref().is_none_or(|group| group.is_terminal()) {
             self.storage.delete_own_commit_intent(commit_id)?;
             return Ok(Some(report(
                 SupersededIntentOutcome::NotMember,

--- a/crates/cgka-engine/tests/deferred_peel_lifecycle.rs
+++ b/crates/cgka-engine/tests/deferred_peel_lifecycle.rs
@@ -1941,6 +1941,199 @@ async fn later_deferring_group_first_sweep_keeps_exact_account_byte_total() {
     );
 }
 
+/// Carol ends up removed from group A while still live in group B, holding one
+/// deferred row in each. Returns her (pre-restart), her storage, the two
+/// groups, group A's deferred row id, and a group-B wrap template plus the
+/// exact byte size one of its rows charges.
+#[cfg(feature = "test-policy-overrides")]
+async fn carol_removed_from_group_a_and_live_in_group_b() -> (
+    Engine<SqliteAccountStorage>,
+    SqliteAccountStorage,
+    GroupId,
+    MessageId,
+    GroupId,
+    TransportMessage,
+    usize,
+) {
+    let (mut alice, mut carol, storage, _peeler, group_a, commit2, commit3) =
+        carol_behind_two_epochs().await;
+    let carol_id = carol.self_id().clone();
+    // Catch carol up so alice's removing commit is one she can actually apply.
+    carol.ingest(commit2).await.unwrap();
+    carol.ingest(commit3).await.unwrap();
+
+    let (removal, pending) = evolution(
+        alice
+            .send(SendIntent::RemoveMembers {
+                group_id: group_a.clone(),
+                members: vec![carol_id],
+            })
+            .await
+            .unwrap(),
+    );
+    alice.confirm_published(pending).await.unwrap();
+
+    // One group-A row carol defers and, once removed, can never release.
+    let deferred_a = send_app(&mut alice, &group_a, "group A deferred bytes").await;
+    assert!(matches!(
+        carol.ingest(deferred_a.clone()).await.unwrap(),
+        IngestOutcome::TransportDeferred { .. }
+    ));
+    assert!(
+        !storage
+            .get_message(&deferred_a.id)
+            .unwrap()
+            .payload
+            .is_empty(),
+        "the group-A row must actually charge the account budget"
+    );
+
+    let group_b = add_group_two_epochs_ahead(&mut alice, &mut carol).await;
+    let template_b = send_app(&mut alice, &group_b, "group B deferred bytes").await;
+    let first_b = TransportMessage {
+        id: MessageId::new(b"terminal-release-b-0001".to_vec()),
+        ..template_b.clone()
+    };
+    assert!(matches!(
+        carol.ingest(first_b.clone()).await.unwrap(),
+        IngestOutcome::TransportDeferred { .. }
+    ));
+    let bytes_b = storage.get_message(&first_b.id).unwrap().payload.len();
+
+    carol.ingest(route(removal, &group_a)).await.unwrap();
+    assert!(
+        carol.group_record(&group_a).unwrap().removed,
+        "the removing commit must have made carol's copy of group A terminal"
+    );
+
+    (
+        carol,
+        storage,
+        group_a,
+        deferred_a.id,
+        group_b,
+        template_b,
+        bytes_b,
+    )
+}
+
+/// Restart carol with the given account byte budget and hand back the engine.
+#[cfg(feature = "test-policy-overrides")]
+fn restart_carol_with_account_budget(
+    storage: SqliteAccountStorage,
+    account_byte_limit: usize,
+) -> Engine<SqliteAccountStorage> {
+    let clock = ManualConvergenceClock::new(2_000, 20_000);
+    let (mut restarted, _, _) =
+        build_counting_client_with_storage_and_clock(b"carol", storage, clock);
+    restarted.hydrate_all_stored_groups().unwrap();
+    restarted.set_deferred_peel_limits_for_tests(512, usize::MAX, account_byte_limit);
+    restarted
+}
+
+/// Account-wide byte accounting is reconstructed from durable deferred rows on
+/// every open, so a terminal group's retired backlog must not keep charging the
+/// account across a restart: a live group has to be able to admit the whole
+/// budget afterwards.
+#[cfg(feature = "test-policy-overrides")]
+#[tokio::test]
+async fn terminal_group_releases_its_account_byte_budget_across_restart() {
+    let (carol, storage, _group_a, _deferred_a, _group_b, template_b, bytes_b) =
+        carol_removed_from_group_a_and_live_in_group_b().await;
+    drop(carol);
+
+    // Exactly two group-B rows worth of account budget.
+    let mut restarted = restart_carol_with_account_budget(storage, bytes_b.saturating_mul(2));
+
+    let second_b = TransportMessage {
+        id: MessageId::new(b"terminal-release-b-0002".to_vec()),
+        ..template_b.clone()
+    };
+    assert!(
+        matches!(
+            restarted.ingest(second_b).await.unwrap(),
+            IngestOutcome::TransportDeferred { .. }
+        ),
+        "a live group must be able to spend the whole account byte budget once \
+         the terminal group's rows are retired"
+    );
+
+    let overflow_b = TransportMessage {
+        id: MessageId::new(b"terminal-release-b-0003".to_vec()),
+        ..template_b
+    };
+    assert!(
+        matches!(
+            restarted.ingest(overflow_b).await.unwrap(),
+            IngestOutcome::ResourceRefused {
+                resource: InboundResourceLimit::TransportDeferredCapacity,
+                ..
+            }
+        ),
+        "the account budget is still enforced past that point"
+    );
+}
+
+/// The terminal gate in `prepare_convergence_input_advance` is the only
+/// recovery for a crash between a marker site's `removed` record write and its
+/// own deferred-row purge — every marker site writes the record first, and
+/// `realize_self_eviction` early-returns on an already-`removed` record, so
+/// nothing else revisits those rows.
+///
+/// The precondition is reached by running the real removal and then putting
+/// group A's row back to `PeelDeferred`: the single inverse of the step a
+/// crash would have skipped. That is a *state* a crash genuinely leaves — a
+/// retained row behind a `removed` record — not a stubbed mechanism, and the
+/// recovery under test is driven entirely through `advance_convergence`.
+#[cfg(feature = "test-policy-overrides")]
+#[tokio::test]
+async fn terminal_gate_retires_a_deferred_row_a_crash_left_behind() {
+    let (carol, storage, group_a, deferred_a, _group_b, template_b, bytes_b) =
+        carol_removed_from_group_a_and_live_in_group_b().await;
+    drop(carol);
+    storage
+        .update_message_state(&deferred_a, MessageState::PeelDeferred)
+        .unwrap();
+
+    // Restart so the account budget is recounted from durable rows: group A's
+    // row is charged again, exactly as it would be after the crash.
+    let mut restarted =
+        restart_carol_with_account_budget(storage.clone(), bytes_b.saturating_mul(2));
+    restarted.drain_events();
+
+    restarted.advance_convergence(&group_a).await.unwrap();
+
+    assert_eq!(
+        storage.get_message(&deferred_a).unwrap().state,
+        MessageState::Failed,
+        "one advance through the terminal gate must retire the row a crash \
+         stranded behind the removed marker"
+    );
+    assert!(
+        !restarted
+            .drain_events()
+            .iter()
+            .any(|event| matches!(event, GroupEvent::TransportObjectResourceRefused { .. })),
+        "the crash-window recovery is as silent as the marker sites"
+    );
+
+    // The budget is really back: group B, already holding one row, can spend
+    // the rest of the two-row account budget. It could not while group A's
+    // stranded row was still charged.
+    let second_b = TransportMessage {
+        id: MessageId::new(b"crash-window-b-0002".to_vec()),
+        ..template_b
+    };
+    assert!(
+        matches!(
+            restarted.ingest(second_b).await.unwrap(),
+            IngestOutcome::TransportDeferred { .. }
+        ),
+        "the retired row's account bytes must be released, not just its \
+         durable state flipped"
+    );
+}
+
 /// A transport object outside the bounded stored-message representation is a
 /// typed, same-id-retryable resource refusal. It must not abort a relay drain
 /// as an internal serialization error.
@@ -2305,17 +2498,15 @@ async fn join_epoch_recorded_on_welcome_join() {
     );
 }
 
-/// Seam parity with `replay_buffered_messages` (5ae9a440): the deferred-peel
-/// sweep must NOT relabel `Processed` a `PeelDeferred` row that
-/// `ingest_group_message` terminalized during the sweep. The reachable case is
-/// `SelfEvicted`: a future-epoch commit sits `PeelDeferred`; once our own leaf
-/// is removed the group is `!is_active` (still `Stable`, not quarantined), so
-/// re-ingesting the deferred row hits the `!is_active` gate, which persists it
-/// `Failed`. That ingest-committed verdict is authoritative — sweeping it back
-/// to `Processed` would feed a row we were evicted on into canonicalization
-/// (`openmls_projection` / `distributed_convergence` select on `Processed`).
-#[tokio::test]
-async fn deferred_peel_self_evicted_row_stays_failed_not_swept_processed() {
+/// Carol holds one future-epoch `PeelDeferred` commit and is then removed by
+/// alice's commit, which she applies through the ordinary ingest seam. Returns
+/// carol, her storage, the group, and the retained future commit.
+async fn carol_removed_while_holding_a_future_epoch_deferred_row() -> (
+    Engine<SqliteAccountStorage>,
+    SqliteAccountStorage,
+    GroupId,
+    TransportMessage,
+) {
     // alice (admin) removes carol; bob keeps the group non-trivial afterwards.
     let (mut alice, _alice_storage) = build_client(b"alice-deferred-self-evict");
     let (mut bob, _bob_storage) = build_client(b"bob-deferred-self-evict");
@@ -2404,15 +2595,140 @@ async fn deferred_peel_self_evicted_row_stays_failed_not_swept_processed() {
         "carol must have been evicted by the removal"
     );
 
-    // The deferred future-commit row re-ingests against the inactive group →
-    // `SelfEvicted`, so ingest persists it `Failed`. Regression: the sweep must
-    // not clobber that `Failed` back to `Processed`.
-    carol.retry_deferred_peels(&group_id).await.unwrap();
+    (carol, carol_storage, group_id, future_commit)
+}
+
+/// A removed copy holds no deferred-peel backlog. The commit that evicted this
+/// device's leaf is the last moment a sweep can ever run for the group, so the
+/// removal itself owes the retirement — with no `retry_deferred_peels` call and
+/// no refusal event.
+#[tokio::test]
+async fn removal_retires_deferred_peel_rows_without_refusal() {
+    let (mut carol, carol_storage, group_id, future_commit) =
+        carol_removed_while_holding_a_future_epoch_deferred_row().await;
+
+    assert!(
+        carol_storage
+            .list_messages_in_states(&group_id, &[MessageState::PeelDeferred], EpochId(0))
+            .unwrap()
+            .is_empty(),
+        "a removed copy must leave no deferred-peel row holding account byte \
+         budget and row slots nothing can ever release"
+    );
     assert_eq!(
         carol_storage.get_message(&future_commit.id).unwrap().state,
         MessageState::Failed,
-        "a row we were evicted on must stay Failed after the deferred-peel \
-         sweep, not be swept into canonicalization as Processed"
+        "the retired row leaves the retry lifecycle"
+    );
+    assert!(
+        !carol
+            .drain_events()
+            .iter()
+            .any(|event| matches!(event, GroupEvent::TransportObjectResourceRefused { .. })),
+        "retiring a terminal group's backlog must be silent"
+    );
+}
+
+/// Seam parity with `replay_buffered_messages` (5ae9a440): the deferred-peel
+/// sweep must NOT relabel `Processed` a row that `ingest_group_message`
+/// terminalized *during* the sweep. The group here stays live and
+/// non-terminal, so the sweep really does enumerate and re-ingest the row —
+/// the reachable terminal verdict is app-message retention: the row was
+/// retained while its epoch was in the future, and by the time a changed peel
+/// context makes it readable the group has moved more than
+/// `max_past_epochs` beyond it, so OpenMLS reports it too distant in the past
+/// and ingest persists `Failed`. That ingest-committed verdict is
+/// authoritative — sweeping it back to `Processed` would feed an
+/// unauthenticated row into canonicalization (`openmls_projection` /
+/// `distributed_convergence` select on `Processed`).
+#[tokio::test]
+async fn deferred_peel_row_terminalized_by_ingest_stays_failed_not_swept_processed() {
+    let (mut alice, _alice_storage) = build_client(b"alice-sweep-terminal");
+    let (mut carol, carol_storage, _carol_peeler) = build_counting_client(b"carol-sweep-terminal");
+
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "sweep-terminal".into(),
+            description: String::new(),
+            members: vec![carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![alice.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol-sweep-terminal"))
+        .await
+        .unwrap();
+    carol.drain_events();
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(1));
+
+    let commit = async |alice: &mut Engine<SqliteAccountStorage>, label: &str| {
+        let (msg, pending) = evolution(
+            alice
+                .send(SendIntent::UpdateGroupData {
+                    group_id: group_id.clone(),
+                    name: Some(label.to_string()),
+                    description: None,
+                })
+                .await
+                .unwrap(),
+        );
+        alice.confirm_published(pending).await.unwrap();
+        route(msg, &group_id)
+    };
+
+    // One commit takes alice to epoch 2; the app message is sealed there —
+    // inside carol's membership, so this is app retention, not the
+    // pre-membership classification. Carol, still at epoch 1, cannot peel it.
+    let mut commits = vec![commit(&mut alice, "alice-edit-0").await];
+    let deferred_app = send_app(&mut alice, &group_id, "readable only far too late").await;
+    assert!(matches!(
+        carol.ingest(deferred_app.clone()).await.unwrap(),
+        IngestOutcome::TransportDeferred { .. }
+    ));
+
+    // Eight more commits carry the group `max_past_epochs` (5) and then some
+    // beyond the app message's epoch before carol catches up.
+    for index in 1..9 {
+        commits.push(commit(&mut alice, &format!("alice-edit-{index}")).await);
+    }
+    for commit in commits {
+        carol.ingest(commit).await.unwrap();
+    }
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(10));
+    assert_eq!(
+        carol_storage.get_message(&deferred_app.id).unwrap().state,
+        MessageState::PeelDeferred,
+        "precondition: the sweep must have a row to enumerate and re-ingest"
+    );
+
+    carol.drain_events();
+    carol.retry_deferred_peels(&group_id).await.unwrap();
+    assert_eq!(
+        carol_storage.get_message(&deferred_app.id).unwrap().state,
+        MessageState::Failed,
+        "a row ingest terminalized inside the sweep must stay Failed, not be \
+         swept into canonicalization as Processed"
+    );
+    assert!(
+        !carol
+            .drain_events()
+            .iter()
+            .any(|event| matches!(event, GroupEvent::TransportObjectResourceRefused { .. })),
+        "the Failed verdict came from ingest's classification, not from a \
+         residence or retry-budget refusal"
+    );
+    assert!(
+        !carol.group_record(&group_id).unwrap().is_terminal(),
+        "the guard only means something on a live, non-terminal group"
     );
 }
 
@@ -2625,5 +2941,214 @@ async fn opaque_retry_batch_does_not_repeat_live_lineage_classification() {
         carol.engine_metrics().deferred_lineage_classifications,
         classifications,
         "the sweep must not rescan the stored graph for each discarded lineage"
+    );
+}
+
+/// Current-profile client on caller-supplied storage and clock, so terminal
+/// group lifecycles (disband) can be driven under an epoch-gated peeler.
+#[cfg(feature = "test-policy-overrides")]
+fn build_current_gated_client<P>(
+    name: &[u8],
+    peeler: P,
+    storage: SqliteAccountStorage,
+    clock: ManualConvergenceClock,
+) -> Engine<SqliteAccountStorage>
+where
+    P: TransportPeeler + 'static,
+{
+    let mut engine = EngineBuilder::new(storage)
+        .identity(pad32(name))
+        .account_identity_proof_signer(proof_signer(name))
+        .protocol_profile(cgka_traits::group::ProtocolProfile::Current)
+        .peeler(Box::new(peeler))
+        .convergence_clock(Arc::new(clock))
+        .build()
+        .unwrap();
+    engine
+        .set_convergence_policy(CanonicalizationPolicy {
+            settlement_quiescence_ms: 0,
+            ..CanonicalizationPolicy::default()
+        })
+        .expect("convergence policy accepted");
+    engine
+}
+
+/// Alice (admin) holds one future-epoch `PeelDeferred` row plus a durable
+/// disband request. Bob runs five epochs ahead of her, so the retained row
+/// stays unpeelable at every epoch alice reaches — including the epoch her own
+/// disband commit lands in. The returned catch-up commits are the two bob
+/// commits alice can still apply.
+#[cfg(feature = "test-policy-overrides")]
+async fn alice_disbanding_with_future_epoch_deferred_row() -> (
+    Engine<SqliteAccountStorage>,
+    SqliteAccountStorage,
+    CountingEpochGatePeeler,
+    ManualConvergenceClock,
+    GroupId,
+    TransportMessage,
+    Vec<TransportMessage>,
+) {
+    let storage = SqliteAccountStorage::in_memory().unwrap();
+    let clock = ManualConvergenceClock::new(0, 10_000);
+    let peeler = CountingEpochGatePeeler::new();
+    let mut alice = build_current_gated_client(
+        b"alice-disband-deferred",
+        peeler.clone(),
+        storage.clone(),
+        clock.clone(),
+    );
+    let mut bob = build_current_gated_client(
+        b"bob-disband-deferred",
+        CountingEpochGatePeeler::new(),
+        SqliteAccountStorage::in_memory().unwrap(),
+        ManualConvergenceClock::new(0, 10_000),
+    );
+
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let (group_id, created) = alice
+        .create_group(CreateGroupRequest {
+            name: "disband-deferred".into(),
+            description: String::new(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![alice.self_id(), bob.self_id()],
+        })
+        .await
+        .unwrap();
+    let welcomes = match created {
+        SendResult::FoundingGroupCreated { welcomes } => welcomes,
+        other => panic!("expected FoundingGroupCreated, got {other:?}"),
+    };
+    bob.join_welcome(welcome_for(&welcomes, b"bob-disband-deferred"))
+        .await
+        .unwrap();
+    alice.drain_events();
+
+    // Five bob commits at source epochs 0..=4. Alice applies the first two
+    // and never sees the rest, so the fifth is four epochs beyond her.
+    let mut commits = Vec::new();
+    for index in 0..5 {
+        let (msg, pending) = evolution(
+            bob.send(SendIntent::UpdateGroupData {
+                group_id: group_id.clone(),
+                name: Some(format!("bob-edit-{index}")),
+                description: None,
+            })
+            .await
+            .unwrap(),
+        );
+        bob.confirm_published(pending).await.unwrap();
+        commits.push(route(msg, &group_id));
+    }
+    let deferred = commits.pop().expect("five bob commits");
+    let catchup = vec![commits[0].clone(), commits[1].clone()];
+
+    assert!(matches!(
+        alice.ingest(deferred.clone()).await.unwrap(),
+        IngestOutcome::TransportDeferred { .. }
+    ));
+    assert_eq!(
+        storage.get_message(&deferred.id).unwrap().state,
+        MessageState::PeelDeferred,
+        "the future-epoch commit is retained pending a later peel"
+    );
+
+    alice
+        .send(SendIntent::Disband {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    assert!(alice.disbanding_in_progress(&group_id).unwrap());
+    alice.drain_events();
+
+    (alice, storage, peeler, clock, group_id, deferred, catchup)
+}
+
+/// The retirement is keyed on the tombstone, never on the disbanding window.
+/// Before the tombstone the group is still live — a peer's own disband commit
+/// can itself be one of these retained rows — so the rows must keep their
+/// retry slots through a peer commit and a full advance inside that window.
+#[cfg(feature = "test-policy-overrides")]
+#[tokio::test]
+async fn deferred_peel_row_in_the_disbanding_window_keeps_its_retry_slot() {
+    let (mut alice, storage, _peeler, _clock, group_id, deferred, catchup) =
+        alice_disbanding_with_future_epoch_deferred_row().await;
+
+    // A peer commit alice can apply, then a full advance: still inside the
+    // disbanding window, which prepares the terminal commit but writes no
+    // tombstone.
+    alice.ingest(catchup[0].clone()).await.unwrap();
+    alice.advance_convergence(&group_id).await.unwrap();
+
+    assert_eq!(
+        storage.get_message(&deferred.id).unwrap().state,
+        MessageState::PeelDeferred,
+        "a row must keep its retry slot until the tombstone is written"
+    );
+    assert!(alice.disbanding_in_progress(&group_id).unwrap());
+    assert!(
+        alice.group_record(&group_id).unwrap().disbanded.is_none(),
+        "no tombstone yet: this is the pre-terminal window"
+    );
+}
+
+/// A disbanded copy holds no deferred-peel backlog. The sweep that releases
+/// those rows only runs for a live `Stable` group, so the settle transaction
+/// that writes the tombstone owes their retirement — silently: the row leaves
+/// the retry lifecycle, it is not refused.
+#[cfg(feature = "test-policy-overrides")]
+#[tokio::test]
+async fn disband_settle_retires_deferred_peel_rows_without_refusal() {
+    let (mut alice, storage, _peeler, clock, group_id, deferred, catchup) =
+        alice_disbanding_with_future_epoch_deferred_row().await;
+
+    for commit in catchup {
+        alice.ingest(commit).await.unwrap();
+    }
+    let prepared = alice.advance_convergence(&group_id).await.unwrap();
+    let pending = match prepared.as_slice() {
+        [SendResult::GroupEvolution { pending, .. }] => *pending,
+        other => panic!("expected one prepared disband commit, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    for _ in 0..3 {
+        alice.advance_convergence(&group_id).await.unwrap();
+        clock.advance_ms(1_000);
+    }
+    assert!(
+        matches!(
+            alice.epoch_state(&group_id),
+            Some(cgka_traits::EpochState::Disbanded(_))
+        ),
+        "disband did not settle within the bounded convergence passes"
+    );
+    alice.drain_events();
+
+    assert!(
+        storage
+            .list_messages_in_states(&group_id, &[MessageState::PeelDeferred], EpochId(0))
+            .unwrap()
+            .is_empty(),
+        "the settled tombstone must leave no deferred-peel row holding account \
+         byte budget and row slots nothing can ever release"
+    );
+    assert_eq!(
+        storage.get_message(&deferred.id).unwrap().state,
+        MessageState::Failed,
+        "the retired row leaves the retry lifecycle"
+    );
+
+    // Past the residence deadline the row would have been refused had it
+    // survived; a terminal group must go quiet instead.
+    clock.advance_ms(cgka_engine::message_processor::MAX_DEFERRED_PEEL_RESIDENCE_MS * 2);
+    alice.advance_convergence(&group_id).await.unwrap();
+    assert!(
+        !alice
+            .drain_events()
+            .iter()
+            .any(|event| matches!(event, GroupEvent::TransportObjectResourceRefused { .. })),
+        "retiring a terminal group's backlog must be silent"
     );
 }

--- a/crates/cgka-engine/tests/record_write_atomicity.rs
+++ b/crates/cgka-engine/tests/record_write_atomicity.rs
@@ -282,6 +282,38 @@ impl LeaveWriteFault {
     }
 }
 
+/// Nth-write arm like [`LeaveWriteFault`], but scoped to
+/// `update_message_state(_, Failed)` so unrelated state transitions in the
+/// same ingest do not consume it.
+#[derive(Clone, Default)]
+struct FailedStateWriteFault(Arc<AtomicUsize>);
+
+impl FailedStateWriteFault {
+    #[cfg(feature = "test-policy-overrides")]
+    fn arm_on_write(&self, write: usize) {
+        assert!(write > 0);
+        self.0.store(write, Ordering::SeqCst);
+    }
+
+    #[cfg(feature = "test-policy-overrides")]
+    fn disarm(&self) {
+        self.0.store(0, Ordering::SeqCst);
+    }
+
+    fn should_fail(&self, new_state: MessageState) -> bool {
+        if new_state != MessageState::Failed {
+            return false;
+        }
+        matches!(
+            self.0
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    (remaining > 0).then(|| remaining - 1)
+                }),
+            Ok(1)
+        )
+    }
+}
+
 /// `SqliteAccountStorage` wrapper that injects a transient `Busy` on
 /// selected record/cache writes. Every other call delegates unchanged.
 struct FaultStorage {
@@ -290,6 +322,7 @@ struct FaultStorage {
     capability_fault: CapabilityWriteFault,
     leave_write_fault: LeaveWriteFault,
     intent_write_fault: LeaveWriteFault,
+    failed_state_fault: FailedStateWriteFault,
     preparation_delay: PreparationDelay,
 }
 
@@ -365,6 +398,11 @@ impl MessageStorage for FaultStorage {
         self.inner.delete_message(id)
     }
     fn update_message_state(&self, id: &MessageId, new_state: MessageState) -> StorageResult<()> {
+        if self.failed_state_fault.should_fail(new_state) {
+            return Err(StorageError::Busy(
+                "injected message-state write failure".into(),
+            ));
+        }
         self.inner.update_message_state(id, new_state)
     }
     fn list_messages(
@@ -761,6 +799,7 @@ fn build_fault_selfremove_client(
         capability_fault: CapabilityWriteFault::default(),
         leave_write_fault: LeaveWriteFault::default(),
         intent_write_fault: LeaveWriteFault::default(),
+        failed_state_fault: FailedStateWriteFault::default(),
         preparation_delay: PreparationDelay::default(),
     })
     .legacy_compatibility_profile()
@@ -785,6 +824,7 @@ fn build_capability_fault_client(
         capability_fault,
         leave_write_fault: LeaveWriteFault::default(),
         intent_write_fault: LeaveWriteFault::default(),
+        failed_state_fault: FailedStateWriteFault::default(),
         preparation_delay: PreparationDelay::default(),
     })
     .legacy_compatibility_profile()
@@ -810,6 +850,7 @@ fn build_leave_write_fault_client(
         capability_fault: CapabilityWriteFault::default(),
         leave_write_fault,
         intent_write_fault: LeaveWriteFault::default(),
+        failed_state_fault: FailedStateWriteFault::default(),
         preparation_delay: PreparationDelay::default(),
     })
     .legacy_compatibility_profile()
@@ -1622,6 +1663,7 @@ async fn slow_preparation_case(
         capability_fault: CapabilityWriteFault::default(),
         leave_write_fault: LeaveWriteFault::default(),
         intent_write_fault: LeaveWriteFault::default(),
+        failed_state_fault: FailedStateWriteFault::default(),
         preparation_delay: delay.clone(),
     })
     .legacy_compatibility_profile()
@@ -1924,6 +1966,7 @@ async fn setup_own_intent_fault_case(
         capability_fault: CapabilityWriteFault::default(),
         leave_write_fault: LeaveWriteFault::default(),
         intent_write_fault: fault,
+        failed_state_fault: FailedStateWriteFault::default(),
         preparation_delay: PreparationDelay::default(),
     })
     .legacy_compatibility_profile()
@@ -2052,4 +2095,240 @@ async fn superseded_own_intent_transfer_is_atomic_on_each_storage_failure() {
             1
         );
     }
+}
+
+/// Marker prefix for synthetic transport objects [`MarkerOpaquePeeler`]
+/// refuses to peel, so a test can retain `PeelDeferred` rows while real MLS
+/// traffic for the same group still peels and applies.
+#[cfg(feature = "test-policy-overrides")]
+const OPAQUE_MARKER: &[u8] = b"opaque-marker::";
+
+#[cfg(feature = "test-policy-overrides")]
+struct MarkerOpaquePeeler;
+
+#[cfg(feature = "test-policy-overrides")]
+#[async_trait]
+impl TransportPeeler for MarkerOpaquePeeler {
+    async fn peel_group_message(
+        &self,
+        msg: &TransportMessage,
+        ctx: &GroupContextSnapshot,
+    ) -> Result<PeeledMessage, PeelerError> {
+        if msg.payload.starts_with(OPAQUE_MARKER) {
+            return Err(PeelerError::DecryptFailed);
+        }
+        MockPeeler.peel_group_message(msg, ctx).await
+    }
+    async fn peel_welcome(&self, msg: &TransportMessage) -> Result<PeeledMessage, PeelerError> {
+        MockPeeler.peel_welcome(msg).await
+    }
+    async fn wrap_group_message(
+        &self,
+        payload: &EncryptedPayload,
+        ctx: &GroupContextSnapshot,
+    ) -> Result<TransportMessage, PeelerError> {
+        MockPeeler.wrap_group_message(payload, ctx).await
+    }
+    async fn wrap_welcome(
+        &self,
+        payload: &EncryptedPayload,
+        recipient: &MemberId,
+    ) -> Result<TransportMessage, PeelerError> {
+        MockPeeler.wrap_welcome(payload, recipient).await
+    }
+}
+
+#[cfg(feature = "test-policy-overrides")]
+fn opaque_row(label: &[u8], group_id: &GroupId) -> TransportMessage {
+    let mut payload = OPAQUE_MARKER.to_vec();
+    payload.extend_from_slice(label);
+    payload.resize(OPAQUE_MARKER.len() + 32, 7);
+    TransportMessage {
+        id: MessageId::new(label.to_vec()),
+        payload,
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource("test".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+    }
+}
+
+/// Retiring a terminal group's deferred-peel backlog is one durable unit.
+/// A storage failure part-way through must leave every row `PeelDeferred` —
+/// a row flipped `Failed` without its in-memory slot returned and without a
+/// transition audit row would be invisible to the retry, which enumerates
+/// `PeelDeferred` only, so it would hold its share of the account budget for
+/// the rest of the engine incarnation.
+#[tokio::test]
+#[cfg(feature = "test-policy-overrides")]
+async fn a_failed_terminal_retirement_leaves_every_row_deferred_for_the_next_pass() {
+    let failed_state_fault = FailedStateWriteFault::default();
+    let inner = SqliteAccountStorage::in_memory().unwrap();
+    let handle = inner.clone();
+    let mut carol = EngineBuilder::new(FaultStorage {
+        inner,
+        fault: PutGroupFault::default(),
+        capability_fault: CapabilityWriteFault::default(),
+        leave_write_fault: LeaveWriteFault::default(),
+        intent_write_fault: LeaveWriteFault::default(),
+        failed_state_fault: failed_state_fault.clone(),
+        preparation_delay: PreparationDelay::default(),
+    })
+    .legacy_compatibility_profile()
+    .identity(pad32(b"carol-retire-atomic"))
+    .account_identity_proof_signer(proof_signer(b"carol-retire-atomic"))
+    .feature_registry(selfremove_registry())
+    .peeler(Box::new(MarkerOpaquePeeler))
+    .build()
+    .unwrap();
+    carol
+        .set_convergence_policy(cgka_engine::canonicalization::CanonicalizationPolicy {
+            settlement_quiescence_ms: 0,
+            ..cgka_engine::canonicalization::CanonicalizationPolicy::default()
+        })
+        .expect("convergence policy accepted");
+    let mut alice = build_selfremove_client(b"alice-retire-atomic");
+
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_a, created) = alice
+        .create_group(CreateGroupRequest {
+            name: "retire atomically".into(),
+            description: String::new(),
+            members: vec![carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![alice.self_id()],
+        })
+        .await
+        .unwrap();
+    let SendResult::GroupCreated { pending, welcomes } = created else {
+        panic!("group creation");
+    };
+    alice.confirm_published(pending).await.unwrap();
+    let welcome = welcomes
+        .iter()
+        .find(|welcome| {
+            matches!(&welcome.envelope, TransportEnvelope::Welcome { recipient }
+                if recipient == &MemberId::new(pad32(b"carol-retire-atomic")))
+        })
+        .cloned()
+        .expect("welcome for carol");
+    carol.join_welcome(welcome).await.unwrap();
+    carol.drain_events();
+
+    // Two retained rows in group A.
+    let rows = [
+        opaque_row(b"retire-atomic-0001", &group_a),
+        opaque_row(b"retire-atomic-0002", &group_a),
+    ];
+    for row in &rows {
+        assert!(matches!(
+            carol.ingest(row.clone()).await.unwrap(),
+            IngestOutcome::TransportDeferred { .. }
+        ));
+    }
+    let row_bytes = handle.get_message(&rows[0].id).unwrap().payload.len();
+
+    // A live group of carol's own, so the shared account budget is observable
+    // after group A goes terminal.
+    let (group_b, created_b) = carol
+        .create_group(CreateGroupRequest {
+            name: "carol's own".into(),
+            description: String::new(),
+            members: vec![],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let SendResult::GroupCreated { pending, .. } = created_b else {
+        panic!("group creation");
+    };
+    carol.confirm_published(pending).await.unwrap();
+    // Exactly the two group-A rows' worth of account budget.
+    carol.set_deferred_peel_limits_for_tests(512, usize::MAX, row_bytes.saturating_mul(2));
+
+    // Alice removes carol. The second row's `Failed` write fails mid-retire.
+    let removal = match alice
+        .send(SendIntent::RemoveMembers {
+            group_id: group_a.clone(),
+            members: vec![MemberId::new(pad32(b"carol-retire-atomic"))],
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::GroupEvolution { msg, pending, .. } => {
+            alice.confirm_published(pending).await.unwrap();
+            TransportMessage {
+                envelope: TransportEnvelope::GroupMessage {
+                    transport_group_id: group_a.as_slice().to_vec(),
+                },
+                ..msg
+            }
+        }
+        other => panic!("expected group evolution, got {other:?}"),
+    };
+    failed_state_fault.arm_on_write(2);
+    // The removing commit may realize the removal on the direct apply or
+    // through a convergence pass; drive both so the retirement runs wherever
+    // this delivery happens to own it.
+    let mut error = carol.ingest(removal).await.err();
+    for _ in 0..4 {
+        if error.is_some()
+            || carol
+                .group_record(&group_a)
+                .is_ok_and(|group| group.removed)
+        {
+            break;
+        }
+        error = carol.advance_convergence(&group_a).await.err();
+    }
+    let error = error.expect("the injected mid-retire write failure must surface");
+    assert!(
+        format!("{error:?}").contains("injected message-state write failure"),
+        "unexpected retire error: {error:?}"
+    );
+
+    for row in &rows {
+        assert_eq!(
+            handle.get_message(&row.id).unwrap().state,
+            MessageState::PeelDeferred,
+            "a failed retirement must leave every row deferred for the next \
+             pass, never a mix the retry cannot see"
+        );
+    }
+    assert!(
+        matches!(
+            carol
+                .ingest(opaque_row(b"budget-probe-0001", &group_b))
+                .await
+                .unwrap(),
+            IngestOutcome::ResourceRefused { .. }
+        ),
+        "nothing was released, so the account budget is still fully charged"
+    );
+
+    // The terminal gate retries on the next advance and completes.
+    failed_state_fault.disarm();
+    carol.advance_convergence(&group_a).await.unwrap();
+    for row in &rows {
+        assert_eq!(
+            handle.get_message(&row.id).unwrap().state,
+            MessageState::Failed,
+            "the retry retires the whole backlog"
+        );
+    }
+    assert!(
+        matches!(
+            carol
+                .ingest(opaque_row(b"budget-probe-0002", &group_b))
+                .await
+                .unwrap(),
+            IngestOutcome::TransportDeferred { .. }
+        ),
+        "the completed retirement released the account bytes"
+    );
 }


### PR DESCRIPTION
When this device's copy of a group became terminal (removed or disbanded), its `PeelDeferred` rows were never retired. The sweep that releases such rows is reached only through `prepare_convergence_input_advance`, which refuses a removed copy outright and a disbanded one via `EpochState::Disbanded`, while `ensure_peel_deferred_usage_initialized` re-counts every group's rows into the deferred-peel account budget (#1682) on each open. Terminal groups held their per-group row slots and their share of the account byte budget forever, and a disbanded group showed pending deferred work in conformance snapshots beside zeroed unresolved inputs.

This started as "add `disbanded` to the sweep gate". Investigation showed that would be a production no-op: the epoch gate already blocks disbanded groups (`solo_disband_is_durable_convergent_terminal_and_restart_safe` asserts it). The rows were the defect.

### Changes

- Retire the rows silently at every marker site: inside the disband settle transaction beside `delete_deferred_peel_generation` (its idempotent re-entry never re-runs the body, so a purge outside it could be skipped forever after a crash); at `realize_self_eviction`; at the commit-apply self-removed arm (`realize_self_eviction` early-returns once `removed` is written, so that seam owns its own purge); at the convergence-reorg marker; and once more in the terminal gate as crash-window recovery.
- Two-phase by necessity: `with_transaction` holds `&self.storage` while the budget release needs `&mut self`. The durable flip enumerates payload-free metadata (`list_deferred_message_metadata`, so the disband write transaction copies no ciphertext) and runs inside the transaction; the in-memory release runs after commit, safe because the counters are derived state rebuilt from durable rows on open. `#[must_use]` on the durable half carries the obligation.
- Rows go to `Failed`, matching every other retired deferred row; `Failed` sits outside every graph-input and pass-opening state set, and same-id redelivery classifies as duplicate. Nothing on this path emits `TransportObjectResourceRefused`. The `removed` marker is reversible and this makes the same bet `discard_queued_outbound_intents_for_removed_group` already makes beside it; the doc says so.
- Consolidate hand-rolled `removed || disbanded.is_some()` onto `Group::is_terminal()` at `own_commit_intent.rs` (two sites), `prepare_convergence_input_advance`, and the self-remove timer. The send gates stay on `removed`: the tombstone gate above each already refuses a disbanded copy and their error names removal. `group_lifecycle.rs:860` stays as is; its predicate excludes disbanded rather than including it. The un-remove heal stays on `removed`; disband is irreversible.

### Tests (`tests/deferred_peel_lifecycle.rs`, all through `ingest` / `advance_convergence` / `confirm_published`)

- Disband settle leaves no deferred rows and emits no refusal after the residence deadline.
- Removal retires deferred rows silently at realization.
- The account byte budget is released across restart.
- A deferred row present during the pre-tombstone disbanding window keeps its retry slot (guards against gating on `disbanding_in_progress()`).
- The terminal gate retires a row a crash left behind the removed marker; silent; budget released.
- The pre-existing regression guard for a row terminalized during a sweep is re-pointed at a live-group shape (too-distant-past classification on a non-terminal group), since the old fixture now leaves the row `Failed` before any sweep and would have asserted nothing.

### Validation

Engine suite 567 passed with `test-policy-overrides`; simulator suite 493 passed; targeted 47 passed; clippy clean with and without the feature; `just fast-ci` green. No schema, binding, or version change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deferred message processing is now cleaned up when groups are removed, disbanded, or otherwise reach a terminal state.
  * Queued actions and retry capacity are released more reliably during group shutdown, including after restarts or crash recovery.
  * Terminal groups no longer schedule unnecessary self-removal timers.
  * Deferred processing failures remain accurately recorded and no longer generate misleading resource-refused events.
* **Tests**
  * Added coverage for cleanup, retry behavior, restart recovery, and disbanding scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->