### PR TITLE
Limit convergence graph reads to relevant rows

### DIFF
--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -1287,7 +1287,7 @@ impl<S: StorageProvider> Engine<S> {
             reject_legacy_group_additions: self.new_protocol_profile
                 == cgka_traits::group::ProtocolProfile::Current,
         };
-        let admitted_message_ids: HashSet<MessageId> = pass
+        let admitted_message_ids: Vec<MessageId> = pass
             .members
             .iter()
             .map(|member| member.message_id.clone())

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -6,7 +6,7 @@
 //! snapshot-and-replay messages for candidate materialization or apply a
 //! selected canonical branch to retained storage.
 
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::provider::EngineOpenMlsProvider;
 use cgka_traits::app_event::AppMessageRetentionDecision;
@@ -39,6 +39,10 @@ use crate::canonicalization::{
     MessageKind, OutboundIntent, PeeledMessage, PeeledMessageKind,
 };
 use crate::convergence::BranchCandidate;
+
+#[cfg(test)]
+#[path = "openmls_projection/tests.rs"]
+mod graph_tests;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum OpenMlsContentKind {
@@ -242,7 +246,7 @@ pub(crate) struct ReplayProfilePolicy {
 #[derive(Clone, Debug)]
 pub(crate) struct StoredCanonicalizationOptions<'a> {
     pub(crate) replay_profile: ReplayProfilePolicy,
-    pub(crate) admitted_message_ids: Option<&'a HashSet<MessageId>>,
+    pub(crate) admitted_message_ids: Option<&'a [MessageId]>,
     pub(crate) admit_app_witnesses: bool,
     pub(crate) replay_probe_budget_override: Option<u64>,
     /// Engine-path seen-id snapshot, shared instead of copied into
@@ -1193,15 +1197,38 @@ fn seed_stored_openmls_graph_inputs<S: StorageProvider>(
     storage: &S,
     group_id: &GroupId,
     retained_anchor_epoch: u64,
-    admitted_message_ids: Option<&HashSet<MessageId>>,
+    admitted_message_ids: Option<&[MessageId]>,
 ) -> Result<StoredOpenMlsGraphInputs, OpenMlsProjectionError> {
     let current_epoch = storage
         .get_group(group_id)
         .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?
         .epoch
         .0;
+    // Keep one read snapshot across the keyed reads or state query batches.
     let records = storage
-        .list_messages(group_id, EpochId(0))
+        .with_transaction(|storage| {
+            if let Some(ids) = admitted_message_ids {
+                // Frozen membership already names the complete batch. Do not
+                // load unrelated history just to intersect it with these ids.
+                return ids.iter().map(|id| storage.get_message(id)).collect();
+            }
+            let mut records = Vec::new();
+            for state in OPENMLS_GRAPH_INPUT_STATES {
+                // Processed rows only witness the retained window. Unresolved
+                // rows below it must still receive their stale-commit verdict.
+                let floor = if state == MessageState::Processed {
+                    retained_anchor_epoch
+                } else {
+                    0
+                };
+                records.extend(storage.list_messages_in_states(
+                    group_id,
+                    &[state],
+                    EpochId(floor),
+                )?);
+            }
+            Ok::<Vec<MessageRecord>, StorageError>(records)
+        })
         .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
     let mut commit_messages = Vec::new();
     let mut pending_messages = Vec::new();
@@ -1210,7 +1237,7 @@ fn seed_stored_openmls_graph_inputs<S: StorageProvider>(
     let mut own_commits = PrevalidatedOwnCommits::default();
 
     for record in records {
-        if admitted_message_ids.is_some_and(|admitted| !admitted.contains(&record.id)) {
+        if record.group_id != *group_id {
             continue;
         }
         if !record_state_can_contribute_to_openmls_graph(record.state) {
@@ -4713,6 +4740,37 @@ mod candidate_branch_peel_halt_tests {
             joiner.join_welcome(welcome).await.unwrap();
         }
         group_id
+    }
+
+    #[tokio::test]
+    async fn graph_seed_keeps_stale_commits() {
+        let (mut alice, storage) = build_client(b"graph-seed");
+        let (mut bob, _) = build_client(b"graph-seed-peer");
+        let group_id = group_with(&mut alice, &mut [&mut bob]).await;
+        let epoch = storage.get_group(&group_id).unwrap().epoch.0;
+        let commit = rival_commit(&storage, &alice.self_id(), &group_id);
+        admit_rival(&storage, &group_id, &commit, epoch);
+
+        let retained =
+            super::seed_stored_openmls_graph_inputs(&storage, &group_id, epoch, None).unwrap();
+        assert!(
+            retained
+                .commit_messages
+                .iter()
+                .any(|row| row.message.id == commit.id)
+        );
+        let stale =
+            super::seed_stored_openmls_graph_inputs(&storage, &group_id, epoch + 1, None).unwrap();
+        assert!(stale.commit_messages.is_empty());
+        assert!(stale.stale_commit_drops.iter().any(|row| {
+            row.message_id == hex::encode(commit.id.as_slice())
+                && row.reason == super::DroppedMessageReason::BeyondAnchor
+        }));
+        // Seeding classifies; only canonical apply may persist the verdict.
+        assert_eq!(
+            storage.get_message(&commit.id).unwrap().state,
+            MessageState::ConvergenceDeferred
+        );
     }
 
     // --- Graph fixtures ------------------------------------------------------

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -1199,18 +1199,18 @@ fn seed_stored_openmls_graph_inputs<S: StorageProvider>(
     retained_anchor_epoch: u64,
     admitted_message_ids: Option<&[MessageId]>,
 ) -> Result<StoredOpenMlsGraphInputs, OpenMlsProjectionError> {
-    let current_epoch = storage
-        .get_group(group_id)
-        .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?
-        .epoch
-        .0;
-    // Keep one read snapshot across the keyed reads or state query batches.
-    let records = storage
+    // Keep the group epoch and message records in the same read snapshot.
+    let (current_epoch, records) = storage
         .with_transaction(|storage| {
+            let current_epoch = storage.get_group(group_id)?.epoch.0;
             if let Some(ids) = admitted_message_ids {
                 // Frozen membership already names the complete batch. Do not
                 // load unrelated history just to intersect it with these ids.
-                return ids.iter().map(|id| storage.get_message(id)).collect();
+                let records = ids
+                    .iter()
+                    .map(|id| storage.get_message(id))
+                    .collect::<Result<Vec<_>, _>>()?;
+                return Ok((current_epoch, records));
             }
             let mut records = Vec::new();
             for state in OPENMLS_GRAPH_INPUT_STATES {
@@ -1227,7 +1227,7 @@ fn seed_stored_openmls_graph_inputs<S: StorageProvider>(
                     EpochId(floor),
                 )?);
             }
-            Ok::<Vec<MessageRecord>, StorageError>(records)
+            Ok::<_, StorageError>((current_epoch, records))
         })
         .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
     let mut commit_messages = Vec::new();

--- a/crates/cgka-engine/src/openmls_projection/tests.rs
+++ b/crates/cgka-engine/src/openmls_projection/tests.rs
@@ -1,0 +1,139 @@
+use super::*;
+use cgka_traits::group::Group;
+use cgka_traits::storage::{GroupStorage, MessageStorage};
+use cgka_traits::transport::{Timestamp, TransportSource};
+use storage_sqlite::SqliteAccountStorage;
+
+fn graph_fixture(history: u64) -> (SqliteAccountStorage, GroupId, Vec<MessageId>) {
+    let storage = SqliteAccountStorage::in_memory().unwrap();
+    let group_id = GroupId::new(vec![1; 16]);
+    storage
+        .put_group(&Group {
+            id: group_id.clone(),
+            name: String::new(),
+            description: String::new(),
+            epoch: EpochId(10),
+            members: Vec::new(),
+            required_capabilities: Default::default(),
+            protocol_profile: ProtocolProfile::Legacy,
+            removed: false,
+            unrecoverable: false,
+            disbanded: None,
+            join_epoch: EpochId(0),
+        })
+        .unwrap();
+    let mut admitted = Vec::new();
+    storage
+        .with_transaction(|storage| {
+            for index in 0..history + 20 {
+                let id = MessageId::new(index.to_be_bytes().to_vec());
+                let retained = index >= history;
+                let payload = StoredMessagePayload::raw_transport(TransportMessage {
+                    id: id.clone(),
+                    payload: vec![42; 4096],
+                    timestamp: Timestamp(0),
+                    causal_deps: Vec::new(),
+                    source: TransportSource("benchmark".into()),
+                    envelope: TransportEnvelope::GroupMessage {
+                        transport_group_id: vec![0; 32],
+                    },
+                })
+                .encode()
+                .unwrap();
+                storage.put_message(&MessageRecord {
+                    id: id.clone(),
+                    group_id: group_id.clone(),
+                    epoch: EpochId(if retained { 10 } else { 0 }),
+                    state: MessageState::Processed,
+                    payload,
+                    deferred_peel: None,
+                })?;
+                if retained {
+                    admitted.push(id);
+                }
+            }
+            Ok::<_, StorageError>(())
+        })
+        .unwrap();
+    (storage, group_id, admitted)
+}
+
+#[test]
+fn graph_seed_read_boundaries() {
+    let (storage, group_id, admitted) = graph_fixture(1);
+    let mut old = storage
+        .get_message(&MessageId::new(0u64.to_be_bytes().to_vec()))
+        .unwrap();
+    old.payload = vec![0xff];
+
+    // Irrelevant payloads must never be decoded, even when malformed.
+    for state in [MessageState::Processed, MessageState::EpochInvalidated] {
+        old.state = state;
+        storage.put_message(&old).unwrap();
+        assert!(seed_stored_openmls_graph_inputs(&storage, &group_id, 10, None).is_ok());
+    }
+    for state in OPENMLS_GRAPH_INPUT_STATES {
+        old.state = state;
+        old.epoch = EpochId(if state == MessageState::Processed {
+            10
+        } else {
+            0
+        });
+        storage.put_message(&old).unwrap();
+        // Retained processed witnesses and unresolved history stay readable
+        // inputs; malformed bytes in either must still propagate an error.
+        assert!(seed_stored_openmls_graph_inputs(&storage, &group_id, 10, None).is_err());
+        assert!(seed_stored_openmls_graph_inputs(&storage, &group_id, 10, Some(&admitted)).is_ok());
+    }
+    assert!(seed_stored_openmls_graph_inputs(&storage, &group_id, 10, Some(&[])).is_ok());
+    assert!(
+        seed_stored_openmls_graph_inputs(
+            &storage,
+            &group_id,
+            10,
+            Some(std::slice::from_ref(&old.id))
+        )
+        .is_err()
+    );
+    let mut other_group = storage.get_group(&group_id).unwrap();
+    other_group.id = GroupId::new(vec![2; 16]);
+    storage.put_group(&other_group).unwrap();
+    old.group_id = other_group.id;
+    storage.put_message(&old).unwrap();
+    assert!(
+        seed_stored_openmls_graph_inputs(
+            &storage,
+            &group_id,
+            10,
+            Some(std::slice::from_ref(&old.id))
+        )
+        .is_ok()
+    );
+    storage.delete_message(&admitted[0]).unwrap();
+    assert!(matches!(
+        seed_stored_openmls_graph_inputs(&storage, &group_id, 10, Some(&admitted)),
+        Err(OpenMlsProjectionError::Storage(_))
+    ));
+}
+
+#[test]
+#[ignore = "manual graph-seeding benchmark"]
+fn graph_seed_benchmark() {
+    use std::hint::black_box;
+    use std::time::Instant;
+
+    let (storage, group_id, ids) = graph_fixture(20_000);
+    for (label, members) in [("candidate", None), ("frozen", Some(ids.as_slice()))] {
+        let mut samples = Vec::new();
+        for _ in 0..9 {
+            let start = Instant::now();
+            black_box(seed_stored_openmls_graph_inputs(&storage, &group_id, 10, members).unwrap());
+            samples.push(start.elapsed());
+        }
+        samples.sort();
+        eprintln!(
+            "{label}: median {:?}; 20000 historical + 20 retained, 4096-byte raw payloads, in-memory SQLite",
+            samples[4]
+        );
+    }
+}


### PR DESCRIPTION
Graph seeding loaded the group's entire message history before filtering it, so small convergence batches paid for unrelated retained payloads. Frozen passes now read their members by id; candidate peeling reads processed rows only within the retained epoch window and keeps unresolved history for stale-commit verdicts. Reads share one transaction, and retained witnesses and proposals remain eligible.

The synthetic graph-seeding benchmark uses in-memory SQLite, 20,000 historical processed rows at epoch 0, 20 retained rows at epoch 10, and 4 KiB raw-transport payloads. Medians of nine runs in the debug test profile on the same machine, excluding fixture setup:

| Path | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| Candidate seeding | 255.871 ms | 0.324 ms | 789× |
| Frozen-pass seeding | 241.629 ms | 0.263 ms | 919× |

These measurements isolate history loading and graph seeding; the synthetic rows contain no replayable MLS graph. They do not establish release-build, file-backed, or end-to-end recovery speedups. Candidate reads still scale with unresolved history and messages inside the retained epoch window.

Run the benchmark with:

```sh
cargo test -p cgka-engine --lib graph_seed_benchmark -- --ignored --nocapture
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when reconstructing historical message and group state.
  - Corrected handling of retained and stale commits across epoch boundaries.
  - Improved filtering of admitted messages, including empty selections and messages from other groups.
  - Added safeguards for malformed stored payloads and storage errors.

- **Tests**
  - Expanded coverage for historical state discovery, epoch filtering, message selection, and graph seeding scenarios.
  - Added coverage for branch reconstruction and unchanged storage state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->