### PR TITLE
fix(app): restore self membership when convergence re-admits this device

### DIFF
--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -4486,13 +4486,15 @@ impl AppClient {
                 .remove_stale_group_push_tokens(&self.state.label, &group_id_hex, &[]);
         }
         self.invalidate_terminal_pending_sends(event, local_account_id_hex, summary)?;
-        // A (re-)join or create restores the local account's membership so a
-        // re-add after removal un-suppresses the group's unread count. Same
-        // source-of-truth write as the departure path above: propagate the
-        // error rather than swallow it.
-        if let cgka_traits::engine::GroupEvent::GroupJoined { group_id, .. }
-        | cgka_traits::engine::GroupEvent::GroupCreated { group_id } = event
-        {
+        // The local account arriving in a group restores its membership so the
+        // group's unread count stops being suppressed. A (re-)join or create is
+        // one such arrival; a roster diff that reports this device as
+        // `MemberAdded` is the other, and it is the only signal a convergence
+        // branch which supersedes our removal ever emits. Same source-of-truth
+        // write as the departure path above: propagate the error rather than
+        // swallow it. Writing `Member` also clears a preserved voluntary
+        // `Left`, which is the intended mdk#1746 behavior on a re-add.
+        if let Some(group_id) = self_arrival_group(event, local_account_id_hex) {
             let group_id_hex = hex::encode(group_id.as_slice());
             self.app.set_group_self_membership(
                 &self.state.label,
@@ -4734,6 +4736,32 @@ fn member_departure(
     match change {
         GroupStateChange::MemberLeft { member } => Some((member, SelfMembership::Left)),
         GroupStateChange::MemberRemoved { member } => Some((member, SelfMembership::Removed)),
+        _ => None,
+    }
+}
+
+/// Classify an engine event that puts the local account back in a group,
+/// returning the group it rejoined. The mirror of [`member_departure`]: a
+/// welcome-driven `GroupJoined` and a local `GroupCreated` are arrivals by
+/// construction, and a `GroupStateChanged` roster diff is one only when the
+/// added member is this device — the case distributed convergence produces when
+/// the winning branch supersedes a removal of us (the engine pins that emission
+/// in `superseded_self_removal_clears_removed_marker_and_restores_send`). Returns
+/// `None` otherwise, so a peer being added changes nothing locally.
+fn self_arrival_group<'a>(
+    event: &'a cgka_traits::engine::GroupEvent,
+    local_account_id_hex: &str,
+) -> Option<&'a cgka_traits::GroupId> {
+    match event {
+        cgka_traits::engine::GroupEvent::GroupJoined { group_id, .. }
+        | cgka_traits::engine::GroupEvent::GroupCreated { group_id } => Some(group_id),
+        cgka_traits::engine::GroupEvent::GroupStateChanged {
+            group_id,
+            change: cgka_traits::engine::GroupStateChange::MemberAdded { member },
+            ..
+        } if hex::encode(member.as_slice()).eq_ignore_ascii_case(local_account_id_hex) => {
+            Some(group_id)
+        }
         _ => None,
     }
 }

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -14119,6 +14119,176 @@ async fn a_drained_self_departure_and_rejoin_move_stored_self_membership() {
     );
 }
 
+/// Distributed convergence can supersede a removal of this device: the winning
+/// branch keeps us in the group, the engine clears the terminal marker, and the
+/// roster diff reports the local account as `MemberAdded`. That arrival is a
+/// membership transition like any other, so the projection must follow it back
+/// to `Member` — otherwise the healed group keeps its unread suppressed and
+/// renders as departed forever, with no later join event to correct it.
+#[tokio::test]
+async fn a_self_member_added_restores_stored_self_membership_after_a_removal() {
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://superseded-removal.example")
+        .with_test_relay_client(relay);
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client
+        .create_group("superseded removal", &[])
+        .await
+        .unwrap();
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let state_change = |change| marmot_account::AccountDeviceEffects {
+        events: vec![cgka_traits::engine::GroupEvent::GroupStateChanged {
+            group_id: group_id.clone(),
+            epoch: cgka_traits::EpochId(1),
+            actor: None,
+            change,
+            origin_commit_id: None,
+        }],
+        ..Default::default()
+    };
+    let local = MemberId::new(hex::decode(&account.account_id_hex).unwrap());
+
+    client
+        .observe_drained_session_events(&state_change(
+            cgka_traits::engine::GroupStateChange::MemberRemoved {
+                member: local.clone(),
+            },
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        app.stored_group_self_membership("alice", &group_id_hex)
+            .unwrap(),
+        Some(SelfMembership::Removed),
+    );
+
+    client
+        .observe_drained_session_events(&state_change(
+            cgka_traits::engine::GroupStateChange::MemberAdded { member: local },
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        app.stored_group_self_membership("alice", &group_id_hex)
+            .unwrap(),
+        Some(SelfMembership::Member),
+        "a superseded removal that re-admits this device must un-suppress the group again"
+    );
+}
+
+/// The same restoration must clear a *voluntary* departure. `Left` is preserved
+/// against a realizing eviction (mdk#1746), but that preservation is about how
+/// a departure is classified, not a veto on coming back: once the roster says
+/// this device is a member again, the group is live and its unread must count.
+#[tokio::test]
+async fn a_self_member_added_clears_a_preserved_voluntary_left() {
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://superseded-leave.example")
+        .with_test_relay_client(relay);
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client.create_group("superseded leave", &[]).await.unwrap();
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let state_change = |change| marmot_account::AccountDeviceEffects {
+        events: vec![cgka_traits::engine::GroupEvent::GroupStateChanged {
+            group_id: group_id.clone(),
+            epoch: cgka_traits::EpochId(1),
+            actor: None,
+            change,
+            origin_commit_id: None,
+        }],
+        ..Default::default()
+    };
+    let local = MemberId::new(hex::decode(&account.account_id_hex).unwrap());
+
+    client
+        .observe_drained_session_events(&state_change(
+            cgka_traits::engine::GroupStateChange::MemberLeft {
+                member: local.clone(),
+            },
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        app.stored_group_self_membership("alice", &group_id_hex)
+            .unwrap(),
+        Some(SelfMembership::Left),
+    );
+
+    client
+        .observe_drained_session_events(&state_change(
+            cgka_traits::engine::GroupStateChange::MemberAdded { member: local },
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        app.stored_group_self_membership("alice", &group_id_hex)
+            .unwrap(),
+        Some(SelfMembership::Member),
+        "re-admission must outrank a preserved voluntary departure"
+    );
+}
+
+/// A peer joining the group says nothing about this device's own membership.
+/// The arrival test is the same self-subject test the departure path uses, so
+/// the two cannot disagree about who arrived.
+#[tokio::test]
+async fn a_peer_member_added_leaves_stored_self_membership_alone() {
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app =
+        MarmotApp::with_relay(dir.path(), "wss://peer-added.example").with_test_relay_client(relay);
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client.create_group("peer added", &[]).await.unwrap();
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let state_change = |change| marmot_account::AccountDeviceEffects {
+        events: vec![cgka_traits::engine::GroupEvent::GroupStateChanged {
+            group_id: group_id.clone(),
+            epoch: cgka_traits::EpochId(1),
+            actor: None,
+            change,
+            origin_commit_id: None,
+        }],
+        ..Default::default()
+    };
+
+    client
+        .observe_drained_session_events(&state_change(
+            cgka_traits::engine::GroupStateChange::MemberRemoved {
+                member: MemberId::new(hex::decode(&account.account_id_hex).unwrap()),
+            },
+        ))
+        .await
+        .unwrap();
+    client
+        .observe_drained_session_events(&state_change(
+            cgka_traits::engine::GroupStateChange::MemberAdded {
+                member: MemberId::new(
+                    hex::decode(nostr::Keys::generate().public_key().to_hex()).unwrap(),
+                ),
+            },
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        app.stored_group_self_membership("alice", &group_id_hex)
+            .unwrap(),
+        Some(SelfMembership::Removed),
+        "a peer's arrival must not re-admit this device"
+    );
+}
+
 /// A departure that takes this device out of the group is terminal for its
 /// copy, exactly as a disband is terminal for everyone's, so both must mark
 /// transport routes dirty. The ingest seam keys the pre-refresh projection save


### PR DESCRIPTION
When distributed convergence supersedes a removal of this device, the engine clears `Group::removed` and reports the roster correction as a `MemberAdded` for self (pinned since #1293 in `superseded_self_removal_clears_removed_marker_and_restores_send`). The app rewrote `self_membership` to `Member` only on `GroupJoined` and `GroupCreated`, so a device healed back into a group kept rendering itself as departed, with its unread count suppressed, forever.

### Changes

- Classify arrivals the way departures already are: `self_arrival_group`, the mirror of `member_departure`, folds join, create, and a self `MemberAdded` into the one existing `set_group_self_membership(.., Member)` write; errors still propagate. A peer's `MemberAdded` changes nothing locally.
- Writing `Member` also clears a preserved voluntary `Left` on a re-add, the intended #1746 behavior; a test guards against a future `Left`-preserving veto on the arrival path.

### Tests

Three tests through the drained engine-event seam: `Removed` → self `MemberAdded` → `Member`; preserved `Left` → `Member`; peer `MemberAdded` leaves it untouched (mutation-probed). No new end-to-end harness: the engine already asserts the producer event with the accepted commit as origin, and unread suppression from the column is pinned in the storage tests.

### Validation

`cargo nextest run -p marmot-app --features test-policy-overrides --lib` 1154 passed; targeted 32 passed; engine `superseded` tests 7 passed; clippy clean; `just fast-ci` green. No schema, binding, or version change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored local membership correctly when the account is re-added to a group after voluntary removal or leaving.
  * Preserved unread counts when membership is restored.
  * Prevented other members’ additions from incorrectly changing the local account’s membership state.

* **Tests**
  * Added coverage for local re-admission and unrelated member additions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->